### PR TITLE
Add auto bandage agent

### DIFF
--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -161,6 +161,15 @@ namespace ClassicUO.Configuration
         public bool EnableMousewheelScaleZoom { get; set; }
         public bool RestoreScaleAfterUnpressCtrl { get; set; }
         public bool BandageSelfOld { get; set; } = true;
+        
+        // Bandage Agent Settings
+        public bool EnableBandageAgent { get; set; } = false;
+        public int BandageAgentDelay { get; set; } = 3000;
+        public bool BandageAgentCheckForBuff { get; set; } = false;
+        public ushort BandageAgentGraphic { get; set; } = 0x0E21;
+        public bool BandageAgentUseNewPacket { get; set; } = true;
+        public int BandageAgentHPPercentage { get; set; } = 80;
+        
         public bool EnableDeathScreen { get; set; } = true;
         public bool EnableBlackWhiteEffect { get; set; } = true;
         public ushort HiddenBodyHue { get; set; } = 0x038E;

--- a/src/ClassicUO.Client/Game/Managers/BandageManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/BandageManager.cs
@@ -1,0 +1,110 @@
+using ClassicUO.Configuration;
+using ClassicUO.Game.Data;
+using ClassicUO.Game.GameObjects;
+using ClassicUO.Game.Managers;
+using ClassicUO.Utility;
+using System;
+
+namespace ClassicUO.Game.Managers
+{
+    internal class BandageManager
+    {
+        public static BandageManager Instance { get; private set; } = new();
+
+        private long nextBandageTime = 0;
+        private bool isEnabled => ProfileManager.CurrentProfile?.EnableBandageAgent ?? false;
+        private int healDelayMs => ProfileManager.CurrentProfile?.BandageAgentDelay ?? 3000;
+        private bool checkForBuff => ProfileManager.CurrentProfile?.BandageAgentCheckForBuff ?? false;
+        private ushort bandageGraphic => ProfileManager.CurrentProfile?.BandageAgentGraphic ?? 0x0E21;
+        private bool useNewBandagePacket => ProfileManager.CurrentProfile?.BandageAgentUseNewPacket ?? true;
+        private int hpPercentageThreshold => ProfileManager.CurrentProfile?.BandageAgentHPPercentage ?? 80;
+
+        public bool HasBandagingBuff { get; set; } = false;
+
+        private BandageManager()
+        {
+            EventSink.OnPlayerStatChange += OnPlayerStatChanged;
+            EventSink.OnBuffAdded += OnBuffAdded;
+            EventSink.OnBuffRemoved += OnBuffRemoved;
+        }
+
+        private void OnPlayerStatChanged(object sender, PlayerStatChangedArgs e)
+        {
+            if (!isEnabled || e.Stat != PlayerStatChangedArgs.PlayerStat.Hits)
+                return;
+
+            OnHpChanged(e.OldValue, e.NewValue);
+        }
+
+        private void OnBuffAdded(object sender, BuffEventArgs e)
+        {
+            if (e.Buff.Type == BuffIconType.Healing)
+            {
+                HasBandagingBuff = true;
+            }
+        }
+
+        private void OnBuffRemoved(object sender, BuffEventArgs e)
+        {
+            if (e.Buff.Type == BuffIconType.Healing)
+            {
+                HasBandagingBuff = false;
+            }
+        }
+
+        private void OnHpChanged(int oldHp, int newHp)
+        {
+            if (World.Player == null || !isEnabled)
+                return;
+
+            var currentHpPercentage = (int)((double)newHp / World.Player.HitsMax * 100);
+
+            if (currentHpPercentage >= hpPercentageThreshold)
+                return;
+
+            // If using buff checking, only prevent healing if buff is present
+            if (checkForBuff && HasBandagingBuff)
+                return;
+
+            // If using delay checking (not buff checking), check time delay
+            if (!checkForBuff && Time.Ticks < nextBandageTime)
+                return;
+
+            AttemptHeal();
+        }
+
+        private void AttemptHeal()
+        {
+            if (World.Player == null)
+                return;
+
+            if (useNewBandagePacket)
+            {
+                if (GameActions.BandageSelf())
+                {
+                    nextBandageTime = Time.Ticks + healDelayMs;
+                }
+            }
+            else
+            {
+                Item bandage = FindBandage();
+                if (bandage == null)
+                    return;
+
+                // Set up auto-target before double-clicking
+                TargetManager.SetAutoTarget(World.Player.Serial, TargetType.Beneficial, CursorTarget.Object);
+                
+                GameActions.DoubleClick(bandage.Serial);
+                nextBandageTime = Time.Ticks + healDelayMs;
+            }
+        }
+
+        private Item FindBandage()
+        {
+            if (World.Player?.FindItemByGraphic(bandageGraphic) is Item bandage)
+                return bandage;
+
+            return World.Player?.FindBandage();
+        }
+    }
+}

--- a/src/ClassicUO.Client/Game/Managers/BandageManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/BandageManager.cs
@@ -57,6 +57,10 @@ namespace ClassicUO.Game.Managers
             if (World.Player == null || !isEnabled)
                 return;
 
+            // Guard against divide-by-zero
+            if (World.Player.HitsMax <= 0)
+                return;
+
             var currentHpPercentage = (int)((double)newHp / World.Player.HitsMax * 100);
 
             if (currentHpPercentage >= hpPercentageThreshold)

--- a/src/ClassicUO.Client/Game/Managers/TargetManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/TargetManager.cs
@@ -2,7 +2,7 @@
 
 // Copyright (c) 2021, andreakarasho
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
 // 1. Redistributions of source code must retain the above copyright
@@ -16,7 +16,7 @@
 // 4. Neither the name of the copyright holder nor the
 //    names of its contributors may be used to endorse or promote products
 //    derived from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ''AS IS'' AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 // WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -155,6 +155,28 @@ namespace ClassicUO.Game.Managers
         }
     }
 
+    public class AutoTargetInfo
+    {
+        public uint TargetSerial { get; set; }
+        public TargetType ExpectedTargetType { get; set; }
+        public CursorTarget ExpectedCursorTarget { get; set; }
+        public bool IsSet => TargetSerial != 0;
+
+        public void Set(uint serial, TargetType targetType, CursorTarget cursorTarget)
+        {
+            TargetSerial = serial;
+            ExpectedTargetType = targetType;
+            ExpectedCursorTarget = cursorTarget;
+        }
+
+        public void Clear()
+        {
+            TargetSerial = 0;
+            ExpectedTargetType = TargetType.Cancel;
+            ExpectedCursorTarget = CursorTarget.Invalid;
+        }
+    }
+
     public static class TargetManager
     {
         private static uint _targetCursorId, _lastAttack;
@@ -202,6 +224,7 @@ namespace ClassicUO.Game.Managers
         }
 
         public static readonly LastTargetInfo LastTargetInfo = new LastTargetInfo();
+        public static readonly AutoTargetInfo NextAutoTarget = new AutoTargetInfo();
 
         public static MultiTargetInfo MultiTargetInfo { get; private set; }
 
@@ -259,6 +282,11 @@ namespace ClassicUO.Game.Managers
             // to send the last active cursorID, so update cursor data later
 
             _targetCursorId = cursorID;
+        }
+
+        public static void SetAutoTarget(uint serial, TargetType targetType, CursorTarget cursorTarget)
+        {
+            NextAutoTarget.Set(serial, targetType, cursorTarget);
         }
 
         public static void CancelTarget()

--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -212,6 +212,7 @@ namespace ClassicUO.Game.Scenes
             SpellDefinition.LoadCustomSpells();
             SpellVisualRangeManager.Instance.OnSceneLoad();
             AutoLootManager.Instance.OnSceneLoad();
+            var _ = BandageManager.Instance;
 
             foreach (var xml in ProfileManager.CurrentProfile.AutoOpenXmlGumps)
             {

--- a/src/ClassicUO.Client/Game/UI/Gumps/AssistantGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/AssistantGump.cs
@@ -36,6 +36,7 @@ public class AssistantGump : BaseOptionsGump
         BuildSpellIndicator();
         BuildJournalFilter();
         BuildTitleBar();
+        BuildBandageAgent();
 
         ChangePage((int)PAGE.AutoLoot);
     }
@@ -477,6 +478,54 @@ public class AssistantGump : BaseOptionsGump
         scroll.Add(PositionHelper.PositionControl(TextBox.GetOne("Note: Progress bars use Unicode block characters (█▓▒░) and may not display correctly on all systems.", ThemeSettings.FONT, ThemeSettings.STANDARD_TEXT_SIZE, ThemeSettings.TEXT_FONT_COLOR, TextBox.RTLOptions.Default(MainContent.RightWidth - 20))));
     }
 
+    private void BuildBandageAgent()
+    {
+        var page = (int)PAGE.BandageAgent;
+        MainContent.AddToLeft(CategoryButton("Auto Bandage", page, MainContent.LeftWidth));
+        MainContent.ResetRightSide();
+
+        ScrollArea scroll = new(0, 0, MainContent.RightWidth, MainContent.Height);
+        MainContent.AddToRight(scroll, false, page);
+        PositionHelper.Reset();
+
+        scroll.Add(PositionHelper.PositionControl(TextBox.GetOne("Automatically use bandages to heal when HP drops below threshold.", ThemeSettings.FONT, ThemeSettings.STANDARD_TEXT_SIZE, ThemeSettings.TEXT_FONT_COLOR, TextBox.RTLOptions.Default(MainContent.RightWidth - 20))));
+        PositionHelper.BlankLine();
+
+        scroll.Add(PositionHelper.PositionControl(new CheckboxWithLabel("Enable bandage agent", 0, profile.EnableBandageAgent, b => profile.EnableBandageAgent = b)));
+        PositionHelper.BlankLine();
+
+        Control c;
+        scroll.Add(c = PositionHelper.PositionControl(new InputFieldWithLabel("Bandage delay (ms)", ThemeSettings.INPUT_WIDTH, profile.BandageAgentDelay.ToString(), true, (s, e) =>
+        {
+            if (int.TryParse(((BaseOptionsGump.InputField.StbTextBox)s).Text, out int delay))
+            {
+                profile.BandageAgentDelay = delay;
+            }
+        })));
+        c.SetTooltip("Delay between bandage attempts in milliseconds");
+        PositionHelper.BlankLine();
+
+        scroll.Add(c = PositionHelper.PositionControl(new SliderWithLabel("HP percentage threshold", 0, ThemeSettings.SLIDER_WIDTH, 10, 95, profile.BandageAgentHPPercentage, (r) => { profile.BandageAgentHPPercentage = r; })));
+        c.SetTooltip("Heal when HP drops below this percentage");
+        PositionHelper.BlankLine();
+
+        scroll.Add(PositionHelper.PositionControl(new CheckboxWithLabel("Use bandaging buff instead of delay", 0, profile.BandageAgentCheckForBuff, b => profile.BandageAgentCheckForBuff = b)));
+        PositionHelper.BlankLine();
+
+        scroll.Add(PositionHelper.PositionControl(new CheckboxWithLabel("Use new bandage packet", 0, profile.BandageAgentUseNewPacket, b => profile.BandageAgentUseNewPacket = b)));
+        PositionHelper.BlankLine();
+
+        InputFieldWithLabel bandageGraphicInput = new("Bandage graphic ID", ThemeSettings.INPUT_WIDTH, profile.BandageAgentGraphic.ToString(), true, (s, e) =>
+        {
+            if (ushort.TryParse(((BaseOptionsGump.InputField.StbTextBox)s).Text, out ushort graphic))
+            {
+                profile.BandageAgentGraphic = graphic;
+            }
+        });
+        bandageGraphicInput.SetTooltip("Graphic ID of bandages to use (default: 0x0E21)");
+        scroll.Add(PositionHelper.PositionControl(bandageGraphicInput));
+    }
+
     public enum PAGE
     {
         None,
@@ -488,7 +537,8 @@ public class AssistantGump : BaseOptionsGump
         HUD,
         SpellIndicator,
         JournalFilter,
-        TitleBar
+        TitleBar,
+        BandageAgent
     }
 
     #region CustomControls

--- a/src/ClassicUO.Client/Network/PacketHandlers.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers.cs
@@ -399,6 +399,7 @@ namespace ClassicUO.Network
                 TargetManager.Target(World.Party.PartyHealTarget);
                 World.Party.PartyHealTimer = 0;
                 World.Party.PartyHealTarget = 0;
+                TargetManager.NextAutoTarget.Clear(); // Clear any queued auto-target
             }
             else if (TargetManager.NextAutoTarget.IsSet)
             {


### PR DESCRIPTION
<img width="925" height="708" alt="image" src="https://github.com/user-attachments/assets/e9f50882-62f7-4e1d-ade0-15fdb6414330" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Auto Bandage agent with configurable options: enable/disable, heal delay, HP threshold, skip when a healing buff is active, packet mode, and bandage item graphic.
  * New “Auto Bandage” page in the Assistant panel with tooltips and inputs to manage these settings.
  * Auto-targeting support added to automatically target yourself during bandaging for fewer clicks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->