### PR TITLE
Grid Highlight loot option

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightData.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightData.cs
@@ -96,6 +96,12 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
             set => _entry.GridHighlightSlot = value;
         }
 
+        public bool LootOnMatch
+        {
+            get => _entry.LootOnMatch;
+            set => _entry.LootOnMatch = value;
+        }
+
         public GridHighlightData()
         {
             _entry = new GridHighlightSetupEntry();
@@ -156,6 +162,11 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
                     {
                         data.item.MatchesHighlightData = true;
                         data.item.HighlightHue = config.Hue;
+
+                        if (config.LootOnMatch)
+                        {
+                            AutoLootManager.Instance.LootItem(data.item);
+                        }
                     }
                 }
             }

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightProfile.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightProfile.cs
@@ -21,6 +21,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
         public List<string> ExcludeNegatives { get; set; } = new();
         public List<string> RequiredRarities { get; set; } = new();
         public GridHighlightSlot GridHighlightSlot { get; set; } = new();
+        public bool LootOnMatch { get; set; } = false;
     }
 
     public class GridHighlightSlot

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightProperties.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightProperties.cs
@@ -57,6 +57,21 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
 
             mainScrollArea.Add(pos.PositionRightOf(new Label("Allow extra properties", true, 0xffff), acceptExtraPropertiesCheckbox));
 
+            // Loot on match checkbox
+            string lootOnMatchTooltip =
+                "Automatically loot items that match this highlight configuration.\n" +
+                "When checked: Items matching this configuration will be added to the auto loot queue.";
+
+            Checkbox lootOnMatchCheckbox;
+            mainScrollArea.Add(pos.Position(lootOnMatchCheckbox = new Checkbox(0x00D2, 0x00D3) { IsChecked = data.LootOnMatch }));
+            lootOnMatchCheckbox.SetTooltip(lootOnMatchTooltip);
+            lootOnMatchCheckbox.ValueChanged += (s, e) =>
+            {
+                data.LootOnMatch = lootOnMatchCheckbox.IsChecked;
+            };
+
+            mainScrollArea.Add(pos.PositionRightOf(new Label("Auto loot on match", true, 0xffff), lootOnMatchCheckbox));
+
             InputField minPropertiesInput;
             mainScrollArea.Add(pos.Position(minPropertiesInput = new InputField(0x0BB8, 0xFF, 0xFFFF, true, 40, 20)));
             minPropertiesInput.SetText(data.MinimumProperty.ToString());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Auto loot on match” option to Grid Highlight settings with a checkbox and descriptive tooltip.
  * When enabled, items that match the highlight configuration are automatically added to the loot queue, in addition to being highlighted and hued.
  * Option is stored per highlight configuration and can be toggled directly in the properties panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->