### PR TITLE
Better z estimate for pathfinding

### DIFF
--- a/src/ClassicUO.Client/LegionScripting/API.cs
+++ b/src/ClassicUO.Client/LegionScripting/API.cs
@@ -1091,7 +1091,7 @@ namespace ClassicUO.LegionScripting
             (() =>
                 {
                     if (z == int.MinValue)
-                        z = World.Player.Z;
+                        z = World.Map.GetTileZ(x, y);
 
                     return Pathfinder.WalkTo(x, y, z, distance);
                 }


### PR DESCRIPTION
Get the tile's z coordinate when no z coordinate is provided. Using the player's z causes pathfinding to fail when the goal's actual z coordinate was significantly higher or lower than the player's original z.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pathfinding accuracy by using the terrain height at the destination when the Z coordinate is not specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->