### PR TITLE
Fix PR builds & upload build artifacts after build/test

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        ref: ${{ github.head_ref || github.ref_name }}
+        ref: ${{ github.event.pull_request.head.sha || github.ref }}
       
     - name: Get submodules
       run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -48,3 +48,9 @@ jobs:
       
     - name: Build
       run: dotnet build -c Release
+
+    - name: Upload Build Artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: build-output
+        path: '**/bin/Release/**/*'


### PR DESCRIPTION
- Use sha directly during git fetch for PR builds. Supposedly referencing the sha directly doesn't require some permission that the refs do. 🤷 
- Uploads build artifacts to github action tab so builds from pushes and PRs can be downloaded and tested.

~~fyi PR is set to merge into main branch. I wasn't entirely clear whether github actions go off the main branch (they seem to for the your publish yaml, but not sure about the build-test yaml) or the branch of the pr. Either way, this probably should be merged or cherry-picked into dev as well.~~

<img width="1293" height="352" alt="image" src="https://github.com/user-attachments/assets/51bde190-e12b-4872-be40-6e9bba71c4b6" />
<img width="1310" height="460" alt="image" src="https://github.com/user-attachments/assets/39e64105-0fd2-4542-834f-245f04c98ae3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **Chores**
  * Improved the workflow for automated builds and tests to ensure the repository is checked out at the exact pull request commit with full history during runs.
  * Added a step to upload build artifacts automatically after the build completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->