### PR TITLE
Add restock and min-on-hand to buy/sell agents

### DIFF
--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -641,6 +641,8 @@ namespace ClassicUO.Configuration
         public int SellAgentMaxUniques { get; set; } = 50;
         public int SellAgentMaxItems { get; set; } = 0;
         public bool BuyAgentEnabled { get; set; }
+        public int BuyAgentMaxUniques { get; set; } = 50;
+        public int BuyAgentMaxItems { get; set; } = 0;
         public bool DisableTargetingGridContainers { get; set; }
         public bool ControllerEnabled { get; set; } = true;
         public bool EnableScavenger { get; set; } = true;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added per-item “Restock Up To” to cap buys and keep minimum stock when selling.
  - Auto Buy now supports global caps: “Max total items (0 = unlimited)” and “Max unique items,” configurable via new sliders.
- Style
  - Configuration screens updated to a clearer 5‑column layout.
  - Added “Restock Up To” field to Buy/Sell and Graphic Filter entries.
  - Improved tooltips and smoother layout refresh when adding/removing entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->