### PR TITLE
Add sort by name to grid container options

### DIFF
--- a/src/ClassicUO.Client/Game/Managers/GridContainerSaveData.cs
+++ b/src/ClassicUO.Client/Game/Managers/GridContainerSaveData.cs
@@ -343,7 +343,7 @@ public class GridContainerEntry
         UseOriginalContainer = container.UseOldContainerStyle ?? false;
         AutoSort = container.AutoSortContainer;
         VisuallyStackNonStackables = container.StackNonStackableItems;
-        SortMode = container.SortMode;
+        SortMode = (int)container.SortMode;
         return this;
     }
 }

--- a/src/ClassicUO.Client/Game/Managers/GridContainerSaveData.cs
+++ b/src/ClassicUO.Client/Game/Managers/GridContainerSaveData.cs
@@ -304,6 +304,8 @@ public class GridContainerEntry
 
     [JsonPropertyName("vs")] public bool VisuallyStackNonStackables { get; set; }
 
+    [JsonPropertyName("sm")] public int SortMode { get; set; }
+
     [JsonPropertyName("ls")] public Dictionary<uint, GridContainerSlotEntry> Slots { get; set; } = new();
 
     public GridContainerSlotEntry GetSlot(uint serial)
@@ -341,6 +343,7 @@ public class GridContainerEntry
         UseOriginalContainer = container.UseOldContainerStyle ?? false;
         AutoSort = container.AutoSortContainer;
         VisuallyStackNonStackables = container.StackNonStackableItems;
+        SortMode = container.SortMode;
         return this;
     }
 }


### PR DESCRIPTION
<img width="495" height="333" alt="image" src="https://github.com/user-attachments/assets/3c787678-d853-4ead-990f-e1f924031af1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added selectable sort modes for grid containers: sort by Graphic + Hue or by Name.
  - Sort preference is saved and restored across sessions.

- UI/UX
  - Left-clicking the sort button opens a sort options menu.
  - Tooltip shows current sort mode and left-click instruction.
  - Alt+Left-Click still toggles auto-sort.

- Behavior Changes
  - Item ordering in grid containers now reflects the chosen sort mode consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->