### PR TITLE
Add global action cooldown

### DIFF
--- a/src/ClassicUO.Client/Game/Managers/GlobalActionCooldown.cs
+++ b/src/ClassicUO.Client/Game/Managers/GlobalActionCooldown.cs
@@ -1,0 +1,17 @@
+using ClassicUO.Configuration;
+
+namespace ClassicUO.Game.Managers
+{
+    public static class GlobalActionCooldown
+    {
+        private static long nextActionTime = 0;
+        private static long cooldownDuration => ProfileManager.CurrentProfile.MoveMultiObjectDelay;
+
+        public static bool IsOnCooldown => Time.Ticks < nextActionTime;
+
+        public static void ResetCooldown()
+        {
+            nextActionTime = Time.Ticks + cooldownDuration;
+        }
+    }
+}

--- a/src/ClassicUO.Client/Game/Managers/GlobalActionCooldown.cs
+++ b/src/ClassicUO.Client/Game/Managers/GlobalActionCooldown.cs
@@ -9,7 +9,7 @@ namespace ClassicUO.Game.Managers
 
         public static bool IsOnCooldown => Time.Ticks < nextActionTime;
 
-        public static void ResetCooldown()
+        public static void BeginCooldown()
         {
             nextActionTime = Time.Ticks + cooldownDuration;
         }

--- a/src/ClassicUO.Client/Game/Managers/MoveItemQueue.cs
+++ b/src/ClassicUO.Client/Game/Managers/MoveItemQueue.cs
@@ -48,6 +48,9 @@ namespace ClassicUO.Game.Managers
 
         public void ProcessQueue()
         {
+            if (_isEmpty)
+                return;
+
             if (GlobalActionCooldown.IsOnCooldown)
                 return;
 

--- a/src/ClassicUO.Client/Game/Managers/MoveItemQueue.cs
+++ b/src/ClassicUO.Client/Game/Managers/MoveItemQueue.cs
@@ -12,13 +12,10 @@ namespace ClassicUO.Game.Managers
         
         public bool IsEmpty => _queue.IsEmpty;
         
-        private static long delay = 1000;
         private readonly ConcurrentQueue<MoveRequest> _queue = new();
-        private long nextMove;
 
         public MoveItemQueue()
         {
-            delay = ProfileManager.CurrentProfile.MoveMultiObjectDelay;
             Instance = this;
         }
 
@@ -50,7 +47,7 @@ namespace ClassicUO.Game.Managers
 
         public void ProcessQueue()
         {
-            if (Time.Ticks < nextMove)
+            if (GlobalActionCooldown.IsOnCooldown)
                 return;
             
             if (Client.Game.GameCursor.ItemHold.Enabled)
@@ -62,7 +59,7 @@ namespace ClassicUO.Game.Managers
             GameActions.PickUp(request.Serial, 0, 0, request.Amount);
             GameActions.DropItem(request.Serial, request.X, request.Y, request.Z, request.Destination);
             
-            nextMove = Time.Ticks + delay;
+            GlobalActionCooldown.ResetCooldown();
         }
 
         public void Clear()

--- a/src/ClassicUO.Client/Game/Managers/MoveItemQueue.cs
+++ b/src/ClassicUO.Client/Game/Managers/MoveItemQueue.cs
@@ -59,7 +59,7 @@ namespace ClassicUO.Game.Managers
             GameActions.PickUp(request.Serial, 0, 0, request.Amount);
             GameActions.DropItem(request.Serial, request.X, request.Y, request.Z, request.Destination);
             
-            GlobalActionCooldown.ResetCooldown();
+            GlobalActionCooldown.BeginCooldown();
         }
 
         public void Clear()

--- a/src/ClassicUO.Client/Game/Managers/UseItemQueue.cs
+++ b/src/ClassicUO.Client/Game/Managers/UseItemQueue.cs
@@ -56,7 +56,7 @@ namespace ClassicUO.Game.Managers
             uint serial = _actions.RemoveFromFront();
             GameActions.DoubleClick(serial);
 
-            GlobalActionCooldown.ResetCooldown();
+            GlobalActionCooldown.BeginCooldown();
         }
 
         public void Add(uint serial)

--- a/src/ClassicUO.Client/Game/Managers/UseItemQueue.cs
+++ b/src/ClassicUO.Client/Game/Managers/UseItemQueue.cs
@@ -40,31 +40,23 @@ namespace ClassicUO.Game.Managers
     {
         public static UseItemQueue Instance { get; private set; }
         public bool IsEmpty => _actions.Count == 0;
+
         private readonly Deque<uint> _actions = new Deque<uint>();
-        private long _timer;
-        private static long _delay = 1000;
 
         public UseItemQueue()
         {
-            _delay = ProfileManager.CurrentProfile.MoveMultiObjectDelay;
-            _timer = Time.Ticks + _delay;
             Instance = this;
         }
 
         public void Update()
         {
-            if (_timer < Time.Ticks)
-            {
-                _timer = Time.Ticks + _delay;
+            if (GlobalActionCooldown.IsOnCooldown) return;
+            if (_actions.Count == 0) return;
 
-                if (_actions.Count == 0)
-                {
-                    return;
-                }
+            uint serial = _actions.RemoveFromFront();
+            GameActions.DoubleClick(serial);
 
-                uint serial = _actions.RemoveFromFront();
-                GameActions.DoubleClick(serial);
-            }
+            GlobalActionCooldown.ResetCooldown();
         }
 
         public void Add(uint serial)

--- a/src/ClassicUO.Client/Game/Managers/UseItemQueue.cs
+++ b/src/ClassicUO.Client/Game/Managers/UseItemQueue.cs
@@ -31,7 +31,6 @@
 #endregion
 
 using ClassicUO.Game.GameObjects;
-using ClassicUO.Configuration;
 using ClassicUO.Utility.Collections;
 
 namespace ClassicUO.Game.Managers
@@ -39,8 +38,9 @@ namespace ClassicUO.Game.Managers
     internal class UseItemQueue
     {
         public static UseItemQueue Instance { get; private set; }
-        public bool IsEmpty => _actions.Count == 0;
+        public bool IsEmpty => _isEmpty;
 
+        private bool _isEmpty = true;
         private readonly Deque<uint> _actions = new Deque<uint>();
 
         public UseItemQueue()
@@ -57,6 +57,7 @@ namespace ClassicUO.Game.Managers
             GameActions.DoubleClick(serial);
 
             GlobalActionCooldown.BeginCooldown();
+            _isEmpty = _actions.Count == 0;
         }
 
         public void Add(uint serial)
@@ -70,11 +71,13 @@ namespace ClassicUO.Game.Managers
             }
 
             _actions.AddToBack(serial);
+            _isEmpty = false;
         }
 
         public void Clear()
         {
             _actions.Clear();
+            _isEmpty = true;
         }
 
         public void ClearCorpses()
@@ -93,6 +96,7 @@ namespace ClassicUO.Game.Managers
                     _actions.RemoveAt(i--);
                 }
             }
+            _isEmpty = _actions.Count == 0;
         }
     }
 }

--- a/src/ClassicUO.Client/Game/Managers/UseItemQueue.cs
+++ b/src/ClassicUO.Client/Game/Managers/UseItemQueue.cs
@@ -50,8 +50,8 @@ namespace ClassicUO.Game.Managers
 
         public void Update()
         {
+            if (_isEmpty) return;
             if (GlobalActionCooldown.IsOnCooldown) return;
-            if (_actions.Count == 0) return;
 
             uint serial = _actions.RemoveFromFront();
             GameActions.DoubleClick(serial);

--- a/src/ClassicUO.Client/Game/Managers/UseItemQueue.cs
+++ b/src/ClassicUO.Client/Game/Managers/UseItemQueue.cs
@@ -38,6 +38,8 @@ namespace ClassicUO.Game.Managers
 {
     internal class UseItemQueue
     {
+        public static UseItemQueue Instance { get; private set; }
+        public bool IsEmpty => _actions.Count == 0;
         private readonly Deque<uint> _actions = new Deque<uint>();
         private long _timer;
         private static long _delay = 1000;
@@ -46,6 +48,7 @@ namespace ClassicUO.Game.Managers
         {
             _delay = ProfileManager.CurrentProfile.MoveMultiObjectDelay;
             _timer = Time.Ticks + _delay;
+            Instance = this;
         }
 
         public void Update()

--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -856,6 +856,19 @@ namespace ClassicUO.Game.Scenes
             BoatMovingManager.Update();
             Pathfinder.ProcessAutoWalk();
             DelayedObjectClickManager.Update();
+
+            if (
+                (currentProfile.CorpseOpenOptions == 1 || currentProfile.CorpseOpenOptions == 3)
+                    && TargetManager.IsTargeting
+                || (currentProfile.CorpseOpenOptions == 2 || currentProfile.CorpseOpenOptions == 3)
+                    && World.Player.IsHidden
+            )
+            {
+                _useItemQueue.ClearCorpses();
+            }
+
+            _useItemQueue.Update();
+
             AutoLootManager.Instance.Update();
             _moveItemQueue.ProcessQueue();
             GridHighlightData.ProcessQueue();
@@ -902,18 +915,6 @@ namespace ClassicUO.Game.Scenes
             }
 
             Macros.Update();
-
-            if (
-                (currentProfile.CorpseOpenOptions == 1 || currentProfile.CorpseOpenOptions == 3)
-                    && TargetManager.IsTargeting
-                || (currentProfile.CorpseOpenOptions == 2 || currentProfile.CorpseOpenOptions == 3)
-                    && World.Player.IsHidden
-            )
-            {
-                _useItemQueue.ClearCorpses();
-            }
-
-            _useItemQueue.Update();
 
             if (Time.Ticks > _nextProfileSave)
             {

--- a/src/ClassicUO.Client/LegionScripting/API.cs
+++ b/src/ClassicUO.Client/LegionScripting/API.cs
@@ -2849,6 +2849,17 @@ namespace ClassicUO.LegionScripting
         public bool IsProcessingMoveQue() => InvokeOnMainThread(() => !MoveItemQueue.Instance.IsEmpty);
 
         /// <summary>
+        /// Check if the use item queue is being processed. You can use this to prevent actions if the queue is being processed.
+        /// Example:
+        /// ```py
+        /// if API.IsProcessingUseItemQueue():
+        ///   API.Pause(0.5)
+        /// ```
+        /// </summary>
+        /// <returns></returns>
+        public bool IsProcessingUseItemQueue() => InvokeOnMainThread(() => !UseItemQueue.Instance.IsEmpty);
+
+        /// <summary>
         /// Save a variable that persists between sessions and scripts.
         /// Example:
         /// ```py

--- a/src/ClassicUO.Client/LegionScripting/API.cs
+++ b/src/ClassicUO.Client/LegionScripting/API.cs
@@ -2860,6 +2860,19 @@ namespace ClassicUO.LegionScripting
         public bool IsProcessingUseItemQueue() => InvokeOnMainThread(() => !UseItemQueue.Instance.IsEmpty);
 
         /// <summary>
+        /// Check if the global cooldown is currently active. This applies to actions like moving or using items,
+        /// and prevents new actions from executing until the cooldown has expired.
+        /// 
+        /// Example:
+        /// ```py
+        /// if API.IsGlobalCooldownActive():
+        ///     API.Pause(0.5)
+        /// ```
+        /// </summary>
+        /// <returns>True if the global cooldown is active; otherwise, false.</returns>
+        public bool IsGlobalCooldownActive() => InvokeOnMainThread(() => GlobalActionCooldown.IsOnCooldown);
+
+        /// <summary>
         /// Save a variable that persists between sessions and scripts.
         /// Example:
         /// ```py

--- a/src/ClassicUO.Client/Network/PacketHandlers.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers.cs
@@ -2344,6 +2344,10 @@ namespace ClassicUO.Network
                     NetClient.Socket.Send_ClientViewRange(World.ClientViewRange);
                 }
 
+                // Reset the global action cooldown here because, for some reason, immediately
+                // sending multiple actions (e.g. reopening paperdoll and reopening containers)
+                // results in the server telling the client it must wait to perform actions.
+                GlobalActionCooldown.ResetCooldown();
                 List<Gump> gumps = ProfileManager.CurrentProfile.ReadGumps(
                     ProfileManager.ProfilePath
                 );

--- a/src/ClassicUO.Client/Network/PacketHandlers.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers.cs
@@ -2347,7 +2347,7 @@ namespace ClassicUO.Network
                 // Reset the global action cooldown here because, for some reason, immediately
                 // sending multiple actions (e.g. reopening paperdoll and reopening containers)
                 // results in the server telling the client it must wait to perform actions.
-                GlobalActionCooldown.ResetCooldown();
+                GlobalActionCooldown.BeginCooldown();
                 List<Gump> gumps = ProfileManager.CurrentProfile.ReadGumps(
                     ProfileManager.ProfilePath
                 );


### PR DESCRIPTION
- Add GlobalActionCooldown for use in action queues to respect UO's global cooldown.
- Switch MoveItemQueue and UseItemQueue to use GlobalActionCooldown, rather than their own cooldowns. This serializes their actions, preventing "please wait" messages from the server when both queues are active.
- Moved UseItemQueue processing before MoveItemQueue processing as that seems to be what would be expected by players. I would want double-clicking objects to occur before moving items around.
- Added python APIs to query UseItemQueue and the GlobalActionCooldown. This enables a script to wait until all actions are completed e.g.:
```python
def wait_until_idle() -> None:
    while API.Pathfinding() or API.IsProcessingMoveQue() or API.IsProcessingUseItemQueue() or API.IsGlobalCooldownActive():
        API.Pause(0.1)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a global action cooldown system to manage delays between actions.
  * Added new scripting API methods to check if the use item queue is processing and if a global cooldown is active.

* **Refactor**
  * Centralized cooldown management for item movement and usage, replacing local timing mechanisms with a global approach.
  * Added explicit tracking of item queue emptiness for move and use item queues.
  * Adjusted update sequence in the game loop for more consistent item queue processing.

* **Bug Fixes**
  * Ensured cooldown resets properly after login to prevent server-enforced delays when reopening containers and paperdolls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->