### PR TITLE
When pathfinding, don't use obstacle avoid feature

### DIFF
--- a/src/ClassicUO.Client/Game/GameObjects/PlayerMobile.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/PlayerMobile.cs
@@ -1612,7 +1612,7 @@ namespace ClassicUO.Game.GameObjects
 
          public bool Walk(Direction direction, bool run)
         {
-            if (!ProfileManager.CurrentProfile.AutoAvoidObstacules)
+            if (!ProfileManager.CurrentProfile.AutoAvoidObstacules || Pathfinder.AutoWalking)
             {
 
                 return WalkNotAvoid(direction, run);


### PR DESCRIPTION
At the moment, obstacle avoidance causes cycles in movements (even when moving manually via keyboard), which causes pathfinding to get stuck moving back and forth in certain scenarios. Obstacle avoidance shouldn't be necessary anyhow as the pathfinding algorithm should have taken obstacles into consideration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved walking behavior to better handle automatic walking scenarios, ensuring smoother navigation when auto-walking is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->