### PR TITLE
Auto-sell improvements

### DIFF
--- a/src/ClassicUO.Client/Configuration/Language.cs
+++ b/src/ClassicUO.Client/Configuration/Language.cs
@@ -593,6 +593,8 @@ namespace ClassicUO.Configuration
             public string AutoSellEnable { get; set; } = "Enable auto sell feature";
             public string AutoSellMaxUniques { get; set; } = "Maximum unique items per transaction";
             public string AutoSellMaxUniquesTooltip { get; set; } = "This is the maximum number of unique items that will be sold at once. A value of 0 means unlimited. A stack of items counts as one towards this limit. Some servers block transactions that sell too many unique items.";
+            public string AutoSellMaxItems { get; set; } = "Maximum total items per transaction";
+            public string AutoSellMaxItemsTooltip { get; set; } = "This is the maximum number of items that will be sold at once. A value of 0 means unlimited. Some servers block transactions that sell too many items.";
 
             public string AutoBuyMenu { get; set; } = "Auto Buy";
             public string AutoBuyEnable { get; set; } = "Enable auto buy feature";

--- a/src/ClassicUO.Client/Configuration/Language.cs
+++ b/src/ClassicUO.Client/Configuration/Language.cs
@@ -591,6 +591,7 @@ namespace ClassicUO.Configuration
 
             public string AutoSellMenu { get; set; } = "Auto Sell";
             public string AutoSellEnable { get; set; } = "Enable auto sell feature";
+            public string AutoSellMaxUniques { get; set; } = "Maximum unique items per transaction";
 
             public string AutoBuyMenu { get; set; } = "Auto Buy";
             public string AutoBuyEnable { get; set; } = "Enable auto buy feature";

--- a/src/ClassicUO.Client/Configuration/Language.cs
+++ b/src/ClassicUO.Client/Configuration/Language.cs
@@ -592,6 +592,7 @@ namespace ClassicUO.Configuration
             public string AutoSellMenu { get; set; } = "Auto Sell";
             public string AutoSellEnable { get; set; } = "Enable auto sell feature";
             public string AutoSellMaxUniques { get; set; } = "Maximum unique items per transaction";
+            public string AutoSellMaxUniquesTooltip { get; set; } = "This is the maximum number of unique items that will be sold at once. A value of 0 means unlimited. A stack of items counts as one towards this limit. Some servers block transactions that sell too many unique items.";
 
             public string AutoBuyMenu { get; set; } = "Auto Buy";
             public string AutoBuyEnable { get; set; } = "Enable auto buy feature";

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -622,6 +622,7 @@ namespace ClassicUO.Configuration
         public float GlobalScale { get; set; } = 1.5f;
         public ushort TurnDelay { get; set; } = 100;
         public bool SellAgentEnabled { get; set; }
+        public int SellAgentMaxUniques { get; set; } = 50;
         public bool BuyAgentEnabled { get; set; }
         public bool DisableTargetingGridContainers { get; set; }
         public bool ControllerEnabled { get; set; } = true;

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -623,6 +623,7 @@ namespace ClassicUO.Configuration
         public ushort TurnDelay { get; set; } = 100;
         public bool SellAgentEnabled { get; set; }
         public int SellAgentMaxUniques { get; set; } = 50;
+        public int SellAgentMaxItems { get; set; } = 0;
         public bool BuyAgentEnabled { get; set; }
         public bool DisableTargetingGridContainers { get; set; }
         public bool ControllerEnabled { get; set; } = true;

--- a/src/ClassicUO.Client/Game/Managers/BuySellAgent.cs
+++ b/src/ClassicUO.Client/Game/Managers/BuySellAgent.cs
@@ -169,6 +169,7 @@ namespace ClassicUO.Game.Managers
             int max_total_items = ProfileManager.CurrentProfile.SellAgentMaxItems;
             bool limit_total_items = max_total_items > 0;
             int max_unique_items = ProfileManager.CurrentProfile.SellAgentMaxUniques;
+            bool limit_unique_items = max_unique_items > 0;
 
             foreach (var sellConfig in sellItems)
             {
@@ -180,6 +181,8 @@ namespace ClassicUO.Game.Managers
                     if (!sellConfig.IsMatch(item.Graphic, item.Hue)) continue;
 
                     if (current_count >= sellConfig.MaxAmount) continue;
+
+                    if (limit_unique_items && unique_items >= max_unique_items) break;
 
                     if (limit_total_items && current_count + total_count >= max_total_items) break;
 
@@ -209,9 +212,6 @@ namespace ClassicUO.Game.Managers
                     }
                 }
                 total_count += current_count;
-
-                if (max_unique_items > 0 && unique_items >= max_unique_items)
-                    break;
             }
             sellPackets.Remove(vendorSerial);
 

--- a/src/ClassicUO.Client/Game/Managers/BuySellAgent.cs
+++ b/src/ClassicUO.Client/Game/Managers/BuySellAgent.cs
@@ -201,7 +201,7 @@ namespace ClassicUO.Game.Managers
                 }
                 total_count += current_count;
 
-                if (unique_items >= max_unique_items)
+                if (max_unique_items > 0 && unique_items >= max_unique_items)
                     break;
             }
             sellPackets.Remove(vendorSerial);

--- a/src/ClassicUO.Client/Game/Managers/BuySellAgent.cs
+++ b/src/ClassicUO.Client/Game/Managers/BuySellAgent.cs
@@ -186,29 +186,18 @@ namespace ClassicUO.Game.Managers
 
                     if (limit_total_items && current_count + total_count >= max_total_items) break;
 
-                    //Made it here, add to sell list
-                    if (current_count + item.Amount < sellConfig.MaxAmount && (!limit_total_items || current_count + total_count + item.Amount < max_total_items))
+                    int amount_sellable = Math.Min(item.Amount, sellConfig.MaxAmount - current_count);
+                    if (limit_total_items)
                     {
-                        sellList.Add(new Tuple<uint, ushort>(item.Serial, item.Amount));
-                        current_count += item.Amount;
-                        val += item.Price * item.Amount;
-                        unique_items++;
+                        amount_sellable = Math.Min(amount_sellable, max_total_items - total_count - current_count);
                     }
-                    else
-                    {
-                        int remainingAmount = sellConfig.MaxAmount - current_count;
-                        if (limit_total_items)
-                        {
-                            remainingAmount = Math.Min(remainingAmount, max_total_items - total_count - current_count);
-                        }
 
-                        if (remainingAmount > 0)
-                        {
-                            sellList.Add(new Tuple<uint, ushort>(item.Serial, (ushort)remainingAmount));
-                            current_count += (ushort)remainingAmount;
-                            val += item.Price * (ushort)remainingAmount;
-                            unique_items++;
-                        }
+                    if (amount_sellable > 0)
+                    {
+                        sellList.Add(new Tuple<uint, ushort>(item.Serial, (ushort)amount_sellable));
+                        current_count += (ushort)amount_sellable;
+                        val += item.Price * (ushort)amount_sellable;
+                        unique_items++;
                     }
                 }
                 total_count += current_count;

--- a/src/ClassicUO.Client/Game/Managers/BuySellAgent.cs
+++ b/src/ClassicUO.Client/Game/Managers/BuySellAgent.cs
@@ -166,6 +166,7 @@ namespace ClassicUO.Game.Managers
             long val = 0;
             ushort total_count = 0;
             ushort unique_items = 0;
+            int max_unique_items = ProfileManager.CurrentProfile.SellAgentMaxUniques;
 
             foreach (var sellConfig in sellItems)
             {
@@ -200,7 +201,7 @@ namespace ClassicUO.Game.Managers
                 }
                 total_count += current_count;
 
-                if (unique_items >= 50)
+                if (unique_items >= max_unique_items)
                     break;
             }
             sellPackets.Remove(vendorSerial);

--- a/src/ClassicUO.Client/Game/UI/Gumps/AssistantGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/AssistantGump.cs
@@ -86,6 +86,10 @@ public class AssistantGump : BaseOptionsGump
         scroll.Add(PositionHelper.PositionControl(new CheckboxWithLabel(lang.GetTazUO.AutoSellEnable, 0, profile.SellAgentEnabled, b => profile.SellAgentEnabled = b)));
         PositionHelper.BlankLine();
 
+        scroll.Add(c = PositionHelper.PositionControl(new SliderWithLabel(lang.GetTazUO.AutoSellMaxItems, 0, ThemeSettings.SLIDER_WIDTH, 0, 100, profile.SellAgentMaxItems, (r) => { profile.SellAgentMaxItems = r; })));
+        c.SetTooltip(lang.GetTazUO.AutoSellMaxItemsTooltip);
+        PositionHelper.BlankLine();
+
         scroll.Add(c = PositionHelper.PositionControl(new SliderWithLabel(lang.GetTazUO.AutoSellMaxUniques, 0, ThemeSettings.SLIDER_WIDTH, 0, 100, profile.SellAgentMaxUniques, (r) => { profile.SellAgentMaxUniques = r; })));
         c.SetTooltip(lang.GetTazUO.AutoSellMaxUniquesTooltip);
         PositionHelper.BlankLine();

--- a/src/ClassicUO.Client/Game/UI/Gumps/AssistantGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/AssistantGump.cs
@@ -85,6 +85,9 @@ public class AssistantGump : BaseOptionsGump
         scroll.Add(PositionHelper.PositionControl(new CheckboxWithLabel(lang.GetTazUO.AutoSellEnable, 0, profile.SellAgentEnabled, b => profile.SellAgentEnabled = b)));
         PositionHelper.BlankLine();
 
+        scroll.Add(PositionHelper.PositionControl(new SliderWithLabel(lang.GetTazUO.AutoSellMaxUniques, 0, ThemeSettings.SLIDER_WIDTH, 1, 100, profile.SellAgentMaxUniques, (r) => { profile.SellAgentMaxUniques = r; })));
+        PositionHelper.BlankLine();
+
         scroll.Add(PositionHelper.PositionControl(new SellAgentConfigs(MainContent.RightWidth - ThemeSettings.SCROLL_BAR_WIDTH - 10)));
     }
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/AssistantGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/AssistantGump.cs
@@ -72,6 +72,7 @@ public class AssistantGump : BaseOptionsGump
     private void BuildAutoSell()
     {
         var page = (int)PAGE.AutoSell;
+        Control c;
         MainContent.AddToLeft(CategoryButton("Auto sell", page, MainContent.LeftWidth));
         MainContent.ResetRightSide();
 
@@ -85,7 +86,8 @@ public class AssistantGump : BaseOptionsGump
         scroll.Add(PositionHelper.PositionControl(new CheckboxWithLabel(lang.GetTazUO.AutoSellEnable, 0, profile.SellAgentEnabled, b => profile.SellAgentEnabled = b)));
         PositionHelper.BlankLine();
 
-        scroll.Add(PositionHelper.PositionControl(new SliderWithLabel(lang.GetTazUO.AutoSellMaxUniques, 0, ThemeSettings.SLIDER_WIDTH, 1, 100, profile.SellAgentMaxUniques, (r) => { profile.SellAgentMaxUniques = r; })));
+        scroll.Add(c = PositionHelper.PositionControl(new SliderWithLabel(lang.GetTazUO.AutoSellMaxUniques, 0, ThemeSettings.SLIDER_WIDTH, 0, 100, profile.SellAgentMaxUniques, (r) => { profile.SellAgentMaxUniques = r; })));
+        c.SetTooltip(lang.GetTazUO.AutoSellMaxUniquesTooltip);
         PositionHelper.BlankLine();
 
         scroll.Add(PositionHelper.PositionControl(new SellAgentConfigs(MainContent.RightWidth - ThemeSettings.SCROLL_BAR_WIDTH - 10)));


### PR DESCRIPTION
- Makes the auto-sell agent's existing limit on max uniques configurable. On older servers, the limit was 5, so the current value of 50 was still large enough that selling failed.
- Adds a configurable limit to the max total items that auto-sell can sell. Older servers limited this to 5.
- For both options, added tooltips and allowed them to be unlimited by setting the slider to 0.
- Moved the check for max unique to before every item stack was checked. This prevented a case where if you had multiple unstackable items, the max unique limit would be bypassed.
- Finally, simplified the auto-sell logic a bit to hopefully make it easier to read.