### PR TITLE
Add option to default new containers to show old style view

### DIFF
--- a/src/ClassicUO.Client/Configuration/Language.cs
+++ b/src/ClassicUO.Client/Configuration/Language.cs
@@ -418,7 +418,7 @@ namespace ClassicUO.Configuration
             #region General
             public string GridContainers { get; set; } = "Grid containers";
             public string EnableGridContainers { get; set; } = "Enable grid containers";
-            public string GridContainersDefaultToOldStyleView { get; set; } = "New containers will show the old style view";
+            public string GridContainersDefaultToOldStyleView { get; set; } = "New containers will open in the old style view";
             public string GridContainerScale { get; set; } = "Grid container scale";
             public string AlsoScaleItems { get; set; } = "Also scale items";
             public string GridItemBorderOpacity { get; set; } = "Grid item border opacity";

--- a/src/ClassicUO.Client/Configuration/Language.cs
+++ b/src/ClassicUO.Client/Configuration/Language.cs
@@ -418,7 +418,7 @@ namespace ClassicUO.Configuration
             #region General
             public string GridContainers { get; set; } = "Grid containers";
             public string EnableGridContainers { get; set; } = "Enable grid containers";
-            public string GridContainersDefaultToOldStyleView { get; set; } = "New containers will open in the old style view";
+            public string GridContainersDefaultToOldStyleView { get; set; } = "Open new containers in the original view";
             public string GridContainerScale { get; set; } = "Grid container scale";
             public string AlsoScaleItems { get; set; } = "Also scale items";
             public string GridItemBorderOpacity { get; set; } = "Grid item border opacity";

--- a/src/ClassicUO.Client/Configuration/Language.cs
+++ b/src/ClassicUO.Client/Configuration/Language.cs
@@ -418,6 +418,7 @@ namespace ClassicUO.Configuration
             #region General
             public string GridContainers { get; set; } = "Grid containers";
             public string EnableGridContainers { get; set; } = "Enable grid containers";
+            public string GridContainersDefaultToOldStyleView { get; set; } = "New containers will show the old style view";
             public string GridContainerScale { get; set; } = "Grid container scale";
             public string AlsoScaleItems { get; set; } = "Also scale items";
             public string GridItemBorderOpacity { get; set; } = "Grid item border opacity";

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -373,6 +373,7 @@ namespace ClassicUO.Configuration
 
         #region GRID CONTAINER
         public bool UseGridLayoutContainerGumps { get; set; } = true;
+        public bool GridContainersDefaultToOldStyleView { get; set; } = false;
         public int GridContainerSearchMode { get; set; } = 1;
         public bool EnableGridContainerAnchor { get; set; } = false;
         public byte GridBorderAlpha { get; set; } = 75;
@@ -626,7 +627,7 @@ namespace ClassicUO.Configuration
         public bool EnableScavenger { get; set; } = true;
         public bool CounterGumpLocked { get; set; }
         public bool NearbyLootConcealsContainerOnOpen { get; set; } = true;
-        
+
         private long lastSave;
         public void Save(string path, bool saveGumps = true)
         {

--- a/src/ClassicUO.Client/Game/UI/Controls/ContextMenuControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ContextMenuControl.cs
@@ -102,11 +102,11 @@ namespace ClassicUO.Game.UI.Controls
             IsSelected = defaultValue;
         }
 
-        public readonly Action Action;
+        public Action Action;
         public readonly bool CanBeSelected;
         public bool IsSelected;
         public List<ContextMenuItemEntry> Items = new List<ContextMenuItemEntry>();
-        public readonly string Text;
+        public string Text;
 
         public void Add(ContextMenuItemEntry subEntry)
         {

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
@@ -319,32 +319,30 @@ namespace ClassicUO.Game.UI.Gumps
         private ContextMenuControl GenContextMenu()
         {
             var control = new ContextMenuControl();
-            control.Add(new ContextMenuItemEntry("Open Original Container", () =>
+            control.Add(new ContextMenuItemEntry("Open Original View", () =>
             {
                 UseOldContainerStyle = true;
                 OpenOldContainer(LocalSerial);
             }));
 
-            string text = ProfileManager.CurrentProfile.GridContainersDefaultToOldStyleView
-                    ? "Open new containers in the grid view"
-                    : "Open new containers in the old style view";
+            string gridViewText = "Open New Containers in the Grid View";
+            string originalViewText = "Open New Containers in the Original View";
+            string text = ProfileManager.CurrentProfile.GridContainersDefaultToOldStyleView ? gridViewText : originalViewText;
             var entry = new ContextMenuItemEntry(text);
             entry.Action = () =>
             {
                 ProfileManager.CurrentProfile.GridContainersDefaultToOldStyleView = !ProfileManager.CurrentProfile.GridContainersDefaultToOldStyleView;
-                entry.Text = text = ProfileManager.CurrentProfile.GridContainersDefaultToOldStyleView
-                    ? "Open new containers in the grid view"
-                    : "Open new containers in the old style view";
+                entry.Text = ProfileManager.CurrentProfile.GridContainersDefaultToOldStyleView ? gridViewText : originalViewText;
             };
             control.Add(entry);
 
-            control.Add(new ContextMenuItemEntry("Stack similar items in original container", () =>
+            control.Add(new ContextMenuItemEntry("Stack Similar Items in the Original View", () =>
             {
                 StackNonStackableItems = !StackNonStackableItems;
                 openRegularGump.ContextMenu = GenContextMenu();
             }, true, StackNonStackableItems));
 
-            control.Add(new ContextMenuItemEntry("Open Grid highlight settings", () =>
+            control.Add(new ContextMenuItemEntry("Open Grid View Highlight Settings", () =>
             {
                 GridHighlightMenu.Open();
             }));

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
@@ -1966,7 +1966,7 @@ namespace ClassicUO.Game.UI.Gumps
             }
             public bool UseOriginalContainerGump(uint container)
             {
-                bool useOriginalContainer = false;
+                bool useOriginalContainer = ProfileManager.CurrentProfile.GridContainersDefaultToOldStyleView;
 
                 XElement thisContainer = rootElement.Element("container_" + container.ToString());
                 if (thisContainer != null)

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
@@ -1966,7 +1966,7 @@ namespace ClassicUO.Game.UI.Gumps
             }
             public bool UseOriginalContainerGump(uint container)
             {
-                bool useOriginalContainer = ProfileManager.CurrentProfile.GridContainersDefaultToOldStyleView;
+                bool useOriginalContainer = ProfileManager.CurrentProfile?.GridContainersDefaultToOldStyleView ?? false;
 
                 XElement thisContainer = rootElement.Element("container_" + container.ToString());
                 if (thisContainer != null)

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
@@ -325,6 +325,11 @@ namespace ClassicUO.Game.UI.Gumps
                 OpenOldContainer(LocalSerial);
             }));
 
+            control.Add(new ContextMenuItemEntry("Toggle whether new containers open in grid view", () =>
+            {
+                ProfileManager.CurrentProfile.GridContainersDefaultToOldStyleView = !ProfileManager.CurrentProfile.GridContainersDefaultToOldStyleView;
+            }));
+
             control.Add(new ContextMenuItemEntry("Stack similar items in original container", () =>
             {
                 StackNonStackableItems = !StackNonStackableItems;

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
@@ -325,10 +325,18 @@ namespace ClassicUO.Game.UI.Gumps
                 OpenOldContainer(LocalSerial);
             }));
 
-            control.Add(new ContextMenuItemEntry("Toggle whether new containers open in grid view", () =>
+            string text = ProfileManager.CurrentProfile.GridContainersDefaultToOldStyleView
+                    ? "Open new containers in the grid view"
+                    : "Open new containers in the old style view";
+            var entry = new ContextMenuItemEntry(text);
+            entry.Action = () =>
             {
                 ProfileManager.CurrentProfile.GridContainersDefaultToOldStyleView = !ProfileManager.CurrentProfile.GridContainersDefaultToOldStyleView;
-            }));
+                entry.Text = text = ProfileManager.CurrentProfile.GridContainersDefaultToOldStyleView
+                    ? "Open new containers in the grid view"
+                    : "Open new containers in the old style view";
+            };
+            control.Add(entry);
 
             control.Add(new ContextMenuItemEntry("Stack similar items in original container", () =>
             {

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
@@ -325,17 +325,15 @@ namespace ClassicUO.Game.UI.Gumps
                 OpenOldContainer(LocalSerial);
             }));
 
-            string gridViewText = "Open New Containers in the Grid View";
-            string originalViewText = "Open New Containers in the Original View";
-            string text = ProfileManager.CurrentProfile.GridContainersDefaultToOldStyleView ? gridViewText : originalViewText;
-            var entry = new ContextMenuItemEntry(text);
-            entry.Action = () =>
-            {
-                ProfileManager.CurrentProfile.GridContainersDefaultToOldStyleView = !ProfileManager.CurrentProfile.GridContainersDefaultToOldStyleView;
-                entry.Text = ProfileManager.CurrentProfile.GridContainersDefaultToOldStyleView ? gridViewText : originalViewText;
-            };
-            control.Add(entry);
-
+            control.Add(new ContextMenuItemEntry
+            (
+                "Open New Containers in the Original View", () =>
+                {
+                    ProfileManager.CurrentProfile.GridContainersDefaultToOldStyleView = !ProfileManager.CurrentProfile.GridContainersDefaultToOldStyleView;
+                    openRegularGump.ContextMenu = GenContextMenu();
+                }, true, ProfileManager.CurrentProfile.GridContainersDefaultToOldStyleView
+            ));
+            
             control.Add(new ContextMenuItemEntry("Stack Similar Items in the Original View", () =>
             {
                 StackNonStackableItems = !StackNonStackableItems;

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
@@ -2592,6 +2592,13 @@ namespace ClassicUO.Game.UI.Gumps
 
             content.AddToRight
             (
+                new CheckboxWithLabel(lang.GetTazUO.GridContainersDefaultToOldStyleView, 0, profile.GridContainersDefaultToOldStyleView, (b) => { profile.GridContainersDefaultToOldStyleView = b; }), true, page
+            );
+
+            content.BlankLine();
+
+            content.AddToRight
+            (
                 new SliderWithLabel
                     (lang.GetTazUO.GridContainerScale, 0, ThemeSettings.SLIDER_WIDTH, 50, 200, profile.GridContainersScale, (i) => { profile.GridContainersScale = (byte)i; }),
                 true, page


### PR DESCRIPTION
I generally prefer the old style containers, but in certain scenarios, I like select containers to use the grid view. Currently, I have to go to settings and toggle grid view to make this work. Adding an option allows the user to default to using the old style view, while selectively marking specific containers as grid view where needed.

- Add option to default newly opened containers to use the old-container style view. Previous containers marked as grid view still show up as grid view when opened.

❌ : Containers saved as grid view prior to enabling this option will open showing the grid view as expected. However, with this option enabled, new containers, if switched to grid view, will reopen in old-style view. It seems the `useOriginalContainer` flag isn't saving correctly, hence why this PR is a draft.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new setting allowing users to choose whether new grid containers open in the old style view. This can be toggled via a checkbox in the TazUO settings page.
  * Context menu option added to toggle the default view style for new grid containers directly from the container interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->