### PR TITLE
feat: added max property count to be able to look for imbuable items

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightData.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightData.cs
@@ -219,16 +219,8 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
                     return false;
             }
 
-            if (MinimumProperty > 0 && matchingPropertiesCount < MinimumProperty)
-            {
-                return false;
-            }
-            if (MaximumProperty > 0 && matchingPropertiesCount > MaximumProperty)
-            {
-                return false;
-            }
-
-            return true;
+            var isMatchingPropertyCount = IsMatchingPropertyCount(matchingPropertiesCount);
+            return isMatchingPropertyCount;
         }
 
         private bool IsMatchFromItemPropertiesData(ItemPropertiesData itemData)
@@ -300,6 +292,12 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
                 matchingPropertiesCount++;
             }
 
+            var isMatchingPropertyCount = IsMatchingPropertyCount(matchingPropertiesCount);
+            return isMatchingPropertyCount;
+        }
+
+        private bool IsMatchingPropertyCount(int matchingPropertiesCount)
+        {
             if (MinimumProperty > 0 && matchingPropertiesCount < MinimumProperty)
             {
                 return false;

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightData.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightData.cs
@@ -60,6 +60,12 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
             set => _entry.MinimumProperty = value;
         }
 
+        public int MaximumProperty
+        {
+            get => _entry.MaximumProperty;
+            set => _entry.MaximumProperty = value;
+        }
+
         public List<string> ExcludeNegatives
         {
             get => _entry.ExcludeNegatives;
@@ -213,7 +219,16 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
                     return false;
             }
 
-            return matchingPropertiesCount >= MinimumProperty;
+            if (MinimumProperty > 0 && matchingPropertiesCount < MinimumProperty)
+            {
+                return false;
+            }
+            if (MaximumProperty > 0 && matchingPropertiesCount > MaximumProperty)
+            {
+                return false;
+            }
+
+            return true;
         }
 
         private bool IsMatchFromItemPropertiesData(ItemPropertiesData itemData)
@@ -285,7 +300,16 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
                 matchingPropertiesCount++;
             }
 
-            return matchingPropertiesCount >= MinimumProperty;
+            if (MinimumProperty > 0 && matchingPropertiesCount < MinimumProperty)
+            {
+                return false;
+            }
+            if (MaximumProperty > 0 && matchingPropertiesCount > MaximumProperty)
+            {
+                return false;
+            }
+
+            return true;
         }
 
         private string Normalize(string input)

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightProfile.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightProfile.cs
@@ -16,6 +16,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
         public bool AcceptExtraProperties { get; set; } = true;
         public bool Overweight { get; set; } = true;
         public int MinimumProperty { get; set; } = 0;
+        public int MaximumProperty { get; set; } = 0;
         public List<string> ExcludeNegatives { get; set; } = new();
         public List<string> RequiredRarities { get; set; } = new();
         public GridHighlightSlot GridHighlightSlot { get; set; } = new();

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightProperties.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightProperties.cs
@@ -35,6 +35,11 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
 
             Add(new AlphaBlendControl(0.85f) { Width = WIDTH, Height = HEIGHT });
 
+            lastYitem = 0;
+
+            // Scroll area
+            Add(mainScrollArea = new ScrollArea(0, 0, WIDTH, HEIGHT, true) { ScrollbarBehaviour = ScrollbarBehaviour.ShowAlways });
+
             // Accept extra properties checkbox
             string acceptExtraPropertiesTooltip =
                 "Highlight items with properties beyond your configuration.\n" +
@@ -42,7 +47,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
                 "When un-checked: The item must match all configured properties and must not have any extra properties.";
 
             Checkbox acceptExtraPropertiesCheckbox;
-            Add(acceptExtraPropertiesCheckbox = new Checkbox(0x00D2, 0x00D3)
+            mainScrollArea.Add(acceptExtraPropertiesCheckbox = new Checkbox(0x00D2, 0x00D3)
             {
                 X = 0,
                 Y = 0,
@@ -55,10 +60,12 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
             };
 
             Label acceptExtraPropertiesLabel;
-            Add(acceptExtraPropertiesLabel = new Label("Allow extra properties", true, 0xffff) { X = 20, Y = 0 });
+            mainScrollArea.Add(acceptExtraPropertiesLabel = new Label("Allow extra properties", true, 0xffff) { X = 20, Y = 0 });
+
+            lastYitem += 20;
 
             InputField minPropertiesInput;
-            Add(minPropertiesInput = new InputField(0x0BB8, 0xFF, 0xFFFF, true, 40, 20) { X = 180, Y = 0 });
+            mainScrollArea.Add(minPropertiesInput = new InputField(0x0BB8, 0xFF, 0xFFFF, true, 40, 20) { X = 0, Y = lastYitem });
             minPropertiesInput.SetText(data.MinimumProperty.ToString());
             minPropertiesInput.TextChanged += (s, e) =>
             {
@@ -72,12 +79,26 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
                 }
             };
             Label minPropertiesLabel;
-            Add(minPropertiesLabel = new Label("Min. property count", true, 0xffff) { X = minPropertiesInput.X + minPropertiesInput.Width, Y = 0 });
+            Add(minPropertiesLabel = new Label("Min. property count", true, 0xffff) { X = minPropertiesInput.X + minPropertiesInput.Width, Y = lastYitem });
 
-            // Scroll area
-            Add(mainScrollArea = new ScrollArea(0, 20, WIDTH, HEIGHT - 20, true) { ScrollbarBehaviour = ScrollbarBehaviour.ShowAlways });
+            InputField maxPropertiesInput;
+            mainScrollArea.Add(maxPropertiesInput = new InputField(0x0BB8, 0xFF, 0xFFFF, true, 40, 20) { X = 180, Y = lastYitem });
+            maxPropertiesInput.SetText(data.MinimumProperty.ToString());
+            maxPropertiesInput.TextChanged += (s, e) =>
+            {
+                if (int.TryParse(maxPropertiesInput.Text, out int val))
+                {
+                    data.MaximumProperty = val;
+                }
+                else
+                {
+                    maxPropertiesInput.Add(new FadingLabel(20, "Couldn't parse number", true, 0xff) { X = 0, Y = 0 });
+                }
+            };
+            Label maxPropertiesLabel;
+            Add(maxPropertiesLabel = new Label("Max. property count", true, 0xffff) { X = maxPropertiesInput.X + maxPropertiesInput.Width, Y = lastYitem });
 
-            lastYitem = 0;
+            lastYitem += 20;
 
             #region Properties
             mainScrollArea.Add(new Label("Property name", true, 0xffff, 120) { X = 0, Y = lastYitem });

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightProperties.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightProperties.cs
@@ -79,11 +79,11 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
                 }
             };
             Label minPropertiesLabel;
-            Add(minPropertiesLabel = new Label("Min. property count", true, 0xffff) { X = minPropertiesInput.X + minPropertiesInput.Width, Y = lastYitem });
+            mainScrollArea.Add(minPropertiesLabel = new Label("Min. property count", true, 0xffff) { X = minPropertiesInput.X + minPropertiesInput.Width, Y = lastYitem });
 
             InputField maxPropertiesInput;
             mainScrollArea.Add(maxPropertiesInput = new InputField(0x0BB8, 0xFF, 0xFFFF, true, 40, 20) { X = 180, Y = lastYitem });
-            maxPropertiesInput.SetText(data.MinimumProperty.ToString());
+            maxPropertiesInput.SetText(data.MaximumProperty.ToString());
             maxPropertiesInput.TextChanged += (s, e) =>
             {
                 if (int.TryParse(maxPropertiesInput.Text, out int val))
@@ -96,7 +96,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
                 }
             };
             Label maxPropertiesLabel;
-            Add(maxPropertiesLabel = new Label("Max. property count", true, 0xffff) { X = maxPropertiesInput.X + maxPropertiesInput.Width, Y = lastYitem });
+            mainScrollArea.Add(maxPropertiesLabel = new Label("Max. property count", true, 0xffff) { X = maxPropertiesInput.X + maxPropertiesInput.Width, Y = lastYitem });
 
             lastYitem += 20;
 

--- a/src/ClassicUO.Client/LegionScripting/docs/API.md
+++ b/src/ClassicUO.Client/LegionScripting/docs/API.md
@@ -7,7 +7,7 @@ You can now type `-updateapi` in game to download the latest API.py file.
   
 [Additional notes](notes.md)  
   
-This was generated on `7/18/25`.
+This was generated on `7-20-25`.
   
 # API  
 


### PR DESCRIPTION
<img width="511" height="728" alt="Screenshot 2025-07-20 at 14 09 44" src="https://github.com/user-attachments/assets/e16c12f9-20a7-4dba-86b6-5ada4f269417" />

Added a filter "Max. Property count"

Use case; being able to create rules like this:
```1. Jewelry (Ring/Bracelet) with Clean SSI
Kept if:
    - It’s a ring or bracelet AND it has Swing Speed Increase 10% (SSI).
    - The item’s property text section (between "Weight" and "Durability") contains only 2–4 properties:
        - 2 or 3 total lines: Always kept.
        - 4 lines: Kept if at least one line is any of:
            Dex Bonus, Int Bonus, Str Bonus, Hit Chance Increase, Damage Increase (if no SDI), Defense Chance Increase, Enhance Potions, Antique, Prized.
        - 5 lines: Only kept if contains Antique or Prized and any of: Dex, Int, Str, HCI, DI, DCI, EP.```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a maximum property count in grid highlight settings.
  * Introduced a new input field in the UI for setting the maximum property count, alongside the minimum property count.

* **Style**
  * Improved the layout of grid highlight property controls by consolidating them into a single scrollable area for better usability.

* **Documentation**
  * Corrected the date format in the API documentation header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->