### PR TITLE
#84 : added Set Favorite Bag and Move to Favorite Bag in MultiItemMov…

### DIFF
--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -368,6 +368,8 @@ namespace ClassicUO.Configuration
 
         public bool DisableSystemChat { get; set; } = false;
 
+        public uint SetFavoriteMoveBagSerial { get; set; } = 0;
+
         #region GRID CONTAINER
         public bool UseGridLayoutContainerGumps { get; set; } = true;
         public int GridContainerSearchMode { get; set; } = 1;

--- a/src/ClassicUO.Client/Game/Managers/TargetManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/TargetManager.cs
@@ -455,8 +455,8 @@ namespace ClassicUO.Game.Managers
                         {
                             ProfileManager.CurrentProfile.SetFavoriteMoveBagSerial = serial;
                             ProfileManager.CurrentProfile.Save(ProfileManager.ProfilePath);
+                            _onTargetSelected?.Invoke(serial);
                         }
-                        _onTargetSelected?.Invoke(serial);
                         _onTargetSelected = null;
 
                         ClearTargetingWithoutTargetCancelPacket();

--- a/src/ClassicUO.Client/Game/Managers/TargetManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/TargetManager.cs
@@ -217,23 +217,23 @@ namespace ClassicUO.Game.Managers
             TargetingType = 0;
         }
 
-        private static Action<uint> _onTargetSelected;
-        private static readonly Dictionary<CursorTarget, Action<uint>> _targetCallbacks = new();
-        public static void SetTargeting(CursorTarget targeting, uint cursorID, TargetType cursorType, Action<uint> callback = null)
+        public static void SetTargeting(CursorTarget targeting, uint cursorID, TargetType cursorType)
         {
             if (targeting == CursorTarget.Invalid)
+            {
                 return;
+            }
 
-            bool lastTargeting = IsTargeting;
+            bool lastTargetting = IsTargeting;
             IsTargeting = cursorType < TargetType.Cancel;
             TargetingState = targeting;
             TargetingType = cursorType;
 
             if (IsTargeting)
             {
-                _onTargetSelected = callback;
+                //UIManager.RemoveTargetLineGump(LastTarget);
             }
-            else if (lastTargeting)
+            else if (lastTargetting)
             {
                 CancelTarget();
             }
@@ -453,11 +453,23 @@ namespace ClassicUO.Game.Managers
                     case CursorTarget.SetFavoriteMoveBag:
                         if (SerialHelper.IsItem(serial))
                         {
-                            ProfileManager.CurrentProfile.SetFavoriteMoveBagSerial = serial;
-                            ProfileManager.CurrentProfile.Save(ProfileManager.ProfilePath);
-                            _onTargetSelected?.Invoke(serial);
+                            Item item = World.Items.Get(serial);
+
+                            if (item != null && item.ItemData.IsContainer)
+                            {
+                                ProfileManager.CurrentProfile.SetFavoriteMoveBagSerial = serial;
+                                ProfileManager.CurrentProfile.Save(ProfileManager.ProfilePath);
+                                GameActions.Print("Favorite move bag set.");
+                            }
+                            else
+                            {
+                                GameActions.Print("That doesn't appear to be a valid container.");
+                            }
                         }
-                        _onTargetSelected = null;
+                        else
+                        {
+                            GameActions.Print("That is not a valid item.");
+                        }
 
                         ClearTargetingWithoutTargetCancelPacket();
                         return;

--- a/src/ClassicUO.Client/Game/UI/Gumps/MultiItemMoveGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/MultiItemMoveGump.cs
@@ -88,12 +88,9 @@ namespace ClassicUO.Game.UI.Gumps
             {
                 if (e.Button == MouseButtonType.Left)
                 {
-                    TargetManager.SetTargeting(CursorTarget.SetFavoriteMoveBag, CursorType.Target, TargetType.Neutral);
-                    uint favoriteMoveBag = ProfileManager.CurrentProfile.SetFavoriteMoveBagSerial;
-                    if (favoriteMoveBag == 0)
-                    {
-                        return;
-                    }
+                    ProfileManager.CurrentProfile.SetFavoriteMoveBagSerial = 0;
+                    ProfileManager.CurrentProfile.Save(ProfileManager.ProfilePath);
+                    GameActions.Print("Favorite move bag has been reset.");
                     delay.IsEditable = false;
                 }
             };

--- a/src/ClassicUO.Client/Game/UI/Gumps/MultiItemMoveGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/MultiItemMoveGump.cs
@@ -26,7 +26,7 @@ namespace ClassicUO.Game.UI.Gumps
         public MultiItemMoveGump(int x, int y) : base(0, 0)
         {
             Width = 200;
-            Height = 100;
+            Height = 105;
 
             X = x < 0 ? 0 : x;
             Y = y < 0 ? 0 : y;
@@ -69,6 +69,67 @@ namespace ClassicUO.Game.UI.Gumps
                 }
             };
 
+            NiceButton moveToBackpack;
+            Add(moveToBackpack = new NiceButton(0, Height - 60, Width, 20, ButtonAction.Default, "Move to backpack", align: Assets.TEXT_ALIGN_TYPE.TS_CENTER));
+            moveToBackpack.SetTooltip("Move selected items to your backpack.");
+            moveToBackpack.MouseUp += (s, e) =>
+            {
+                if (e.Button == MouseButtonType.Left)
+                {
+                    delay.IsEditable = false;
+                    processItemMoves(World.Player.FindItemByLayer(Data.Layer.Backpack));
+                }
+            };
+
+            NiceButton resetFavorite;
+            Add(resetFavorite = new NiceButton(0, Height - 40, 100, 20, ButtonAction.Default, "Reset favorite", align: Assets.TEXT_ALIGN_TYPE.TS_CENTER));
+            resetFavorite.SetTooltip("Reset your favorite container.");
+            resetFavorite.MouseUp += (s, e) =>
+            {
+                if (e.Button == MouseButtonType.Left)
+                {
+                    TargetManager.SetTargeting(CursorTarget.SetFavoriteMoveBag, CursorType.Target, TargetType.Neutral);
+                    uint favoriteMoveBag = ProfileManager.CurrentProfile.SetFavoriteMoveBagSerial;
+                    if (favoriteMoveBag == 0)
+                    {
+                        return;
+                    }
+                    delay.IsEditable = false;
+                }
+            };
+
+            NiceButton moveToFavorite;
+            Add(moveToFavorite = new NiceButton(100, Height - 40, 100, 20, ButtonAction.Default, "To favorite", align: Assets.TEXT_ALIGN_TYPE.TS_CENTER));
+            moveToFavorite.SetTooltip("Move selected items to your favorite container.");
+            moveToFavorite.MouseUp += (s, e) =>
+            {
+                if (e.Button == MouseButtonType.Left)
+                {
+                    uint favoriteMoveBag = ProfileManager.CurrentProfile.SetFavoriteMoveBagSerial;
+                    if (favoriteMoveBag == 0)
+                    {
+                        TargetManager.SetTargeting(CursorTarget.SetFavoriteMoveBag, CursorType.Target, TargetType.Neutral, serial =>
+                        {
+                            ProfileManager.CurrentProfile.SetFavoriteMoveBagSerial = serial;
+                            ProfileManager.CurrentProfile.Save(ProfileManager.ProfilePath);
+
+                            Item container = World.Items.Get(serial);
+                            if (container != null)
+                            {
+                                delay.IsEditable = false;
+                                processItemMoves(container);
+                            }
+                        });
+                        return;
+                    }
+                    Item container = World.Items.Get(favoriteMoveBag);
+                    if (container != null)
+                    {
+                        delay.IsEditable = false;
+                        processItemMoves(container);
+                    }
+                }
+            };
 
             NiceButton cancel;
             Add(cancel = new NiceButton(0, Height - 20, 100, 20, ButtonAction.Default, "Cancel", align: Assets.TEXT_ALIGN_TYPE.TS_CENTER));
@@ -91,18 +152,6 @@ namespace ClassicUO.Game.UI.Gumps
                     GameActions.Print("Where should we move these items?");
                     TargetManager.SetTargeting(CursorTarget.MoveItemContainer, CursorType.Target, TargetType.Neutral);
                     delay.IsEditable = false;
-                }
-            };
-
-            NiceButton moveToBackpack;
-            Add(moveToBackpack = new NiceButton(0, Height - 40, Width, 20, ButtonAction.Default, "Move to backpack", align: Assets.TEXT_ALIGN_TYPE.TS_CENTER));
-            moveToBackpack.SetTooltip("Move selected items to your backpack.");
-            moveToBackpack.MouseUp += (s, e) =>
-            {
-                if (e.Button == MouseButtonType.Left)
-                {
-                    delay.IsEditable = false;
-                    processItemMoves(World.Player.FindItemByLayer(Data.Layer.Backpack));
                 }
             };
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/MultiItemMoveGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/MultiItemMoveGump.cs
@@ -81,16 +81,15 @@ namespace ClassicUO.Game.UI.Gumps
                 }
             };
 
-            NiceButton resetFavorite;
-            Add(resetFavorite = new NiceButton(0, Height - 40, 100, 20, ButtonAction.Default, "Reset favorite", align: Assets.TEXT_ALIGN_TYPE.TS_CENTER));
-            resetFavorite.SetTooltip("Reset your favorite container.");
-            resetFavorite.MouseUp += (s, e) =>
+            NiceButton setFavorite;
+            Add(setFavorite = new NiceButton(0, Height - 40, 100, 20, ButtonAction.Default, "Set favorite bag", align: Assets.TEXT_ALIGN_TYPE.TS_CENTER));
+            setFavorite.SetTooltip("Set your preferred destination container for future item moves.");
+            setFavorite.MouseUp += (s, e) =>
             {
                 if (e.Button == MouseButtonType.Left)
                 {
-                    ProfileManager.CurrentProfile.SetFavoriteMoveBagSerial = 0;
-                    ProfileManager.CurrentProfile.Save(ProfileManager.ProfilePath);
-                    GameActions.Print("Favorite move bag has been reset.");
+                    GameActions.Print("Target a container to set as your favorite.");
+                    TargetManager.SetTargeting(CursorTarget.SetFavoriteMoveBag, CursorType.Target, TargetType.Neutral);
                     delay.IsEditable = false;
                 }
             };
@@ -105,25 +104,20 @@ namespace ClassicUO.Game.UI.Gumps
                     uint favoriteMoveBag = ProfileManager.CurrentProfile.SetFavoriteMoveBagSerial;
                     if (favoriteMoveBag == 0)
                     {
-                        TargetManager.SetTargeting(CursorTarget.SetFavoriteMoveBag, CursorType.Target, TargetType.Neutral, serial =>
-                        {
-                            ProfileManager.CurrentProfile.SetFavoriteMoveBagSerial = serial;
-                            ProfileManager.CurrentProfile.Save(ProfileManager.ProfilePath);
-
-                            Item container = World.Items.Get(serial);
-                            if (container != null)
-                            {
-                                delay.IsEditable = false;
-                                processItemMoves(container);
-                            }
-                        });
+                        GameActions.Print("No favorite container set. Please target one.");
+                        TargetManager.SetTargeting(CursorTarget.SetFavoriteMoveBag, CursorType.Target, TargetType.Neutral);
                         return;
                     }
+
                     Item container = World.Items.Get(favoriteMoveBag);
                     if (container != null)
                     {
                         delay.IsEditable = false;
                         processItemMoves(container);
+                    }
+                    else
+                    {
+                        GameActions.Print("Favorite container is not available.");
                     }
                 }
             };


### PR DESCRIPTION
This PR introduces the ability for users to designate a "Favorite Move Bag" as a destination for item transfers in the ItemMover interface.

![Screenshot 2025-07-04 at 18 05 25](https://github.com/user-attachments/assets/a2549411-3ae1-4781-9c5e-518775f69510)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to set and use a favorite container for moving multiple items, including options to move items to the favorite container or reset the favorite selection.
  * Introduced new buttons in the multi-item move interface for moving items to the backpack, to the favorite container, or resetting the favorite container.
* **UI Improvements**
  * Enhanced the multi-item move window layout to accommodate new actions and tooltips for better usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->