### PR TITLE
feat: added terrain to ExternalImages

### DIFF
--- a/src/ClassicUO.Assets/PNGLoader.cs
+++ b/src/ClassicUO.Assets/PNGLoader.cs
@@ -129,15 +129,15 @@ namespace ClassicUO.Assets
             };
         }
 
-        public TerrainInfo LoadTerrainTexture(uint tileId)
+        public ArtInfo LoadTerrainTexture(uint tileId)
         {
             Texture2D texture;
 
             if (terrain_availableIDs == null)
-                return new TerrainInfo();
+                return new ArtInfo();
 
             int index = Array.IndexOf(terrain_availableIDs, tileId);
-            if (index == -1) return new TerrainInfo();
+            if (index == -1) return new ArtInfo();
 
             terrain_textureCache.TryGetValue(tileId, out texture);
 
@@ -163,29 +163,15 @@ namespace ClassicUO.Assets
             }
 
             if (texture == null)
-                return new TerrainInfo();
+                return new ArtInfo();
 
-            return new TerrainInfo()
+            return new ArtInfo()
             {
                 Pixels = GetPixels(texture),
                 Width = texture.Width,
                 Height = texture.Height
             };
         }
-
-        public class TerrainInfo
-        {
-            public uint[] Pixels { get; set; }
-            public int Width { get; set; }
-            public int Height { get; set; }
-            public TerrainInfo()
-            {
-                Pixels = Array.Empty<uint>();
-                Width = 0;
-                Height = 0;
-            }
-        }
-
 
         private uint[] GetPixels(Texture2D texture)
         {

--- a/src/ClassicUO.Assets/PNGLoader.cs
+++ b/src/ClassicUO.Assets/PNGLoader.cs
@@ -246,6 +246,10 @@ namespace ClassicUO.Assets
                             }
                         }
                     }
+                    else
+                    {
+                        Directory.CreateDirectory(artPath);
+                    }
 
                     string terrainPath = Path.Combine(exePath, IMAGES_FOLDER, TERRAIN_EXTERNAL_FOLDER);
                     if (Directory.Exists(terrainPath))
@@ -264,7 +268,7 @@ namespace ClassicUO.Assets
                     }
                     else
                     {
-                        Directory.CreateDirectory(artPath);
+                        Directory.CreateDirectory(terrainPath);
                     }
                 });
         }

--- a/src/ClassicUO.Renderer/Arts/Art.cs
+++ b/src/ClassicUO.Renderer/Arts/Art.cs
@@ -92,8 +92,8 @@ namespace ClassicUO.Renderer.Arts
 
                     if (idx > 0x4000)
                     {
-                        uint staticIdx = idx - 0x4000;
-                        _picker.Set(staticIdx, artInfo.Width, artInfo.Height, artInfo.Pixels);
+                        idx -= 0x4000;
+                        _picker.Set(idx, artInfo.Width, artInfo.Height, artInfo.Pixels);
 
                         var pos1 = 0;
                         int minX = artInfo.Width,
@@ -115,7 +115,7 @@ namespace ClassicUO.Renderer.Arts
                             }
                         }
 
-                        _realArtBounds[staticIdx] = new Rectangle(minX, minY, maxX - minX, maxY - minY);
+                        _realArtBounds[idx] = new Rectangle(minX, minY, maxX - minX, maxY - minY);
                     }
                 }
             }


### PR DESCRIPTION
Added the option to override terrain textures using ExternalImages/terrain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for loading and displaying terrain textures from PNG files in a dedicated "terrain" folder, allowing custom terrain visuals.
  * Implemented caching for loaded terrain textures to improve performance.
* **Enhancements**
  * Improved the way land tile textures are loaded by prioritizing terrain PNG overrides before falling back to other sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->