### PR TITLE
Add legion scripting and name overhead option gump to hide hud

### DIFF
--- a/src/ClassicUO.Client/Game/Data/HideHudFlags.cs
+++ b/src/ClassicUO.Client/Game/Data/HideHudFlags.cs
@@ -25,6 +25,8 @@ public enum HideHudFlags : ulong //Up to 63 gump types for ulong
     CounterBar = 1 << 16,
     InfoBar = 1 << 17,
     SpellIcons = 1 << 18,
+    NameOverheadGump = 1 << 19,
+    ScriptManagerGump = 1 << 20,
 
-    All = (1UL << 19) - 1 //Update 19 if more are added
+    All = (1UL << 21) - 1 //Update 21 if more are added
 }

--- a/src/ClassicUO.Client/Game/Managers/HideHudManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/HideHudManager.cs
@@ -63,6 +63,10 @@ public static class HideHudManager
                 gump.IsVisible = isVisible;
             else if (ByteFlagHelper.HasFlag(flags, (ulong)HideHudFlags.SpellIcons) && (gump is UseSpellButtonGump))
                 gump.IsVisible = isVisible;
+            else if (ByteFlagHelper.HasFlag(flags, (ulong)HideHudFlags.NameOverheadGump) && gump is NameOverHeadHandlerGump)
+                gump.IsVisible = isVisible;
+            else if (ByteFlagHelper.HasFlag(flags, (ulong)HideHudFlags.ScriptManagerGump) && gump is LegionScripting.ScriptManagerGump)
+                gump.IsVisible = isVisible;
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Hide HUD now includes the Name Overhead display and the Script Manager panel.
  - Global and per-element Hide HUD toggles consistently show/hide these panels alongside other HUD components.
  - Behavior applies across screens where these panels appear, matching existing visibility rules.
  - No changes required to existing settings; integration is seamless with current preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->