### PR TITLE
Feat: Add deselect option to Multi Move features

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
@@ -1058,15 +1058,24 @@ namespace ClassicUO.Game.UI.Gumps
                     }
                     else if (Keyboard.Alt && _item != null)
                     {
-                        // Toggle already handled in Update() to unify click and drag behavior.
-                        if (MultiItemMoveGump.IsSelected(_item.Serial))
+                        // If no drag occurred, toggle on click to prevent missed quick taps.
+                        bool nowSelected;
+                        if (!_altDragActive)
                         {
-                            MultiItemMoveGump.ShowNextTo(gridContainer);
+                            nowSelected = MultiItemMoveGump.ToggleItem(_item);
+                            // reflect highlight immediately
+                            SelectHighlight = MultiItemMoveGump.IsSelected(_item.Serial);
                         }
                         else
                         {
-                            MultiItemMoveGump.HideIfNoSelection();
+                            nowSelected = MultiItemMoveGump.IsSelected(_item.Serial);
                         }
+
+                        if (nowSelected)
+                            MultiItemMoveGump.ShowNextTo(gridContainer);
+                        else
+                            MultiItemMoveGump.HideIfNoSelection();
+
                         Mouse.CancelDoubleClick = true;
                     }
                     else if (Keyboard.Shift && _item != null && ProfileManager.CurrentProfile.EnableAutoLoot && !ProfileManager.CurrentProfile.HoldShiftForContext && !ProfileManager.CurrentProfile.HoldShiftToSplitStack)

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
@@ -1059,22 +1059,19 @@ namespace ClassicUO.Game.UI.Gumps
                     else if (Keyboard.Alt && _item != null)
                     {
                         // If no drag occurred, toggle on click to prevent missed quick taps.
-                        bool nowSelected;
                         if (!_altDragActive)
                         {
-                            nowSelected = MultiItemMoveGump.ToggleItem(_item);
+                            SelectHighlight = MultiItemMoveGump.ToggleItem(_item);
                             // reflect highlight immediately
                             SelectHighlight = MultiItemMoveGump.IsSelected(_item.Serial);
                         }
                         else
                         {
-                            nowSelected = MultiItemMoveGump.IsSelected(_item.Serial);
+                            SelectHighlight = MultiItemMoveGump.IsSelected(_item.Serial);
                         }
 
-                        if (nowSelected)
+                        if (SelectHighlight)
                             MultiItemMoveGump.ShowNextTo(gridContainer);
-                        else
-                            MultiItemMoveGump.HideIfNoSelection();
 
                         Mouse.CancelDoubleClick = true;
                     }
@@ -1237,7 +1234,9 @@ namespace ClassicUO.Game.UI.Gumps
                     }
                 }
 
-                SelectHighlight = _item != null && MultiItemMoveGump.IsSelected(_item.Serial);
+                if (SelectHighlight && !itemNull)
+                    if (!MultiItemMoveGump.IsSelected(_item.Serial))
+                        SelectHighlight = false;
 
                 base.Draw(batcher, x, y);
 
@@ -1404,19 +1403,10 @@ namespace ClassicUO.Game.UI.Gumps
                     // Toggle immediately for the item currently under the cursor
                     if (_item != null && hit.MouseIsOver && _toggledThisAltDrag.Add(_item.Serial))
                     {
-                        bool nowSelected = MultiItemMoveGump.ToggleItem(_item);
+                        SelectHighlight = MultiItemMoveGump.ToggleItem(_item);
 
-                        if (nowSelected)
-                        {
+                        if (SelectHighlight)
                             MultiItemMoveGump.ShowNextTo(gridContainer);
-                        }
-                        else
-                        {
-                            MultiItemMoveGump.HideIfNoSelection();
-                        }
-
-                        // reflect highlight immediately
-                        SelectHighlight = MultiItemMoveGump.IsSelected(_item.Serial);
                     }
                 }
                 else if (_altDragActive)

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
@@ -234,11 +234,10 @@ namespace ClassicUO.Game.UI.Gumps
             openRegularGump.SetTooltip(
                 "/c[orange]Grid Container Controls:/cd\n" +
                 "Ctrl + Click to lock an item in place\n" +
-                "Alt + Click to add an item to the quick move queue\n" +
-                "Alt + Double Click to add all similar items to the quick move queue\n" +
+                "Alt + Click to toggle selection for multi-move\n" +
+                "Alt + Double Click to select all similar items\n" +
                 "Shift + Click to add an item to your auto loot list\n" +
                 "Sort and single click looting can be enabled with the icons on the right side");
-
             quickDropBackpack = new ResizableStaticPic(World.Player.FindItemByLayer(Layer.Backpack).DisplayedGraphic, 20, 20)
             {
                 X = Width - openRegularGump.Width - 20 - borderWidth,
@@ -980,6 +979,8 @@ namespace ClassicUO.Game.UI.Gumps
                 }
                 else if (Keyboard.Alt && _item != null)
                 {
+                    if (MultiItemMoveGump.TrySelect(_item))
+                        SelectHighlight = true;
                     var graphic = _item.Graphic;
                     var hue = _item.Hue;
                     foreach (var gridItem in gridContainer.gridSlotManager.GridSlots.Values)
@@ -1378,7 +1379,9 @@ namespace ClassicUO.Game.UI.Gumps
             {
                 base.Update();
 
-                bool comboActive = Keyboard.Alt && Mouse.LButtonPressed;
+                bool comboActive = Keyboard.Alt && Mouse.LButtonPressed
+                   && !Client.Game.GameCursor.ItemHold.Enabled
+                   && !TargetManager.IsTargeting;
 
                 if (comboActive)
                 {

--- a/src/ClassicUO.Client/Game/UI/Gumps/MultiItemMoveGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/MultiItemMoveGump.cs
@@ -1,160 +1,259 @@
-﻿using ClassicUO.Configuration;
+﻿using System;
+using System.Collections.Concurrent;
+using ClassicUO.Assets;
+using ClassicUO.Configuration;
+using ClassicUO.Game.Data;
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.UI.Controls;
+using ClassicUO.Game.UI.Gumps.GridHighLight;
 using ClassicUO.Input;
 using ClassicUO.Renderer;
 using ClassicUO.Utility;
-using System.Collections.Concurrent;
 
 namespace ClassicUO.Game.UI.Gumps
 {
-    internal class MultiItemMoveGump : Gump
+    internal class MultiItemMoveGump : NineSliceGump
     {
-        private Label label;
+        private const int WIDTH = 220;
+        private const int HEIGHT = 150;
 
-        public static ConcurrentQueue<Item> MoveItems = new ConcurrentQueue<Item>();
+        public static int PreferredWidth => UIManager.GetGump<MultiItemMoveGump>()?.Width ?? WIDTH;
+        public static int PreferredHeight => UIManager.GetGump<MultiItemMoveGump>()?.Height ?? HEIGHT;
 
+        public static void ShowNextTo(Control anchor, int padding = -2)
+        {
+            int w = PreferredWidth;
+            int screenH = Client.Game.Window.ClientBounds.Height;
+
+            int x = anchor.X >= w + padding
+                ? anchor.X - (w + padding)           // left of anchor
+                : anchor.X + anchor.Width + padding; // right of anchor
+
+            int y = Math.Max(0, Math.Min(anchor.Y, screenH - PreferredHeight));
+
+            AddMultiItemMoveGumpToUI(x, y);
+
+            UIManager.GetGump<MultiItemMoveGump>()?.SetInScreen();
+        }
+
+        // ===== Selection + queue =====
+        public static readonly ConcurrentQueue<Item> MoveItems = new ConcurrentQueue<Item>();
+        private static readonly ConcurrentDictionary<uint, byte> _selected = new ConcurrentDictionary<uint, byte>();
+        private static int SelectedCount => _selected.Count;
+
+        // ===== Processing state =====
         public static int ObjDelay = 1000;
-
-        private static bool processing;
-        private static ProcessType processType;
+        private static bool processing = false;
+        private static ProcessType processType = ProcessType.None;
         private static long nextMove;
         private static uint tradeId, containerId;
         private static int groundX, groundY, groundZ;
 
-        public MultiItemMoveGump(int x, int y) : base(0, 0)
+        // ===== UI =====
+        private Label _header;
+        private InputField _delayInput;
+
+        public static bool IsSelected(uint serial) => _selected.ContainsKey(serial);
+
+        public static void HideIfNoSelection()
         {
-            Width = 200;
-            Height = 105;
+            if (SelectedCount == 0)
+            {
+                processing = false;
+                ResetDestination();
+                UIManager.GetGump<MultiItemMoveGump>()?.Dispose();
+            }
+        }
 
-            X = x < 0 ? 0 : x;
-            Y = y < 0 ? 0 : y;
-            SetInScreen();
-
+        public MultiItemMoveGump(int x, int y)
+            // resizable = true, with sensible minimums
+            : base(x, y, WIDTH, HEIGHT, ModernUIConstants.ModernUIPanel,
+                   ModernUIConstants.ModernUIPanel_BoderSize, true, WIDTH, HEIGHT)
+        {
             CanMove = true;
-            CanCloseWithRightClick = false;
             AcceptMouseInput = true;
+            CanCloseWithRightClick = false;
 
             ObjDelay = ProfileManager.CurrentProfile.MoveMultiObjectDelay;
 
-            Add(new AlphaBlendControl(0.75f) { Width = Width, Height = Height });
+            Build();
+        }
 
-            Add(label = new Label($"Moving {MoveItems.Count} items.", true, 0xff, Width, align: Assets.TEXT_ALIGN_TYPE.TS_CENTER));
+        protected override void OnResize(int oldWidth, int oldHeight, int newWidth, int newHeight)
+        {
+            base.OnResize(oldWidth, oldHeight, newWidth, newHeight);
+            Build();
+        }
 
-            Add(new Label($"Object delay:", true, 0xff, 150) { Y = label.Height + 5 });
-            StbTextBox delay;
-            Add(delay = new StbTextBox(0xFF, 3000, 50, true, FontStyle.None, 0x048)
+        private void Build()
+        {
+            Clear();
+
+            // Content area inside the modern border
+            int cx = BorderSize;
+            int cy = BorderSize;
+            int cw = Width - (BorderSize * 2);
+            int ch = Height - (BorderSize * 2);
+            int contentBottom = cy + ch;
+
+            // Header
+            Add(_header = new Label(TextForHeader(), true, 0xFFFF, cw, align: TEXT_ALIGN_TYPE.TS_CENTER)
             {
-                X = 150,
-                Y = label.Height + 5,
-                Width = 50,
-                Height = 20,
-                Multiline = false,
-                NumbersOnly = true,
+                X = cx,
+                Y = cy
             });
-            delay.SetText(ObjDelay.ToString());
-            delay.Add(new AlphaBlendControl(0.5f)
+
+            // "Object delay" + numeric input (right-aligned)
+            int delayRowY = cy + _header.Height + 5;
+
+            Add(new Label("Object delay:", true, 0xFFFF, 150)
             {
-                Hue = 0x0481,
-                Width = delay.Width,
-                Height = delay.Height
+                X = cx,
+                Y = delayRowY
             });
-            delay.TextChanged += (s, e) =>
+
+            Add(_delayInput = new InputField(0x0BB8, 0xFF, 0xFFFF, true, 56, 20)
             {
-                if (int.TryParse(delay.Text, out int newDelay))
+                X = cx + (cw - 56), // right edge of content
+                Y = delayRowY,
+                NumbersOnly = true
+            });
+            _delayInput.SetText(ObjDelay.ToString());
+            _delayInput.TextChanged += (s, e) =>
+            {
+                if (int.TryParse(_delayInput.Text, out int newDelay))
                 {
                     ObjDelay = newDelay;
                     ProfileManager.CurrentProfile.MoveMultiObjectDelay = newDelay;
                 }
             };
 
-            NiceButton moveToBackpack;
-            Add(moveToBackpack = new NiceButton(0, Height - 60, Width, 20, ButtonAction.Default, "Move to backpack", align: Assets.TEXT_ALIGN_TYPE.TS_CENTER));
-            moveToBackpack.SetTooltip("Move selected items to your backpack.");
-            moveToBackpack.MouseUp += (s, e) =>
+            // --- Buttons: position from the content bottom so spacing stays correct when resizing ---
+            const int GAP = 6;                  // small gap between left/right buttons
+            int halfW = (cw - GAP) / 2;
+
+            int rowY1 = contentBottom - 72;     // Move to backpack (full width)
+            int rowY2 = contentBottom - 44;     // Set favorite / To favorite
+            int rowY3 = contentBottom - 20;     // Cancel / Move to
+
+            NiceButton b;
+
+            // Move to backpack (full width)
+            Add(b = new NiceButton(cx, rowY1, cw, 20, ButtonAction.Activate, "Move to backpack", align: TEXT_ALIGN_TYPE.TS_CENTER));
+            b.SetTooltip("Move selected items to your backpack.");
+            b.MouseUp += (s, e) =>
             {
                 if (e.Button == MouseButtonType.Left)
                 {
-                    delay.IsEditable = false;
-                    processItemMoves(World.Player.FindItemByLayer(Data.Layer.Backpack));
+                    var bp = World.Player.FindItemByLayer(Layer.Backpack);
+                    if (bp != null) processItemMoves(bp);
                 }
             };
 
-            NiceButton setFavorite;
-            Add(setFavorite = new NiceButton(0, Height - 40, 100, 20, ButtonAction.Default, "Set favorite bag", align: Assets.TEXT_ALIGN_TYPE.TS_CENTER));
-            setFavorite.SetTooltip("Set your preferred destination container for future item moves.");
-            setFavorite.MouseUp += (s, e) =>
+            // Set favorite (left)
+            Add(b = new NiceButton(cx, rowY2, halfW, 20, ButtonAction.Activate, "Set favorite bag", align: TEXT_ALIGN_TYPE.TS_CENTER));
+            b.SetTooltip("Set your preferred destination container for future item moves.");
+            b.MouseUp += (s, e) =>
             {
                 if (e.Button == MouseButtonType.Left)
                 {
                     GameActions.Print("Target a container to set as your favorite.");
                     TargetManager.SetTargeting(CursorTarget.SetFavoriteMoveBag, CursorType.Target, TargetType.Neutral);
-                    delay.IsEditable = false;
                 }
             };
 
-            NiceButton moveToFavorite;
-            Add(moveToFavorite = new NiceButton(100, Height - 40, 100, 20, ButtonAction.Default, "To favorite", align: Assets.TEXT_ALIGN_TYPE.TS_CENTER));
-            moveToFavorite.SetTooltip("Move selected items to your favorite container.");
-            moveToFavorite.MouseUp += (s, e) =>
+            // To favorite (right)
+            Add(b = new NiceButton(cx + halfW + GAP, rowY2, halfW, 20, ButtonAction.Activate, "To favorite", align: TEXT_ALIGN_TYPE.TS_CENTER));
+            b.SetTooltip("Move selected items to your favorite container.");
+            b.MouseUp += (s, e) =>
             {
                 if (e.Button == MouseButtonType.Left)
                 {
-                    uint favoriteMoveBag = ProfileManager.CurrentProfile.SetFavoriteMoveBagSerial;
-                    if (favoriteMoveBag == 0)
+                    uint fav = ProfileManager.CurrentProfile.SetFavoriteMoveBagSerial;
+                    if (fav == 0)
                     {
                         GameActions.Print("No favorite container set. Please target one.");
                         TargetManager.SetTargeting(CursorTarget.SetFavoriteMoveBag, CursorType.Target, TargetType.Neutral);
                         return;
                     }
 
-                    Item container = World.Items.Get(favoriteMoveBag);
-                    if (container != null)
-                    {
-                        delay.IsEditable = false;
-                        processItemMoves(container);
-                    }
-                    else
-                    {
-                        GameActions.Print("Favorite container is not available.");
-                    }
+                    Item cont = World.Items.Get(fav);
+                    if (cont != null) processItemMoves(cont);
+                    else GameActions.Print("Favorite container is not available.");
                 }
             };
 
-            NiceButton cancel;
-            Add(cancel = new NiceButton(0, Height - 20, 100, 20, ButtonAction.Default, "Cancel", align: Assets.TEXT_ALIGN_TYPE.TS_CENTER));
-            cancel.MouseUp += (s, e) =>
+            // Cancel (left)
+            Add(b = new NiceButton(cx, rowY3, halfW, 20, ButtonAction.Activate, "Cancel", align: TEXT_ALIGN_TYPE.TS_CENTER));
+            b.MouseUp += (s, e) =>
             {
                 if (e.Button == MouseButtonType.Left)
                 {
-                    MoveItems = new ConcurrentQueue<Item>();
-                    cancel.Dispose();
+                    ClearAll();
+                    Dispose();
                 }
             };
 
-            NiceButton move;
-            Add(move = new NiceButton(100, Height - 20, 100, 20, ButtonAction.Default, "Move to", align: Assets.TEXT_ALIGN_TYPE.TS_CENTER));
-            move.SetTooltip("Select a container or a ground tile to move these items to.");
-            move.MouseUp += (s, e) =>
+            // Move to (right)
+            Add(b = new NiceButton(cx + halfW + GAP, rowY3, halfW, 20, ButtonAction.Activate, "Move to", align: TEXT_ALIGN_TYPE.TS_CENTER));
+            b.SetTooltip("Select a container or a ground tile to move these items to.");
+            b.MouseUp += (s, e) =>
             {
                 if (e.Button == MouseButtonType.Left)
                 {
                     GameActions.Print("Where should we move these items?");
                     TargetManager.SetTargeting(CursorTarget.MoveItemContainer, CursorType.Target, TargetType.Neutral);
-                    delay.IsEditable = false;
                 }
             };
-
-            Add(new SimpleBorder() { Width = Width, Height = Height, Alpha = 0.75f });
         }
+
+        // ===== Selection API used by GridContainer =====
+
+        public static bool TrySelect(Item item)
+        {
+            if (item == null) return false;
+            if (!_selected.TryAdd(item.Serial, 1)) return false; // already selected
+            MoveItems.Enqueue(item);
+            return true;
+        }
+
+        /// <summary>
+        /// Toggle selection state of an item. Returns true if now selected; false if deselected.
+        /// </summary>
+        public static bool ToggleItem(Item item)
+        {
+            if (item == null) return false;
+
+            if (_selected.TryRemove(item.Serial, out _))
+            {
+                // deselected
+                return false;
+            }
+
+            _selected[item.Serial] = 1;
+            MoveItems.Enqueue(item);
+            return true;
+        }
+
+        public static void AddMultiItemMoveGumpToUI(int x, int y)
+        {
+            if (SelectedCount > 0)
+            {
+                var g = UIManager.GetGump<MultiItemMoveGump>();
+                if (g == null || g.IsDisposed)
+                    UIManager.Add(new MultiItemMoveGump(x, y));
+            }
+        }
+
+        // ===== Target entry points =====
 
         public static void OnContainerTarget(uint serial)
         {
             if (SerialHelper.IsItem(serial))
             {
                 Item moveToContainer = World.Items.Get(serial);
-                if (!moveToContainer.ItemData.IsContainer)
+                if (moveToContainer == null || !moveToContainer.ItemData.IsContainer)
                 {
                     GameActions.Print("That does not appear to be a container...");
                     return;
@@ -163,24 +262,18 @@ namespace ClassicUO.Game.UI.Gumps
                 processItemMoves(moveToContainer);
             }
         }
+
         public static void OnContainerTarget(int x, int y, int z)
         {
             processItemMoves(x, y, z);
         }
+
         public static void OnTradeWindowTarget(uint tradeID)
         {
             processItemMoves(tradeID);
         }
 
-        public static void AddMultiItemMoveGumpToUI(int x, int y)
-        {
-            if (MoveItems.Count > 0)
-            {
-                Gump moveItemGump = UIManager.GetGump<MultiItemMoveGump>();
-                if (moveItemGump == null)
-                    UIManager.Add(new MultiItemMoveGump(x, y));
-            }
-        }
+        // ===== Processing impl =====
 
         private static void processItemMoves(Item container)
         {
@@ -212,55 +305,109 @@ namespace ClassicUO.Game.UI.Gumps
         {
             base.Update();
 
+            // live header
+            if (_header != null)
+                _header.Text = TextForHeader();
+
             if (!processing)
                 return;
-            
+
             if (Time.Ticks < nextMove)
                 return;
-            
+
             if (Client.Game.GameCursor.ItemHold.Enabled)
                 return;
-            
-            if(MoveItems.TryDequeue(out Item moveItem))
-            {
-                switch (processType)
-                {
-                    case ProcessType.Ground: 
-                        Assets.StaticTiles itemData = Assets.TileDataLoader.Instance.StaticData[moveItem.Graphic];
-                        MoveItemQueue.Instance.Enqueue(moveItem, 0, moveItem.Amount, groundX, groundY, groundZ + (sbyte)(itemData.Height == 0xFF ? 0 : itemData.Height));
-                        break;
 
-                    case ProcessType.Container:
-                        MoveItemQueue.Instance.Enqueue(moveItem, containerId, moveItem.Amount);
-                        break;
-                    
-                    case ProcessType.TradeWindow:
-                        MoveItemQueue.Instance.Enqueue(moveItem, tradeId, moveItem.Amount, RandomHelper.GetValue(0, 20), RandomHelper.GetValue(0, 20), 0);
-                        break;
+            if (MoveItems.TryDequeue(out Item moveItem))
+            {
+                if (_selected.ContainsKey(moveItem.Serial))
+                {
+                    switch (processType)
+                    {
+                        case ProcessType.Ground:
+                            var itemData = TileDataLoader.Instance.StaticData[moveItem.Graphic];
+                            MoveItemQueue.Instance.Enqueue(
+                                moveItem,
+                                0,
+                                moveItem.Amount,
+                                groundX,
+                                groundY,
+                                groundZ + (sbyte)(itemData.Height == 0xFF ? 0 : itemData.Height));
+                            break;
+
+                        case ProcessType.Container:
+                            MoveItemQueue.Instance.Enqueue(moveItem, containerId, moveItem.Amount);
+                            break;
+
+                        case ProcessType.TradeWindow:
+                            MoveItemQueue.Instance.Enqueue(
+                                moveItem,
+                                tradeId,
+                                moveItem.Amount,
+                                RandomHelper.GetValue(0, 20),
+                                RandomHelper.GetValue(0, 20),
+                                0);
+                            break;
+
+                        case ProcessType.None:
+                        default:
+                            processing = false;
+                            ResetDestination();
+                            break;
+                    }
+
+                    _selected.TryRemove(moveItem.Serial, out _);
+                    nextMove = Time.Ticks + ObjDelay;
                 }
-                
-                nextMove = Time.Ticks + ObjDelay;
+                // else: was deselected after enqueue -> skip
             }
-            
-            if(MoveItems.Count < 1)//No more items left
+
+            if (MoveItems.IsEmpty && SelectedCount == 0)
             {
                 processing = false;
+                ResetDestination();
             }
-            
         }
 
         public override bool Draw(UltimaBatcher2D batcher, int x, int y)
         {
-            if (MoveItems.Count < 1)
+            // auto-close if nothing to do
+            if (SelectedCount < 1 && MoveItems.IsEmpty)
+            {
+                processing = false;
+                ResetDestination();
                 Dispose();
-
-            label.Text = $"Moving {MoveItems.Count} items.";
+                return false;
+            }
 
             return base.Draw(batcher, x, y);
         }
-        
+
+        private static string TextForHeader()
+        {
+            var count = SelectedCount;
+            return processing ? $"Moving {count} items." : $"Selected {count} items.";
+        }
+
+        private static void ClearAll()
+        {
+            _selected.Clear();
+            while (MoveItems.TryDequeue(out _)) { }
+            processing = false;
+            ResetDestination();
+        }
+
+        private static void ResetDestination()
+        {
+            processType = ProcessType.None;
+            containerId = 0;
+            tradeId = 0;
+            groundX = groundY = groundZ = 0;
+        }
+
         protected enum ProcessType
         {
+            None = 0,
             Container,
             Ground,
             TradeWindow

--- a/src/ClassicUO.Client/Game/UI/Gumps/MultiItemMoveGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/MultiItemMoveGump.cs
@@ -15,7 +15,7 @@ namespace ClassicUO.Game.UI.Gumps
 {
     internal class MultiItemMoveGump : NineSliceGump
     {
-        private const int WIDTH = 220;
+        private const int WIDTH = 230;
         private const int HEIGHT = 150;
 
         public static int PreferredWidth => UIManager.GetGump<MultiItemMoveGump>()?.Width ?? WIDTH;

--- a/src/ClassicUO.Client/Game/UI/Gumps/MultiItemMoveGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/MultiItemMoveGump.cs
@@ -65,15 +65,6 @@ namespace ClassicUO.Game.UI.Gumps
 
         public static bool IsSelected(uint serial) => _selected.ContainsKey(serial);
 
-        public static void HideIfNoSelection()
-        {
-            if (SelectedCount == 0)
-            {
-                ClearAll();
-                UIManager.GetGump<MultiItemMoveGump>()?.Dispose();
-            }
-        }
-
         public MultiItemMoveGump(int x, int y)
             // resizable = true, with sensible minimums
             : base(x, y, WIDTH, HEIGHT, ModernUIConstants.ModernUIPanel,
@@ -132,21 +123,12 @@ namespace ClassicUO.Game.UI.Gumps
             {
                 if (int.TryParse(_delayInput.Text, out int newDelay))
                 {
-                    newDelay = Math.Max(0, Math.Min(5000, newDelay));
+                    newDelay = Math.Max(0, newDelay);
                     if (newDelay == ObjDelay) return;
                     ObjDelay = newDelay;
                     ProfileManager.CurrentProfile.MoveMultiObjectDelay = newDelay;
                     if (_delayInput.Text != newDelay.ToString())
                         _delayInput.SetText(newDelay.ToString());
-                }
-                else if (string.IsNullOrWhiteSpace(_delayInput.Text))
-                {
-                    if (ObjDelay != 0)
-                    {
-                        ObjDelay = 0;
-                        ProfileManager.CurrentProfile.MoveMultiObjectDelay = 0;
-                    }
-                    _delayInput.SetText("0");
                 }
             };
 
@@ -403,7 +385,7 @@ namespace ClassicUO.Game.UI.Gumps
         public override bool Draw(UltimaBatcher2D batcher, int x, int y)
         {
             // auto-close if nothing is selected
-            if (SelectedCount < 1 && MoveItems.IsEmpty)
+            if (SelectedCount == 0 || MoveItems.IsEmpty)
             {
                 ClearAll();
                 Dispose();

--- a/src/ClassicUO.Client/Game/UI/Gumps/MultiItemMoveGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/MultiItemMoveGump.cs
@@ -277,12 +277,12 @@ namespace ClassicUO.Game.UI.Gumps
 
         public static void OnContainerTarget(int x, int y, int z)
         {
-            processItemMoves(x, y, z);
+            ProcessItemMoves(x, y, z);
         }
 
         public static void OnTradeWindowTarget(uint tradeID)
         {
-            processItemMoves(tradeID);
+            ProcessItemMoves(tradeID);
         }
 
         // ===== Processing impl =====
@@ -297,7 +297,7 @@ namespace ClassicUO.Game.UI.Gumps
             }
         }
 
-        private static void processItemMoves(int x, int y, int z)
+        private static void ProcessItemMoves(int x, int y, int z)
         {
             processType = ProcessType.Ground;
             groundX = x;
@@ -306,7 +306,7 @@ namespace ClassicUO.Game.UI.Gumps
             processing = true;
         }
 
-        private static void processItemMoves(uint tradeID)
+        private static void ProcessItemMoves(uint tradeID)
         {
             tradeId = tradeID;
             processType = ProcessType.TradeWindow;


### PR DESCRIPTION
Closes #79 

Rewrote MultiItemMoveGump using the new NineSliceGump (Modern UI) while keeping the original layout and actions.

Added Alt+click and Alt+drag toggle selection/deselection (no more one-way enqueue).

<img width="318" height="217" alt="image" src="https://github.com/user-attachments/assets/a188f923-7c96-4c9d-b77b-4399f14f8bb3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Alt-drag now toggles per-gesture item selection in grids.
  * Multi-item move panel rebuilt: resizable, anchors next to the grid, shows live selected count, delay control, clearer action buttons, auto-closes when idle.
  * New move targets: backpack, favorite bag, ground coordinates, and trade window; selection query and toggle controls exposed.

* **Refactor**
  * Unified input handling for more consistent click/drag and multi-item selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->