### PR TITLE
Limit packets per frame to remove stutter in largely populated areas

### DIFF
--- a/src/ClassicUO.Client/GameController.cs
+++ b/src/ClassicUO.Client/GameController.cs
@@ -117,7 +117,6 @@ namespace ClassicUO
 
         protected override void Initialize()
         {
-            AsyncNetClient.MessageReceived += SocketOnMessageReceived;
             if (GraphicManager.GraphicsDevice.Adapter.IsProfileSupported(GraphicsProfile.HiDef))
             {
                 GraphicManager.GraphicsProfile = GraphicsProfile.HiDef;
@@ -134,10 +133,17 @@ namespace ClassicUO
             base.Initialize();
         }
 
-        private void SocketOnMessageReceived(object sender, byte[] e)
+        private const int MAX_PACKETS_PER_FRAME = 25;
+
+        private void ProcessNetworkPackets()
         {
-            var c = PacketHandlers.Handler.ParsePackets(e);
-            AsyncNetClient.Socket.Statistics.TotalPacketsReceived += (uint)c;
+            int packetsProcessed = 0;
+            while (AsyncNetClient.Socket.TryDequeuePacket(out byte[] message) && packetsProcessed < MAX_PACKETS_PER_FRAME)
+            {
+                var c = PacketHandlers.Handler.ParsePackets(message);
+                AsyncNetClient.Socket.Statistics.TotalPacketsReceived += (uint)c;
+                packetsProcessed++;
+            }
         }
 
         protected override void LoadContent()
@@ -466,7 +472,7 @@ namespace ClassicUO
             Profiler.ExitContext("Mouse");
 
             Profiler.EnterContext("Packets");
-            AsyncNetClient.Socket.ProcessIncomingMessages();
+            ProcessNetworkPackets();
             Profiler.ExitContext("Packets");
 
             Plugin.Tick();

--- a/src/ClassicUO.Client/GameController.cs
+++ b/src/ClassicUO.Client/GameController.cs
@@ -138,7 +138,7 @@ namespace ClassicUO
         private void ProcessNetworkPackets()
         {
             int packetsProcessed = 0;
-            while (AsyncNetClient.Socket.TryDequeuePacket(out byte[] message) && packetsProcessed < MAX_PACKETS_PER_FRAME)
+            while (packetsProcessed < MAX_PACKETS_PER_FRAME && AsyncNetClient.Socket.TryDequeuePacket(out byte[] message))
             {
                 var c = PacketHandlers.Handler.ParsePackets(message);
                 AsyncNetClient.Socket.Statistics.TotalPacketsReceived += (uint)c;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced memory allocations by using pooled buffers for network I/O and added small pacing to the network loop to reduce busy-waiting.
  * Capped per-frame packet processing to a fixed budget to avoid frame hitches under heavy traffic.

* **Stability**
  * Ensured pooled buffers are always released to prevent resource leaks and improved outgoing data handling for more predictable network behavior.

* **Breaking Changes**
  * Replaced event-driven packet delivery with a per-frame polling model and added explicit dequeue/clear packet methods for incoming messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->