### PR TITLE
Multi-select in your Multi-move

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
@@ -912,7 +912,7 @@ namespace ClassicUO.Game.UI.Gumps
                 {
                     GameActions.GrabItem(_item, _item.Amount);
                 }
-                else if (Keyboard.Alt && Mouse.LButtonPressed && _item != null)
+                else if (Keyboard.Alt && _item != null)
                 {
                     var graphic = _item.Graphic;
                     var hue = _item.Hue;

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
@@ -214,6 +214,7 @@ namespace ClassicUO.Game.UI.Gumps
                 "/c[orange]Grid Container Controls:/cd\n" +
                 "Ctrl + Click to lock an item in place\n" +
                 "Alt + Click to add an item to the quick move queue\n" +
+                "Alt + Double Click to add all similar items to the quick move queue\n" +
                 "Shift + Click to add an item to your auto loot list\n" +
                 "Sort and single click looting can be enabled with the icons on the right side");
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
@@ -900,6 +900,7 @@ namespace ClassicUO.Game.UI.Gumps
                     return;
 
                 if (!Keyboard.Ctrl &&
+                    !Keyboard.Alt &&
                     ProfileManager.CurrentProfile.DoubleClickToLootInsideContainers &&
                     gridContainer.isCorpse &&
                     !_item.IsDestroyed &&
@@ -907,9 +908,34 @@ namespace ClassicUO.Game.UI.Gumps
                     container != World.Player.FindItemByLayer(Layer.Backpack) &&
                     !_item.IsLocked &&
                     _item.IsLootable)
+                {
                     GameActions.GrabItem(_item, _item.Amount);
+                }
+                else if (Keyboard.Alt && Mouse.LButtonPressed && _item != null)
+                {
+                    var graphic = _item.Graphic;
+                    var hue = _item.Hue;
+                    foreach (var gridItem in gridContainer.gridSlotManager.GridSlots.Values)
+                    {
+                        var item = gridItem?._item;
+                        if (item is null ||
+                            graphic != item.Graphic ||
+                            hue != item.Hue ||
+                            MultiItemMoveGump.MoveItems.Contains(item))
+                        {
+                            continue;
+                        }
+
+                        MultiItemMoveGump.MoveItems.Enqueue(item);
+                        gridItem.SelectHighlight = true;
+                    }
+
+                    MultiItemMoveGump.AddMultiItemMoveGumpToUI(gridContainer.X - 200, gridContainer.Y);
+                }
                 else
+                {
                     GameActions.DoubleClick(LocalSerial);
+                }
 
                 e.Result = true;
             }
@@ -967,7 +993,6 @@ namespace ClassicUO.Game.UI.Gumps
                             MultiItemMoveGump.MoveItems.Enqueue(_item);
                         MultiItemMoveGump.AddMultiItemMoveGumpToUI(gridContainer.X - 200, gridContainer.Y);
                         SelectHighlight = true;
-                        Mouse.CancelDoubleClick = true;
                     }
                     else if (Keyboard.Shift && _item != null && ProfileManager.CurrentProfile.EnableAutoLoot && !ProfileManager.CurrentProfile.HoldShiftForContext && !ProfileManager.CurrentProfile.HoldShiftToSplitStack)
                     {


### PR DESCRIPTION
- Add ability to alt+2x click to add all similar items to multi-move

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to Alt + double-click items in grid containers to select and queue multiple matching items for quick batch moving, with a dedicated multi-item move interface.

* **Bug Fixes**
  * Improved double-click behavior with modifier keys for more consistent item selection and movement actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->