### PR TITLE
Convert durability gump to new modern ui expandable gump

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/DurabilityGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/DurabilityGump.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
 using ClassicUO.Assets;
+using ClassicUO.Game.Data;
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.UI.Controls;
@@ -51,9 +52,9 @@ namespace ClassicUO.Game.UI.Gumps
         }
     }
 
-    internal class DurabilitysGump : Gump
+    internal class DurabilitysGump : NineSliceGump
     {
-        private const int WIDTH = 300, HEIGHT = 400;
+        private static int lastWidth = 300, lastHeight = 400;
         private static int lastX, lastY;
 
         private enum DurabilityColors
@@ -65,40 +66,33 @@ namespace ClassicUO.Game.UI.Gumps
         }
 
         private readonly Dictionary<string, ContextMenuItemEntry> _menuItems = new Dictionary<string, ContextMenuItemEntry>();
-        private DataBox _dataBox;
+        private VBoxContainer _dataBox;
         public override GumpType GumpType => GumpType.DurabilityGump;
 
-        public DurabilitysGump() : base(0, 0)
+        public DurabilitysGump() : base(lastX, lastY, lastWidth, lastHeight, ModernUIConstants.ModernUIPanel, ModernUIConstants.ModernUIPanel_BoderSize, true, 200, 200)
         {
             LayerOrder = UILayer.Default;
             CanCloseWithRightClick = true;
             CanMove = true;
 
-            Width = WIDTH;
-            Height = HEIGHT;
+            Width = lastWidth;
+            Height = lastHeight;
 
             X = lastX;
             Y = lastY;
 
-            if (lastX == default || lastY == default)
+            if (lastX == 0 || lastY == 0)
             {
                 X = lastX = (Client.Game.Scene.Camera.Bounds.Width - Width) / 2;
                 Y = lastY = Client.Game.Scene.Camera.Bounds.Y + 20;
             }
 
+            Build();
+        }
 
-            var _borderControl = new BorderControl(0, 0, Width, Height, 4);
-
-            Add(_borderControl);
-
-            Add
-            (
-                new AlphaBlendControl(0.9f)
-                {
-                    Width = Width,
-                    Height = Height
-                }
-            );
+        private void Build()
+        {
+            Clear();
 
             BuildHeader();
 
@@ -109,27 +103,20 @@ namespace ClassicUO.Game.UI.Gumps
 
             Add(area);
 
-
-            _dataBox = new DataBox(0, 0, Width - 40, Height - 20);
+            _dataBox = new VBoxContainer(Width - 40);
             area.Add(_dataBox);
-            UpdateContents();
+
+            RequestUpdateContents();
         }
 
 
         private void BuildHeader()
         {
-            var a = new Area();
-            a.Width = Width;
-            a.WantUpdateSize = false;
-            a.CanMove = true;
-
-            Label l;
-            a.Add(l = new Label("Equipment Durability", true, 0xFF));
+            Label l = new ("Equipment Durability", true, 0xFF);
             l.X = (Width >> 1) - (l.Width >> 1);
             l.Y = (l.Height >> 1) >> 1;
-            a.Height = l.Y + l.Height;
 
-            Add(a);
+            Add(l);
         }
 
         public override void Dispose()
@@ -142,12 +129,10 @@ namespace ClassicUO.Game.UI.Gumps
         protected override void UpdateContents()
         {
             _dataBox.Clear();
-            _dataBox.WantUpdateSize = true;
             Rectangle barBounds = Client.Game.Gumps.GetGump((uint)DurabilityColors.RED).UV;
-            var startY = 0;
 
             var items = World.DurabilityManager?.Durabilities ?? new List<DurabiltyProp>();
-            
+
             foreach (var durability in items.OrderBy(d => d.Percentage))
             {
                 if (durability.MaxDurabilty <= 0)
@@ -168,7 +153,6 @@ namespace ClassicUO.Game.UI.Gumps
                 a.CanMove = true;
                 a.Height = 44;
                 a.Width = Width - (a.X * 2) - 40;
-                a.Y = startY;
 
                 Label name;
                 a.Add(name = new Label($"{(string.IsNullOrWhiteSpace(item.Name) ? item.Layer : item.Name)}", true, 0xFFFF, ishtml: true));
@@ -203,14 +187,15 @@ namespace ClassicUO.Game.UI.Gumps
                 );
 
                 _dataBox.Add(a);
-
-                startY += a.Height + 4;
             }
         }
 
-        public override void Update()
+        protected override void OnResize(int oldWidth, int oldHeight, int newWidth, int newHeight)
         {
-            base.Update();
+            base.OnResize(oldWidth, oldHeight, newWidth, newHeight);
+            Build();
+            lastWidth = newWidth;
+            lastHeight = newHeight;
         }
 
         public override void Save(XmlTextWriter writer)
@@ -219,6 +204,8 @@ namespace ClassicUO.Game.UI.Gumps
 
             writer.WriteAttributeString("lastX", X.ToString());
             writer.WriteAttributeString("lastY", Y.ToString());
+            writer.WriteAttributeString("lastWidth", lastWidth.ToString());
+            writer.WriteAttributeString("lastHeight", lastHeight.ToString());
         }
 
         public override void Restore(XmlElement xml)
@@ -227,11 +214,8 @@ namespace ClassicUO.Game.UI.Gumps
 
             int.TryParse(xml.GetAttribute("lastX"), out X);
             int.TryParse(xml.GetAttribute("lastY"), out Y);
-        }
-
-        public override bool Draw(UltimaBatcher2D batcher, int x, int y)
-        {
-            return base.Draw(batcher, x, y);
+            int.TryParse(xml.GetAttribute("lastWidth"), out Width);
+            int.TryParse(xml.GetAttribute("lastHeight"), out Height);
         }
     }
 }

--- a/src/ClassicUO.Client/Game/UI/Gumps/DurabilityGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/DurabilityGump.cs
@@ -216,6 +216,7 @@ namespace ClassicUO.Game.UI.Gumps
             int.TryParse(xml.GetAttribute("lastY"), out Y);
             int.TryParse(xml.GetAttribute("lastWidth"), out Width);
             int.TryParse(xml.GetAttribute("lastHeight"), out Height);
+            Build();
         }
     }
 }

--- a/src/ClassicUO.Client/Game/UI/Gumps/NineSliceGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/NineSliceGump.cs
@@ -217,48 +217,56 @@ public class NineSliceGump : Gump
             switch (_dragCorner)
             {
                 case ResizeCorner.TopLeft:
-                    // Top-left: position moves, size shrinks in both directions
-                    newWidth = Math.Max(_borderSize * 2, _dragStartSize.X - deltaX);
-                    newHeight = Math.Max(_borderSize * 2, _dragStartSize.Y - deltaY);
-                    // Only move position if we're actually resizing (not at minimum size)
-                    if (newWidth > _borderSize * 2 || deltaX < 0)
-                        newX = _dragStartPosition.X + (_dragStartSize.X - newWidth);
-                    if (newHeight > _borderSize * 2 || deltaY < 0)
-                        newY = _dragStartPosition.Y + (_dragStartSize.Y - newHeight);
+                    // Calculate desired size first
+                    int desiredWidth = _dragStartSize.X - deltaX;
+                    int desiredHeight = _dragStartSize.Y - deltaY;
+
+                    // Apply minimum constraints
+                    newWidth = Math.Max(Math.Max(_borderSize * 2, _minWidth), desiredWidth);
+                    newHeight = Math.Max(Math.Max(_borderSize * 2, _minHeight), desiredHeight);
+
+                    // Only adjust position based on actual size change
+                    newX = _dragStartPosition.X + (_dragStartSize.X - newWidth);
+                    newY = _dragStartPosition.Y + (_dragStartSize.Y - newHeight);
                     break;
 
                 case ResizeCorner.TopRight:
-                    // Top-right: X position stays fixed, width grows, height shrinks with Y moving
-                    newWidth = Math.Max(_borderSize * 2, _dragStartSize.X + deltaX);
-                    newHeight = Math.Max(_borderSize * 2, _dragStartSize.Y - deltaY);
-                    newX = _dragStartPosition.X; // X position doesn't change
-                    // Only move Y position to keep top-right corner fixed
-                    if (newHeight > _borderSize * 2 || deltaY < 0)
-                        newY = _dragStartPosition.Y + (_dragStartSize.Y - newHeight);
+                    int desiredWidthTR = _dragStartSize.X + deltaX;
+                    int desiredHeightTR = _dragStartSize.Y - deltaY;
+
+                    newWidth = Math.Max(Math.Max(_borderSize * 2, _minWidth), desiredWidthTR);
+                    newHeight = Math.Max(Math.Max(_borderSize * 2, _minHeight), desiredHeightTR);
+
+                    newX = _dragStartPosition.X; // X position doesn't change for top-right
+                    newY = _dragStartPosition.Y + (_dragStartSize.Y - newHeight);
                     break;
 
                 case ResizeCorner.BottomLeft:
-                    // Bottom-left: Y position stays fixed, width shrinks with X moving, height grows
-                    newWidth = Math.Max(_borderSize * 2, _dragStartSize.X - deltaX);
-                    newHeight = Math.Max(_borderSize * 2, _dragStartSize.Y + deltaY);
-                    newY = _dragStartPosition.Y; // Y position doesn't change
-                    // Only move X position to keep bottom-left corner fixed
-                    if (newWidth > _borderSize * 2 || deltaX < 0)
-                        newX = _dragStartPosition.X + (_dragStartSize.X - newWidth);
+                    int desiredWidthBL = _dragStartSize.X - deltaX;
+                    int desiredHeightBL = _dragStartSize.Y + deltaY;
+
+                    newWidth = Math.Max(Math.Max(_borderSize * 2, _minWidth), desiredWidthBL);
+                    newHeight = Math.Max(Math.Max(_borderSize * 2, _minHeight), desiredHeightBL);
+
+                    newX = _dragStartPosition.X + (_dragStartSize.X - newWidth);
+                    newY = _dragStartPosition.Y; // Y position doesn't change for bottom-left
                     break;
 
                 case ResizeCorner.BottomRight:
-                    // Bottom-right: position stays fixed, size grows in both directions
-                    newWidth = Math.Max(_borderSize * 2, _dragStartSize.X + deltaX);
-                    newHeight = Math.Max(_borderSize * 2, _dragStartSize.Y + deltaY);
+                    int desiredWidthBR = _dragStartSize.X + deltaX;
+                    int desiredHeightBR = _dragStartSize.Y + deltaY;
+
+                    newWidth = Math.Max(Math.Max(_borderSize * 2, _minWidth), desiredWidthBR);
+                    newHeight = Math.Max(Math.Max(_borderSize * 2, _minHeight), desiredHeightBR);
+
                     // Position doesn't change for bottom-right
                     newX = _dragStartPosition.X;
                     newY = _dragStartPosition.Y;
                     break;
             }
 
-            // Apply changes
-            if ((newWidth != Width || newHeight != Height || newX != X || newY != Y) && newWidth >= _minWidth && newHeight >= _minHeight)
+            // Apply changes - no additional size check needed since we already applied constraints
+            if (newWidth != Width || newHeight != Height || newX != X || newY != Y)
             {
                 X = newX;
                 Y = newY;
@@ -268,7 +276,7 @@ public class NineSliceGump : Gump
             }
         }
 
-        // Fixed: Reset drag state if mouse button is released (backup check)
+        // Reset drag state if mouse button is released
         if (_isDragging && !Mouse.LButtonPressed)
         {
             _isDragging = false;


### PR DESCRIPTION
<img width="219" height="292" alt="image" src="https://github.com/user-attachments/assets/6aececfd-4526-4da5-9569-bb83c1e92e42" />

Closes #64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added resizable support to the Durability window, allowing users to adjust its size and have their preferred dimensions remembered across sessions.

* **Improvements**
  * Enhanced layout and visual organization of durability entries for better readability.
  * Simplified and improved the header display in the Durability window.

* **Bug Fixes**
  * Improved resizing behavior to ensure minimum size constraints are always respected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->