### PR TITLE
Add GetStaticsAt and GetStaticsInArea to python API

### DIFF
--- a/src/ClassicUO.Client/LegionScripting/API.cs
+++ b/src/ClassicUO.Client/LegionScripting/API.cs
@@ -2273,6 +2273,93 @@ namespace ClassicUO.LegionScripting
         /// <returns>A GameObject of that location.</returns>
         public PyGameObject GetTile(int x, int y) => MainThreadQueue.InvokeOnMainThread(() => { return new PyGameObject(World.Map.GetTile(x, y)); });
 
+        /// <summary>
+        /// Gets all static objects at a specific position (x, y coordinates).
+        /// This includes trees, vegetation, buildings, and other non-movable scenery.
+        /// Example:
+        /// ```py
+        /// statics = API.GetStaticsAt(1000, 1000)
+        /// for static in statics:
+        ///     API.Print(f"Static ID: {static.ID}, Z: {static.Z}")
+        /// ```
+        /// </summary>
+        /// <param name="x">X coordinate</param>
+        /// <param name="y">Y coordinate</param>
+        /// <returns>List of PyStatic objects at the specified position</returns>
+        public List<PyStatic> GetStaticsAt(int x, int y) => MainThreadQueue.InvokeOnMainThread(() =>
+        {
+            var statics = new List<PyStatic>();
+            var chunk = World.Map.GetChunk(x, y);
+
+            if (chunk != null)
+            {
+                var obj = chunk.GetHeadObject(x % 8, y % 8);
+
+                while (obj != null)
+                {
+                    if (obj is Static staticObj)
+                    {
+                        statics.Add(new PyStatic(staticObj));
+                    }
+                    obj = obj.TNext;
+                }
+            }
+
+            return statics;
+        });
+
+        /// <summary>
+        /// Gets all static objects within a rectangular area defined by coordinates.
+        /// This includes trees, vegetation, buildings, and other non-movable scenery.
+        /// Example:
+        /// ```py
+        /// statics = API.GetStaticsInArea(1000, 1000, 1010, 1010)
+        /// API.Print(f"Found {len(statics)} statics in area")
+        /// for static in statics:
+        ///     if static.IsVegetation:
+        ///         API.Print(f"Vegetation at {static.X}, {static.Y}")
+        /// ```
+        /// </summary>
+        /// <param name="x1">Starting X coordinate</param>
+        /// <param name="y1">Starting Y coordinate</param>
+        /// <param name="x2">Ending X coordinate</param>
+        /// <param name="y2">Ending Y coordinate</param>
+        /// <returns>List of PyStatic objects within the specified area</returns>
+        public List<PyStatic> GetStaticsInArea(int x1, int y1, int x2, int y2) => MainThreadQueue.InvokeOnMainThread(() =>
+        {
+            var statics = new List<PyStatic>();
+
+            // Ensure coordinates are in correct order
+            int minX = Math.Min(x1, x2);
+            int maxX = Math.Max(x1, x2);
+            int minY = Math.Min(y1, y2);
+            int maxY = Math.Max(y1, y2);
+
+            for (int x = minX; x <= maxX; x++)
+            {
+                for (int y = minY; y <= maxY; y++)
+                {
+                    var chunk = World.Map.GetChunk(x, y);
+
+                    if (chunk != null)
+                    {
+                        var obj = chunk.GetHeadObject(x % 8, y % 8);
+
+                        while (obj != null)
+                        {
+                            if (obj is Static staticObj)
+                            {
+                                statics.Add(new PyStatic(staticObj));
+                            }
+                            obj = obj.TNext;
+                        }
+                    }
+                }
+            }
+
+            return statics;
+        });
+
         #region Gumps
 
         /// <summary>

--- a/src/ClassicUO.Client/LegionScripting/API.cs
+++ b/src/ClassicUO.Client/LegionScripting/API.cs
@@ -2279,8 +2279,8 @@ namespace ClassicUO.LegionScripting
         /// Example:
         /// ```py
         /// statics = API.GetStaticsAt(1000, 1000)
-        /// for static in statics:
-        ///     API.Print(f"Static ID: {static.ID}, Z: {static.Z}")
+        /// for s in statics:
+        ///     API.SysMsg(f"Static Graphic: {s.Graphic}, Z: {s.Z}")
         /// ```
         /// </summary>
         /// <param name="x">X coordinate</param>
@@ -2289,7 +2289,10 @@ namespace ClassicUO.LegionScripting
         public List<PyStatic> GetStaticsAt(int x, int y) => MainThreadQueue.InvokeOnMainThread(() =>
         {
             var statics = new List<PyStatic>();
-            var chunk = World.Map.GetChunk(x, y);
+            
+            if (World.Map is null) return new List<PyStatic>();
+            
+            var chunk = World.Map.GetChunk(x, y, false);
 
             if (chunk != null)
             {
@@ -2314,10 +2317,10 @@ namespace ClassicUO.LegionScripting
         /// Example:
         /// ```py
         /// statics = API.GetStaticsInArea(1000, 1000, 1010, 1010)
-        /// API.Print(f"Found {len(statics)} statics in area")
-        /// for static in statics:
-        ///     if static.IsVegetation:
-        ///         API.Print(f"Vegetation at {static.X}, {static.Y}")
+        /// API.SysMsg(f"Found {len(statics)} statics in area")
+        /// for s in statics:
+        ///     if s.IsVegetation:
+        ///         API.SysMsg(f"Vegetation Graphic: {s.Graphic} at {s.X}, {s.Y}")
         /// ```
         /// </summary>
         /// <param name="x1">Starting X coordinate</param>
@@ -2328,6 +2331,8 @@ namespace ClassicUO.LegionScripting
         public List<PyStatic> GetStaticsInArea(int x1, int y1, int x2, int y2) => MainThreadQueue.InvokeOnMainThread(() =>
         {
             var statics = new List<PyStatic>();
+            
+            if (World.Map is null) return new List<PyStatic>();
 
             // Ensure coordinates are in correct order
             int minX = Math.Min(x1, x2);
@@ -2339,7 +2344,7 @@ namespace ClassicUO.LegionScripting
             {
                 for (int y = minY; y <= maxY; y++)
                 {
-                    var chunk = World.Map.GetChunk(x, y);
+                    var chunk = World.Map.GetChunk(x, y, false);
 
                     if (chunk != null)
                     {

--- a/src/ClassicUO.Client/LegionScripting/PyClasses/PyStatic.cs
+++ b/src/ClassicUO.Client/LegionScripting/PyClasses/PyStatic.cs
@@ -18,14 +18,14 @@ public class PyStatic : PyGameObject
     /// <summary>
     /// Initializes a new instance of the <see cref="PyStatic"/> class from a <see cref="Static"/> object.
     /// </summary>
-    /// <param name="static">The static object to wrap.</param>
-    internal PyStatic(Static @static) : base(@static)
+    /// <param name="staticObj">The static object to wrap.</param>
+    internal PyStatic(Static staticObj) : base(staticObj)
     {
-        IsImpassible = @static.ItemData.IsImpassable;
-        Graphic = @static.OriginalGraphic;
-        IsVegetation = @static.IsVegetation;
-        X = @static.X;
-        Y = @static.Y;
+        IsImpassible = staticObj.ItemData.IsImpassable;
+        Graphic = staticObj.OriginalGraphic;
+        IsVegetation = staticObj.IsVegetation;
+        X = staticObj.X;
+        Y = staticObj.Y;
     }
 
     /// <summary>

--- a/src/ClassicUO.Client/LegionScripting/PyClasses/PyStatic.cs
+++ b/src/ClassicUO.Client/LegionScripting/PyClasses/PyStatic.cs
@@ -9,12 +9,23 @@ namespace ClassicUO.LegionScripting.PyClasses;
 /// </summary>
 public class PyStatic : PyGameObject
 {
+    public bool IsImpassible { get; }
+    public ushort Graphic { get; }
+    public bool IsVegetation { get; }
+    public int X { get; }
+    public int Y { get; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="PyStatic"/> class from a <see cref="Static"/> object.
     /// </summary>
     /// <param name="static">The static object to wrap.</param>
     internal PyStatic(Static @static) : base(@static)
     {
+        IsImpassible = @static.ItemData.IsImpassable;
+        Graphic = @static.OriginalGraphic;
+        IsVegetation = @static.IsVegetation;
+        X = @static.X;
+        Y = @static.Y;
     }
 
     /// <summary>

--- a/src/ClassicUO.Client/LegionScripting/docs/API.md
+++ b/src/ClassicUO.Client/LegionScripting/docs/API.md
@@ -21,7 +21,7 @@ You can now type `-updateapi` in game to download the latest API.py file.
 
 [Additional notes](../notes/)  
 
-*This was generated on `8/13/25`.*
+*This was generated on `8/18/25`.*
 
 ## Properties
 ### `JournalEntries`
@@ -2006,6 +2006,56 @@ You can now type `-updateapi` in game to download the latest API.py file.
 | `y` | `int` | ❌ No |  |
 
 **Return Type:** `PyGameObject`
+
+---
+
+### GetStaticsAt
+`(x, y)`
+ Gets all static objects at a specific position (x, y coordinates).
+ This includes trees, vegetation, buildings, and other non-movable scenery.
+ Example:
+ ```py
+ statics = API.GetStaticsAt(1000, 1000)
+ for static in statics:
+     API.Print(f"Static ID: {static.ID}, Z: {static.Z}")
+ ```
+
+
+**Parameters:**
+
+| Name | Type | Optional | Description |
+| --- | --- | --- | --- |
+| `x` | `int` | ❌ No | X coordinate |
+| `y` | `int` | ❌ No | Y coordinate |
+
+**Return Type:** `List<PyStatic>`
+
+---
+
+### GetStaticsInArea
+`(x1, y1, x2, y2)`
+ Gets all static objects within a rectangular area defined by coordinates.
+ This includes trees, vegetation, buildings, and other non-movable scenery.
+ Example:
+ ```py
+ statics = API.GetStaticsInArea(1000, 1000, 1010, 1010)
+ API.Print(f"Found {len(statics)} statics in area")
+ for static in statics:
+     if static.IsVegetation:
+         API.Print(f"Vegetation at {static.X}, {static.Y}")
+ ```
+
+
+**Parameters:**
+
+| Name | Type | Optional | Description |
+| --- | --- | --- | --- |
+| `x1` | `int` | ❌ No | Starting X coordinate |
+| `y1` | `int` | ❌ No | Starting Y coordinate |
+| `x2` | `int` | ❌ No | Ending X coordinate |
+| `y2` | `int` | ❌ No | Ending Y coordinate |
+
+**Return Type:** `List<PyStatic>`
 
 ---
 

--- a/src/ClassicUO.Client/LegionScripting/docs/API.md
+++ b/src/ClassicUO.Client/LegionScripting/docs/API.md
@@ -2016,8 +2016,8 @@ You can now type `-updateapi` in game to download the latest API.py file.
  Example:
  ```py
  statics = API.GetStaticsAt(1000, 1000)
- for static in statics:
-     API.Print(f"Static ID: {static.ID}, Z: {static.Z}")
+ for s in statics:
+     API.SysMsg(f"Static Graphic: {s.Graphic}, Z: {s.Z}")
  ```
 
 
@@ -2039,10 +2039,10 @@ You can now type `-updateapi` in game to download the latest API.py file.
  Example:
  ```py
  statics = API.GetStaticsInArea(1000, 1000, 1010, 1010)
- API.Print(f"Found {len(statics)} statics in area")
- for static in statics:
-     if static.IsVegetation:
-         API.Print(f"Vegetation at {static.X}, {static.Y}")
+ API.SysMsg(f"Found {len(statics)} statics in area")
+ for s in statics:
+     if s.IsVegetation:
+         API.SysMsg(f"Vegetation Graphic: {s.Graphic} at {s.X}, {s.Y}")
  ```
 
 

--- a/src/ClassicUO.Client/LegionScripting/docs/API.py
+++ b/src/ClassicUO.Client/LegionScripting/docs/API.py
@@ -151,6 +151,11 @@ class PyProfile:
     AutoLootEnabled: bool = None
 
 class PyStatic:
+    IsImpassible: bool = None
+    Graphic: int = None
+    IsVegetation: bool = None
+    X: int = None
+    Y: int = None
     __class__: str = None
 
 JournalEntries = None
@@ -1372,6 +1377,36 @@ def GetTile(x: int, y: int) -> PyGameObject:
      tile = API.GetTile(1414, 1515)
      if tile:
        API.SysMsg(f"Found a tile with graphic: {tile.Graphic}")
+     ```
+    
+    """
+    pass
+
+def GetStaticsAt(x: int, y: int) -> list[Any]:
+    """
+     Gets all static objects at a specific position (x, y coordinates).
+     This includes trees, vegetation, buildings, and other non-movable scenery.
+     Example:
+     ```py
+     statics = API.GetStaticsAt(1000, 1000)
+     for static in statics:
+         API.Print(f"Static ID: {static.ID}, Z: {static.Z}")
+     ```
+    
+    """
+    pass
+
+def GetStaticsInArea(x1: int, y1: int, x2: int, y2: int) -> list[Any]:
+    """
+     Gets all static objects within a rectangular area defined by coordinates.
+     This includes trees, vegetation, buildings, and other non-movable scenery.
+     Example:
+     ```py
+     statics = API.GetStaticsInArea(1000, 1000, 1010, 1010)
+     API.Print(f"Found {len(statics)} statics in area")
+     for static in statics:
+         if static.IsVegetation:
+             API.Print(f"Vegetation at {static.X}, {static.Y}")
      ```
     
     """

--- a/src/ClassicUO.Client/LegionScripting/docs/API.py
+++ b/src/ClassicUO.Client/LegionScripting/docs/API.py
@@ -1389,8 +1389,8 @@ def GetStaticsAt(x: int, y: int) -> list[Any]:
      Example:
      ```py
      statics = API.GetStaticsAt(1000, 1000)
-     for static in statics:
-         API.Print(f"Static ID: {static.ID}, Z: {static.Z}")
+     for s in statics:
+         API.SysMsg(f"Static Graphic: {s.Graphic}, Z: {s.Z}")
      ```
     
     """
@@ -1403,10 +1403,10 @@ def GetStaticsInArea(x1: int, y1: int, x2: int, y2: int) -> list[Any]:
      Example:
      ```py
      statics = API.GetStaticsInArea(1000, 1000, 1010, 1010)
-     API.Print(f"Found {len(statics)} statics in area")
-     for static in statics:
-         if static.IsVegetation:
-             API.Print(f"Vegetation at {static.X}, {static.Y}")
+     API.SysMsg(f"Found {len(statics)} statics in area")
+     for s in statics:
+         if s.IsVegetation:
+             API.SysMsg(f"Vegetation Graphic: {s.Graphic} at {s.X}, {s.Y}")
      ```
     
     """

--- a/src/ClassicUO.Client/LegionScripting/docs/PyStatic.md
+++ b/src/ClassicUO.Client/LegionScripting/docs/PyStatic.md
@@ -9,6 +9,26 @@ description:  Represents a Python-accessible static object (non-interactive scen
 
 
 ## Properties
+### `IsImpassible`
+
+**Type:** `bool`
+
+### `Graphic`
+
+**Type:** `ushort`
+
+### `IsVegetation`
+
+**Type:** `bool`
+
+### `X`
+
+**Type:** `int`
+
+### `Y`
+
+**Type:** `int`
+
 ### `__class__`
 
 **Type:** `string`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added scripting APIs to list static objects at a specific tile (GetStaticsAt) or within a rectangular area (GetStaticsInArea).
  - Enhanced PyStatic with new read-only properties: IsImpassible, Graphic, IsVegetation, X, and Y for easier filtering and inspection.

- Documentation
  - Updated API docs, class docs, and Python stubs with the new functions, PyStatic attributes, examples, and updated metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->