### PR TITLE
Change skill ups message frequency

### DIFF
--- a/src/ClassicUO.Client/Configuration/Language.cs
+++ b/src/ClassicUO.Client/Configuration/Language.cs
@@ -204,7 +204,7 @@ namespace ClassicUO.Configuration
             public string DragAnchored { get; set; } = "Anchor opened health bars together";
             public string ShowStatsChangedMsg { get; set; } = "Show stats changed messages";
             public string ShowSkillsChangedMsg { get; set; } = "Show skills changed messages";
-            public string ChangeVolume { get; set; } = "Changed by";
+            public string ChangeVolume { get; set; } = "Every tenth (0.1)";
             #endregion
 
             #region General->TerrainStatics

--- a/src/ClassicUO.Client/Network/PacketHandlers.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers.cs
@@ -2116,14 +2116,17 @@ namespace ClassicUO.Network
                             if (isSingleUpdate)
                             {
                                 float change = realVal / 10.0f - skill.Value;
+                                int deltaThreshold = ProfileManager.CurrentProfile?.ShowSkillsChangedDeltaValue ?? 0;
 
                                 if (
                                     change != 0.0f
                                     && !float.IsNaN(change)
                                     && ProfileManager.CurrentProfile != null
                                     && ProfileManager.CurrentProfile.ShowSkillsChangedMessage
-                                    && Math.Abs(change * 10)
-                                        >= ProfileManager.CurrentProfile.ShowSkillsChangedDeltaValue
+                                    && (
+                                        deltaThreshold <= 0
+                                        || skill.ValueFixed / deltaThreshold != realVal / deltaThreshold
+                                    )
                                 )
                                 {
                                     GameActions.Print(


### PR DESCRIPTION
This PR changes when skill increase/decrease messages are shown. With this change, when the total skill crosses a multiple of the user-configured value, a message will be shown.

For example, if set to 5, the user would expect to see something like:

```
Your skill in Mining has increases by 0.1.  It is now 3.5.
Your skill in Mining has increases by 0.1.  It is now 4.0.
Your skill in Mining has increases by 0.1.  It is now 4.5.
Your skill in Mining has increases by 0.1.  It is now 5.0.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skill change messages are now displayed based on threshold-based bucket comparisons, providing clearer updates when skill values cross defined increments.

* **Style**
  * Updated language for the volume change setting to clarify that changes are measured in tenths (0.1 increments).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->