### PR TITLE
Add a spell indicator config editor to the assistant menu

### DIFF
--- a/src/ClassicUO.Client/Game/Managers/SpellVisualRangeManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/SpellVisualRangeManager.cs
@@ -22,13 +22,14 @@ namespace ClassicUO.Game.Managers
     public partial class SpellVisualRangeJsonContext : JsonSerializerContext
     {
     }
-    
+
     public class SpellVisualRangeManager
     {
         public static SpellVisualRangeManager Instance => instance ??= new SpellVisualRangeManager();
 
         public Vector2 LastCursorTileLoc { get; set; } = Vector2.Zero;
         public DateTime LastSpellTime { get; private set; } = DateTime.Now;
+        public Dictionary<int, SpellRangeInfo> SpellRangeCache => spellRangeCache;
 
         private string savePath = Path.Combine(CUOEnviroment.ExecutablePath ?? "", "Data", "Profiles", "SpellVisualRange.json");
         private string overridePath = Path.Combine(ProfileManager.ProfilePath ?? "", "SpellVisualRange.json");

--- a/src/ClassicUO.Client/Game/Managers/SpellVisualRangeManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/SpellVisualRangeManager.cs
@@ -10,7 +10,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
+using Timer = System.Timers.Timer;
 
 namespace ClassicUO.Game.Managers
 {
@@ -235,6 +237,9 @@ namespace ClassicUO.Game.Managers
         }
 
         #region Save and load
+        private Timer saveTimer;
+        private readonly object saveLock = new object();
+        private volatile bool hasPendingChanges = false;
         private void Load()
         {
             spellRangeCache.Clear();
@@ -283,7 +288,6 @@ namespace ClassicUO.Game.Managers
                         CreateAndLoadDataFile();
                         AfterLoad();
                         loaded = true;
-                        Save();
                     }
 
                 }
@@ -434,15 +438,64 @@ namespace ClassicUO.Game.Managers
             });
         }
 
-        public void Save()
+        public void DelayedSave()
         {
+            lock (saveLock)
+            {
+                hasPendingChanges = true;
+
+                // Cancel existing timer if it's running
+                saveTimer?.Dispose();
+
+                saveTimer = new Timer();
+                saveTimer.Interval = 500;
+                saveTimer.Elapsed += (_,_) => { PerformSave(); };
+            }
+        }
+
+        private void PerformSave()
+        {
+            lock (saveLock)
+            {
+                if (!hasPendingChanges)
+                    return;
+
+                hasPendingChanges = false;
+            }
+
+            string tempPath = null;
             try
             {
+                tempPath = Path.GetTempFileName();
                 var options = new JsonSerializerOptions() { WriteIndented = true };
                 string fileData = JsonSerializer.Serialize(spellRangeCache.Values.ToArray(), options);
-                File.WriteAllText(savePath, fileData);
+                File.WriteAllText(tempPath, fileData);
+
+                if (File.Exists(savePath))
+                    File.Delete(savePath);
+                File.Move(tempPath, savePath);
             }
-            catch (Exception e) { Console.WriteLine(e.ToString()); }
+            catch (Exception e)
+            {
+                Log.Error($"Save failed: {e}");
+            }
+            finally
+            {
+                if (tempPath != null && File.Exists(tempPath))
+                    File.Delete(tempPath);
+            }
+        }
+
+        public void Save()
+        {
+            lock (saveLock)
+            {
+                saveTimer?.Dispose();
+                if (hasPendingChanges)
+                {
+                    PerformSave();
+                }
+            }
         }
         #endregion
 

--- a/src/ClassicUO.Client/Game/UI/Controls/ClickableColorBox.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ClickableColorBox.cs
@@ -2,7 +2,7 @@
 
 // Copyright (c) 2021, andreakarasho
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
 // 1. Redistributions of source code must retain the above copyright
@@ -16,7 +16,7 @@
 // 4. Neither the name of the copyright holder nor the
 //    names of its contributors may be used to endorse or promote products
 //    derived from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ''AS IS'' AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -94,7 +94,7 @@ namespace ClassicUO.Game.UI.Controls
                 UIManager.GetGump<ColorPickerGump>()?.Dispose();
                 if (useModernSelector)
                 {
-                    UIManager.Add(new ModernColorPicker(s => Hue = s) { X = 100, Y = 100 });
+                    UIManager.Add(new ModernColorPicker(s => Hue = s));
                 }
                 else
                 {

--- a/src/ClassicUO.Client/Game/UI/Gumps/AssistantGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/AssistantGump.cs
@@ -423,7 +423,7 @@ public class AssistantGump : BaseOptionsGump
             spellRangeInfo.ShowCastRangeDuringCasting = showrangeduringcast.IsChecked;
             spellRangeInfo.FreezeCharacterWhileCasting = freezewhilecasting.IsChecked;
             spellRangeInfo.ExpectTargetCursor = targetcursorexpected.IsChecked;
-            SpellVisualRangeManager.Instance.Save();
+            SpellVisualRangeManager.Instance.DelayedSave();
         }
     }
     private class AutoLootConfigs : Control

--- a/src/ClassicUO.Client/Game/UI/Gumps/AssistantGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/AssistantGump.cs
@@ -311,9 +311,9 @@ public class AssistantGump : BaseOptionsGump
     {
         private int id = -1;
         private SpellVisualRangeManager.SpellRangeInfo spellRangeInfo;
-        private InputFieldWithLabel name, powerwords, cursorsize, castrange, maxduration, casttime;
-        private CheckboxWithLabel islinear, showrangeduringcast, freezewhilecasting, targetcursorexpected;
-        private ModernColorPickerWithLabel cursorhue, hue;
+        private InputFieldWithLabel name, powerWords, cursorSize, castRange, maxDuration, castTime;
+        private CheckboxWithLabel islinear, showRangeDuringCast, freezeWhileCasting, targetCursorExpected;
+        private ModernColorPickerWithLabel cursorHue, hue;
         public SpellRangeEditor(int width)
         {
             CanMove = true;
@@ -330,30 +330,30 @@ public class AssistantGump : BaseOptionsGump
             pos.SetColumnAlignment(1, TableColumnAlignment.Right);
 
             Add(pos.Position(name = new InputFieldWithLabel("Name", ThemeSettings.INPUT_WIDTH, string.Empty, false, onInputChanged)));
-            Add(pos.Position(powerwords = new InputFieldWithLabel("Power Words", ThemeSettings.INPUT_WIDTH, string.Empty, false, onInputChanged)));
-            powerwords.SetTooltip("Power words must be exact, this is the best way we can detect spells.");
+            Add(pos.Position(powerWords = new InputFieldWithLabel("Power Words", ThemeSettings.INPUT_WIDTH, string.Empty, false, onInputChanged)));
+            powerWords.SetTooltip("Power words must be exact, this is the best way we can detect spells.");
 
-            Add(pos.Position(cursorsize = new InputFieldWithLabel("Cursor Size", ThemeSettings.INPUT_WIDTH, string.Empty, true, onInputChanged)));
-            cursorsize.SetTooltip("This is the area to show around the cursor, intended for area spells that affect the area near your target.");
-            Add(pos.Position(castrange = new InputFieldWithLabel("Cast Range", ThemeSettings.INPUT_WIDTH, string.Empty, true, onInputChanged)));
-            Add(pos.Position(casttime = new InputFieldWithLabel("Cast Time", ThemeSettings.INPUT_WIDTH, string.Empty, false, onInputChanged)));
-            Add(pos.Position(maxduration = new InputFieldWithLabel("Max Duration", ThemeSettings.INPUT_WIDTH, string.Empty, true, onInputChanged)));
-            maxduration.SetTooltip("This is a fallback in-case the spell detection fails.");
+            Add(pos.Position(cursorSize = new InputFieldWithLabel("Cursor Size", ThemeSettings.INPUT_WIDTH, string.Empty, true, onInputChanged)));
+            cursorSize.SetTooltip("This is the area to show around the cursor, intended for area spells that affect the area near your target.");
+            Add(pos.Position(castRange = new InputFieldWithLabel("Cast Range", ThemeSettings.INPUT_WIDTH, string.Empty, true, onInputChanged)));
+            Add(pos.Position(castTime = new InputFieldWithLabel("Cast Time", ThemeSettings.INPUT_WIDTH, string.Empty, false, onInputChanged)));
+            Add(pos.Position(maxDuration = new InputFieldWithLabel("Max Duration", ThemeSettings.INPUT_WIDTH, string.Empty, true, onInputChanged)));
+            maxDuration.SetTooltip("This is a fallback in-case the spell detection fails.");
 
             pos.SetColumnAlignment(0, TableColumnAlignment.Left);
             pos.SetColumnAlignment(1, TableColumnAlignment.Left);
 
-            Add(pos.Position(cursorhue = new ModernColorPickerWithLabel("Cursor Hue", 0, onHueSelected)));
+            Add(pos.Position(cursorHue = new ModernColorPickerWithLabel("Cursor Hue", 0, onHueSelected)));
             Add(pos.Position(hue = new ModernColorPickerWithLabel("Range Hue", 0, onHueSelected)));
 
             Add(pos.Position(islinear = new CheckboxWithLabel("Is linear", 0, false, onCheckBoxChanged)));
             islinear.SetTooltip("Used for spells like wall of stone that create a line.");
 
-            Add(pos.Position(showrangeduringcast = new CheckboxWithLabel("Show range while casting", 0, false, onCheckBoxChanged)));
-            Add(pos.Position(freezewhilecasting = new CheckboxWithLabel("Freeze yourself while casting", 0, false, onCheckBoxChanged)));
-            freezewhilecasting.SetTooltip("Prevent yourself from moving and disrupting your spell.");
+            Add(pos.Position(showRangeDuringCast = new CheckboxWithLabel("Show range while casting", 0, false, onCheckBoxChanged)));
+            Add(pos.Position(freezeWhileCasting = new CheckboxWithLabel("Freeze yourself while casting", 0, false, onCheckBoxChanged)));
+            freezeWhileCasting.SetTooltip("Prevent yourself from moving and disrupting your spell.");
 
-            Add(pos.Position(targetcursorexpected = new CheckboxWithLabel("Spell should create a target cursor", 0, false, onCheckBoxChanged)));
+            Add(pos.Position(targetCursorExpected = new CheckboxWithLabel("Spell should create a target cursor", 0, false, onCheckBoxChanged)));
         }
 
         public void SetSpellRangeInfo(SpellVisualRangeManager.SpellRangeInfo info)
@@ -364,17 +364,17 @@ public class AssistantGump : BaseOptionsGump
                 return;
 
             name.SetText(info.Name);
-            powerwords.SetText(info.PowerWords);
-            cursorsize.SetText(info.CursorSize.ToString());
-            cursorhue.Hue = info.CursorHue;
-            castrange.SetText(info.CastRange.ToString());
+            powerWords.SetText(info.PowerWords);
+            cursorSize.SetText(info.CursorSize.ToString());
+            cursorHue.Hue = info.CursorHue;
+            castRange.SetText(info.CastRange.ToString());
             hue.Hue = info.Hue;
-            casttime.SetText(info.CastTime.ToString());
-            maxduration.SetText(info.MaxDuration.ToString());
+            castTime.SetText(info.CastTime.ToString());
+            maxDuration.SetText(info.MaxDuration.ToString());
             islinear.IsChecked = info.IsLinear;
-            showrangeduringcast.IsChecked = info.ShowCastRangeDuringCasting;
-            freezewhilecasting.IsChecked = info.FreezeCharacterWhileCasting;
-            targetcursorexpected.IsChecked = info.ExpectTargetCursor;
+            showRangeDuringCast.IsChecked = info.ShowCastRangeDuringCasting;
+            freezeWhileCasting.IsChecked = info.FreezeCharacterWhileCasting;
+            targetCursorExpected.IsChecked = info.ExpectTargetCursor;
 
             //Set these at the end to prevent the input saving being triggered via SetText
             id = info.ID;
@@ -401,28 +401,28 @@ public class AssistantGump : BaseOptionsGump
                 return;
 
             spellRangeInfo.Name = name.Text;
-            spellRangeInfo.PowerWords = powerwords.Text;
+            spellRangeInfo.PowerWords = powerWords.Text;
 
-            if (int.TryParse(cursorsize.Text, out int ri))
+            if (int.TryParse(cursorSize.Text, out int ri))
                 spellRangeInfo.CursorSize = ri;
 
-            spellRangeInfo.CursorHue = cursorhue.Hue;
+            spellRangeInfo.CursorHue = cursorHue.Hue;
 
-            if(int.TryParse(castrange.Text, out ri))
+            if(int.TryParse(castRange.Text, out ri))
                 spellRangeInfo.CastRange = ri;
 
             spellRangeInfo.Hue = hue.Hue;
 
-            if(double.TryParse(casttime.Text, out double d))
+            if(double.TryParse(castTime.Text, out double d))
                 spellRangeInfo.CastTime = d;
 
-            if(int.TryParse(maxduration.Text, out ri))
+            if(int.TryParse(maxDuration.Text, out ri))
                 spellRangeInfo.MaxDuration = ri;
 
             spellRangeInfo.IsLinear = islinear.IsChecked;
-            spellRangeInfo.ShowCastRangeDuringCasting = showrangeduringcast.IsChecked;
-            spellRangeInfo.FreezeCharacterWhileCasting = freezewhilecasting.IsChecked;
-            spellRangeInfo.ExpectTargetCursor = targetcursorexpected.IsChecked;
+            spellRangeInfo.ShowCastRangeDuringCasting = showRangeDuringCast.IsChecked;
+            spellRangeInfo.FreezeCharacterWhileCasting = freezeWhileCasting.IsChecked;
+            spellRangeInfo.ExpectTargetCursor = targetCursorExpected.IsChecked;
             SpellVisualRangeManager.Instance.DelayedSave();
         }
     }

--- a/src/ClassicUO.Client/Game/UI/Gumps/AssistantGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/AssistantGump.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
@@ -32,6 +33,7 @@ public class AssistantGump : BaseOptionsGump
         BuildMobileGraphicFilter();
         BuildSpellBar();
         BuildHUD();
+        BuildSpellIndicator();
 
         ChangePage((int)PAGE.AutoLoot);
     }
@@ -263,6 +265,34 @@ public class AssistantGump : BaseOptionsGump
         }
     }
 
+    private void BuildSpellIndicator()
+    {
+        var page = (int)PAGE.SpellIndicator;
+        MainContent.AddToLeft(CategoryButton("Spell Indicators", page, MainContent.LeftWidth));
+        MainContent.ResetRightSide();
+
+        ScrollArea scroll = new(0, 0, MainContent.RightWidth, MainContent.Height);
+        MainContent.AddToRight(scroll, false, page);
+
+        PositionHelper.Reset();
+
+        SpellRangeEditor editor = new (scroll.Width - 20);
+
+        InputFieldWithLabel search = new ("Spell search", ThemeSettings.INPUT_WIDTH, string.Empty, false, (s, e) =>
+        {
+            if (SpellDefinition.TryGetSpellFromName(((BaseOptionsGump.InputField.StbTextBox)s).Text, out SpellDefinition spell))
+            {
+                if(SpellVisualRangeManager.Instance.SpellRangeCache.TryGetValue(spell.ID, out SpellVisualRangeManager.SpellRangeInfo info))
+                    editor.SetSpellRangeInfo(info);
+            }
+        });
+
+        scroll.Add(PositionHelper.PositionControl(search));
+        PositionHelper.BlankLine();
+        PositionHelper.BlankLine();
+        scroll.Add(PositionHelper.PositionControl(editor));
+    }
+
     public enum PAGE
     {
         None,
@@ -271,11 +301,131 @@ public class AssistantGump : BaseOptionsGump
         AutoBuy,
         MobileGraphicFilter,
         SpellBar,
-        HUD
+        HUD,
+        SpellIndicator,
     }
 
     #region CustomControls
 
+    private class SpellRangeEditor : Control
+    {
+        private int id = -1;
+        private SpellVisualRangeManager.SpellRangeInfo spellRangeInfo;
+        private InputFieldWithLabel name, powerwords, cursorsize, castrange, maxduration, casttime;
+        private CheckboxWithLabel islinear, showrangeduringcast, freezewhilecasting, targetcursorexpected;
+        private ModernColorPickerWithLabel cursorhue, hue;
+        public SpellRangeEditor(int width)
+        {
+            CanMove = true;
+            AcceptMouseInput = true;
+            Width = width;
+            Build();
+        }
+
+        private void Build()
+        {
+            Positioner pos = new Positioner();
+            pos.StartTable(2, (Width-40) / 2);
+            pos.SetColumnAlignment(0, TableColumnAlignment.Right);
+            pos.SetColumnAlignment(1, TableColumnAlignment.Right);
+
+            Add(pos.Position(name = new InputFieldWithLabel("Name", ThemeSettings.INPUT_WIDTH, string.Empty, false, onInputChanged)));
+            Add(pos.Position(powerwords = new InputFieldWithLabel("Power Words", ThemeSettings.INPUT_WIDTH, string.Empty, false, onInputChanged)));
+            powerwords.SetTooltip("Power words must be exact, this is the best way we can detect spells.");
+
+            Add(pos.Position(cursorsize = new InputFieldWithLabel("Cursor Size", ThemeSettings.INPUT_WIDTH, string.Empty, true, onInputChanged)));
+            cursorsize.SetTooltip("This is the area to show around the cursor, intended for area spells that affect the area near your target.");
+            Add(pos.Position(castrange = new InputFieldWithLabel("Cast Range", ThemeSettings.INPUT_WIDTH, string.Empty, true, onInputChanged)));
+            Add(pos.Position(casttime = new InputFieldWithLabel("Cast Time", ThemeSettings.INPUT_WIDTH, string.Empty, false, onInputChanged)));
+            Add(pos.Position(maxduration = new InputFieldWithLabel("Max Duration", ThemeSettings.INPUT_WIDTH, string.Empty, true, onInputChanged)));
+            maxduration.SetTooltip("This is a fallback in-case the spell detection fails.");
+
+            pos.SetColumnAlignment(0, TableColumnAlignment.Left);
+            pos.SetColumnAlignment(1, TableColumnAlignment.Left);
+
+            Add(pos.Position(cursorhue = new ModernColorPickerWithLabel("Cursor Hue", 0, onHueSelected)));
+            Add(pos.Position(hue = new ModernColorPickerWithLabel("Range Hue", 0, onHueSelected)));
+
+            Add(pos.Position(islinear = new CheckboxWithLabel("Is linear", 0, false, onCheckBoxChanged)));
+            islinear.SetTooltip("Used for spells like wall of stone that create a line.");
+
+            Add(pos.Position(showrangeduringcast = new CheckboxWithLabel("Show range while casting", 0, false, onCheckBoxChanged)));
+            Add(pos.Position(freezewhilecasting = new CheckboxWithLabel("Freeze yourself while casting", 0, false, onCheckBoxChanged)));
+            freezewhilecasting.SetTooltip("Prevent yourself from moving and disrupting your spell.");
+
+            Add(pos.Position(targetcursorexpected = new CheckboxWithLabel("Spell should create a target cursor", 0, false, onCheckBoxChanged)));
+        }
+
+        public void SetSpellRangeInfo(SpellVisualRangeManager.SpellRangeInfo info)
+        {
+            id = -1;
+            spellRangeInfo = null;
+            if (info == null)
+                return;
+
+            name.SetText(info.Name);
+            powerwords.SetText(info.PowerWords);
+            cursorsize.SetText(info.CursorSize.ToString());
+            cursorhue.Hue = info.CursorHue;
+            castrange.SetText(info.CastRange.ToString());
+            hue.Hue = info.Hue;
+            casttime.SetText(info.CastTime.ToString());
+            maxduration.SetText(info.MaxDuration.ToString());
+            islinear.IsChecked = info.IsLinear;
+            showrangeduringcast.IsChecked = info.ShowCastRangeDuringCasting;
+            freezewhilecasting.IsChecked = info.FreezeCharacterWhileCasting;
+            targetcursorexpected.IsChecked = info.ExpectTargetCursor;
+
+            //Set these at the end to prevent the input saving being triggered via SetText
+            id = info.ID;
+            spellRangeInfo = info;
+        }
+        private void onHueSelected(ushort _)
+        {
+            Save();
+        }
+
+        private void onCheckBoxChanged(bool _)
+        {
+            Save();
+        }
+
+        private void onInputChanged(object _, EventArgs __)
+        {
+            Save();
+        }
+
+        private void Save()
+        {
+            if(id < 0 || spellRangeInfo == null)
+                return;
+
+            spellRangeInfo.Name = name.Text;
+            spellRangeInfo.PowerWords = powerwords.Text;
+
+            if (int.TryParse(cursorsize.Text, out int ri))
+                spellRangeInfo.CursorSize = ri;
+
+            spellRangeInfo.CursorHue = cursorhue.Hue;
+
+            if(int.TryParse(castrange.Text, out ri))
+                spellRangeInfo.CastRange = ri;
+
+            spellRangeInfo.Hue = hue.Hue;
+
+            if(double.TryParse(casttime.Text, out double d))
+                spellRangeInfo.CastTime = d;
+
+            if(int.TryParse(maxduration.Text, out ri))
+                spellRangeInfo.MaxDuration = ri;
+
+            spellRangeInfo.IsLinear = islinear.IsChecked;
+            spellRangeInfo.ShowCastRangeDuringCasting = showrangeduringcast.IsChecked;
+            spellRangeInfo.FreezeCharacterWhileCasting = freezewhilecasting.IsChecked;
+            spellRangeInfo.ExpectTargetCursor = targetcursorexpected.IsChecked;
+            SpellVisualRangeManager.Instance.Save();
+        }
+    }
     private class AutoLootConfigs : Control
     {
         private DataBox _dataBox;

--- a/src/ClassicUO.Client/Game/UI/Gumps/BaseOptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/BaseOptionsGump.cs
@@ -544,7 +544,7 @@ public class BaseOptionsGump : Gump
             }
         }
     }
-    
+
     protected class HotkeyBox : Control
     {
         private bool _actived;
@@ -1750,7 +1750,7 @@ public class BaseOptionsGump : Gump
 
             SearchValueChanged += ModernOptionsGump_SearchValueChanged;
         }
-        
+
         public override void Dispose()
         {
             base.Dispose();
@@ -2211,7 +2211,7 @@ public class BaseOptionsGump : Gump
             SearchValueChanged += ModernOptionsGump_SearchValueChanged;
             this.options = options;
         }
-        
+
         public override void Dispose()
         {
             base.Dispose();
@@ -2271,7 +2271,7 @@ public class BaseOptionsGump : Gump
             private int _selectedIndex = 0;
             private readonly int[] _originalIndices;
             private readonly string[] _sortedItems;
-            
+
 
             public Combobox(int width, string[] items, int selected = -1, int maxHeight = 400, Action<int, string> onOptionSelected = null)
             {
@@ -2286,10 +2286,10 @@ public class BaseOptionsGump : Gump
                 _originalIndices = Enumerable.Range(0, items.Length).ToArray();
                 _sortedItems = new string[items.Length];
                 Array.Copy(items, _sortedItems, items.Length);
-    
+
                 // Sort both arrays together
                 Array.Sort(_sortedItems, _originalIndices);
-    
+
                 // Find the display index for the selected original index
                 int displayIndex = selected > -1 ? Array.IndexOf(_originalIndices, selected) : -1;
 
@@ -2301,7 +2301,7 @@ public class BaseOptionsGump : Gump
                 _label.X = 2;
                 _label.Y = (Height >> 1) - (_label.Height >> 1);
                 Add(_label);
-                
+
                 _selectedIndex = displayIndex;
             }
 
@@ -2504,6 +2504,7 @@ public class BaseOptionsGump : Gump
 
     protected class InputFieldWithLabel : Control, SearchableOption
     {
+        public string Text => _inputField.Text;
         private readonly InputField _inputField;
         private readonly TextBox _label;
 
@@ -2530,7 +2531,7 @@ public class BaseOptionsGump : Gump
 
             SearchValueChanged += ModernOptionsGump_SearchValueChanged;
         }
-        
+
         public override void Dispose()
         {
             base.Dispose();
@@ -2555,6 +2556,11 @@ public class BaseOptionsGump : Gump
             {
                 _label.Alpha = 1f;
             }
+        }
+
+        public void SetText(string text)
+        {
+            _inputField.SetText(text);
         }
 
         public bool Search(string text)
@@ -2597,14 +2603,18 @@ public class BaseOptionsGump : Gump
 
             SearchValueChanged += ModernOptionsGump_SearchValueChanged;
         }
-        
+
         public override void Dispose()
         {
             base.Dispose();
             SearchValueChanged -= ModernOptionsGump_SearchValueChanged;
         }
 
-        public ushort Hue => _colorPicker.Hue;
+        public ushort Hue
+        {
+            get { return _colorPicker.Hue; }
+            set { _colorPicker.Hue = value; }
+        }
 
         private void ModernOptionsGump_SearchValueChanged(object sender, EventArgs e)
         {

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernColorPicker.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernColorPicker.cs
@@ -79,6 +79,8 @@ namespace ClassicUO.Game.UI.Gumps
             Add(next = new NiceButton(WIDTH - borderSize - 20, HEIGHT - borderSize - 20, 20, 20, ButtonAction.Activate, ">") { IsSelectable = false });
             next.MouseUp += (sender, e) => { if (e.Button == Input.MouseButtonType.Left) { cPage++; FillHueDisplays(cPage); page.Text = (cPage + 1).ToString(); } };
 
+            CenterXInViewPort();
+            CenterYInViewPort();
         }
 
         private void FillHueDisplays(int page = 0)
@@ -160,7 +162,7 @@ namespace ClassicUO.Game.UI.Gumps
                     if (isClickable)
                     {
                         UIManager.GetGump<ModernColorPicker>()?.Dispose();
-                        UIManager.Add(new ModernColorPicker(s => Hue = s) { X = 100, Y = 100 });
+                        UIManager.Add(new ModernColorPicker(s => Hue = s));
                     }
                     else
                     {

--- a/src/ClassicUO.Client/Game/UI/Positioner.cs
+++ b/src/ClassicUO.Client/Game/UI/Positioner.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using ClassicUO.Game.UI.Controls;
 
 namespace ClassicUO.Game.UI;
@@ -21,6 +22,7 @@ public class Positioner
     private int _columnWidth;
     private int _columnPadding;
     private int _maxRowHeight = 0;
+    private Dictionary<int, TableColumnAlignment> _tableColumnAlignments = new();
 
     public Positioner(int leftPadding = 2, int topPadding = 5, int blankLineHeight = 20, int indentation = 40)
     {
@@ -77,6 +79,13 @@ public class Positioner
         _maxRowHeight = 0;
     }
 
+    public void SetColumnAlignment(int column, TableColumnAlignment alignment)
+    {
+        if (!_tableMode) return;
+
+        _tableColumnAlignments[column] = alignment;
+    }
+
     /// <summary>
     /// End table positioning mode and return to normal positioning
     /// </summary>
@@ -99,6 +108,7 @@ public class Positioner
         _tableColumns = 0;
         _currentColumn = 0;
         _maxRowHeight = 0;
+        _tableColumnAlignments.Clear();
     }
 
     /// <summary>
@@ -134,11 +144,28 @@ public class Positioner
     private Control PositionInTable(Control c)
     {
         // Calculate column position
-        int columnX = _tableStartX + (_currentColumn * (_columnWidth + _columnPadding));
+        int columnX;
+        int alignedX = columnX = _tableStartX + (_currentColumn * (_columnWidth + _columnPadding));
 
         // If using auto-width, we can't pre-calculate positions perfectly
         // This is a simple implementation that assumes uniform spacing
-        c.X = columnX;
+
+        if (_tableColumnAlignments.TryGetValue(_currentColumn, out TableColumnAlignment align))
+        {
+            switch (align)
+            {
+                case TableColumnAlignment.Left:
+                    break;
+                case TableColumnAlignment.Center:
+                    alignedX += (_columnWidth - c.Width) / 2;
+                    break;
+                case TableColumnAlignment.Right:
+                    alignedX += _columnWidth - c.Width;
+                    break;
+            }
+        }
+
+        c.X = alignedX;
         c.Y = _tableStartY;
 
         // Track the maximum height in this row
@@ -226,4 +253,11 @@ public class Positioner
         int currentRow = _tableStartY == Y ? 0 : (_tableStartY - Y) / (_maxRowHeight + TopPadding);
         return (_tableColumns, _currentColumn, currentRow);
     }
+}
+
+public enum TableColumnAlignment
+{
+    Left,
+    Center,
+    Right
 }

--- a/src/ClassicUO.Client/Game/UI/Positioner.cs
+++ b/src/ClassicUO.Client/Game/UI/Positioner.cs
@@ -144,13 +144,12 @@ public class Positioner
     private Control PositionInTable(Control c)
     {
         // Calculate column position
-        int columnX;
-        int alignedX = columnX = _tableStartX + (_currentColumn * (_columnWidth + _columnPadding));
+        int alignedX = _tableStartX + (_currentColumn * (_columnWidth + _columnPadding));
 
         // If using auto-width, we can't pre-calculate positions perfectly
         // This is a simple implementation that assumes uniform spacing
 
-        if (_tableColumnAlignments.TryGetValue(_currentColumn, out TableColumnAlignment align))
+        if (_columnWidth > 0 && _tableColumnAlignments.TryGetValue(_currentColumn, out TableColumnAlignment align))
         {
             switch (align)
             {


### PR DESCRIPTION
<img width="925" height="534" alt="image" src="https://github.com/user-attachments/assets/cf48e1bb-c17d-4124-9f1f-662c94856470" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "SpellIndicator" page to the AssistantGump UI, enabling users to search for spells and edit their visual range properties with a detailed editor.
  * Introduced column-specific horizontal alignment options (Left, Center, Right) for table layouts in the UI.
  * Exposed spell range data cache for improved management.

* **Improvements**
  * Color pickers now open centered in the viewport instead of at a fixed position.
  * Enhanced color picker and input field controls to allow external setting and retrieval of values.
  * Implemented delayed save mechanism for spell visual range data to optimize save operations.
  * Removed fixed positioning when opening color pickers for a more flexible UI experience.

* **Style**
  * Minor formatting and whitespace adjustments for improved code readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->