### PR TITLE
fix(legionscripting): enable culture + dynamic PyClass bindings for I…

### DIFF
--- a/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
@@ -18,6 +18,7 @@ using static ClassicUO.LegionScripting.Commands;
 using static ClassicUO.LegionScripting.Expressions;
 using System.Text.Json.Serialization;
 using Microsoft.Scripting;
+using System.Globalization;
 
 namespace ClassicUO.LegionScripting
 {
@@ -878,6 +879,27 @@ namespace ClassicUO.LegionScripting
             if (pythonEngine != null && !LegionScripting.LScriptSettings.DisableModuleCache)
                 return;
 
+            try
+            {
+                Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+                Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-US");
+                CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("en-US");
+                CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("en-US");
+            }
+            catch (Exception er)
+            {
+                Console.WriteLine($"Culture error: {er}");
+            }
+
+            try
+            {
+                Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+            }
+            catch (Exception er)
+            {
+                Console.WriteLine($"Encoding error: {er}");
+            }
+
             pythonEngine = Python.CreateEngine();
 
             string dir = System.IO.Path.GetDirectoryName(FullPath);
@@ -895,7 +917,19 @@ namespace ClassicUO.LegionScripting
             pythonScope = pythonEngine.CreateScope();
             var api = new API(pythonEngine);
             scopedAPI = api;
-            pythonEngine.GetBuiltinModule().SetVariable("API", api);
+
+            var builtins = pythonEngine.GetBuiltinModule();
+            builtins.SetVariable("API", api);
+
+            var asm = typeof(ScriptFile).Assembly;
+            var pyClassesNamespace = "ClassicUO.LegionScripting.PyClasses";
+
+            var pyTypes = asm.GetTypes()
+                .Where(t => t.Namespace == pyClassesNamespace);
+            foreach (var t in pyTypes)
+            {
+                builtins.SetVariable(t.Name, t);
+            }
         }
 
         public void PythonScriptStopped()

--- a/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
@@ -881,14 +881,13 @@ namespace ClassicUO.LegionScripting
 
             try
             {
-                Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
-                Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-US");
-                CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("en-US");
-                CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("en-US");
+                var c = new CultureInfo("en-US");
+                Thread.CurrentThread.CurrentCulture = c;
+                Thread.CurrentThread.CurrentUICulture = c;
             }
             catch (Exception er)
             {
-                Console.WriteLine($"Culture error: {er}");
+                Log.Error($"Culture error: {er}");
             }
 
             try
@@ -897,7 +896,7 @@ namespace ClassicUO.LegionScripting
             }
             catch (Exception er)
             {
-                Console.WriteLine($"Encoding error: {er}");
+                Log.Error($"Encoding error: {er}");
             }
 
             pythonEngine = Python.CreateEngine();
@@ -922,13 +921,21 @@ namespace ClassicUO.LegionScripting
             builtins.SetVariable("API", api);
 
             var asm = typeof(ScriptFile).Assembly;
-            var pyClassesNamespace = "ClassicUO.LegionScripting.PyClasses";
+            const string pyClassesNamespace = "ClassicUO.LegionScripting.PyClasses";
 
             var pyTypes = asm.GetTypes()
-                .Where(t => t.Namespace == pyClassesNamespace);
+                .Where(t => t.Namespace == pyClassesNamespace
+                            && t.IsClass
+                            && !t.IsAbstract);
             foreach (var t in pyTypes)
             {
-                builtins.SetVariable(t.Name, t);
+                var name = t.Name.Split('`')[0];
+                if (builtins.ContainsVariable(name))
+                {
+                    Log.Debug($"PyClasses exposure skipped due to name collision: {name}");
+                    continue;
+                }
+                builtins.SetVariable(name, t);
             }
         }
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,7 +5,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
-    <InvariantGlobalization>true</InvariantGlobalization>
+    <InvariantGlobalization>false</InvariantGlobalization>
     <UseSystemResourceKeys>true</UseSystemResourceKeys>
   </PropertyGroup>
 


### PR DESCRIPTION
- Disabled invariant globalization (<InvariantGlobalization>false</InvariantGlobalization>) and forced en-US CultureInfo to fix IronPython StringOps initialization errors.
- Added LegionScripts and iplib paths to IronPython search paths for reliable module imports.
- Made SetupPythonScope dynamic: automatically exposes all classes under ClassicUO.LegionScripting.PyClasses as builtins, instead of hardcoding PyGameObject, PyItem, PyMobile, etc.

This resolves import failures and runtime errors with IronPython globalization. Scripts now load reliably, and new PyClasses are automatically exposed without additional C# changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Python scripts can now access additional Legion scripting classes via built-ins, simplifying script authoring and avoiding duplicate-name exposures.

* **Bug Fixes**
  * Standardized culture settings for the Python host to improve number/date parsing and formatting.
  * Improved text encoding support (including legacy code pages) to reduce encoding-related errors.

* **Chores**
  * Builds switched to culture-aware globalization instead of invariant mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->