### PR TITLE
Add basic scripting info gump

### DIFF
--- a/src/ClassicUO.Client/Game/GameActions.cs
+++ b/src/ClassicUO.Client/Game/GameActions.cs
@@ -602,6 +602,7 @@ namespace ClassicUO.Game
 
             // Record action for script recording
             ClassicUO.LegionScripting.ScriptRecorder.Instance.RecordAttack(serial);
+            ScriptingInfoGump.AddOrUpdateInfo("Last Attacked", serial);
 
             TargetManager.LastAttack = serial;
             Socket.Send_AttackRequest(serial);
@@ -617,6 +618,8 @@ namespace ClassicUO.Game
             // Record action for script recording (only for items)
             if (SerialHelper.IsItem(serial))
                 ClassicUO.LegionScripting.ScriptRecorder.Instance.RecordUseItem(serial);
+
+            ScriptingInfoGump.AddOrUpdateInfo("Last Object", serial);
 
             if (serial != World.Player && SerialHelper.IsMobile(serial) && World.Player.InWarMode)
             {
@@ -861,6 +864,8 @@ namespace ClassicUO.Game
             Client.Game.GameCursor.ItemHold.Set(item, (ushort)amount, offset);
             Client.Game.GameCursor.ItemHold.IsGumpTexture = is_gump;
             Socket.Send_PickUpRequest(item, (ushort)amount);
+            ScriptingInfoGump.AddOrUpdateInfo("Last Picked Up Item", item.Serial);
+
 
             if (item.OnGround)
             {
@@ -929,6 +934,7 @@ namespace ClassicUO.Game
         {
             // Record action for script recording
             ClassicUO.LegionScripting.ScriptRecorder.Instance.RecordReplyGump(server, button, switches, entries);
+            ScriptingInfoGump.AddOrUpdateInfo("Last Gump Response", button);
 
             Socket.Send_GumpResponse(local,
                                      server,
@@ -1031,7 +1037,9 @@ namespace ClassicUO.Game
                 Socket.Send_CastSpell(index);
 
                 // Record action for script recording
-                ClassicUO.LegionScripting.ScriptRecorder.Instance.RecordCastSpell(SpellDefinition.FullIndexGetSpell(index).Name);
+                var name = SpellDefinition.FullIndexGetSpell(index).Name;
+                ClassicUO.LegionScripting.ScriptRecorder.Instance.RecordCastSpell(name);
+                ScriptingInfoGump.AddOrUpdateInfo("Last Spell", name);
             }
         }
 
@@ -1047,6 +1055,7 @@ namespace ClassicUO.Game
             {
                 // Record action for script recording
                 ClassicUO.LegionScripting.ScriptRecorder.Instance.RecordCastSpell(name);
+                ScriptingInfoGump.AddOrUpdateInfo("Last Spell", name);
 
                 CastSpell(spellDef.ID);
                 return true;
@@ -1094,6 +1103,7 @@ namespace ClassicUO.Game
                 if (index < World.Player.Skills.Length)
                     skillName = World.Player.Skills[index].Name;
                 ClassicUO.LegionScripting.ScriptRecorder.Instance.RecordUseSkill(skillName);
+                ScriptingInfoGump.AddOrUpdateInfo("Last Skill", skillName);
 
                 LastSkillIndex = index;
                 Socket.Send_UseSkill(index);
@@ -1116,6 +1126,7 @@ namespace ClassicUO.Game
         {
             // Record action for script recording
             ClassicUO.LegionScripting.ScriptRecorder.Instance.RecordContextMenu(serial, index);
+            ScriptingInfoGump.AddOrUpdateInfo("Last Context Menu response", index);
 
             Socket.Send_PopupMenuSelection(serial, index);
         }

--- a/src/ClassicUO.Client/LegionScripting/ScriptManagerGump.cs
+++ b/src/ClassicUO.Client/LegionScripting/ScriptManagerGump.cs
@@ -61,6 +61,10 @@ namespace ClassicUO.LegionScripting
             {
                 UIManager.Add(new ScriptRecordingGump());
             }));
+            refresh.ContextMenu.Add(new ContextMenuItemEntry("Scripting Info", () =>
+            {
+                ScriptingInfoGump.Show();
+            }));
 
             refresh.MouseDown += (s, e) =>
             {

--- a/src/ClassicUO.Client/LegionScripting/ScriptingInfoGump.cs
+++ b/src/ClassicUO.Client/LegionScripting/ScriptingInfoGump.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using ClassicUO.Assets;
+using ClassicUO.Game;
+using ClassicUO.Game.Data;
+using ClassicUO.Game.Managers;
+using ClassicUO.Game.UI.Controls;
+using ClassicUO.Game.UI.Gumps;
+using ClassicUO.Input;
+using Microsoft.Xna.Framework;
+
+namespace ClassicUO.LegionScripting
+{
+    internal class ScriptingInfoGump : NineSliceGump
+    {
+        private ModernScrollArea scrollArea;
+        private VBoxContainer container;
+        private TextBox titleTextBox;
+        private static Dictionary<string, object> infoEntries = new();
+
+        private const int MIN_WIDTH = 250;
+        private const int MIN_HEIGHT = 200;
+        private static int lastX = 200, lastY = 200;
+        private static int lastWidth = 300, lastHeight = 400;
+
+        public static ScriptingInfoGump Instance { get; private set; }
+
+        private ScriptingInfoGump() : base(lastX, lastY, lastWidth, lastHeight, ModernUIConstants.ModernUIPanel, ModernUIConstants.ModernUIPanel_BoderSize, true, MIN_WIDTH, MIN_HEIGHT)
+        {
+            CanCloseWithRightClick = true;
+            AcceptMouseInput = true;
+            CanMove = true;
+
+            InitializeComponents();
+            UpdateUI();
+        }
+
+        public static void Show()
+        {
+            Instance?.Dispose();
+            UIManager.Add(Instance = new ScriptingInfoGump());
+        }
+
+        private void InitializeComponents()
+        {
+            // Title
+            titleTextBox = TextBox.GetOne("Scripting Info", TrueTypeLoader.EMBEDDED_FONT, 18, Color.DarkOrange, TextBox.RTLOptions.Default(Width - 2 * BorderSize));
+            titleTextBox.X = BorderSize;
+            titleTextBox.Y = BorderSize;
+            titleTextBox.AcceptMouseInput = false;
+            Add(titleTextBox);
+
+            // Scroll area
+            var scrollAreaY = titleTextBox.Y + titleTextBox.Height + 10;
+            var scrollAreaHeight = Height - scrollAreaY - BorderSize;
+            scrollArea = new ModernScrollArea(BorderSize, scrollAreaY, Width - 2 * BorderSize, scrollAreaHeight);
+            Add(scrollArea);
+
+            // Container for info entries
+            container = new VBoxContainer(scrollArea.Width - 20, 5, 5);
+            scrollArea.Add(container);
+        }
+
+        public static void AddOrUpdateInfo(string key, object value)
+        {
+            infoEntries[key] = value;
+            Instance?.UpdateUI();
+        }
+
+        public static void RemoveInfo(string key)
+        {
+            if (infoEntries.ContainsKey(key))
+            {
+                infoEntries.Remove(key);
+                Instance?.UpdateUI();
+            }
+        }
+
+        public void UpdateUI()
+        {
+            container?.Clear();
+            foreach (KeyValuePair<string, object> entry in infoEntries)
+            {
+                container?.Add(new InfoEntry(entry.Key, entry.Value?.ToString() ?? "", container.Width - 10));
+            }
+        }
+
+        protected override void OnMove(int x, int y)
+        {
+            lastX = X;
+            lastY = Y;
+            base.OnMove(x, y);
+        }
+
+        public override void Dispose()
+        {
+            Instance = null;
+            base.Dispose();
+        }
+
+        protected override void OnResize(int oldWidth, int oldHeight, int newWidth, int newHeight)
+        {
+            base.OnResize(oldWidth, oldHeight, newWidth, newHeight);
+            lastWidth = Width;
+            lastHeight = Height;
+
+            // Update title width
+            if (titleTextBox != null)
+            {
+                titleTextBox.Width = Width - 2 * BorderSize;
+            }
+
+            // Update scroll area
+            if (scrollArea != null)
+            {
+                var scrollAreaY = titleTextBox.Y + titleTextBox.Height + 10;
+                var scrollAreaHeight = Height - scrollAreaY - BorderSize;
+
+                scrollArea.Y = scrollAreaY;
+                scrollArea.Width = Width - 2 * BorderSize;
+                scrollArea.Height = scrollAreaHeight;
+            }
+
+            // Update container width
+            if (container != null)
+            {
+                container.Width = scrollArea.Width - 20;
+
+                // Update all entries width
+                foreach (var entry in container.Children.OfType<InfoEntry>())
+                {
+                    entry.UpdateWidth(container.Width - 10);
+                }
+            }
+        }
+
+        private class InfoEntry : Control
+        {
+            private HBoxContainer hContainer;
+            private TextBox keyTextBox;
+            private TextBox valueTextBox;
+            private string currentValue;
+
+            public InfoEntry(string key, string value, int width)
+            {
+                AcceptMouseInput = true;
+                CanMove = true;
+                Width = width;
+                Height = 20;
+                currentValue = value;
+
+                hContainer = new HBoxContainer(Height, 0, 0);
+                hContainer.Width = width;
+                Add(hContainer);
+
+                // Key text (non-clickable)
+                keyTextBox = TextBox.GetOne($"{key}:", TrueTypeLoader.EMBEDDED_FONT, 14, Color.White, TextBox.RTLOptions.Default(width / 2));
+                keyTextBox.AcceptMouseInput = false;
+                hContainer.Add(keyTextBox);
+
+                // Value text (clickable for copy)
+                valueTextBox = TextBox.GetOne(value, TrueTypeLoader.EMBEDDED_FONT, 14, Color.LightBlue, TextBox.RTLOptions.Default(width / 2).MouseInput());
+                valueTextBox.CanMove = true;
+                valueTextBox.MouseUp += CopyToClipboard;
+                hContainer.Add(valueTextBox);
+            }
+
+            public void UpdateWidth(int newWidth)
+            {
+                Width = newWidth;
+                hContainer.Width = newWidth;
+                keyTextBox.Width = newWidth / 2;
+                valueTextBox.Width = newWidth / 2;
+            }
+
+            private void CopyToClipboard(object s, MouseEventArgs e)
+            {
+                try
+                {
+                    if (!string.IsNullOrEmpty(currentValue))
+                    {
+                        SetClipboardText(currentValue);
+                        GameActions.Print("Copied to clipboard!");
+                    }
+                }
+                catch (Exception)
+                {
+                    // Ignore clipboard errors
+                }
+            }
+
+            private static void SetClipboardText(string text)
+            {
+                SDL2.SDL.SDL_SetClipboardText(text);
+            }
+        }
+    }
+}

--- a/src/ClassicUO.Client/Network/PacketHandlers.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers.cs
@@ -51,6 +51,8 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
+using ClassicUO.LegionScripting;
+using Constants = ClassicUO.Game.Constants;
 
 namespace ClassicUO.Network
 {
@@ -6773,6 +6775,7 @@ namespace ClassicUO.Network
         )
         {
             ClassicUO.LegionScripting.ScriptRecorder.Instance.RecordWaitForGump(gumpID.ToString());
+            ScriptingInfoGump.AddOrUpdateInfo("Last Gump Opened", gumpID);
             List<string> cmdlist = _parser.GetTokens(layout);
             int cmdlen = cmdlist.Count;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Scripting Info panel accessible from the Script Manager’s context menu.
  - The panel displays recent actions, including: Last Attacked, Last Object, Last Picked Up Item, Last Gump Opened, Last Gump Response, Last Spell, Last Skill, and Last Context Menu response.
  - Values are clickable to copy details to the clipboard for quick reuse.
- Improvements
  - Live updates to the Scripting Info panel after relevant in-game actions, keeping information current without disrupting gameplay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->