### PR TITLE
Add Mount, SetMount to macros and API

### DIFF
--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -517,6 +517,8 @@ namespace ClassicUO.Configuration
 
         public int TextBorderSize { get; set; } = 1;
 
+        public uint SavedMountSerial { get; set; } = 0;
+
         public bool UseModernShopGump { get; set; } = false;
 
         public int MaxJournalEntries { get; set; } = 250;

--- a/src/ClassicUO.Client/Game/Managers/MacroManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/MacroManager.cs
@@ -2717,11 +2717,11 @@ namespace ClassicUO.Game.Managers
         SpellBarRowUp,
         SpellBarRowDown,
         Dismount,
-        Mount,
-        SetMount,
         ToggleHouses,
         ToggleHudVisible,
-        Resync
+        Resync,
+        Mount,
+        SetMount,
     }
 
     public enum MacroSubType

--- a/src/ClassicUO.Client/Game/Managers/MacroManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/MacroManager.cs
@@ -1122,8 +1122,35 @@ namespace ClassicUO.Game.Managers
                     var m = World.Player.FindItemByLayer(Layer.Mount);
                     if (m != null)
                     {
-                        GameActions.DoubleClick(World.Player);
+                        GameActions.DoubleClickQueued(World.Player);
                     }
+                    break;
+
+                case MacroType.Mount:
+                    if (ProfileManager.CurrentProfile.SavedMountSerial != 0)
+                    {
+                        Entity mount = World.Get(ProfileManager.CurrentProfile.SavedMountSerial);
+                        if (mount != null)
+                        {
+                            GameActions.DoubleClickQueued(ProfileManager.CurrentProfile.SavedMountSerial);
+                        }
+                        else
+                        {
+                            GameActions.Print("Saved mount not found. Target a new mount.", 32);
+                            TargetManager.SetTargeting(CursorTarget.SetMount, 0, TargetType.Neutral);
+                        }
+                    }
+                    else
+                    {
+                        GameActions.Print("No mount set. Target a mount to save it.", 48);
+                        TargetManager.SetTargeting(CursorTarget.SetMount, 0, TargetType.Neutral);
+                        result = 1;
+                    }
+                    break;
+
+                case MacroType.SetMount:
+                    GameActions.Print("Target a mount to save it for the Mount macro.", 48);
+                    TargetManager.SetTargeting(CursorTarget.SetMount, 0, TargetType.Neutral);
                     break;
 
                 case MacroType.OpenDoor:
@@ -2690,6 +2717,8 @@ namespace ClassicUO.Game.Managers
         SpellBarRowUp,
         SpellBarRowDown,
         Dismount,
+        Mount,
+        SetMount,
         ToggleHouses,
         ToggleHudVisible,
         Resync

--- a/src/ClassicUO.Client/Game/Managers/TargetManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/TargetManager.cs
@@ -58,6 +58,7 @@ namespace ClassicUO.Game.Managers
         SetTargetClientSide = 3,
         Grab,
         SetGrabBag,
+        SetMount,
         HueCommandTarget,
         IgnorePlayerTarget,
         MoveItemContainer,
@@ -494,6 +495,24 @@ namespace ClassicUO.Game.Managers
                         ClearTargetingWithoutTargetCancelPacket();
 
                         return;
+
+                    case CursorTarget.SetMount:
+
+                        if (SerialHelper.IsMobile(serial))
+                        {
+                            ProfileManager.CurrentProfile.SavedMountSerial = serial;
+                            Entity mount = World.Get(serial);
+                            string mountName = mount?.Name ?? "mount";
+                            GameActions.Print($"Mount set: {mountName} (Serial: {serial})", 48);
+                        }
+                        else
+                        {
+                            GameActions.Print("You must target a mobile/creature to set as your mount.", 32);
+                        }
+
+                        ClearTargetingWithoutTargetCancelPacket();
+
+                        return;
                     case CursorTarget.SetFavoriteMoveBag:
                         if (SerialHelper.IsItem(serial))
                         {
@@ -527,6 +546,25 @@ namespace ClassicUO.Game.Managers
                         if (SerialHelper.IsItem(serial))
                         {
                             MultiItemMoveGump.OnContainerTarget(serial);
+                        }
+                        ClearTargetingWithoutTargetCancelPacket();
+                        return;
+                }
+            }
+            else
+            {
+                // Handle cases where entity is null but we still want to use the serial
+                switch (TargetingState)
+                {
+                    case CursorTarget.SetMount:
+                        if (SerialHelper.IsMobile(serial))
+                        {
+                            ProfileManager.CurrentProfile.SavedMountSerial = serial;
+                            GameActions.Print($"Mount set (Serial: {serial})", 48);
+                        }
+                        else
+                        {
+                            GameActions.Print("You must target a mobile/creature to set as your mount.", 32);
                         }
                         ClearTargetingWithoutTargetCancelPacket();
                         return;

--- a/src/ClassicUO.Client/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameSceneInputHandler.cs
@@ -796,6 +796,24 @@ namespace ClassicUO.Game.Scenes
                             }
                         }
                         break;
+                    case CursorTarget.SetMount:
+                        if (SelectedObject.Object is Mobile m)
+                        {
+                            if (SerialHelper.IsMobile(m))
+                            {
+                                ProfileManager.CurrentProfile.SavedMountSerial = m;
+                                Entity mount = World.Get(m);
+                                string mountName = mount?.Name ?? "mount";
+                                GameActions.Print($"Mount set: {mountName} (Serial: {m.Serial})", 48);
+                            }
+                            TargetManager.Reset();
+                        }
+                        else
+                        {
+                            GameActions.Print("You must target a mobile/creature to set as your mount.", 32);
+                        }
+
+                        break;
                 }
             }
             else

--- a/src/ClassicUO.Client/LegionScripting/API.cs
+++ b/src/ClassicUO.Client/LegionScripting/API.cs
@@ -1330,17 +1330,26 @@ namespace ClassicUO.LegionScripting
         /// API.Mount(0x12345678)
         /// ```
         /// </summary>
-        /// <param name="serial"></param>
+        /// <param name="serial">Defaults to saved mount</param>
         /// <param name="skipQueue">Defaults true, set to false to use a double click queue</param>
-        public void Mount(uint serial, bool skipQueue = true) => MainThreadQueue.InvokeOnMainThread
-        (() =>
+        public void Mount(uint serial = uint.MaxValue, bool skipQueue = true) => MainThreadQueue.InvokeOnMainThread
+        (void () =>
             {
+                if (serial == uint.MaxValue)
+                    serial = ProfileManager.CurrentProfile.SavedMountSerial;
+
                 if (skipQueue)
                     GameActions.DoubleClick(serial);
                 else
                     GameActions.DoubleClickQueued(serial);
             }
         );
+
+        /// <summary>
+        /// This will set your saved mount for this character.
+        /// </summary>
+        /// <param name="serial"></param>
+        public void SetMount(uint serial) => MainThreadQueue.InvokeOnMainThread(void () => ProfileManager.CurrentProfile.SavedMountSerial = serial);
 
         /// <summary>
         /// Wait for a target cursor.

--- a/src/ClassicUO.Client/LegionScripting/API.cs
+++ b/src/ClassicUO.Client/LegionScripting/API.cs
@@ -1333,7 +1333,7 @@ namespace ClassicUO.LegionScripting
         /// <param name="serial">Defaults to saved mount</param>
         /// <param name="skipQueue">Defaults true, set to false to use a double click queue</param>
         public void Mount(uint serial = uint.MaxValue, bool skipQueue = true) => MainThreadQueue.InvokeOnMainThread
-        (void () =>
+        (() =>
             {
                 if (serial == uint.MaxValue)
                     serial = ProfileManager.CurrentProfile.SavedMountSerial;
@@ -1349,7 +1349,10 @@ namespace ClassicUO.LegionScripting
         /// This will set your saved mount for this character.
         /// </summary>
         /// <param name="serial"></param>
-        public void SetMount(uint serial) => MainThreadQueue.InvokeOnMainThread(void () => ProfileManager.CurrentProfile.SavedMountSerial = serial);
+        public void SetMount(uint serial) => MainThreadQueue.InvokeOnMainThread(() =>
+        {
+            ProfileManager.CurrentProfile.SavedMountSerial = serial;
+        });
 
         /// <summary>
         /// Wait for a target cursor.

--- a/src/ClassicUO.Client/LegionScripting/docs/API.md
+++ b/src/ClassicUO.Client/LegionScripting/docs/API.md
@@ -21,7 +21,7 @@ You can now type `-updateapi` in game to download the latest API.py file.
 
 [Additional notes](../notes/)  
 
-*This was generated on `8/13/25`.*
+*This was generated on `8/18/25`.*
 
 ## Properties
 ### `JournalEntries`
@@ -1253,8 +1253,23 @@ You can now type `-updateapi` in game to download the latest API.py file.
 
 | Name | Type | Optional | Description |
 | --- | --- | --- | --- |
-| `serial` | `uint` | ❌ No |  |
+| `serial` | `uint` | ✅ Yes | Defaults to saved mount |
 | `skipQueue` | `bool` | ✅ Yes | Defaults true, set to false to use a double click queue |
+
+**Return Type:** `void` *(Does not return anything)*
+
+---
+
+### SetMount
+`(serial)`
+ This will set your saved mount for this character.
+
+
+**Parameters:**
+
+| Name | Type | Optional | Description |
+| --- | --- | --- | --- |
+| `serial` | `uint` | ❌ No |  |
 
 **Return Type:** `void` *(Does not return anything)*
 

--- a/src/ClassicUO.Client/LegionScripting/docs/API.py
+++ b/src/ClassicUO.Client/LegionScripting/docs/API.py
@@ -881,13 +881,20 @@ def Dismount(skipQueue: bool = True) -> None:
     """
     pass
 
-def Mount(serial: int, skipQueue: bool = True) -> None:
+def Mount(serial: int = 1337, skipQueue: bool = True) -> None:
     """
      Attempt to mount(double click)
      Example:
      ```py
      API.Mount(0x12345678)
      ```
+    
+    """
+    pass
+
+def SetMount(serial: int) -> None:
+    """
+     This will set your saved mount for this character.
     
     """
     pass


### PR DESCRIPTION
*Dismount was already in.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added “Mount” and “Set Mount” macros to save and use a preferred creature, with on-screen confirmations and guidance when none is set.
  - You can target a mount via the cursor to save it for future use.
  - Dismount actions are now queued for smoother, more reliable execution.

- **Documentation**
  - Scripting/API updated: Mount defaults to the saved mount (serial optional) and a new SetMount(serial) API is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->