### PR TITLE
Add skipQueue to API.Mount/Dismount and fix use queue when using mobiles

### DIFF
--- a/src/ClassicUO.Client/Game/Managers/UseItemQueue.cs
+++ b/src/ClassicUO.Client/Game/Managers/UseItemQueue.cs
@@ -61,11 +61,6 @@ namespace ClassicUO.Game.Managers
 
                 if (World.Get(serial) != null)
                 {
-                    if (SerialHelper.IsMobile(serial))
-                    {
-                        serial |= 0x8000_0000;
-                    }
-
                     GameActions.DoubleClick(serial);
                 }
             }

--- a/src/ClassicUO.Client/LegionScripting/API.cs
+++ b/src/ClassicUO.Client/LegionScripting/API.cs
@@ -1325,12 +1325,17 @@ namespace ClassicUO.LegionScripting
         /// API.Dismount()
         /// ```
         /// </summary>
-        public void Dismount() => InvokeOnMainThread
+        /// <param name="skipQueue">Defaults true, set to false to use a double click queue</param>
+        public void Dismount(bool skipQueue = true) => InvokeOnMainThread
         (() =>
             {
                 if (World.Player.FindItemByLayer(Layer.Mount) != null)
-                    GameActions.DoubleClick(World.Player);
-
+                {
+                    if (skipQueue)
+                        GameActions.DoubleClick(World.Player);
+                    else
+                        GameActions.DoubleClickQueued(World.Player);
+                }
             }
         );
 
@@ -1342,7 +1347,16 @@ namespace ClassicUO.LegionScripting
         /// ```
         /// </summary>
         /// <param name="serial"></param>
-        public void Mount(uint serial) => InvokeOnMainThread(() => { GameActions.DoubleClick(serial); });
+        /// <param name="skipQueue">Defaults true, set to false to use a double click queue</param>
+        public void Mount(uint serial, bool skipQueue = true) => InvokeOnMainThread
+        (() =>
+            {
+                if (skipQueue)
+                    GameActions.DoubleClick(serial);
+                else
+                    GameActions.DoubleClickQueued(serial);
+            }
+        );
 
         /// <summary>
         /// Wait for a target cursor.


### PR DESCRIPTION
- Adds skipQueue parameter to API.Mount and API.Dismount.
- Removes bitwise OR that was causing mobile usage to fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to choose whether mounting and dismounting actions are executed immediately or queued.

* **Refactor**
  * Improved handling of double-click actions on entities for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->