### PR TITLE
Add Gump.ShouldBeSaved and add GumpTypes for Menu/Dialog

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/Gump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/Gump.cs
@@ -58,7 +58,9 @@ namespace ClassicUO.Game.UI.Gumps
 
         public string PacketGumpText { get; set; } = string.Empty;
 
-        public bool CanBeSaved => GumpType != Gumps.GumpType.None || ServerSerial != 0;
+        public virtual bool ShouldBeSaved => true;
+
+        public bool CanBeSaved => ShouldBeSaved && (GumpType != Gumps.GumpType.None || ServerSerial != 0);
 
         public virtual GumpType GumpType { get; }
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/GumpType.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GumpType.cs
@@ -64,6 +64,8 @@ namespace ClassicUO.Game.UI.Gumps
         DurabilityGump = 6465,
         GridContainer = 8787,
         NearbyCorpseLoot,
-        SpellBar
+        SpellBar,
+        MenuGump,
+        TextEntryDialogGump,
     }
 }

--- a/src/ClassicUO.Client/Game/UI/Gumps/MenuGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/MenuGump.cs
@@ -46,6 +46,7 @@ namespace ClassicUO.Game.UI.Gumps
         private bool _isDown,
             _isLeft;
         private readonly HSliderBar _slider;
+        public override bool ShouldBeSaved => false;
         public override GumpType GumpType => GumpType.MenuGump;
 
         public MenuGump(uint serial, uint serv, string name) : base(serial, serv)

--- a/src/ClassicUO.Client/Game/UI/Gumps/MenuGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/MenuGump.cs
@@ -46,6 +46,7 @@ namespace ClassicUO.Game.UI.Gumps
         private bool _isDown,
             _isLeft;
         private readonly HSliderBar _slider;
+        public override GumpType GumpType => GumpType.MenuGump;
 
         public MenuGump(uint serial, uint serv, string name) : base(serial, serv)
         {

--- a/src/ClassicUO.Client/Game/UI/Gumps/TextEntryDialogGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/TextEntryDialogGump.cs
@@ -39,6 +39,7 @@ namespace ClassicUO.Game.UI.Gumps
     internal class TextEntryDialogGump : Gump
     {
         private readonly StbTextBox _textBox;
+        public override bool ShouldBeSaved => false;
         public override GumpType GumpType => GumpType.TextEntryDialogGump;
 
         public TextEntryDialogGump

--- a/src/ClassicUO.Client/Game/UI/Gumps/TextEntryDialogGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/TextEntryDialogGump.cs
@@ -39,6 +39,7 @@ namespace ClassicUO.Game.UI.Gumps
     internal class TextEntryDialogGump : Gump
     {
         private readonly StbTextBox _textBox;
+        public override GumpType GumpType => GumpType.TextEntryDialogGump;
 
         public TextEntryDialogGump
         (


### PR DESCRIPTION
Add GumpTypes for Menu/Dialog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new types for menu and text entry dialog windows, improving identification and handling of these interface elements.
  * Introduced a new property to control whether interface windows should be saved, enhancing customization of window persistence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->