### PR TITLE
Return empty texture when not found to prevent crashes

### DIFF
--- a/src/ClassicUO.Assets/PNGLoader.cs
+++ b/src/ClassicUO.Assets/PNGLoader.cs
@@ -13,7 +13,8 @@ namespace ClassicUO.Assets
 
         private string exePath;
 
-        public Dictionary<string, Texture2D> EmbeddedArt = new Dictionary<string, Texture2D>();
+        private Dictionary<string, Texture2D> EmbeddedArt = new Dictionary<string, Texture2D>();
+        private Texture2D _emptyTexture;
 
         private uint[] gump_availableIDs;
         private Dictionary<uint, (uint[] pixels, int width, int height)> gump_textureCache = new Dictionary<uint, (uint[], int, int)>();
@@ -25,6 +26,23 @@ namespace ClassicUO.Assets
 
         public static PNGLoader _instance;
         public static PNGLoader Instance => _instance ?? (_instance = new PNGLoader());
+
+        public bool TryGetEmbeddedTexture(string name, out Texture2D texture)
+        {
+            if (EmbeddedArt.TryGetValue(name, out texture))
+            {
+                return true;
+            }
+
+            if (_emptyTexture == null && GraphicsDevice != null)
+            {
+                _emptyTexture = new Texture2D(GraphicsDevice, 1, 1);
+                _emptyTexture.SetData(new Color[] { Color.Transparent });
+            }
+
+            texture = _emptyTexture;
+            return false;
+        }
 
         public Texture2D GetImageTexture(string fullImagePath)
         {

--- a/src/ClassicUO.Client/Game/Data/ModernUIConstants.cs
+++ b/src/ClassicUO.Client/Game/Data/ModernUIConstants.cs
@@ -9,7 +9,7 @@ public static class ModernUIConstants
     /// Standard Modern UI Panel. Used for a general gump background.
     /// Recommended to use with the NineSliceGump class.
     /// </summary>
-    public static Texture2D ModernUIPanel => PNGLoader.Instance.EmbeddedArt["TUOGumpBg.png"];
+    public static Texture2D ModernUIPanel { get { PNGLoader.Instance.TryGetEmbeddedTexture("TUOGumpBg.png", out var texture); return texture; } }
 
     /// <summary>
     /// Border size of the modern ui panel, used for the NineSliceGump class.
@@ -21,8 +21,8 @@ public static class ModernUIConstants
     /// See ModernUIButtonDown for "clicked" texture.
     /// Recommended to use with the NineSliceGump class.
     /// </summary>
-    public static Texture2D ModernUIButtonUp => PNGLoader.Instance.EmbeddedArt["TUOUIButtonUp.png"];
-    public static Texture2D ModernUIButtonDown => PNGLoader.Instance.EmbeddedArt["TUOUIButtonDown.png"];
+    public static Texture2D ModernUIButtonUp { get { PNGLoader.Instance.TryGetEmbeddedTexture("TUOUIButtonUp.png", out var texture); return texture; } }
+    public static Texture2D ModernUIButtonDown { get { PNGLoader.Instance.TryGetEmbeddedTexture("TUOUIButtonDown.png", out var texture); return texture; } }
 
     public const int ModernUIButton_BorderSize = 4;
 }

--- a/src/ClassicUO.Client/Game/UI/Gumps/DiscordGump/DiscordGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/DiscordGump/DiscordGump.cs
@@ -88,7 +88,8 @@ public class DiscordGump : Gump
     {
         AcceptMouseInput = true;
 
-        _discordLogo = new(LEFT_WIDTH / 2 - 66, HEIGHT / 2 - 50, PNGLoader.Instance.EmbeddedArt["Discord-Symbol-Blurple-SM.png"]);
+        PNGLoader.Instance.TryGetEmbeddedTexture("Discord-Symbol-Blurple-SM.png", out var discordTexture);
+        _discordLogo = new(LEFT_WIDTH / 2 - 66, HEIGHT / 2 - 50, discordTexture);
         Add(_discordLogo);
 
         AlphaBlendControl c;

--- a/src/ClassicUO.Client/Game/UI/Gumps/DiscordGump/DiscordUserListItem.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/DiscordGump/DiscordUserListItem.cs
@@ -111,7 +111,8 @@ public class DiscordUserListItem : Control
 
         if(user.GameActivity() != null) //In TUO
         {
-            var tuo = new EmbeddedGumpPic(Width - 75, 2, PNGLoader.Instance.EmbeddedArt["TazUOSM.png"]);
+            PNGLoader.Instance.TryGetEmbeddedTexture("TazUOSM.png", out var tuoTexture);
+            var tuo = new EmbeddedGumpPic(Width - 75, 2, tuoTexture);
             Add(tuo);
         }
         

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernPaperdoll.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernPaperdoll.cs
@@ -23,7 +23,15 @@ namespace ClassicUO.Game.UI.Gumps
         #region CONST
         private const int WIDTH = 250, HEIGHT = 380;
         private const int CELL_SPACING = 2, TOP_SPACING = 40;
-        private Texture2D MordernPaperdollGump = PNGLoader.Instance.EmbeddedArt["modern-paperdollgump.png"];
+        private Texture2D MordernPaperdollGump;
+        
+        private void InitializeTexture()
+        {
+            if (MordernPaperdollGump == null)
+            {
+                PNGLoader.Instance.TryGetEmbeddedTexture("modern-paperdollgump.png", out MordernPaperdollGump);
+            }
+        }
         #endregion
 
         #region VARS
@@ -58,6 +66,7 @@ namespace ClassicUO.Game.UI.Gumps
             itemLayerSlots = new Dictionary<Layer[], ItemSlot>();
             #endregion
 
+            InitializeTexture();
             Add(backgroundImage = new EmbeddedGumpPic(0, 0, MordernPaperdollGump, ProfileManager.CurrentProfile.ModernPaperDollHue));
 
             HitBox _menuHit = new HitBox(Width - 26, 1, 25, 16, alpha: 0f);

--- a/src/ClassicUO.Client/Game/UI/Gumps/SpellBar/SpellBar.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/SpellBar/SpellBar.cs
@@ -115,9 +115,11 @@ public class SpellBar : Gump
         rowLabel.Y = (Height - rowLabel.Height) >> 1;
         Add(rowLabel);
 
-        var up = new EmbeddedGumpPic(Width - 31, 0, PNGLoader.Instance.EmbeddedArt["upicon.png"], 148);
+        PNGLoader.Instance.TryGetEmbeddedTexture("upicon.png", out var upTexture);
+        var up = new EmbeddedGumpPic(Width - 31, 0, upTexture, 148);
         up.MouseUp += (sender, e) => { ChangeRow(false); };
-        var down = new EmbeddedGumpPic(Width - 31, Height - 16, PNGLoader.Instance.EmbeddedArt["downicon.png"], 148);
+        PNGLoader.Instance.TryGetEmbeddedTexture("downicon.png", out var downTexture);
+        var down = new EmbeddedGumpPic(Width - 31, Height - 16, downTexture, 148);
         down.MouseUp += (sender, e) => { ChangeRow(true); };
 
         Add(up);


### PR DESCRIPTION
For PNG Loader embedded assets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved stability by safely handling missing UI textures, preventing crashes.
  - More robust loading for Modern Paperdoll, Discord icon, and Spell Bar icons with graceful fallbacks.
  - UI constants now avoid exceptions when assets are unavailable.

- Refactor
  - Centralized texture retrieval behind a safe public API.
  - Introduced lazy initialization for embedded textures to reduce failures during startup and rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->