### PR TITLE
Add optional avoid overlap to nameplates

### DIFF
--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -377,6 +377,7 @@ namespace ClassicUO.Configuration
         public bool NamePlateHideAtFullHealth { get; set; } = true;
         public bool NamePlateHideAtFullHealthInWarmode { get; set; } = true;
         public byte NamePlateBorderOpacity { get; set; } = 50;
+        public bool NamePlateAvoidOverlap { get; set; }
 
         public bool LeftAlignToolTips { get; set; } = false;
         public bool ForceCenterAlignTooltipMobiles { get; set; } = true;

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
@@ -2992,6 +2992,11 @@ namespace ClassicUO.Game.UI.Gumps
                     (lang.GetTazUO.BackgroundOpacity, 0, ThemeSettings.SLIDER_WIDTH, 0, 100, profile.NamePlateOpacity, (i) => { profile.NamePlateOpacity = (byte)i; }), true, page
             );
 
+            content.AddToRight
+            (
+                new CheckboxWithLabel("Avoid overlap", 0, profile.NamePlateAvoidOverlap, (b) => { profile.NamePlateAvoidOverlap = b; }), true, page
+            );
+
             #endregion
 
             #region Mobiles

--- a/src/ClassicUO.Client/Game/UI/Gumps/NameOverheadGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/NameOverheadGump.cs
@@ -77,7 +77,7 @@ namespace ClassicUO.Game.UI.Gumps
                 currentHeight = value;
             }
         }
-        
+
         public new UILayer LayerOrder {
             get
             {
@@ -94,7 +94,7 @@ namespace ClassicUO.Game.UI.Gumps
             CanMove = false;
             AcceptMouseInput = true;
             CanCloseWithRightClick = true;
-            
+
             Entity entity = World.Get(serial);
 
             if (entity == null)
@@ -532,23 +532,23 @@ namespace ClassicUO.Game.UI.Gumps
         private static List<NameOverheadGump> GetAllVisibleNameOverheads()
         {
             var result = new List<NameOverheadGump>();
-            
+
             for (var node = UIManager.Gumps.First; node != null; node = node.Next)
             {
-                if (node.Value is NameOverheadGump nameGump && 
-                    !nameGump.IsDisposed && 
+                if (node.Value is NameOverheadGump nameGump &&
+                    !nameGump.IsDisposed &&
                     nameGump.IsVisible)
                 {
                     result.Add(nameGump);
                 }
             }
-            
+
             return result;
         }
 
-        private Rectangle GetBounds(int x, int y)
+        private Rectangle GetBounds(int x, int y, int width, int height)
         {
-            return new Rectangle(x, y, Width, Height);
+            return new Rectangle(x, y, width, height);
         }
 
         private Point AdjustPositionToAvoidOverlap(int originalX, int originalY)
@@ -566,7 +566,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             while (iterations < maxIterations)
             {
-                var proposedBounds = GetBounds(adjustedX, adjustedY);
+                var proposedBounds = GetBounds(adjustedX, adjustedY, Width, Height);
                 bool hasCollision = false;
 
                 foreach (var other in allNameOverheads)
@@ -574,8 +574,8 @@ namespace ClassicUO.Game.UI.Gumps
                     if (other == this || other.LocalSerial == this.LocalSerial)
                         continue;
 
-                    var otherBounds = GetBounds(other.X, other.Y);
-                    
+                    var otherBounds = GetBounds(other.X, other.Y, other.Width, other.Height);
+
                     if (proposedBounds.Intersects(otherBounds))
                     {
                         adjustedY = otherBounds.Bottom + COLLISION_SPACING;

--- a/src/ClassicUO.Client/Game/UI/Gumps/NameOverheadGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/NameOverheadGump.cs
@@ -42,6 +42,7 @@ using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
+using System.Collections.Generic;
 
 namespace ClassicUO.Game.UI.Gumps
 {
@@ -58,6 +59,7 @@ namespace ClassicUO.Game.UI.Gumps
         private Texture2D _borderColor = SolidColorTextureCache.GetTexture(Color.Black);
         private Vector2 _textDrawOffset = Vector2.Zero;
         private static int currentHeight = 22;
+        private static readonly int COLLISION_SPACING = 2;
 
         public static int CurrentHeight
         {
@@ -527,6 +529,70 @@ namespace ClassicUO.Game.UI.Gumps
             base.OnMouseExit(x, y);
         }
 
+        private static List<NameOverheadGump> GetAllVisibleNameOverheads()
+        {
+            var result = new List<NameOverheadGump>();
+            
+            for (var node = UIManager.Gumps.First; node != null; node = node.Next)
+            {
+                if (node.Value is NameOverheadGump nameGump && 
+                    !nameGump.IsDisposed && 
+                    nameGump.IsVisible)
+                {
+                    result.Add(nameGump);
+                }
+            }
+            
+            return result;
+        }
+
+        private Rectangle GetBounds(int x, int y)
+        {
+            return new Rectangle(x, y, Width, Height);
+        }
+
+        private Point AdjustPositionToAvoidOverlap(int originalX, int originalY)
+        {
+            if (!ProfileManager.CurrentProfile.NamePlateAvoidOverlap)
+            {
+                return new Point(originalX, originalY);
+            }
+
+            var allNameOverheads = GetAllVisibleNameOverheads();
+            var adjustedX = originalX;
+            var adjustedY = originalY;
+            var maxIterations = 10;
+            var iterations = 0;
+
+            while (iterations < maxIterations)
+            {
+                var proposedBounds = GetBounds(adjustedX, adjustedY);
+                bool hasCollision = false;
+
+                foreach (var other in allNameOverheads)
+                {
+                    if (other == this || other.LocalSerial == this.LocalSerial)
+                        continue;
+
+                    var otherBounds = GetBounds(other.X, other.Y);
+                    
+                    if (proposedBounds.Intersects(otherBounds))
+                    {
+                        adjustedY = otherBounds.Bottom + COLLISION_SPACING;
+                        hasCollision = true;
+                        break;
+                    }
+                }
+
+                if (!hasCollision)
+                    break;
+
+                iterations++;
+            }
+
+            return new Point(adjustedX, adjustedY);
+        }
+
         public override void Update()
         {
             base.Update();
@@ -736,6 +802,10 @@ namespace ClassicUO.Game.UI.Gumps
             {
                 return false;
             }
+
+            var adjustedPos = AdjustPositionToAvoidOverlap(x, y);
+            x = adjustedPos.X;
+            y = adjustedPos.Y;
 
             X = x;
             Y = y;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Avoid overlap” toggle for nameplates in Options.
  * When enabled, nameplates automatically adjust positions to prevent overlap, improving readability in crowded scenes.
  * The setting is saved to your profile and persists between sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->