### PR TITLE
wiki: Feature bot to point TazUO instead of git

### DIFF
--- a/FeaturesBot.py
+++ b/FeaturesBot.py
@@ -8,7 +8,7 @@ motd = [
 [ Auto Bandage ]
 ```
 > TazUO added auto bandaging to keep you healed. \n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/Auto-Bandage>
+See more -> <https://tazuo.org/wiki/auto-bandage>
 """,
 
 """
@@ -16,7 +16,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/Auto-Bandage>
 [ Profile backups ]
 ```
 > TazUO backs up your profiles 3 times, just in-case. \n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Profile-Backups>
+See more -> <https://tazuo.org/wiki/tazuoprofile-backups>
 """,
 
 """
@@ -24,7 +24,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Profile-Backups>
 [ Toggle hud visibility ]
 ```
 > You can quickly hide/show your gumps on screen to keep your screen de-cluttered. \n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Hide-Hud>
+See more -> <https://tazuo.org/wiki/tazuohide-hud>
 """,
 
 """
@@ -39,7 +39,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Hide-Hud>
 [ Spell bar ]
 ```
 > TazUO added a spell bar to easily manage, store, and cast spells via hotkey or click. \n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.SpellBar>
+See more -> <https://tazuo.org/wiki/tazuospellbar>
 """,
 
 """
@@ -55,7 +55,7 @@ Top Menu -> More -> Tools -> Quick spell cast
 [ Python Scripting ]
 ```
 > TazUO added built-in pthon scripting to the client. \n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Legion-Scripting>
+See more -> <https://tazuo.org/wiki/tazuolegion-scripting>
 """,
 
 """
@@ -63,7 +63,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Legion-Scripting>
 [ Legion Scripting ]
 ```
 > TazUO added a custom scripting language similar to UOSteam built directly into the client. \n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Legion-Scripting>
+See more -> <https://tazuo.org/wiki/tazuolegion-scripting>
 """,
 
 """
@@ -113,7 +113,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Legion-Scripting>
 [ Advance nameplate options ]
 ```
 > TUO added a very customizable nameplate system.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Nameplate-options>
+See more -> <https://tazuo.org/wiki/tazuonameplate-options>
 """,
 
 """
@@ -121,7 +121,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Nameplate-options>
 [ Spell casting indicators ]
 ```
 > TUO added a very customizable spell casting indicator system, including displaying range, cast time, and area size.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Spell-Indicators>
+See more -> <https://tazuo.org/wiki/tazuospell-indicators>
 """,
 
 """
@@ -136,7 +136,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Spell-Indicators>
 [ Simple auto loot ]
 ```
 > TUO added a simple auto loot feature in `3.10.0`, check out the wiki for more info.\n
-`Options->TazUO->Misc` | <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Simple-Auto-Loot>
+`Options->TazUO->Misc` | <https://tazuo.org/wiki/tazuosimple-auto-loot>
 """,
 
 """
@@ -144,7 +144,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Spell-Indicators>
 [ Health indicator ]
 ```
 > TUO added a simple health indicator(red border around the window) to more easily notice when your health drops.\n
-`Options->TazUO->Misc` | <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Miscellaneous#health-indicator>
+`Options->TazUO->Misc` | <https://tazuo.org/wiki/tazuomiscellaneous#health-indicator>
 """,
 
 """
@@ -168,7 +168,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Spell-Indicators>
 [ Journal Entries ]
 ```
 > TUO allows you to adjust how many journal entries to save, from 200-2000.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Journal>
+See more -> <https://tazuo.org/wiki/tazuojournal>
 """,
 
 """
@@ -176,7 +176,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Journal>
 [ Sound overrides ]
 ```
 > TUO allows you to easily override sounds without modifying your client.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TUO.Sound-Override>
+See more -> <https://tazuo.org/wiki/tuo.sound-override>
 """,
 
 """
@@ -184,7 +184,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TUO.Sound-Override>
 [ -colorpicker command ]
 ```
 > TUO added an easy way to browse colors in your UO install, try it out.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Commands#-colorpicker>
+See more -> <https://tazuo.org/wiki/tazuocommands#-colorpicker>
 """,
 
 """
@@ -192,7 +192,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Commands#-colorpicker
 [ -radius command ]
 ```
 > TUO added an easy way to see a precise radius around you, see the wiki for screenshots and instructions.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Commands#-radius>
+See more -> <https://tazuo.org/wiki/tazuocommands#-radius>
 """,
 
 """
@@ -200,7 +200,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Commands#-radius>
 [ Skill progress bar ]
 ```
 > TUO added progress bars when your skills increase or decrease.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Skill-Progress-Bar>
+See more -> <https://tazuo.org/wiki/tazuoskill-progress-bar>
 """,
 
 """
@@ -208,7 +208,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Skill-Progress-Bar>
 [ Account selector ]
 ```
 > A simple right-click on the account input of the login screen will bring up an option to select other accounts you have logged into.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Account-Selector>
+See more -> <https://tazuo.org/wiki/tazuoaccount-selector>
 """,
 
 """
@@ -216,7 +216,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Account-Selector>
 [ Alternate paperdoll ]
 ```
 > TUO has a more mordern alternative to the original paperdoll gump.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Alternate-Paperdoll>
+See more -> <https://tazuo.org/wiki/tazuoalternate-paperdoll>
 """,
 
 """
@@ -224,7 +224,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Alternate-Paperdoll>
 [ Improved buff bar ]
 ```
 > TUO has an improved buff bar with a customizable progress bar letting you easily see when that buff will expire.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Buff-Bars>
+See more -> <https://tazuo.org/wiki/tazuobuff-bars>
 """,
 
 """
@@ -232,7 +232,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Buff-Bars>
 [ Circle of transparency ]
 ```
 > TUO has added a new type of circle of transparency and increased the max radius from 200 -> 1000.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Circle-of-transparency>
+See more -> <https://tazuo.org/wiki/tazuocircle-of-transparency>
 """,
 
 """
@@ -240,7 +240,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Circle-of-transparenc
 [ Cast command ]
 ```
 > TUO added a `-cast SPELLNAME` command to easily cast spells.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Commands#-cast-spellname>
+See more -> <https://tazuo.org/wiki/tazuocommands#-cast-spellname>
 """,
 
 """
@@ -248,7 +248,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Commands#-cast-spelln
 [ Skill command ]
 ```
 > TUO added a `-skill SKILLNAME` command to easily use skills.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Commands#-skill-skillname>
+See more -> <https://tazuo.org/wiki/tazuocommands#-skill-skillname>
 """,
 
 """
@@ -256,7 +256,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Commands#-skill-skill
 [ Marktile command ]
 ```
 > TUO added a `-marktile` command to highlight specific places in game on the ground. Screenshots and more details available on the wiki.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Commands#-marktile>
+See more -> <https://tazuo.org/wiki/tazuocommands#-marktile>
 """,
 
 """
@@ -264,7 +264,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Commands#-marktile>
 [ Customizable cooldown bars ]
 ```
 > TUO added customizable cool down bars that can be triggered on the text of your choosing, be sure to see the wiki for screenshots and instructions.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Cooldown-bars>
+See more -> <https://tazuo.org/wiki/tazuocooldown-bars>
 """,
 
 """
@@ -272,7 +272,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Cooldown-bars>
 [ Custom healthbar additions ]
 ```
 > TUO further enhanced the custom healthbars with distance indicators, see the wiki for screenshots and more details.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Custom-Health-Bar>
+See more -> <https://tazuo.org/wiki/tazuocustom-health-bar>
 """,
 
 """
@@ -280,7 +280,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Custom-Health-Bar>
 [ Damage number hues ]
 ```
 > In TUO you can customize the colors for different types of damage numbers on screen.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Damage-number-hues>
+See more -> <https://tazuo.org/wiki/tazuodamage-number-hues>
 """,
 
 """
@@ -288,7 +288,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Damage-number-hues>
 [ Drag select modifiers ]
 ```
 > TUO added a few optional key modifiers to the drag select(for opening many healthbars at once). See the wiki for a more detailed explanation.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Drag-Select-Modifiers>
+See more -> <https://tazuo.org/wiki/tazuodrag-select-modifiers>
 """,
 
 """
@@ -296,7 +296,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Drag-Select-Modifiers
 [ Durability gump ]
 ```
 > TUO added a new durability gump to easily track durability of items, see the wiki for screenshots and more details.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Durability-Gump>
+See more -> <https://tazuo.org/wiki/tazuodurability-gump>
 """,
 
 """
@@ -304,7 +304,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Durability-Gump>
 [ Follow mode ]
 ```
 > TUO modified the `alt + left click` to follow a player or npc, now you can adjust the follow distance and alt clicking their healthbar instead of the mobile themselves.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Follow-mode>
+See more -> <https://tazuo.org/wiki/tazuofollow-mode>
 """,
 
 """
@@ -312,7 +312,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Follow-mode>
 [ Grid highlighting based on item properties ]
 ```
 > TUO allows you to set up custom rules to highlight specific items in a grid container, allowing you to easily see the items that hold value to you.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Grid-highlighting-based-on-item-properties>
+See more -> <https://tazuo.org/wiki/tazuogrid-highlighting-based-on-item-properties>
 """,
 
 """
@@ -320,7 +320,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Grid-highlighting-bas
 [ Health Lines ]
 ```
 > TUO added the option to scale the size of health lines underneath mobiles.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Health-Lines>
+See more -> <https://tazuo.org/wiki/tazuohealth-lines>
 """,
 
 """
@@ -328,7 +328,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Health-Lines>
 [ Hidden Characters ]
 ```
 > TUO added the option to customize what you look like while hidden with colors and opacity.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Hidden-Characters>
+See more -> <https://tazuo.org/wiki/tazuohidden-characters>
 """,
 
 """
@@ -336,7 +336,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Hidden-Characters>
 [ Hidden gump lock ]
 ```
 > Most gumps can be locked in place to prevent accidental movement or closing by `Ctrl + Alt + Left Click` the gump.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Hidden-Gump-Features#hidden-gump-lock>
+See more -> <https://tazuo.org/wiki/tazuohidden-gump-features#hidden-gump-lock>
 """,
 
 """
@@ -344,7 +344,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Hidden-Gump-Features#
 [ Hidden gump opacity ]
 ```
 > Most gumps can have their opacity adjusted by holding `Ctrl + Alt` while scrolling over them.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Hidden-Gump-Features#ctrl--alt--mouse-wheel-opacity-adjustment>
+See more -> <https://tazuo.org/wiki/tazuohidden-gump-features#ctrl--alt--mouse-wheel-opacity-adjustment>
 """,
 
 """
@@ -352,7 +352,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Hidden-Gump-Features#
 [ Info bar ]
 ```
 > TUO added the ability to use text or built-in graphics for the info bar along with customizable font and size, see the wiki for screenshots and more details.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Info-Bar>
+See more -> <https://tazuo.org/wiki/tazuoinfo-bar>
 """,
 
 """
@@ -360,7 +360,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Info-Bar>
 [ Item tooltip comparisons ]
 ```
 > TUO added the ability to compare an item in a container to the item you have equiped in that slot by pressing `Ctrl` while hovering over the item.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Item-Comparison>
+See more -> <https://tazuo.org/wiki/tazuoitem-comparison>
 """,
 
 """
@@ -368,7 +368,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Item-Comparison>
 [ Modern Journal ]
 ```
 > TUO added a much more modern and advanced journal that replaced the original.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Journal>
+See more -> <https://tazuo.org/wiki/tazuojournal>
 """,
 
 """
@@ -376,7 +376,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Journal>
 [ Grid containers ]
 ```
 > TUO added a small feature called grid containers. Not related to grid loot built into CUO. Check out all the features of this in the wiki.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Grid-Containers>
+See more -> <https://tazuo.org/wiki/tazuogrid-containers>
 """,
 
 """
@@ -384,7 +384,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Grid-Containers>
 [ Macro buttons ]
 ```
 > TUO added the ability to customize buttons with size, color and graphics for your macro buttons.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Macro-Button-Editor>
+See more -> <https://tazuo.org/wiki/tazuomacro-button-editor>
 """,
 
 """
@@ -392,7 +392,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Macro-Button-Editor>
 [ Spell icons ]
 ```
 > TUO allows you to scale spell icons, and display linked hotkeys. See the wiki for details and instructions.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Miscellaneous#spell-icons>
+See more -> <https://tazuo.org/wiki/tazuomiscellaneous#spell-icons>
 """,
 
 """
@@ -400,7 +400,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Miscellaneous#spell-i
 [ Nameplate healthbars ]
 ```
 > TUO allows nameplates to be used as healthbars. More details on the wiki.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Nameplate-Healthbars>
+See more -> <https://tazuo.org/wiki/tazuonameplate-healthbars>
 """,
 
 """
@@ -408,7 +408,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Nameplate-Healthbars>
 [ PNG replacer ]
 ```
 > TUO added the ability to replace in-game artwork with your own by using simple png files, no client modifications required.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.PNG-Replacer>
+See more -> <https://tazuo.org/wiki/tazuopng-replacer>
 """,
 
 """
@@ -416,7 +416,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.PNG-Replacer>
 [ Server owners and utilizing the chat tab ]
 ```
 > TUO added a seperate tab in the journal for built in global chat(osi friendly, works on ServUO but most servers leave it disabled). See more about how to use this simple feature on your server.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Server-Owners>
+See more -> <https://tazuo.org/wiki/tazuoserver-owners>
 """,
 
 """
@@ -424,7 +424,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Server-Owners>
 [ SOS locator ]
 ```
 > TUO made it easy to sail the seas by decoding those cryptic coords given when opening an SOS.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.SOS-Locator>
+See more -> <https://tazuo.org/wiki/tazuosos-locator>
 """,
 
 """
@@ -432,7 +432,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.SOS-Locator>
 [ Status Gumps ]
 ```
 > TUO made it so you can have your status gump and healthbar gump open at the same time!\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Status-Gump>
+See more -> <https://tazuo.org/wiki/tazuostatus-gump>
 """,
 
 """
@@ -440,7 +440,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Status-Gump>
 [ Tooltip overrides ]
 ```
 > TUO added the ability to customize tooltips in almost any way you desire, make them easy to read specific to you!\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Tooltip-Override>
+See more -> <https://tazuo.org/wiki/tazuotooltip-override>
 """,
 
 """
@@ -448,7 +448,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Tooltip-Override>
 [ Treasure map locator ]
 ```
 > TUO made it easier than ever to locate treasure via treasure maps, see how on the wiki.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Treasure-Maps-&-SOS>
+See more -> <https://tazuo.org/wiki/tazuotreasure-maps-&-sos>
 """,
 
 """
@@ -456,7 +456,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Treasure-Maps-&-SOS>
 [ Modern fonts! ]
 ```
 > TUO has made it possible to use your own fonts in many places in the game, see more in wiki.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.TTF-Fonts>
+See more -> <https://tazuo.org/wiki/tazuottf-fonts>
 """,
 
 """
@@ -464,7 +464,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.TTF-Fonts>
 [ Launcher ]
 ```
 > TUO has a launcher available to easily manage multiple profiles and check for updates to TazUO for you.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Updater-Launcher>
+See more -> <https://tazuo.org/wiki/tazuoupdater-launcher>
 """,
 
 """
@@ -472,7 +472,7 @@ See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Updater-Launcher>
 [ Quick move ]
 ```
 > TUO allows you to select multiple items and move them quickly and easily with `Alt + Left Click`.\n
-See more -> <https://github.com/PlayTazUO/TazUO/wiki/TazUO.Grid-Containers#quick-move>
+See more -> <https://tazuo.org/wiki/tazuogrid-containers#quick-move>
 """,
 ]
 

--- a/FeaturesBot.py
+++ b/FeaturesBot.py
@@ -448,7 +448,7 @@ See more -> <https://tazuo.org/wiki/tazuotooltip-override>
 [ Treasure map locator ]
 ```
 > TUO made it easier than ever to locate treasure via treasure maps, see how on the wiki.\n
-See more -> <https://tazuo.org/wiki/tazuotreasure-maps-&-sos>
+See more -> <https://tazuo.org/wiki/tazuotreasure-maps--sos/>
 """,
 
 """

--- a/FeaturesBot.py
+++ b/FeaturesBot.py
@@ -176,7 +176,7 @@ See more -> <https://tazuo.org/wiki/tazuojournal>
 [ Sound overrides ]
 ```
 > TUO allows you to easily override sounds without modifying your client.\n
-See more -> <https://tazuo.org/wiki/tuo.sound-override>
+See more -> <https://tazuo.org/wiki/tuosound-override>
 """,
 
 """


### PR DESCRIPTION
- All Links checked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new MOTD entry: "Damage numbers in your journal" with descriptive text.

* **Documentation**
  * Updated “See more” links in MOTD entries to point to the tazuo.org wiki for many features (Auto Bandage, Profile backups, HUD toggle, spell bar, scripting, nameplates, indicators, auto loot, health indicator, journal, sounds, commands, and more).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->