### PR TITLE
Feat: AutoLoot toggle in GridHighlight and AutoLootManager to work on OSI

### DIFF
--- a/src/ClassicUO.Client/Game/GameObjects/Item.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Item.cs
@@ -167,23 +167,19 @@ namespace ClassicUO.Game.GameObjects
 
         public int MultiDistanceBonus { get; private set; }
 
-        private static bool IsCorpseGraphic(ushort g)
-        {
-            /*MathHelper.InRange(Graphic, 0x0ECA, 0x0ED2) ||*/
-            if (g == 0x2006) return true;
-
-            return false;
-        }
+        private static bool IsCorpseGraphic(ushort g) => g == 0x2006;
 
         public bool IsCorpse => IsCorpseGraphic(Graphic);
 
         public Item FindRootCorpse()
         {
             Item cur = this;
-            int guard = 0;
+            var visited = new HashSet<uint>();
 
-            while (SerialHelper.IsItem(cur.Container) && guard++ < 32)
+            while (SerialHelper.IsItem(cur.Container))
             {
+                if (!visited.Add(cur.Container))
+                    return null; // Circular reference detected
                 var parent = World.Items.Get(cur.Container);
                 if (parent == null) break;
                 if (IsCorpseGraphic(parent.Graphic)) return parent;

--- a/src/ClassicUO.Client/Game/GameObjects/Item.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Item.cs
@@ -167,8 +167,34 @@ namespace ClassicUO.Game.GameObjects
 
         public int MultiDistanceBonus { get; private set; }
 
-        public bool IsCorpse => /*MathHelper.InRange(Graphic, 0x0ECA, 0x0ED2) ||*/
-            Graphic == 0x2006;
+        private static bool IsCorpseGraphic(ushort g)
+        {
+            /*MathHelper.InRange(Graphic, 0x0ECA, 0x0ED2) ||*/
+            if (g == 0x2006) return true;
+
+            return false;
+        }
+
+        public bool IsCorpse => IsCorpseGraphic(Graphic);
+
+        public Item FindRootCorpse()
+        {
+            Item cur = this;
+            int guard = 0;
+
+            while (SerialHelper.IsItem(cur.Container) && guard++ < 32)
+            {
+                var parent = World.Items.Get(cur.Container);
+                if (parent == null) break;
+                if (IsCorpseGraphic(parent.Graphic)) return parent;
+                cur = parent;
+            }
+            return null;
+        }
+
+        public bool IsInsideCorpse => FindRootCorpse() != null;
+
+        public bool IsCorpseOrInsideCorpse => IsCorpse || IsInsideCorpse;
 
         public bool IsHumanCorpse => IsCorpse &&
             MathHelper.InRange(Amount, 0x0190, 0x0193) ||

--- a/src/ClassicUO.Client/Game/Managers/AutoLootManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/AutoLootManager.cs
@@ -1,4 +1,6 @@
 ﻿using ClassicUO.Configuration;
+using ClassicUO.Game;
+using ClassicUO.Game.Data;
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.UI.Gumps;
 using ClassicUO.Utility;
@@ -9,182 +11,247 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace ClassicUO.Game.Managers
 {
     internal class AutoLootManager
     {
-        public static AutoLootManager Instance { get; private set; } = new ();
-        public bool IsLoaded { get { return loaded; } }
+        public static AutoLootManager Instance { get; private set; } = new();
+        public bool IsLoaded => loaded;
         public List<AutoLootConfigEntry> AutoLootList { get => autoLootItems; set => autoLootItems = value; }
 
-        private HashSet<uint> quickContainsLookup = new ();
-        private static Queue<uint> lootItems = new ();
-        private List<AutoLootConfigEntry> autoLootItems = new ();
-        private bool loaded = false;
+        private const bool DEBUG = false;
+        private const ushort DBG_COLOR = 0x0044;
+        private void Log(string msg)
+        {
+            if (!DEBUG) return;
+            try { GameActions.Print($"[AutoLoot] {msg}", DBG_COLOR); } catch { }
+            try { System.Diagnostics.Debug.WriteLine($"[AutoLoot] {msg}"); } catch { }
+        }
+        private static string Info(Item i)
+        {
+            if (i == null) return "null";
+            return $"ser={i.Serial:X8} gfx={i.Graphic:X4} amt={i.Amount} xy=({i.X},{i.Y}) dist={i.Distance} corpse={(i.IsCorpse ? "Y" : "N")} inside={(i.FindRootCorpse() != null ? "Y" : "N")}";
+        }
+
+        private readonly HashSet<uint> quickContainsLookup = new();
+        private static readonly Queue<uint> lootItems = new();
+        private List<AutoLootConfigEntry> autoLootItems = new();
+        private bool loaded;
         private readonly string savePath = Path.Combine(CUOEnviroment.ExecutablePath, "Data", "Profiles", "AutoLoot.json");
-        private long nextLootTime = Time.Ticks;
+
         private ProgressBarGump progressBarGump;
-        private int currentLootTotalCount = 0;
-        private bool IsEnabled { get { return ProfileManager.CurrentProfile.EnableAutoLoot; } }
+        private int currentLootTotalCount;
+        private bool IsEnabled => ProfileManager.CurrentProfile.EnableAutoLoot;
+
+        private readonly HashSet<uint> _scanningCorpses = new();
+        private readonly HashSet<uint> _openedCorpses = new();
+        private readonly HashSet<uint> _openedContainers = new();
 
         private AutoLootManager() { }
 
+        private Item GetCorpseAnchor(Item maybeCorpseOrChild)
+        {
+            if (maybeCorpseOrChild == null) return null;
+            if (maybeCorpseOrChild.OnGround && maybeCorpseOrChild.IsCorpse) return maybeCorpseOrChild;
+            var rootCorpse = maybeCorpseOrChild.FindRootCorpse();
+            if (rootCorpse != null) return rootCorpse;
+            return maybeCorpseOrChild;
+        }
+
+        private bool InRangeChebyshev(Item target, int range, string tag)
+        {
+            var p = World.Player;
+            target = GetCorpseAnchor(target);
+            if (p == null || target == null) return false;
+            int dx = Math.Abs((int)p.X - (int)target.X);
+            int dy = Math.Abs((int)p.Y - (int)target.Y);
+            int chev = Math.Max(dx, dy);
+            Log($"Range[{tag}]: player=({p.X},{p.Y}) target=({target.X},{target.Y}) chev={chev} item.dist={target.Distance} range={range}");
+            return chev <= range;
+        }
+
+        private bool InRangeAnchor(Item itemOrCorpse, int range, out Item anchor)
+        {
+            anchor = GetCorpseAnchor(itemOrCorpse);
+            return InRangeChebyshev(anchor, range, "anchor");
+        }
 
         public bool IsBeingLooted(uint serial) => quickContainsLookup.Contains(serial);
 
         public void LootItem(uint serial)
         {
             var item = World.Items.Get(serial);
-            if (item != null)
-            {
-                LootItem(item);
-            }
+            if (item != null) LootItem(item);
+            else Log($"LootItem(serial): missing {serial:X8}");
         }
 
         public void LootItem(Item item)
         {
-            if (item == null || !quickContainsLookup.Add(item.Serial)) return;
+            if (item == null) return;
+            if (!quickContainsLookup.Add(item.Serial)) return;
 
-            lootItems.Enqueue(item);
+            Log($"Queued {item.Serial:X8} {item.Graphic:X4} x{item.Amount}");
+            lootItems.Enqueue(item.Serial);
             currentLootTotalCount++;
+
+            PumpMoveOnce();
+            MoveItemQueue.Instance?.ProcessQueue();
         }
 
         public void ForceLootContainer(uint serial)
         {
-            Item cont = World.Items.Get(serial);
-            
+            var cont = World.Items.Get(serial);
+            Log($"ForceLootContainer({serial:X8}) cont={Info(cont)}");
             if (cont == null) return;
-            
-            if (cont.Distance <= ProfileManager.CurrentProfile.AutoOpenCorpseRange)
-            {
-                for (LinkedObject i = cont.Items; i != null; i = i.Next)
-                {
-                    CheckAndLoot((Item)i);
-                }
-            }
-        }
 
-        /// <summary>
-        /// Check an item against the loot list, if it needs to be auto looted it will be.
-        /// </summary>
-        private void CheckAndLoot(Item i)
-        {
-            if (!loaded || i == null || quickContainsLookup.Contains(i.Serial)) return;
-            
-            if(i.IsCorpse)
-            {
-                HandleCorpse(i);
+            var anchor = GetCorpseAnchor(cont);
+            Log($"ForceLootContainer: anchor={Info(anchor)}");
 
+            if (!InRangeChebyshev(anchor, ProfileManager.CurrentProfile.AutoOpenCorpseRange, "ForceLootContainer"))
+            {
+                Log("ForceLootContainer: out of range");
                 return;
             }
 
-            if (IsOnLootList(i))
+            if (anchor.IsCorpse && !_openedCorpses.Contains(anchor.Serial))
             {
-                LootItem(i);
+                Log($"ForceLootContainer: opening corpse {anchor.Serial:X8}");
+                GameActions.DoubleClick(anchor);
+                _openedCorpses.Add(anchor.Serial);
+                return;
             }
+
+            if (anchor.IsCorpse)
+            {
+                HandleCorpse(anchor);
+                return;
+            }
+
+            for (LinkedObject n = cont.Items; n != null; n = n.Next)
+            {
+                var child = (Item)n;
+                Log($"ForceLootContainer: child {Info(child)}");
+                if (child == null) continue;
+
+                if (child.IsCorpse) HandleCorpse(child);
+                else if (IsOnLootList(child)) LootItem(child);
+            }
+
+            MoveItemQueue.Instance?.ProcessQueue();
         }
 
-        /// <summary>
-        /// Check if an item is on the auto loot list.
-        /// </summary>
-        /// <param name="i">The item to check the loot list against</param>
-        /// <returns></returns>
+        private void CheckAndLoot(Item i)
+        {
+            Log($"CheckAndLoot({Info(i)})");
+            if (!loaded || i == null || quickContainsLookup.Contains(i.Serial)) return;
+
+            if (i.IsCorpse) { HandleCorpse(i); return; }
+
+            var corpse = i.FindRootCorpse();
+            if (corpse != null)
+            {
+                if (_scanningCorpses.Contains(corpse.Serial))
+                {
+                    if (IsOnLootList(i)) LootItem(i);
+                }
+                else HandleCorpse(corpse);
+                return;
+            }
+
+            if (IsOnLootList(i)) LootItem(i);
+        }
+
         private bool IsOnLootList(Item i)
         {
             if (!loaded) return false;
-
             foreach (var entry in autoLootItems)
-            {
-                if (entry.Match(i))
-                {
-                    return true;
-                }
-            }
+                if (entry.Match(i)) return true;
             return false;
         }
-        
-        /// <summary>
-        /// Add an entry for auto looting to match against when opening corpses.
-        /// </summary>
-        /// <param name="graphic"></param>
-        /// <param name="hue"></param>
-        /// <param name="name"></param>
-        /// <returns></returns>
+
         public AutoLootConfigEntry AddAutoLootEntry(ushort graphic = 0, ushort hue = ushort.MaxValue, string name = "")
         {
-            AutoLootConfigEntry item = new AutoLootConfigEntry() { Graphic = graphic, Hue = hue, Name = name };
-
-            foreach (AutoLootConfigEntry entry in autoLootItems)
-            {
-                if (entry.Equals(item))
-                {
-                    return entry;
-                }
-            }
+            var item = new AutoLootConfigEntry { Graphic = graphic, Hue = hue, Name = name };
+            foreach (var entry in autoLootItems)
+                if (entry.Equals(item)) return entry;
 
             autoLootItems.Add(item);
-
             return item;
         }
 
-        /// <summary>
-        /// Search through a corpse and check items that need to be looted.
-        /// Only call this after checking that autoloot IsEnabled
-        /// </summary>
-        /// <param name="corpse"></param>
         private void HandleCorpse(Item corpse)
         {
-            if (corpse != null && corpse.IsCorpse && corpse.Distance <= ProfileManager.CurrentProfile.AutoOpenCorpseRange && (!corpse.IsHumanCorpse || ProfileManager.CurrentProfile.AutoLootHumanCorpses))
+            var anchorCorpse = GetCorpseAnchor(corpse);
+            Log($"HandleCorpse ENTER corpse={Info(corpse)}  anchor={Info(anchorCorpse)}");
+
+            if (anchorCorpse == null || !anchorCorpse.IsCorpse) return;
+            if (!InRangeChebyshev(anchorCorpse, ProfileManager.CurrentProfile.AutoOpenCorpseRange, "HandleCorpse")) return;
+            if (anchorCorpse.IsHumanCorpse && !ProfileManager.CurrentProfile.AutoLootHumanCorpses) return;
+            if (!_scanningCorpses.Add(anchorCorpse.Serial)) return;
+
+            try
             {
-                for (LinkedObject i = corpse.Items; i != null; i = i.Next)
+                if (!_openedCorpses.Contains(anchorCorpse.Serial))
                 {
-                    CheckAndLoot((Item)i);
+                    Log($"HandleCorpse: opening corpse {anchorCorpse.Serial:X8}");
+                    GameActions.DoubleClick(anchorCorpse);
+                    _openedCorpses.Add(anchorCorpse.Serial);
+                    return;
                 }
+
+                var visited = new HashSet<uint>();
+                var stack = new Stack<Item>();
+                stack.Push(anchorCorpse);
+
+                while (stack.Count > 0)
+                {
+                    var container = stack.Pop();
+                    if (container == null || !visited.Add(container.Serial)) continue;
+
+                    for (LinkedObject node = container.Items; node != null; node = node.Next)
+                    {
+                        var child = (Item)node;
+                        if (child == null) continue;
+
+                        if (child.ItemData.IsContainer)
+                        {
+                            if (!_openedContainers.Contains(child.Serial))
+                            {
+                                Log($"HandleCorpse: opening subcontainer {Info(child)}");
+                                GameActions.DoubleClick(child);
+                                _openedContainers.Add(child.Serial);
+                                return; // open one per pass
+                            }
+
+                            if (child.Items != null) stack.Push(child);
+                            continue;
+                        }
+
+                        if (IsOnLootList(child)) LootItem(child);
+                    }
+                }
+            }
+            finally
+            {
+                _scanningCorpses.Remove(anchorCorpse.Serial);
             }
         }
 
         public void TryRemoveAutoLootEntry(string UID)
         {
-            int removeAt = -1;
-
-            for (int i = 0; i < autoLootItems.Count; i++)
-            {
-                if (autoLootItems[i].UID == UID)
-                {
-                    removeAt = i;
-                }
-            }
-
-            if (removeAt > -1)
-            {
-                autoLootItems.RemoveAt(removeAt);
-            }
+            int ix = autoLootItems.FindIndex(e => e.UID == UID);
+            if (ix >= 0) autoLootItems.RemoveAt(ix);
         }
-       
-        /// <summary>
-        /// Checks if item is a corpse, or if its root container is corpse and handles them appropriately.
-        /// </summary>
-        /// <param name="i"></param>
+
         private void CheckCorpse(Item i)
         {
             if (i == null) return;
-
-            if (i.IsCorpse)
-            {
-                HandleCorpse(i);
-                return;
-            }
-
-            var root = World.Items.Get(i.RootContainer);
-            if (root != null && root.IsCorpse)
-            {
-                HandleCorpse(root);
-                return;
-            }
+            if (i.IsCorpse) { HandleCorpse(i); return; }
+            var corpse = i.FindRootCorpse();
+            if (corpse != null) { HandleCorpse(corpse); return; }
         }
-        
+
         public void OnSceneLoad()
         {
             Load();
@@ -204,90 +271,123 @@ namespace ClassicUO.Game.Managers
             EventSink.OnPositionChanged -= OnPositionChanged;
             Save();
         }
- 
+
         private void OnPositionChanged(object sender, PositionChangedArgs e)
         {
             if (!loaded) return;
 
-            if(ProfileManager.CurrentProfile.EnableScavenger)
+            if (ProfileManager.CurrentProfile.EnableScavenger)
                 foreach (Item item in World.Items.Values)
                 {
                     if (item == null || !item.OnGround || item.IsCorpse) continue;
-                    if (item.Distance >= 3) continue;
+                    if (!InRangeChebyshev(item, 3, "Scavenger")) continue;
                     CheckAndLoot(item);
                 }
+
+            PumpMoveOnce();
+            MoveItemQueue.Instance?.ProcessQueue();
         }
 
         private void OnOpenContainer(object sender, uint e)
         {
             if (!loaded || !IsEnabled) return;
 
-            CheckCorpse((Item)sender);
+            var cont = World.Items.Get(e);
+            if (cont == null) return;
+
+            var anchorCorpse = GetCorpseAnchor(cont);
+
+            if (anchorCorpse != null && anchorCorpse.IsCorpse)
+            {
+                if (anchorCorpse.OnGround) _openedCorpses.Add(anchorCorpse.Serial);
+                _openedContainers.Add(cont.Serial);
+                HandleCorpse(anchorCorpse);
+                PumpMoveOnce();
+                MoveItemQueue.Instance?.ProcessQueue();
+                return;
+            }
+
+            _openedContainers.Add(cont.Serial);
+
+            for (LinkedObject n = cont.Items; n != null; n = n.Next)
+            {
+                var child = (Item)n;
+                if (child == null) continue;
+                if (IsOnLootList(child)) LootItem(child);
+            }
+
+            PumpMoveOnce();
+            MoveItemQueue.Instance?.ProcessQueue();
         }
-        
+
         private void OnItemCreatedOrUpdated(object sender, EventArgs e)
         {
             if (!loaded || !IsEnabled) return;
-            
             if (sender is Item i)
+            {
                 CheckCorpse(i);
+                PumpMoveOnce();
+                MoveItemQueue.Instance?.ProcessQueue();
+            }
         }
-        
+
         private void OnOPLReceived(object sender, OPLEventArgs e)
         {
             if (!loaded || !IsEnabled) return;
             var item = World.Items.Get(e.Serial);
-            if (item != null)
-                CheckCorpse(item);
+            if (item != null) CheckCorpse(item);
+
+            PumpMoveOnce();
+            MoveItemQueue.Instance?.ProcessQueue();
         }
 
         public void Update()
         {
-            if (!loaded || !IsEnabled || !World.InGame) return;
+            PumpMoveOnce();
+            MoveItemQueue.Instance?.ProcessQueue();
+        }
 
-            if (lootItems.Count == 0)
+        private void PumpMoveOnce()
+        {
+            if (!loaded || !World.InGame) return;
+            if (lootItems.Count == 0) { progressBarGump?.Dispose(); return; }
+            if (Client.Game.GameCursor.ItemHold.Enabled) return;
+
+            var moveSerial = lootItems.Dequeue();
+            if (moveSerial == 0) return;
+
+            if (lootItems.Count == 0) currentLootTotalCount = 0;
+
+            quickContainsLookup.Remove(moveSerial);
+            CreateProgressBar();
+
+            if (progressBarGump != null && !progressBarGump.IsDisposed)
+                progressBarGump.CurrentPercentage = 1 - ((double)lootItems.Count / Math.Max(1, currentLootTotalCount));
+
+            var m = World.Items.Get(moveSerial);
+            if (m == null) return;
+
+            if (!InRangeAnchor(m, ProfileManager.CurrentProfile.AutoOpenCorpseRange, out var anchor))
             {
-                progressBarGump?.Dispose();
+                lootItems.Enqueue(moveSerial);
                 return;
             }
 
-            if (nextLootTime > Time.Ticks) return;
-
-            if (Client.Game.GameCursor.ItemHold.Enabled)
-                return; //Prevent moving stuff while holding an item.
-
-            var moveItem = lootItems.Dequeue();
-            if (moveItem != 0)
+            var corpse = m.FindRootCorpse();
+            if (corpse != null && !_openedCorpses.Contains(corpse.Serial))
             {
-                if (lootItems.Count == 0) //Que emptied out                
-                    currentLootTotalCount = 0;
-
-                quickContainsLookup.Remove(moveItem);
-
-                CreateProgressBar();
-
-                if (progressBarGump != null && !progressBarGump.IsDisposed)
-                {
-                    progressBarGump.CurrentPercentage = 1 - ((double)lootItems.Count / (double)currentLootTotalCount);
-                }
-
-                Item m = World.Items.Get(moveItem);
-
-                if (m != null)
-                {
-                    if (m.Distance > ProfileManager.CurrentProfile.AutoOpenCorpseRange)
-                    {
-                        Item rc = World.Items.Get(m.RootContainer);
-                        if (rc != null && rc.Distance > ProfileManager.CurrentProfile.AutoOpenCorpseRange)
-                            return;
-                    }
-                    
-                    MoveItemQueue.Instance?.EnqueueQuick(m);
-                    
-                    //GameActions.GrabItem(m, m.Amount);
-                    nextLootTime = Time.Ticks + ProfileManager.CurrentProfile.MoveMultiObjectDelay;
-                }
+                GameActions.DoubleClick(corpse);
+                _openedCorpses.Add(corpse.Serial);
+                lootItems.Enqueue(moveSerial);
+                return;
             }
+
+            var pack = World.Player?.FindItemByLayer(Layer.Backpack);
+            if (pack == null) { lootItems.Enqueue(moveSerial); return; }
+
+            if (m.Container == pack.Serial) return;
+
+            MoveItemQueue.Instance?.EnqueueQuick(m);
         }
 
         private void CreateProgressBar()
@@ -308,45 +408,39 @@ namespace ClassicUO.Game.Managers
         {
             if (loaded) return;
 
-            Task.Factory.StartNew(() =>
+            try
             {
                 if (!File.Exists(savePath))
                 {
                     autoLootItems = new List<AutoLootConfigEntry>();
-                    loaded = true;
                 }
                 else
                 {
-                    try
-                    {
-                        string data = File.ReadAllText(savePath);
-                        AutoLootConfigEntry[] tItem = JsonSerializer.Deserialize<AutoLootConfigEntry[]>(data);
-                        autoLootItems = tItem.ToList<AutoLootConfigEntry>();
-                        loaded = true;
-                    }
-                    catch
-                    {
-                        GameActions.Print("There was an error loading your auto loot config file, please check it with a json validator.", 32);
-                        loaded = false;
-                    }
-
+                    string data = File.ReadAllText(savePath);
+                    autoLootItems = JsonSerializer.Deserialize<AutoLootConfigEntry[]>(data)?.ToList()
+                                    ?? new List<AutoLootConfigEntry>();
                 }
-            });
+                loaded = true;
+            }
+            catch
+            {
+                GameActions.Print("Error loading AutoLoot.json (check JSON).", 32);
+                autoLootItems = new List<AutoLootConfigEntry>();
+                loaded = true;
+            }
         }
 
         public void Save()
         {
-            if (loaded)
-            {
-                try
-                {
-                    var options = new JsonSerializerOptions() { WriteIndented = true };
-                    string fileData = JsonSerializer.Serialize(autoLootItems, options);
+            if (!loaded) return;
 
-                    File.WriteAllText(savePath, fileData);
-                }
-                catch (Exception e) { Console.WriteLine(e.ToString()); }
+            try
+            {
+                var options = new JsonSerializerOptions { WriteIndented = true };
+                string fileData = JsonSerializer.Serialize(autoLootItems, options);
+                File.WriteAllText(savePath, fileData);
             }
+            catch { }
         }
 
         public class AutoLootConfigEntry
@@ -356,46 +450,28 @@ namespace ClassicUO.Game.Managers
             public ushort Hue { get; set; } = ushort.MaxValue;
             public string RegexSearch { get; set; } = string.Empty;
             private bool RegexMatch => !string.IsNullOrEmpty(RegexSearch);
-            /// <summary>
-            /// Do not set this manually.
-            /// </summary>
             public string UID { get; set; } = Guid.NewGuid().ToString();
 
             public bool Match(Item compareTo)
             {
                 if (Graphic != -1 && Graphic != compareTo.Graphic) return false;
-
                 if (!HueCheck(compareTo.Hue)) return false;
-
                 if (RegexMatch && !RegexCheck(compareTo)) return false;
-
                 return true;
             }
 
             private bool HueCheck(ushort value)
             {
-                if (Hue == ushort.MaxValue) //Ignore hue.
-                {
-                    return true;
-                }
-                else if (Hue == value) //Hue must match, and it does
-                {
-                    return true;
-                }
-                else //Hue is not ignored, and does not match
-                {
-                    return false;
-                }
+                if (Hue == ushort.MaxValue) return true;
+                if (Hue == value) return true;
+                return false;
             }
 
             private bool RegexCheck(Item compareTo)
             {
-                string search = "";
-                if (World.OPL.TryGetNameAndData(compareTo, out string name, out string data))
-                    search += name + data;
-                else
-                    search = StringHelper.GetPluralAdjustedString(compareTo.ItemData.Name);
-
+                string search;
+                if (World.OPL.TryGetNameAndData(compareTo, out string name, out string data)) search = name + data;
+                else search = StringHelper.GetPluralAdjustedString(compareTo.ItemData.Name);
                 return RegexHelper.GetRegex(RegexSearch, RegexOptions.Multiline).IsMatch(search);
             }
 

--- a/src/ClassicUO.Client/Game/Managers/AutoLootManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/AutoLootManager.cs
@@ -489,7 +489,7 @@ namespace ClassicUO.Game.Managers
                 progressBarGump = new ProgressBarGump("Auto looting...", 0)
                 {
                     Y = (ProfileManager.CurrentProfile.GameWindowPosition.Y + ProfileManager.CurrentProfile.GameWindowSize.Y) - 150,
-                    ForegrouneColor = Color.DarkOrange
+                    ForegroundColor = Color.DarkOrange
                 };
                 progressBarGump.CenterXInViewPort();
                 UIManager.Add(progressBarGump);

--- a/src/ClassicUO.Client/Game/Managers/AutoLootManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/AutoLootManager.cs
@@ -16,7 +16,7 @@ namespace ClassicUO.Game.Managers
 {
     internal class AutoLootManager
     {
-        public static AutoLootManager Instance { get; private set; } = new();
+        public static readonly AutoLootManager Instance = new();
         public bool IsLoaded => loaded;
         public List<AutoLootConfigEntry> AutoLootList { get => autoLootItems; set => autoLootItems = value; }
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightData.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightData.cs
@@ -62,6 +62,9 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
             if (item.ItemData.IsContainer) return;      // skip containers; AutoLoot scans them
             if (AutoLootManager.Instance == null) return; // AutoLoot not initialized
 
+            var rootCorpse = item.FindRootCorpse();
+            if (rootCorpse != null && !rootCorpse.Opened) return;
+
             AutoLootManager.Instance.LootItem(item);   // central handler does range/open/move
         }
 
@@ -111,7 +114,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
                         data.item.MatchesHighlightData = true;
                         data.item.HighlightHue = config.Hue;
 
-                        if (config.AutoLoot && (data.item.IsCorpse || data.item.FindRootCorpse() != null))
+                        if (config.AutoLoot && data.item.FindRootCorpse() != null)
                         {
                             TryAutoLoot(data.item);
                         }

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightData.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightData.cs
@@ -60,8 +60,9 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
             if (item == null) return;
             if (!item.IsLootable) return;               // skip hair/face/etc.
             if (item.ItemData.IsContainer) return;      // skip containers; AutoLoot scans them
+            if (AutoLootManager.Instance == null) return; // AutoLoot not initialized
 
-            AutoLootManager.Instance?.LootItem(item);   // central handler does range/open/move
+            AutoLootManager.Instance.LootItem(item);   // central handler does range/open/move
         }
 
         public void Delete()

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightProfile.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightProfile.cs
@@ -15,6 +15,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
         public ushort Hue { get; set; }
         public List<GridHighlightProperty> Properties { get; set; } = new();
         public bool AcceptExtraProperties { get; set; } = true;
+        public bool AutoLoot { get; set; } = false;
         public bool Overweight { get; set; } = true;
         public int MinimumProperty { get; set; } = 0;
         public int MaximumProperty { get; set; } = 0;

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightProperties.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightProperties.cs
@@ -55,7 +55,19 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
                 data.AcceptExtraProperties = acceptExtraPropertiesCheckbox.IsChecked;
             };
 
-            mainScrollArea.Add(pos.PositionRightOf(new Label("Allow extra properties", true, 0xffff), acceptExtraPropertiesCheckbox));
+            mainScrollArea.Add(temp = pos.PositionRightOf(new Label("Allow extra properties", true, 0xffff), acceptExtraPropertiesCheckbox));
+
+            string autoLootCheckboxTooltip = "Auto loot highlighted items from corpses.";
+
+            Checkbox autoLootCheckboxCheckbox;
+            mainScrollArea.Add(pos.PositionRightOf(autoLootCheckboxCheckbox = new Checkbox(0x00D2, 0x00D3) {  IsChecked = data.AutoLoot }, temp, 20));
+            autoLootCheckboxCheckbox.SetTooltip(autoLootCheckboxTooltip);
+            autoLootCheckboxCheckbox.ValueChanged += (s, e) =>
+            {
+                data.AutoLoot = autoLootCheckboxCheckbox.IsChecked;
+            };
+
+            mainScrollArea.Add(temp = pos.PositionRightOf(new Label("Auto loot", true, 0xffff), autoLootCheckboxCheckbox));
 
             InputField minPropertiesInput;
             mainScrollArea.Add(pos.Position(minPropertiesInput = new InputField(0x0BB8, 0xFF, 0xFFFF, true, 40, 20)));

--- a/src/ClassicUO.Client/Game/UI/Gumps/ProgressBarGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ProgressBarGump.cs
@@ -10,7 +10,7 @@ namespace ClassicUO.Game.UI.Gumps
         public double MaxValue { get; set; } = 1;
         public double MinValue { get; set; } = 0;
         public double CurrentPercentage { get; set; }
-        public Color ForegrouneColor { get; set; } = Color.Blue;
+        public Color ForegroundColor { get; set; } = Color.Blue;
 
         private Vector3 hueVector = ShaderHueTranslator.GetHueVector(0, false, 0.6f);
         public ProgressBarGump(string title, double startPercentage = 1.0, int width = 200, int height = 20) : base(0, 0)
@@ -35,7 +35,7 @@ namespace ClassicUO.Game.UI.Gumps
             base.Draw(batcher, x, y);
 
             batcher.Draw(
-                SolidColorTextureCache.GetTexture(ForegrouneColor),
+                SolidColorTextureCache.GetTexture(ForegroundColor),
                 new Rectangle
                 (
                     x,

--- a/src/ClassicUO.Client/Game/UI/Gumps/ProgressBarGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ProgressBarGump.cs
@@ -34,13 +34,15 @@ namespace ClassicUO.Game.UI.Gumps
         {
             base.Draw(batcher, x, y);
 
+            // Clamp percentage to [0,1] to avoid negative/overflow widths
+            var pct = CurrentPercentage < 0 ? 0 : (CurrentPercentage > 1 ? 1 : CurrentPercentage);
             batcher.Draw(
                 SolidColorTextureCache.GetTexture(ForegroundColor),
                 new Rectangle
                 (
                     x,
                     y,
-                    (int)(CurrentPercentage * Width),
+                    (int)(pct * Width),
                     Height
                 ),
                 hueVector);

--- a/src/ClassicUO.Client/Game/UI/Gumps/ProgressBarGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ProgressBarGump.cs
@@ -36,6 +36,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             // Clamp percentage to [0,1] to avoid negative/overflow widths
             var pct = CurrentPercentage < 0 ? 0 : (CurrentPercentage > 1 ? 1 : CurrentPercentage);
+            if (double.IsNaN(pct)) pct = 0;
             batcher.Draw(
                 SolidColorTextureCache.GetTexture(ForegroundColor),
                 new Rectangle


### PR DESCRIPTION
Anchor all range/open logic to the real corpse so OSI coordinates/range are correct.

Open the corpse once; traverse subcontainers safely (one open per pass) and queue leaf items.

GridHighlight can auto-loot matched items from corpses even if global AutoLoot is off (fallback path).

<img width="572" height="775" alt="image" src="https://github.com/user-attachments/assets/78c92b39-dc35-4e36-ab33-e3f4a1fadd4a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Per-profile "Auto Loot" toggle in Grid Highlight UI and per-entry AutoLoot option; automatic looting triggers from highlights.
  - Progress indicator during looting with corrected foreground color.

- **Bug Fixes**
  - Safer corpse/nested-container looting with cycle-safe root detection and queue underflow protection.
  - Reduced out-of-range looting and cleared state leaks; improved range/anchor checks and throttling.

- **Refactor**
  - More robust anchor-based range logic, distance caching, deterministic queue pumping, and safer load/save behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->