### PR TITLE
Enable option to draw borders on cave tile art

### DIFF
--- a/src/ClassicUO.Client/Configuration/Language.cs
+++ b/src/ClassicUO.Client/Configuration/Language.cs
@@ -529,7 +529,7 @@ namespace ClassicUO.Configuration
             public string UseLandTexturesWhereAvailable { get; set; } = "Use land textures where available(Experimental)";
             public string SOSGumpID { get; set; } = "SOS Gump ID";
             public string UseWASDMovement { get; set; } = "Use WASD movement instead of arrow keys";
-            public string BorderCaveTiles { get; set; } = "Apply a border to static item art";
+            public string ApplyBorderCaveTiles { get; set; } = "Apply a border to cave tile art";
             public string ForcedHouseTransparencyLevel { get; set; } = "Forced house transparency";
             public string EnableHouseTransparency { get; set; } = "Enable forced house transparency";
             public string HouseTransparencyTileHue { get; set; } = "House transparency tile hue";

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -637,7 +637,6 @@ namespace ClassicUO.Configuration
         public bool ForceHouseTransparency { get; set; }
         public ulong HideHudGumpFlags { get; set; }
         public bool DisableGrayEnemies { get; set; }
-        public bool EnableCaveTileBorders { get; set; }
 
         private long lastSave;
         public void Save(string path, bool saveGumps = true)

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -637,6 +637,7 @@ namespace ClassicUO.Configuration
         public bool ForceHouseTransparency { get; set; }
         public ulong HideHudGumpFlags { get; set; }
         public bool DisableGrayEnemies { get; set; }
+        public bool EnableCaveTileBorders { get; set; }
 
         private long lastSave;
         public void Save(string path, bool saveGumps = true)

--- a/src/ClassicUO.Client/Game/Data/StaticFilters.cs
+++ b/src/ClassicUO.Client/Game/Data/StaticFilters.cs
@@ -2,7 +2,7 @@
 
 // Copyright (c) 2021, andreakarasho
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
 // 1. Redistributions of source code must retain the above copyright
@@ -16,7 +16,7 @@
 // 4. Neither the name of the copyright holder nor the
 //    names of its contributors may be used to endorse or promote products
 //    derived from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ''AS IS'' AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -33,12 +33,14 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using ClassicUO.Configuration;
 using ClassicUO.Assets;
 using ClassicUO.Renderer;
 using ClassicUO.Utility;
 using ClassicUO.Utility.Logging;
+using Microsoft.Xna.Framework;
 
 namespace ClassicUO.Game.Data
 {
@@ -238,24 +240,102 @@ namespace ClassicUO.Game.Data
             }
         }
 
-        public static void ApplyStaticBorder()
+        public static void ApplyCaveTileBorder()
         {
             Log.Trace("Applying statics border...");
-            foreach (ushort graphic in CaveTiles)
+
+            // Group graphics by their atlas texture to minimize GetData/SetData calls
+            var textureGroups = CaveTiles.GroupBy(graphic => Client.Game.Arts.GetArt(graphic).Texture)
+                .Where(g => g.Key != null);
+
+            foreach (var textureGroup in textureGroups)
             {
-                ref readonly var artInfo = ref Client.Game.Arts.GetArt(graphic);
+                var atlasTexture = textureGroup.Key;
+                uint[] atlasPixels = new uint[atlasTexture.Width * atlasTexture.Height];
+                atlasTexture.GetData(atlasPixels);
 
-                if (artInfo.Texture != null)
+                bool atlasModified = false;
+
+                foreach (ushort graphic in textureGroup)
                 {
-                    uint[] pixels = new uint[artInfo.Texture.Width * artInfo.Texture.Height];
-                    artInfo.Texture.GetData(pixels);
+                    ref readonly var artInfo = ref Client.Game.Arts.GetArt(graphic);
 
-                    AddBlackBorder(pixels, artInfo.Texture.Width, artInfo.Texture.Height);
-                    artInfo.Texture.SetData(pixels);
-                    break;//Can't directly access the atlas to only modify one area of it without modifying the atlas. That is doable, but in the meantime we will just border everything.
+                    if (ApplyBorderToAtlasRegion(atlasPixels, atlasTexture.Width, atlasTexture.Height, artInfo.UV))
+                    {
+                        atlasModified = true;
+                    }
+                }
+
+                if (atlasModified)
+                {
+                    atlasTexture.SetData(atlasPixels);
                 }
             }
         }
+
+    private static bool ApplyBorderToAtlasRegion(uint[] atlasPixels, int atlasWidth, int atlasHeight, Rectangle uv)
+    {
+        if (uv.Width <= 0 || uv.Height <= 0)
+            return false;
+
+        bool modified = false;
+
+        // Apply your border logic adapted for atlas coordinates
+        for (int yy = 0; yy < uv.Height; yy++)
+        {
+            int atlasY = uv.Y + yy;
+            if (atlasY < 0 || atlasY >= atlasHeight) continue;
+
+            int startY = yy != 0 ? -1 : 0;
+            int endY = yy + 1 < uv.Height ? 2 : 1;
+
+            for (int xx = 0; xx < uv.Width; xx++)
+            {
+                int atlasX = uv.X + xx;
+                if (atlasX < 0 || atlasX >= atlasWidth) continue;
+
+                int atlasIndex = atlasY * atlasWidth + atlasX;
+                ref uint pixel = ref atlasPixels[atlasIndex];
+
+                if (pixel == 0)
+                {
+                    continue;
+                }
+
+                int startX = xx != 0 ? -1 : 0;
+                int endX = xx + 1 < uv.Width ? 2 : 1;
+
+                for (int i = startY; i < endY; i++)
+                {
+                    int currentY = yy + i;
+                    int currentAtlasY = uv.Y + currentY;
+
+                    // Bounds check for atlas
+                    if (currentAtlasY < 0 || currentAtlasY >= atlasHeight) continue;
+
+                    for (int j = startX; j < endX; j++)
+                    {
+                        int currentX = xx + j;
+                        int currentAtlasX = uv.X + currentX;
+
+                        // Bounds check for atlas
+                        if (currentAtlasX < 0 || currentAtlasX >= atlasWidth) continue;
+
+                        int currentAtlasIndex = currentAtlasY * atlasWidth + currentAtlasX;
+                        ref uint currentPixel = ref atlasPixels[currentAtlasIndex];
+
+                        if (currentPixel == 0u)
+                        {
+                            pixel = 0xFF_00_00_00;
+                            modified = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        return modified;
+    }
 
         public static void CleanTreeTextures()
         {

--- a/src/ClassicUO.Client/Game/Managers/MacroManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/MacroManager.cs
@@ -2018,7 +2018,7 @@ namespace ClassicUO.Game.Managers
                     break;
 
                 case MacroType.BorderCaveTiles:
-                    StaticFilters.ApplyStaticBorder();
+                    StaticFilters.ApplyCaveTileBorder();
                     ProfileManager.CurrentProfile.EnableCaveBorder = !ProfileManager.CurrentProfile.EnableCaveBorder;
 
                     break;

--- a/src/ClassicUO.Client/Game/Managers/MacroManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/MacroManager.cs
@@ -2018,8 +2018,9 @@ namespace ClassicUO.Game.Managers
                     break;
 
                 case MacroType.BorderCaveTiles:
-                    StaticFilters.ApplyCaveTileBorder();
                     ProfileManager.CurrentProfile.EnableCaveBorder = !ProfileManager.CurrentProfile.EnableCaveBorder;
+                    if(ProfileManager.CurrentProfile.EnableCaveBorder)
+                        StaticFilters.ApplyCaveTileBorder();
 
                     break;
 

--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -212,12 +212,14 @@ namespace ClassicUO.Game.Scenes
             {
                 XmlGumpHandler.TryAutoOpenByName(xml);
             }
-            
+
             PersistentVars.Load();
             LegionScripting.LegionScripting.Init();
             BuySellAgent.Load();
             GraphicsReplacement.Load();
             SpellBarManager.Load();
+            if(ProfileManager.CurrentProfile.EnableCaveBorder)
+                StaticFilters.ApplyCaveTileBorder();
         }
 
         private void ChatOnMessageReceived(object sender, MessageEventArgs e)
@@ -369,7 +371,7 @@ namespace ClassicUO.Game.Scenes
             {
                 return;
             }
-            
+
             SpellBarManager.Unload();
             _moveItemQueue.Clear();
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
@@ -3368,8 +3368,21 @@ namespace ClassicUO.Game.UI.Gumps
                 c = new CheckboxWithLabel(lang.GetTazUO.UseWASDMovement, isChecked: profile.UseWASDInsteadArrowKeys, valueChanged: (e) => { profile.UseWASDInsteadArrowKeys = e; }),
                 true, page
             );
-
             c.SetTooltip("This only works if you have enable chat by pressing enter, and chat disabled. Otherwise you will still be typing into your chatbar.");
+
+            content.BlankLine();
+
+            content.AddToRight
+            (
+                c = new CheckboxWithLabel(lang.GetTazUO.ApplyBorderCaveTiles, isChecked: profile.EnableCaveBorder, valueChanged: (e) =>
+                {
+                    profile.EnableCaveBorder = e;
+                    if(e)
+                        StaticFilters.ApplyCaveTileBorder();
+                }),
+                true, page
+            );
+            c.SetTooltip("After disabling, you need to restart the client to revert to no borders.");
 
             #region HideHouses
             content.BlankLine();

--- a/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/OptionsGump.cs
@@ -5308,7 +5308,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             if (_currentProfile.EnableCaveBorder != _enableCaveBorder.IsChecked)
             {
-                StaticFilters.ApplyStaticBorder();
+                StaticFilters.ApplyCaveTileBorder();
                 _currentProfile.EnableCaveBorder = _enableCaveBorder.IsChecked;
             }
 


### PR DESCRIPTION
<img width="1284" height="622" alt="image" src="https://github.com/user-attachments/assets/a4275296-03f2-4461-af32-57b3c3e945f8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option in settings to apply a border effect to cave tile art. When enabled, cave tiles will display with a distinct border for enhanced visibility.

* **Improvements**
  * The border effect for cave tiles now applies more efficiently, updating all relevant graphics at once for smoother performance.

* **UI Updates**
  * Introduced a new checkbox in the options menu to toggle the cave tile border effect. A tooltip indicates that a client restart is required to fully disable the effect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->