### PR TITLE
Allow sharing items in discord

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/DiscordGump/DiscordChatAreaControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/DiscordGump/DiscordChatAreaControl.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using ClassicUO.Assets;
+using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.Managers;
 using Discord.Sdk;
 using Microsoft.Xna.Framework;
@@ -62,6 +63,25 @@ public class DiscordChatAreaControl : Control
 
         _chatInput.EnterPressed += ChatInputOnEnterPressed;
         Add(_chatInput);
+
+        NiceButton button = new NiceButton(Width - 150, 0, 125, 25, ButtonAction.Default, "Share Item");
+        button.IsSelected = true;
+        button.MouseUp += (sender, args) =>
+        {
+            if (_selectedChannel == 0) return;
+
+            TargetHelper.TargetObject((e) =>
+            {
+                if (e == null) return;
+
+                if (SerialHelper.IsItem(e.Serial))
+                {
+                    Item item = World.Items.Get(e.Serial);
+                    DiscordManager.Instance.SendChannelItem(_selectedChannel, item, isDM);
+                }
+            });
+        };
+        Add(button);
     }
 
     private void ChatInputOnEnterPressed(object sender, EventArgs e)

--- a/src/ClassicUO.Client/Game/UI/Gumps/DiscordGump/DiscordMessageControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/DiscordGump/DiscordMessageControl.cs
@@ -12,13 +12,13 @@ public class DiscordMessageControl : Control
     {
         Width = width;
         CanMove = true;
-        
-        
+
+
         DateTime time = DateTimeOffset.FromUnixTimeMilliseconds((long)msg.SentTimestamp()).UtcDateTime.ToLocalTime();
 
         var content = msg.Content();
 
-        if (string.IsNullOrEmpty(content))
+        if (string.IsNullOrEmpty(content) && (msg.Metadata() == null || msg.Metadata().Count == 0) )
         {
             var adtl = msg.AdditionalContent();
 
@@ -37,10 +37,39 @@ public class DiscordMessageControl : Control
         var name = TextBox.GetOne($"[{time.ToShortTimeString()}] {msg.Author()?.DisplayName()}: ", TrueTypeLoader.EMBEDDED_FONT, 20f, DiscordManager.GetUserhue(msg.AuthorId()), TextBox.RTLOptions.Default());
         var message = TextBox.GetOne(content, TrueTypeLoader.EMBEDDED_FONT, 20f, Color.White, TextBox.RTLOptions.Default(width - name.Width));
         message.X = name.Width;
-        
+
+        int h = Math.Max(name.Height, message.Height);
+
         Add(name);
         Add(message);
 
-        Height = message.Height;
+        var meta = msg.Metadata();
+        if (meta != null && meta.Count > 0)
+        {
+            if (meta.TryGetValue("graphic", out var graphic) && ushort.TryParse(graphic, out var g))
+            {
+                if(meta.TryGetValue("hue", out var hue) && ushort.TryParse(hue, out var hue2))
+                {
+                    var item = new StaticPic(g, hue2);
+                    item.X = name.Width;
+                    item.Y = h;
+
+                    var hitbox = new HitBox(item.X, item.Y, Math.Max(item.Width, 50), Math.Max(item.Height, 50));
+
+                    string ttip = meta["name"];
+                    if(meta.TryGetValue("data", out var data))
+                        ttip += "\n" + data;
+                    ttip = ToolTipOverrideData.ProcessTooltipText(ttip);
+
+                    hitbox.SetTooltip(ttip);
+
+                    Add(item);
+                    Add(hitbox);
+                    h = Math.Max(h, item.Height);
+                }
+            }
+        }
+
+        Height = h;
     }
 }


### PR DESCRIPTION
<img width="470" height="391" alt="image" src="https://github.com/user-attachments/assets/58544445-e4f7-436b-aff2-26c7b3b24977" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Share Item" button in the Discord chat area, allowing users to select and share in-game items directly to Discord channels or direct messages.
  * Shared items now display their graphic and details within Discord messages, including tooltips for additional item information.

* **Improvements**
  * Enhanced display of Discord messages to better handle empty content and to visually present shared item metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->