### PR TITLE
Pathfinding performance improvements

### DIFF
--- a/src/ClassicUO.Client/Game/Pathfinder.cs
+++ b/src/ClassicUO.Client/Game/Pathfinder.cs
@@ -1203,7 +1203,15 @@ namespace ClassicUO.Game
                 {
                     if (existing.IsValid && existing.Cost <= node.Cost)
                     {
-                        // Existing priority is better or equal, so ignore
+                        // Existing priority is better or equal, so ignore this node.
+
+                        // While it breaks encapsulation to perform this inside
+                        // the priority queue, it is safe to return this node
+                        // to the object pool early at this point because we know
+                        // the caller will discard its reference to this node, so
+                        // it cannot be used later during path reconstruction.
+                        node.Return();
+
                         return;
                     }
 

--- a/src/ClassicUO.Client/Game/Pathfinder.cs
+++ b/src/ClassicUO.Client/Game/Pathfinder.cs
@@ -1107,24 +1107,19 @@ namespace ClassicUO.Game
                 (pn) => {pn.Reset();},
                 15
                 );
-
-            private static int created, returned;
             
             private PathNode()
             {
-                created++;
             }
 
             public static PathNode Get()
             {
-                //Console.WriteLine($"PATHNODE: Created: {created}, {returned}");
                 return _pool.Get();
             }
 
             public void Return()
             {
                 _pool.Return(this);
-                returned++;
             }
 
             public bool IsValid { get; set; }

--- a/src/ClassicUO.Client/Game/Pathfinder.cs
+++ b/src/ClassicUO.Client/Game/Pathfinder.cs
@@ -1233,7 +1233,6 @@ namespace ClassicUO.Game
                     }
 
                     RemoveAt(0);
-                    _lookup.Remove(GetKey(top));
                     return top;
                 }
 
@@ -1300,8 +1299,9 @@ namespace ClassicUO.Game
 
             void RemoveAt(int index)
             {
-                var keyToRemove = GetKey(_heap[index]);
-                _lookup.Remove(keyToRemove);
+                var node = _heap[index];
+                var key = GetKey(node);
+                _lookup.Remove(key);
 
                 int lastIndex = _heap.Count - 1;
                 if (index != lastIndex)

--- a/src/ClassicUO.Utility/ObjectPool.cs
+++ b/src/ClassicUO.Utility/ObjectPool.cs
@@ -1,0 +1,39 @@
+namespace ClassicUO.Utility;
+
+using System;
+using System.Collections.Generic;
+
+public class ObjectPool<T> where T : class
+{
+    private readonly Stack<T> _pool;
+    private readonly Func<T> _factory;
+    private readonly Action<T> _onReturn;
+
+    public ObjectPool(Func<T> factory, Action<T> onReturn = null, int initialCapacity = 0)
+    {
+        _factory = factory ?? throw new ArgumentNullException(nameof(factory));
+        _onReturn = onReturn;
+        _pool = new Stack<T>(initialCapacity);
+
+        for (int i = 0; i < initialCapacity; i++)
+            _pool.Push(_factory());
+    }
+
+    public T Get()
+    {
+        return _pool.Count > 0 ? _pool.Pop() : _factory();
+    }
+
+    public void Return(T obj)
+    {
+        _onReturn?.Invoke(obj);
+        _pool.Push(obj);
+    }
+
+    public void Clear()
+    {
+        _pool.Clear();
+    }
+
+    public int Count => _pool.Count;
+}

--- a/src/ClassicUO.Utility/ObjectPool.cs
+++ b/src/ClassicUO.Utility/ObjectPool.cs
@@ -8,6 +8,7 @@ public class ObjectPool<T> where T : class
     private readonly Stack<T> _pool;
     private readonly Func<T> _factory;
     private readonly Action<T> _onReturn;
+    public int MaxCapacity { get; set; } = 3000;
 
     public ObjectPool(Func<T> factory, Action<T> onReturn = null, int initialCapacity = 0)
     {
@@ -27,7 +28,8 @@ public class ObjectPool<T> where T : class
     public void Return(T obj)
     {
         _onReturn?.Invoke(obj);
-        _pool.Push(obj);
+        if (_pool.Count < MaxCapacity)
+            _pool.Push(obj);
     }
 
     public void Clear()


### PR DESCRIPTION
- Primarily replaces the 15k length arrays and linear memory searches with a priority queue and dict.
- Includes a basic priority queue since .net 4 doesn't have one apparently. Implemented using a binary heap. Priority queue also includes a dict as well to implement O(1) `Contains`. 
- Been running for several hours now in a lumberjacking script, and so far so good.
- I'm seeing a 10x performance increase in cases where a path can be found (0.1 sec down to 0.01 sec). And seeing a worst-case performance improved 20x, where a path does not exist (0.4 to 0.6 sec down to 0.02 to 0.03 sec).

---
**Before:**
<img width="594" height="215" alt="image" src="https://github.com/user-attachments/assets/7bb26024-04d4-404b-bc20-ed2a896bba5e" />

---
**After:**
<img width="604" height="177" alt="image" src="https://github.com/user-attachments/assets/fa853943-b919-454a-84ea-1b505fd86b98" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved pathfinding performance and efficiency by switching to dynamic data structures and a priority queue.
  * Increased the maximum path node capacity, allowing for more complex routes.
  * Enhanced reliability and maintainability of movement and auto-walk features.
  * Reduced memory allocations through object pooling and reusable collections.

* **New Features**
  * Pathfinding now supports longer and more intricate paths due to increased node limits.
  * Introduced a generic object pooling system to optimize resource management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->