### PR TITLE
Add python APIs to manipulate holding/dropping items to/from the cursor

### DIFF
--- a/src/ClassicUO.Client/Game/ItemHold.cs
+++ b/src/ClassicUO.Client/Game/ItemHold.cs
@@ -37,15 +37,16 @@ using Microsoft.Xna.Framework;
 
 namespace ClassicUO.Game
 {
-    sealed class ItemHold
+    public sealed class ItemHold
     {
         private bool _enabled;
 
-        public Point MouseOffset;
+        public Point MouseOffset { get; internal set; }
 
-        public bool IsFixedPosition;
-        public bool IgnoreFixedPosition;
-        public int FixedX, FixedY;
+        public bool IsFixedPosition { get; internal set; }
+        public bool IgnoreFixedPosition { get; internal set; }
+        public int FixedX { get; internal set; }
+        public int FixedY { get; internal set; }
 
         public bool OnGround { get; private set; }
         public ushort X { get; private set; }
@@ -55,7 +56,7 @@ namespace ClassicUO.Game
         public uint Serial { get; private set; }
         public ushort Graphic { get; private set; }
         public ushort DisplayedGraphic { get; private set; }
-        public bool IsGumpTexture { get; set; }
+        public bool IsGumpTexture { get; internal set; }
         public ushort Hue { get; private set; }
         public ushort Amount { get; private set; }
         public ushort TotalAmount { get; private set; }
@@ -69,7 +70,7 @@ namespace ClassicUO.Game
         public bool Enabled
         {
             get => _enabled;
-            set
+            internal set
             {
                 _enabled = value;
 
@@ -83,11 +84,11 @@ namespace ClassicUO.Game
             }
         }
 
-        public bool Dropped { get; set; }
-        public bool UpdatedInWorld { get; set; }
+        public bool Dropped { get; internal set; }
+        public bool UpdatedInWorld { get; internal set; }
         public ref StaticTiles ItemData => ref TileDataLoader.Instance.StaticData[Graphic];
 
-        public void Set(Item item, ushort amount, Point? offset = null)
+        internal void Set(Item item, ushort amount, Point? offset = null)
         {
             Enabled = true;
             Serial = item.Serial;
@@ -115,7 +116,7 @@ namespace ClassicUO.Game
             IsGumpTexture = false;
         }
 
-        public void Clear()
+        internal void Clear()
         {
             Serial = 0;
             X = 0xFFFF;

--- a/src/ClassicUO.Client/LegionScripting/API.cs
+++ b/src/ClassicUO.Client/LegionScripting/API.cs
@@ -628,11 +628,11 @@ namespace ClassicUO.LegionScripting
         /// </summary>
         /// <param name="serial">The unique serial identifier of the item to drop.</param>
         /// <param name="x">
-        /// The X coordinate of the ground drop location. Unused if dropping into container.
+        /// The X coordinate of the ground drop location, or the X position inside a container if a container is specified.
         /// If not specified, defaults to the player's current X position.
         /// </param>
         /// <param name="y">
-        /// The Y coordinate of the ground drop location. Unused if dropping into container.
+        /// The Y coordinate of the ground drop location, or the X position inside a container if a container is specified.
         /// If not specified, defaults to the player's current Y position.
         /// </param>
         /// <param name="z">
@@ -652,6 +652,25 @@ namespace ClassicUO.LegionScripting
             }
 
             GameActions.DropItem(serial, x, y, z, container);
+        });
+
+        /// <summary>
+        /// Retrieves data of the currently held item on the game cursor.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="ItemHold"/> instance representing the held item data.
+        /// </returns>
+        /// <remarks>
+        /// The held item does not exist in the world as a proper <see cref="Item"/> object, but its data is temporarily tracked
+        /// in an <see cref="ItemHold"/> instance. This allows inspection of its properties while it's being held or manipulated.
+        /// If an item is being held on the cursor, ItemHold.Enabled will be true and ItemHold.Dropped will be false.
+        /// </remarks>
+        public ItemHold GetHeldItemData() => MainThreadQueue.InvokeOnMainThread(() =>
+        {
+            if (Client.Game?.GameCursor?.ItemHold is not ItemHold hold)
+                return null;
+
+            return hold;
         });
 
         /// <summary>

--- a/src/ClassicUO.Client/LegionScripting/API.cs
+++ b/src/ClassicUO.Client/LegionScripting/API.cs
@@ -611,6 +611,50 @@ namespace ClassicUO.LegionScripting
         );
 
         /// <summary>
+        /// Picks up an item from the game world and places it onto the mouse cursor.
+        /// </summary>
+        /// <param name="serial">The unique serial identifier of the item to pick up.</param>
+        /// <param name="amt">
+        /// The amount of the item to pick up. 
+        /// If 0, the full stack will be picked up (if stackable).
+        /// </param>
+        public void PickUpToCursor(uint serial, int amt = 0) => MainThreadQueue.InvokeOnMainThread(() =>
+        {
+            GameActions.PickUp(serial, 0, 0, amt);
+        });
+
+        /// <summary>
+        /// Drops an item currently held by the mouse cursor into a container or on the ground at a specified position.
+        /// </summary>
+        /// <param name="serial">The unique serial identifier of the item to drop.</param>
+        /// <param name="x">
+        /// The X coordinate of the ground drop location. Unused if dropping into container.
+        /// If not specified, defaults to the player's current X position.
+        /// </param>
+        /// <param name="y">
+        /// The Y coordinate of the ground drop location. Unused if dropping into container.
+        /// If not specified, defaults to the player's current Y position.
+        /// </param>
+        /// <param name="z">
+        /// The Z coordinate (elevation) of the ground drop location. Unused if dropping into container.
+        /// If not specified, defaults to the Z value of the static or map land at (x, y) if x and y are specified.
+        /// </param>
+        /// <param name="container">
+        /// The serial of the container to drop the item into. 
+        /// If unspecified, the item will be dropped on the ground.
+        /// </param>
+        public void DropFromCursor(uint serial, int x = ushort.MaxValue, int y = ushort.MaxValue, int z = sbyte.MaxValue, uint container = uint.MaxValue) => MainThreadQueue.InvokeOnMainThread(() =>
+        {
+            if (container == uint.MaxValue && z == sbyte.MaxValue && x != ushort.MaxValue && y != ushort.MaxValue)
+            {
+                World.Map.GetMapZ(x, y, out var landZ, out var staticZ);
+                z = Math.Max(landZ, staticZ);
+            }
+
+            GameActions.DropItem(serial, x, y, z, container);
+        });
+
+        /// <summary>
         /// Use a skill.
         /// Example:
         /// ```py


### PR DESCRIPTION
- Adds APIs to pickup and drop items to/from the mouse cursor.
- Adds API to get data of item held on the cursor. The current design poofs an item from `World.Items` when picked up onto the cursor, so ItemHold containing serial and item data is returned in lieu of an Item or PyItem. ItemHold was made publicly readonly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scripting support for picking up items to the mouse cursor, dropping items from the cursor, and retrieving data about the currently held item.

* **Refactor**
  * Improved encapsulation and access controls for item holding functionality, enhancing internal consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->