### PR TITLE
Added the ability to highlight items by its name

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightData.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightData.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
-using IronPython.Runtime.Operations;
 
 namespace ClassicUO.Game.UI.Gumps.GridHighLight
 {
@@ -353,8 +352,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
 
         private bool MatchesSlot(byte layer)
         {
-            bool isOtherChecked = (bool)typeof(GridHighlightSlot).GetProperty("Other").GetValue(EquipmentSlots);
-            if (isOtherChecked) {
+            if (EquipmentSlots.Other) {
                 return true;
             }
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightProfile.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightProfile.cs
@@ -11,6 +11,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
     public class GridHighlightSetupEntry
     {
         public string Name { get; set; }
+        public List<string> ItemNames { get; set; } = new();
         public ushort Hue { get; set; }
         public List<GridHighlightProperty> Properties { get; set; } = new();
         public bool AcceptExtraProperties { get; set; } = true;

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightProperties.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightProperties.cs
@@ -100,6 +100,32 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
 
             lastYitem += 20;
 
+            #region Name
+            mainScrollArea.Add(new Label("Item name", true, 0xffff, 120) { X = 0, Y = lastYitem });
+
+            lastYitem += 20;
+
+            for (int i = 0; i < data.ItemNames.Count; i++)
+            {
+                AddOther(data.ItemNames, i, lastYitem);
+                lastYitem += 25;
+            }
+
+            NiceButton addItemNameBtn;
+            mainScrollArea.Add(addItemNameBtn = new NiceButton(0, lastYitem, 180, 20, ButtonAction.Activate, "Add Item Name") { IsSelectable = false });
+            addItemNameBtn.MouseUp += (s, e) =>
+            {
+                if (e.Button == Input.MouseButtonType.Left)
+                {
+                    data.ItemNames.Add("");
+                    Dispose();
+                    UIManager.Add(new GridHighlightProperties(keyLoc, X, Y));
+                }
+            };
+
+            lastYitem += 30;
+            #endregion
+
             #region Properties
             mainScrollArea.Add(new Label("Property name", true, 0xffff, 120) { X = 0, Y = lastYitem });
             mainScrollArea.Add(new Label("Min value", true, 0xffff, 120) { X = 180, Y = lastYitem });
@@ -231,9 +257,8 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
                 lastYitem += 25;
             }
 
-            NiceButton addNegBtn;
-            mainScrollArea.Add(addNegBtn = new NiceButton(0, lastYitem, 180, 20, ButtonAction.Activate, "Add Disqualifying Property") { IsSelectable = false });
-            addNegBtn.MouseUp += (s, e) =>
+            mainScrollArea.Add(addItemNameBtn = new NiceButton(0, lastYitem, 180, 20, ButtonAction.Activate, "Add Disqualifying Property") { IsSelectable = false });
+            addItemNameBtn.MouseUp += (s, e) =>
             {
                 if (e.Button == Input.MouseButtonType.Left)
                 {
@@ -279,25 +304,28 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
             return System.Text.RegularExpressions.Regex.Replace(input, "(\\B[A-Z])", " $1");
         }
 
-        private void AddOther(List<string> others, int index, int y, HashSet<string>[] propertySets)
+        private void AddOther(List<string> others, int index, int y, HashSet<string>[] propertySets = null)
         {
             while (others.Count <= index)
             {
                 others.Add("");
             }
 
-            Combobox propCombobox;
             InputField propInput;
             propInput = new InputField(0x0BB8, 0xFF, 0xFFFF, true, 157, 25) { Y = y };
-            string[] values = GridHighlightRules.FlattenAndDistinctParameters(propertySets);
-            mainScrollArea.Add(propCombobox = new Combobox(0, lastYitem, 175, values, 0, 200, true) { });
-            propCombobox.OnOptionSelected += (s, e) =>
+            if (propertySets != null)
             {
-                var tVal = propCombobox.SelectedIndex;
+                string[] values = GridHighlightRules.FlattenAndDistinctParameters(propertySets);
+                Combobox propCombobox;
+                mainScrollArea.Add(propCombobox = new Combobox(0, lastYitem, 175, values, 0, 200, true) { });
+                propCombobox.OnOptionSelected += (s, e) =>
+                    {
+                        var tVal = propCombobox.SelectedIndex;
 
-                string v = values[tVal];
-                propInput.SetText(v);
-            };
+                        string v = values[tVal];
+                        propInput.SetText(v);
+                    };
+            }
 
             mainScrollArea.Add(propInput);
             propInput.SetText(others[index]);

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightProperties.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightProperties.cs
@@ -101,6 +101,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
             lastYitem += 20;
 
             #region Name
+            AddSectionDivider();
             mainScrollArea.Add(new Label("Item name", true, 0xffff, 120) { X = 0, Y = lastYitem });
 
             lastYitem += 20;
@@ -127,6 +128,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
             #endregion
 
             #region Properties
+            AddSectionDivider();
             mainScrollArea.Add(new Label("Property name", true, 0xffff, 120) { X = 0, Y = lastYitem });
             mainScrollArea.Add(new Label("Min value", true, 0xffff, 120) { X = 180, Y = lastYitem });
             mainScrollArea.Add(new Label("Optional", true, 0xffff, 120) { X = 255, Y = lastYitem });
@@ -159,6 +161,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
             lastYitem += 30;
 
             #region Equipment slot
+            AddSectionDivider();
             string[] slotNames = new[]
             {
                 "Talisman", "RightHand", "LeftHand",
@@ -233,6 +236,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
             lastYitem += ((slotNames.Length + colCount - 1) / colCount) * checkboxHeight + 10;
 
             #region Negative
+            AddSectionDivider();
             mainScrollArea.Add(new Label("Disqualifying Properties", true, 0xffff) { X = 0, Y = lastYitem });
             Checkbox weightCheckbox;
             mainScrollArea.Add(weightCheckbox = new Checkbox(0x00D2, 0x00D3)
@@ -272,6 +276,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
             lastYitem += 30;
 
             #region Rarity
+            AddSectionDivider();
             mainScrollArea.Add(new Label("Item Rarity Filters", true, 0xffff) { X = 0, Y = lastYitem });
             lastYitem += 20;
             mainScrollArea.Add(new Label("Only items with at least one of these rarities will match", true, 0xffff) { X = 0, Y = lastYitem });
@@ -298,6 +303,15 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
 
             this.keyLoc = keyLoc;
         }
+
+    private void AddSectionDivider()
+    {
+        lastYitem += 5;
+
+        mainScrollArea.Add(new Line(0, lastYitem, WIDTH, 1, Color.Gray.PackedValue));
+
+        lastYitem += 5;
+    }
 
         private string SplitCamelCase(string input)
         {


### PR DESCRIPTION
Added the ability to highlight items by its name

<img width="511" height="729" alt="Screenshot 2025-07-25 at 11 41 52" src="https://github.com/user-attachments/assets/60b62f57-9722-415f-801c-42dfea9b3f1e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to filter and highlight items by name in the grid highlight feature.
  * Introduced an editable list for item names, allowing users to add, edit, or remove names for filtering.
  * Improved UI with clear visual dividers between filter sections for better usability.

* **Enhancements**
  * Refined equipment slot matching logic for more accurate filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->