### PR TITLE
Improvements and bug fixes to login

### DIFF
--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -1016,6 +1016,7 @@ namespace ClassicUO.Configuration
                             gump.Restore(xml);
                             gump.X = x;
                             gump.Y = y;
+                            gump.SetInScreen();
 
                             if (gump.LocalSerial != 0)
                             {
@@ -1058,6 +1059,7 @@ namespace ClassicUO.Configuration
                             gump.Restore(xml);
                             gump.X = x;
                             gump.Y = y;
+                            gump.SetInScreen();
 
                             if (gump.LocalSerial != 0)
                             {
@@ -1156,6 +1158,7 @@ namespace ClassicUO.Configuration
                                     gump.Restore(xml);
                                     gump.X = x;
                                     gump.Y = y;
+                                    gump.SetInScreen();
 
                                     if (!gump.IsDisposed)
                                     {

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -787,6 +787,7 @@ namespace ClassicUO.Configuration
         public List<Gump> ReadGumps(string path)
         {
             List<Gump> gumps = new List<Gump>();
+            List<(Gump gump, GumpType type, int x, int y, uint serial, uint parent, XmlElement xml)> nestedGumps = new();
 
             // load skillsgroup
             SkillsGroupManager.Load();
@@ -828,6 +829,7 @@ namespace ClassicUO.Configuration
                             int x = int.Parse(xml.GetAttribute(nameof(x)));
                             int y = int.Parse(xml.GetAttribute(nameof(y)));
                             uint serial = uint.Parse(xml.GetAttribute(nameof(serial)));
+                            uint? parent = uint.TryParse(xml.GetAttribute(nameof(parent)), out var result) ? result : null;
 
                             if (uint.TryParse(xml.GetAttribute("serverSerial"), out uint serverSerial))
                             {
@@ -1004,6 +1006,12 @@ namespace ClassicUO.Configuration
                                 continue;
                             }
 
+                            if (parent.HasValue)
+                            {
+                                nestedGumps.Add((gump, type, x, y, serial, parent.Value, xml));
+                                continue;
+                            }
+
                             gump.LocalSerial = serial;
                             gump.Restore(xml);
                             gump.X = x;
@@ -1022,6 +1030,50 @@ namespace ClassicUO.Configuration
                         catch (Exception ex)
                         {
                             Log.Error(ex.ToString());
+                        }
+                    }
+
+                    HashSet<uint> processedSerials = new();
+                    while (nestedGumps.Count != 0)
+                    {
+                        int initialCount = nestedGumps.Count;
+                        foreach (var entry in nestedGumps.ToList())
+                        {
+                            var (gump, type, x, y, serial, parent, xml) = entry;
+                            bool parentIsInList = nestedGumps.Any(g => parent == g.serial);
+                            if (parentIsInList)
+                            {
+                                continue;
+                            }
+
+                            if (!processedSerials.Contains(parent) && World.Get(parent) is null)
+                            {
+                                continue;
+                            }
+
+                            processedSerials.Add(serial);
+                            nestedGumps.Remove(entry);
+
+                            gump.LocalSerial = serial;
+                            gump.Restore(xml);
+                            gump.X = x;
+                            gump.Y = y;
+
+                            if (gump.LocalSerial != 0)
+                            {
+                                UIManager.SavePosition(gump.LocalSerial, new Point(x, y));
+                            }
+
+                            if (!gump.IsDisposed)
+                            {
+                                gumps.Add(gump);
+                            }
+                        }
+
+                        if (initialCount == nestedGumps.Count)
+                        {
+                            Log.Warn($"[Profile.ReadGumps] Skipping nested gumps: {string.Join(", ", nestedGumps)}");
+                            break;
                         }
                     }
 

--- a/src/ClassicUO.Client/Game/GameActions.cs
+++ b/src/ClassicUO.Client/Game/GameActions.cs
@@ -190,7 +190,9 @@ namespace ClassicUO.Game
 
                 if (paperDollGump == null)
                 {
-                    DoubleClick(serial | 0x80000000);
+                    // Bitwish ORing 0x8000_0000 signals to the server to send the
+                    // OpenPaperdoll packet for the player specifically.
+                    DoubleClickQueued(serial | 0x8000_0000);
                 }
                 else
                 {

--- a/src/ClassicUO.Client/Game/Managers/UseItemQueue.cs
+++ b/src/ClassicUO.Client/Game/Managers/UseItemQueue.cs
@@ -58,11 +58,7 @@ namespace ClassicUO.Game.Managers
                 }
 
                 uint serial = _actions.RemoveFromFront();
-
-                if (World.Get(serial) != null)
-                {
-                    GameActions.DoubleClick(serial);
-                }
+                GameActions.DoubleClick(serial);
             }
         }
 

--- a/src/ClassicUO.Client/Game/Managers/UseItemQueue.cs
+++ b/src/ClassicUO.Client/Game/Managers/UseItemQueue.cs
@@ -31,6 +31,7 @@
 #endregion
 
 using ClassicUO.Game.GameObjects;
+using ClassicUO.Configuration;
 using ClassicUO.Utility.Collections;
 
 namespace ClassicUO.Game.Managers
@@ -39,18 +40,19 @@ namespace ClassicUO.Game.Managers
     {
         private readonly Deque<uint> _actions = new Deque<uint>();
         private long _timer;
-
+        private static long _delay = 1000;
 
         public UseItemQueue()
         {
-            _timer = Time.Ticks + 1000;
+            _delay = ProfileManager.CurrentProfile.MoveMultiObjectDelay;
+            _timer = Time.Ticks + _delay;
         }
 
         public void Update()
         {
             if (_timer < Time.Ticks)
             {
-                _timer = Time.Ticks + 1000;
+                _timer = Time.Ticks + _delay;
 
                 if (_actions.Count == 0)
                 {

--- a/src/ClassicUO.Client/Game/UI/Gumps/ContainerGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ContainerGump.cs
@@ -568,6 +568,12 @@ namespace ClassicUO.Game.UI.Gumps
             base.Save(writer);
             writer.WriteAttributeString("graphic", Graphic.ToString());
             writer.WriteAttributeString("isminimized", IsMinimized.ToString());
+
+            var item = World.Items.Get(LocalSerial);
+            if (item is not null)
+            {
+                writer.WriteAttributeString("parent", item.Container.ToString());
+            }
         }
 
         public override void Restore(XmlElement xml)

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
@@ -386,6 +386,12 @@ namespace ClassicUO.Game.UI.Gumps
                 ProfileManager.CurrentProfile.BackpackGridSize = new Point(Width, Height);
             }
 
+            var item = World.Items.Get(LocalSerial);
+            if (item is not null)
+            {
+                writer.WriteAttributeString("parent", item.Container.ToString());
+            }
+
             writer.WriteAttributeString("ogContainer", originalContainerItemGraphic.ToString());
         }
         public override void Restore(XmlElement xml)

--- a/src/ClassicUO.Client/Game/UI/Gumps/PaperdollGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/PaperdollGump.cs
@@ -670,8 +670,7 @@ namespace ClassicUO.Game.UI.Gumps
             {
                 BuildGump();
 
-                //GameActions.DoubleClick(0x8000_0000 | LocalSerial);
-                Client.Game.GetScene<GameScene>()?.DoubleClickDelayed(LocalSerial);
+                GameActions.OpenPaperdoll(LocalSerial);
 
                 IsMinimized = bool.Parse(xml.GetAttribute("isminimized"));
                 X = ProfileManager.CurrentProfile.PaperdollPosition.X;

--- a/src/ClassicUO.Client/Network/PacketHandlers.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers.cs
@@ -2329,12 +2329,10 @@ namespace ClassicUO.Network
                 var scene = new GameScene();
                 Client.Game.SetScene(scene);
 
-                //GameActions.OpenPaperdoll(World.Player);
                 GameActions.RequestMobileStatus(World.Player);
                 NetClient.Socket.Send_OpenChat("");
 
                 NetClient.Socket.Send_SkillsRequest(World.Player);
-                scene.DoubleClickDelayed(World.Player);
 
                 if (Client.Version >= Utility.ClientVersion.CV_306E)
                 {


### PR DESCRIPTION
Bugs fixed:
- Dismounting upon login
- Containers not restoring correctly upon login
- Gumps restoring off-screen upon login

Changes:
- Moved some attempts to re-open the paperdoll at LoginComplete to the paperdoll gump restore method.
- Removed serial validation on queued double-click. This was preventing queued paperdoll opening.
- When restoring gumps at login, restore the containers in topological order wrt their nested position inside one another.
- Put all restoration of paperdoll gump and container gumps into UseItemQueue.
- UseItemQueue now uses MoveItemQueue's delay since they are the same delay server-side as best I can tell.
- Gump.SetInScreen() after restoring gumps so that they don't restore off-screen e.g. if you resize the window smaller before quitting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for saving and restoring nested containers, preserving parent-child relationships for gumps.
  * Container and grid container windows now record their parent container information during saving.

* **Bug Fixes**
  * Ensured gumps are positioned within screen bounds when restored.

* **Improvements**
  * Configurable delay added for use item queue actions.
  * Refined the process for opening and restoring the paperdoll UI for enhanced reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->