### PR TITLE
Improve saving, update tiles on add/remove

### DIFF
--- a/src/ClassicUO.Client/Game/Managers/TileMarkerManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/TileMarkerManager.cs
@@ -54,7 +54,7 @@ namespace ClassicUO.Game.Managers
             markedTiles[location] = hue;
 
             // Update all live tiles at this location
-            UpdateLiveTilesAt(x, y, hue);
+            UpdateLiveTilesAt(x, y, map, hue);
         }
 
         public void RemoveTile(int x, int y, int map)
@@ -64,7 +64,7 @@ namespace ClassicUO.Game.Managers
             if (markedTiles.Remove(location))
             {
                 // Reset hue to 0 for all live tiles at this location
-                UpdateLiveTilesAt(x, y, 0);
+                UpdateLiveTilesAt(x, y, map, 0);
             }
         }
 
@@ -149,9 +149,9 @@ namespace ClassicUO.Game.Managers
             }
         }
 
-        private void UpdateLiveTilesAt(int x, int y, ushort hue)
+        private void UpdateLiveTilesAt(int x, int y, int map, ushort hue)
         {
-            if (World.Map == null) return;
+            if (World.Map == null || World.Map.Index != map) return;
 
             var chunk = World.Map.GetChunk(x, y, false);
             if (chunk == null) return;

--- a/src/ClassicUO.Client/Game/Managers/TileMarkerManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/TileMarkerManager.cs
@@ -2,36 +2,68 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.Serialization.Formatters.Binary;
+using System.Text.Json;
+using ClassicUO.Game.GameObjects;
+using ClassicUO.Game.Map;
 
 namespace ClassicUO.Game.Managers
 {
+    [Serializable]
+    internal class TileMarkerData
+    {
+        public ushort MarkerHue { get; set; }
+        public ushort OriginalHue { get; set; }
+    }
+
     internal class TileMarkerManager
     {
         public static TileMarkerManager Instance { get; private set; } = new TileMarkerManager();
 
-        private Dictionary<string, ushort> markedTiles = new Dictionary<string, ushort>();
+        private Dictionary<string, TileMarkerData> markedTiles = new Dictionary<string, TileMarkerData>();
 
         private TileMarkerManager() { Load(); }
 
-        private string savePath = Path.Combine(CUOEnviroment.ExecutablePath, "Data", "Profiles", "TileMarkers.bin");
+        private string SavePath => Path.Combine(ProfileManager.ProfilePath ?? CUOEnviroment.ExecutablePath, "TileMarkers.json");
 
         public void AddTile(int x, int y, int map, ushort hue)
         {
-            markedTiles[FormatLocKey(x, y, map)] = hue;
-
-            World.Map.GetTile(x, y).Hue = hue;
+            string key = FormatLocKey(x, y, map);
+            
+            // Store original hue if not already marked (use 0 as default for new markers)
+            ushort originalHue = 0;
+            if (markedTiles.ContainsKey(key))
+            {
+                // Keep the existing original hue
+                originalHue = markedTiles[key].OriginalHue;
+            }
+            
+            markedTiles[key] = new TileMarkerData { MarkerHue = hue, OriginalHue = originalHue };
+            
+            // Update all live tiles at this location
+            UpdateLiveTilesAt(x, y, hue);
         }
 
         public void RemoveTile(int x, int y, int map)
         {
-            if (markedTiles.ContainsKey(FormatLocKey(x, y, map)))
-                markedTiles.Remove(FormatLocKey(x, y, map));
+            string key = FormatLocKey(x, y, map);
+            
+            if (markedTiles.TryGetValue(key, out TileMarkerData data))
+            {
+                markedTiles.Remove(key);
+                
+                // Restore original hue to all live tiles at this location
+                UpdateLiveTilesAt(x, y, data.OriginalHue);
+            }
         }
 
         public bool IsTileMarked(int x, int y, int map, out ushort hue)
         {
-            if (markedTiles.TryGetValue(FormatLocKey(x, y, map), out hue)) return true;
+            if (markedTiles.TryGetValue(FormatLocKey(x, y, map), out TileMarkerData data))
+            {
+                hue = data.MarkerHue;
+                return true;
+            }
+            hue = 0;
             return false;
         }
 
@@ -44,27 +76,84 @@ namespace ClassicUO.Game.Managers
         {
             try
             {
-                using (FileStream fs = new FileStream(savePath, FileMode.Create, FileAccess.Write))
-                {
-                    BinaryFormatter bf = new BinaryFormatter();
-                    bf.Serialize(fs, markedTiles);
-                }
+                Directory.CreateDirectory(Path.GetDirectoryName(SavePath));
+                var options = new JsonSerializerOptions { WriteIndented = true };
+                string json = JsonSerializer.Serialize(markedTiles, options);
+                File.WriteAllText(SavePath, json);
             }
-            catch { Console.WriteLine("Failed to save marked tile data."); }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Failed to save marked tile data: {ex.Message}");
+            }
         }
 
         private void Load()
         {
-            if(File.Exists(savePath))
+            try
+            {
+                if (File.Exists(SavePath))
+                {
+                    string json = File.ReadAllText(SavePath);
+                    markedTiles = JsonSerializer.Deserialize<Dictionary<string, TileMarkerData>>(json) ?? new Dictionary<string, TileMarkerData>();
+                }
+                else
+                {
+                    // Try to migrate from old binary format
+                    MigrateFromLegacyFormat();
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Failed to load marked tile data: {ex.Message}");
+                markedTiles = new Dictionary<string, TileMarkerData>();
+            }
+        }
+        
+        private void MigrateFromLegacyFormat()
+        {
+            string legacyPath = Path.Combine(CUOEnviroment.ExecutablePath, "Data", "Profiles", "TileMarkers.bin");
+            if (File.Exists(legacyPath))
+            {
                 try
                 {
-                    using (FileStream fs = File.OpenRead(savePath))
+                    using (FileStream fs = File.OpenRead(legacyPath))
                     {
-                        BinaryFormatter bf = new BinaryFormatter();
-                        markedTiles = (Dictionary<string, ushort>)bf.Deserialize(fs);
+                        var bf = new System.Runtime.Serialization.Formatters.Binary.BinaryFormatter();
+                        var oldData = (Dictionary<string, ushort>)bf.Deserialize(fs);
+                        
+                        foreach (var kvp in oldData)
+                        {
+                            markedTiles[kvp.Key] = new TileMarkerData { MarkerHue = kvp.Value, OriginalHue = 0 };
+                        }
+                        
+                        // Save in new format and delete old file
+                        Save();
+                        File.Delete(legacyPath);
                     }
                 }
-                catch { }
+                catch
+                {
+                    // Migration failed, start fresh
+                }
+            }
+        }
+        
+        private void UpdateLiveTilesAt(int x, int y, ushort hue)
+        {
+            if (World.Map == null) return;
+            
+            var chunk = World.Map.GetChunk(x, y, false);
+            if (chunk == null) return;
+            
+            // Get all tiles at this location and update their hue
+            for (GameObject obj = chunk.GetHeadObject(x % 8, y % 8); obj != null; obj = obj.TNext)
+            {
+                // Update both Land and Static tiles
+                if (obj is Land || obj is Static)
+                {
+                    obj.Hue = hue;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tile markers now persist in a human-readable JSON file.
  * Automatic migration of existing markers from the legacy format on first run.
  * Live synchronization applies marker hue to land and static tiles at a location.

* **Bug Fixes**
  * Marker hue changes now reliably reflect across related tiles.
  * Improved resilience when loading/saving marker data, with graceful fallbacks on errors.

* **Behavior Change**
  * Removing a marker resets tile hue to default (previous hue is no longer restored).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->