### PR TITLE
Add Moveable/Immoveable nameplate options

### DIFF
--- a/src/ClassicUO.Client/Game/GameObjects/Item.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Item.cs
@@ -146,6 +146,8 @@ namespace ClassicUO.Game.GameObjects
 
         public bool IsLocked => (Flags & Flags.Movable) == 0 && ItemData.Weight > 90;
 
+        public bool IsMovable => (Flags & Flags.Movable) != 0;
+
         public ushort MultiGraphic { get; private set; }
 
         public bool IsMulti

--- a/src/ClassicUO.Client/Game/Managers/NameOverHeadManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/NameOverHeadManager.cs
@@ -79,7 +79,11 @@ namespace ClassicUO.Game.Managers
         Murderer = 1 << 18,
         Invulnerable = 1 << 19,
 
-        AllItems = Containers | Gold | Stackable | LockedDown | Other,
+        // Items cont.
+        Moveable = 1 << 20,
+        Immoveable = 1 << 21,
+
+        AllItems = Containers | Gold | Stackable | LockedDown | Moveable | Immoveable | Other,
         AllMobiles = Humanoid | Monster | OwnFollowers | Self,
         MobilesAndCorpses = AllMobiles | MonsterCorpses | HumanoidCorpses,
     }
@@ -195,6 +199,12 @@ namespace ClassicUO.Game.Managers
                 return true;
 
             if (item.IsLocked && ActiveOverheadOptions.HasFlag(NameOverheadOptions.LockedDown))
+                return true;
+
+            if (item.IsMovable && ActiveOverheadOptions.HasFlag(NameOverheadOptions.Moveable))
+                return true;
+
+            if (!item.IsMovable && ActiveOverheadOptions.HasFlag(NameOverheadOptions.Immoveable))
                 return true;
 
             if (ActiveOverheadOptions.HasFlag(NameOverheadOptions.Other))

--- a/src/ClassicUO.Client/Game/UI/Controls/NameOverheadAssignControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/NameOverheadAssignControl.cs
@@ -108,6 +108,9 @@ namespace ClassicUO.Game.UI.Controls
             AddCheckbox("Stackable", NameOverheadOptions.Stackable, 0, y);
             AddCheckbox("Locked down", NameOverheadOptions.LockedDown, 150, y);
             y += 22;
+            AddCheckbox("Moveable", NameOverheadOptions.Moveable, 0, y);
+            AddCheckbox("Immoveable", NameOverheadOptions.Immoveable, 150, y);
+            y += 22;
             AddCheckbox("Other items", NameOverheadOptions.Other, 0, y);
             y += 28;
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
@@ -5467,6 +5467,9 @@ namespace ClassicUO.Game.UI.Gumps
                 PositionHelper.PositionControl(AddCheckbox("Stackable", NameOverheadOptions.Stackable));
                 PositionHelper.PositionExact(AddCheckbox("Locked down", NameOverheadOptions.LockedDown), rightPosX, PositionHelper.LAST_Y);
 
+                PositionHelper.PositionControl(AddCheckbox("Moveable", NameOverheadOptions.Moveable));
+                PositionHelper.PositionExact(AddCheckbox("Immoveable", NameOverheadOptions.Immoveable), rightPosX, PositionHelper.LAST_Y);
+
                 PositionHelper.PositionControl(AddCheckbox("Other items", NameOverheadOptions.Other));
 
 


### PR DESCRIPTION
- Add Nameplate options to display Moveable items and Immoveable items. Unlike the existing Locked item option, Immoveable doesn't care about the weight, so it captures items like interactive books on tables, small coffers, etc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new "Moveable" and "Immoveable" filter options for item name overhead display.
  * Introduced corresponding checkboxes in the name overhead options UI, allowing users to filter items by their movability status.

* **Enhancements**
  * Improved item filtering logic to distinguish between movable and immovable items in overhead displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->