### PR TITLE
Don't exclude invulnerable entities as followers

### DIFF
--- a/src/ClassicUO.Client/LegionScripting/Utility.cs
+++ b/src/ClassicUO.Client/LegionScripting/Utility.cs
@@ -276,7 +276,7 @@ namespace ClassicUO.LegionScripting
                             }
                             break;
                         case ScanTypeObject.Followers:
-                            if (!(mobile.IsRenamable && mobile.NotorietyFlag != NotorietyFlag.Invulnerable && mobile.NotorietyFlag != NotorietyFlag.Enemy))
+                            if (!(mobile.IsRenamable && mobile.NotorietyFlag != NotorietyFlag.Enemy))
                             {
                                 continue;
                             }


### PR DESCRIPTION
Fix for issue that causes `API.NearestEntity` to not find followers who are invulnerable.