### PR TITLE
Rename "Base" to "Total" in Advanced Skills Gump

### DIFF
--- a/src/ClassicUO.Client/Resources/ResGumps.resx
+++ b/src/ClassicUO.Client/Resources/ResGumps.resx
@@ -1013,7 +1013,7 @@ Time left: {1:00}:{2:00}:{3:00}</value>
     <value>Real</value>
   </data>
   <data name="Base" xml:space="preserve">
-    <value>Base</value>
+    <value>Total</value>
   </data>
   <data name="Cap" xml:space="preserve">
     <value>Cap</value>


### PR DESCRIPTION
Rename "Base" to "Total" in Advanced Skills Gump

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated a label in the user interface from "Base" to "Total".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->