### PR TITLE
fix: Parrot as robe graphic.

### DIFF
--- a/src/ClassicUO.Client/Game/GameObjects/Views/MobileView.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Views/MobileView.cs
@@ -1219,7 +1219,8 @@ namespace ClassicUO.Game.GameObjects
                         return robe != null
                             && robe.Graphic != 0x9985
                             && robe.Graphic != 0x9986
-                            && robe.Graphic != 0xA412;
+                            && robe.Graphic != 0xA412
+                            && robe.Graphic != 0xA2CB;
                     }
 
                     break;
@@ -1233,7 +1234,7 @@ namespace ClassicUO.Game.GameObjects
                         && robe.Graphic != 0x9985
                         && robe.Graphic != 0x9986
                         && robe.Graphic != 0xA412
-                        && robe.Graphic != 0xA2CA
+                        && robe.Graphic != 0xA2CB
                     )
                     {
                         return true;
@@ -1265,7 +1266,8 @@ namespace ClassicUO.Game.GameObjects
                         && robe.Graphic != 0
                         && robe.Graphic != 0x9985
                         && robe.Graphic != 0x9986
-                        && robe.Graphic != 0xA412;
+                        && robe.Graphic != 0xA412
+                        && robe.Graphic != 0xA2CB;
 
                 case Layer.Helmet:
                 case Layer.Hair:

--- a/src/ClassicUO.Client/Game/UI/Controls/PaperDollInteractable.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/PaperDollInteractable.cs
@@ -70,6 +70,33 @@ namespace ClassicUO.Game.UI.Controls
             Layer.Talisman
         };
 
+        private static readonly Layer[] _layerOrder_parrot_fix =
+        {
+            Layer.Shirt,
+            Layer.Pants,
+            Layer.Shoes,
+            Layer.Legs,
+            Layer.Arms,
+            Layer.Torso,
+            Layer.Tunic,
+            Layer.Cloak,
+            Layer.Ring,
+            Layer.Bracelet,
+            Layer.Face,
+            Layer.Gloves,
+            Layer.Skirt,
+            Layer.Waist,
+            Layer.Necklace,
+            Layer.Hair,
+            Layer.Beard,
+            Layer.Earrings,
+            Layer.Helmet,
+            Layer.OneHanded,
+            Layer.TwoHanded,
+            Layer.Talisman,
+            Layer.Robe
+        };
+
         private readonly PaperDollGump _paperDollGump;
 
         private bool _updateUI;
@@ -182,6 +209,7 @@ namespace ClassicUO.Game.UI.Controls
             // equipment
             Item equipItem = mobile.FindItemByLayer(Layer.Cloak);
             Item arms = mobile.FindItemByLayer(Layer.Arms);
+            Item robe = mobile.FindItemByLayer(Layer.Robe);
 
             bool switch_arms_with_torso = false;
 
@@ -205,7 +233,14 @@ namespace ClassicUO.Game.UI.Controls
 
             if (equipItem != null)
             {
-                layers = equipItem.ItemData.IsContainer ? _layerOrder_quiver_fix : _layerOrder;
+                if (robe != null && robe.Graphic == 0xA2CB) // parrot
+                {
+                    layers = _layerOrder_parrot_fix;
+                }
+                else
+                {
+                    layers = equipItem.ItemData.IsContainer ? _layerOrder_quiver_fix : _layerOrder;
+                }
             }
             else if (
                 HasFakeItem


### PR DESCRIPTION
- Parrot graphic was not showing correctly on paperdoll.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed equipment occlusion so shoes, tunics, torso, and arms are no longer hidden incorrectly when wearing the Parrot robe.
  * Improved paperdoll layering logic to correctly display items when a parrot is equipped, preventing visual overlap with other gear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->