### PR TITLE
Position MultiItemMoveGump to side with available space

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
@@ -931,7 +931,8 @@ namespace ClassicUO.Game.UI.Gumps
                         gridItem.SelectHighlight = true;
                     }
 
-                    MultiItemMoveGump.AddMultiItemMoveGumpToUI(gridContainer.X - 200, gridContainer.Y);
+                    int multimoveX = gridContainer.X >= 200 ? gridContainer.X - 200 : gridContainer.X + gridContainer.Width;
+                    MultiItemMoveGump.AddMultiItemMoveGumpToUI(multimoveX, gridContainer.Y);
                 }
                 else
                 {
@@ -992,7 +993,8 @@ namespace ClassicUO.Game.UI.Gumps
                     {
                         if (!MultiItemMoveGump.MoveItems.Contains(_item))
                             MultiItemMoveGump.MoveItems.Enqueue(_item);
-                        MultiItemMoveGump.AddMultiItemMoveGumpToUI(gridContainer.X - 200, gridContainer.Y);
+                        int multimoveX = gridContainer.X >= 200 ? gridContainer.X - 200 : gridContainer.X + gridContainer.Width;
+                        MultiItemMoveGump.AddMultiItemMoveGumpToUI(multimoveX, gridContainer.Y);
                         SelectHighlight = true;
                     }
                     else if (Keyboard.Shift && _item != null && ProfileManager.CurrentProfile.EnableAutoLoot && !ProfileManager.CurrentProfile.HoldShiftForContext && !ProfileManager.CurrentProfile.HoldShiftToSplitStack)
@@ -1078,7 +1080,8 @@ namespace ClassicUO.Game.UI.Gumps
                 {
                     if (!MultiItemMoveGump.MoveItems.Contains(_item))
                         MultiItemMoveGump.MoveItems.Enqueue(_item);
-                    MultiItemMoveGump.AddMultiItemMoveGumpToUI(gridContainer.X - 200, gridContainer.Y);
+                    int multimoveX = gridContainer.X >= 200 ? gridContainer.X - 200 : gridContainer.X + gridContainer.Width;
+                    MultiItemMoveGump.AddMultiItemMoveGumpToUI(multimoveX, gridContainer.Y);
                     SelectHighlight = true;
                 }
 
@@ -1109,7 +1112,8 @@ namespace ClassicUO.Game.UI.Gumps
                     {
                         if (!MultiItemMoveGump.MoveItems.Contains(_item))
                             MultiItemMoveGump.MoveItems.Enqueue(_item);
-                        MultiItemMoveGump.AddMultiItemMoveGumpToUI(gridContainer.X - 200, gridContainer.Y);
+                        int multimoveX = gridContainer.X >= 200 ? gridContainer.X - 200 : gridContainer.X + gridContainer.Width;
+                        MultiItemMoveGump.AddMultiItemMoveGumpToUI(multimoveX, gridContainer.Y);
                         SelectHighlight = true;
                     }
 


### PR DESCRIPTION
- Makes MultiItemMoveGump appear to right of grid container if not enough space on the left.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the positioning of the MultiItemMoveGump UI element to ensure it displays correctly based on the grid container's location, preventing it from appearing off-screen or overlapping when near the left edge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->