### PR TITLE
Add option to remove the "System:" prefix in journal

### DIFF
--- a/src/ClassicUO.Client/Configuration/Language.cs
+++ b/src/ClassicUO.Client/Configuration/Language.cs
@@ -448,6 +448,7 @@ namespace ClassicUO.Configuration
             public string JournalBackgroundColor { get; set; } = "Background color";
             public string JournalStyle { get; set; } = "Journal style";
             public string JournalHideBorders { get; set; } = "Hide borders";
+            public string JournalHideSystemPrefix { get; set; } = "Hide \"System:\" prefix";
             public string HideTimestamp { get; set; } = "Hide timestamp";
             public string JournalAnchor { get; set; } = "Make anchorable";
             #endregion

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -507,6 +507,7 @@ namespace ClassicUO.Configuration
         public int MaxJournalEntries { get; set; } = 250;
         public bool HideJournalBorder { get; set; } = false;
         public bool HideJournalTimestamp { get; set; } = false;
+        public bool HideJournalSystemPrefix { get; set; } = false;
 
         public int HealthLineSizeMultiplier { get; set; } = 1;
 

--- a/src/ClassicUO.Client/Game/Managers/JournalManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/JournalManager.cs
@@ -84,11 +84,14 @@ namespace ClassicUO.Game.Managers
                 CreateWriter();
             }
 
-            string output = $"[{timeNow:G}]  {name}: {text}";
-
+            string output;
             if (string.IsNullOrWhiteSpace(name))
             {
                 output = $"[{timeNow:G}]  {text}";
+            }
+            else
+            {
+                output = $"[{timeNow:G}]  {name}: {text}";
             }
 
             _fileWriter?.WriteLine(output);

--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -241,7 +241,14 @@ namespace ClassicUO.Game.Scenes
 
                     if (e.Parent == null || !SerialHelper.IsValid(e.Parent.Serial))
                     {
-                        name = ResGeneral.System;
+                        if (ProfileManager.CurrentProfile.HideJournalSystemPrefix)
+                        {
+                            name = null;
+                        }
+                        else
+                        {
+                            name = ResGeneral.System;
+                        }
                     }
                     else
                     {
@@ -253,15 +260,21 @@ namespace ClassicUO.Game.Scenes
                     break;
 
                 case MessageType.System:
-                    name =
-                        string.IsNullOrEmpty(e.Name)
-                        || string.Equals(
-                            e.Name,
-                            "system",
-                            StringComparison.InvariantCultureIgnoreCase
-                        )
-                            ? ResGeneral.System
-                            : e.Name;
+                    if (string.IsNullOrEmpty(e.Name) || string.Equals(e.Name, "system", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        if (ProfileManager.CurrentProfile.HideJournalSystemPrefix)
+                        {
+                            name = null;
+                        }
+                        else
+                        {
+                            name = ResGeneral.System;
+                        }
+                    }
+                    else
+                    {
+                        name = e.Name;
+                    }
 
                     text = e.Text;
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/JournalGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/JournalGump.cs
@@ -296,17 +296,18 @@ namespace ClassicUO.Game.UI.Gumps
 
         private void AddJournalEntry(object sender, JournalEntry entry)
         {
-            var usrSend = entry.Name != string.Empty ? $"{entry.Name}" : string.Empty;
-
             // Check if ignored person
-            if (!string.IsNullOrEmpty(usrSend) && IgnoreManager.IgnoredCharsList.Contains(usrSend))
+            if (!string.IsNullOrEmpty(entry.Name) && IgnoreManager.IgnoredCharsList.Contains(entry.Name))
                 return;
 
-            string text = $"{usrSend}: {entry.Text}";
-
-            if (string.IsNullOrEmpty(usrSend))
+            string text;
+            if (string.IsNullOrEmpty(entry.Name))
             {
                 text = entry.Text;
+            }
+            else
+            {
+                text = $"{entry.Name}: {entry.Text}";
             }
 
             _journalEntries.AddEntry

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
@@ -2844,6 +2844,8 @@ namespace ClassicUO.Game.UI.Gumps
             content.BlankLine();
             content.AddToRight(c = new CheckboxWithLabel(lang.GetTazUO.HideTimestamp, 0, profile.HideJournalTimestamp, (b) => { profile.HideJournalTimestamp = b; }), true, page);
             content.BlankLine();
+            content.AddToRight(c = new CheckboxWithLabel(lang.GetTazUO.JournalHideSystemPrefix, 0, profile.HideJournalSystemPrefix, (b) => { profile.HideJournalSystemPrefix = b; }), true, page);
+            content.BlankLine();
 
             content.AddToRight
             (

--- a/src/ClassicUO.Client/Game/UI/Gumps/ResizableJournal.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ResizableJournal.cs
@@ -406,7 +406,17 @@ namespace ClassicUO.Game.UI.Gumps
                 return;
             if (!string.IsNullOrEmpty(journalEntry.Name) && IgnoreManager.IgnoredCharsList.Contains(journalEntry.Name))
                 return;
-            _journalArea.AddEntry($"{journalEntry.Name}: {journalEntry.Text}", journalEntry.Hue, journalEntry.Time, journalEntry.TextType, journalEntry.MessageType);
+
+            string text;
+            if (string.IsNullOrEmpty(journalEntry.Name))
+            {
+                text = journalEntry.Text;
+            }
+            else
+            {
+                text = $"{journalEntry.Name}: {journalEntry.Text}";
+            }
+            _journalArea.AddEntry(text, journalEntry.Hue, journalEntry.Time, journalEntry.TextType, journalEntry.MessageType);
         }
 
         private void InitJournalEntries()


### PR DESCRIPTION
- Added an option to remove the "System:" prefix from system messages in the journal. To me, the prefix felt like it resulted in wasted screen real estate having to keep the journal that much wider to accommodate the "System:" prefix which could be inferred from the message itself.

---
Ahh, yes.. Looks so good! 😌 

<img width="546" height="248" alt="image" src="https://github.com/user-attachments/assets/878079bd-4886-4efd-83c5-7173c1e1d330" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to hide the "System:" prefix in journal entries. This can be toggled in the journal settings.
* **User Interface**
  * Introduced a new checkbox in the journal settings to control the visibility of the "System:" prefix.
* **Improvements**
  * Journal entries now display cleaner formatting when the "System:" prefix is hidden, removing unnecessary colons or empty fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->