### PR TITLE
restores legacy mini hp bar on single targets

### DIFF
--- a/src/ClassicUO.Client/Configuration/Language.cs
+++ b/src/ClassicUO.Client/Configuration/Language.cs
@@ -143,6 +143,7 @@ namespace ClassicUO.Configuration
             public string HPShowWhen_Always { get; set; } = "Always";
             public string HPShowWhen_Less100 { get; set; } = "Less than 100%";
             public string HPShowWhen_Smart { get; set; } = "Smart";
+            public string HPShowWhen_TargetOnly { get; set; } = "Target Only";
             public string HighlightPoisoned { get; set; } = "Highlight poisoned mobiles";
             public string PoisonHighlightColor { get; set; } = "Highlight color";
             public string HighlightPara { get; set; } = "Highlight paralyzed mobiles";

--- a/src/ClassicUO.Client/Game/Managers/HealthLinesManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/HealthLinesManager.cs
@@ -79,6 +79,49 @@ namespace ClassicUO.Game.Managers
             var animations = Client.Game.UO.Animations;
             var isEnabled = IsEnabled;
 
+            if (showWhen == 3)
+            {
+                Mobile target = null;
+                var tm = _world.TargetManager;
+                uint[] possibleSerials = {
+                    tm.LastTargetInfo?.Serial ?? 0,
+                    tm.LastAttack,
+                    tm.SelectedTarget,
+                    tm.NewTargetSystemSerial
+                };
+
+                foreach (uint serial in possibleSerials)
+                {
+                    if (serial != 0 && _world.Mobiles.TryGetValue(serial, out Mobile mob) && !mob.IsDestroyed)
+                    {
+                        target = mob;
+                        break;
+                    }
+                }
+
+                if (target != null)
+                {
+                    int current = target.Hits;
+                    int max = target.HitsMax;
+                    if (max > 0)
+                    {
+                        Point p = target.RealScreenPosition;
+                        p.X += (int)target.Offset.X + 22 + 5;
+                        p.Y += (int)(target.Offset.Y - target.Offset.Z) + 22 + 5;
+                        var offsetY = 0;
+                        p.X -= 5;
+                        p = Client.Game.Scene.Camera.WorldToScreen(p);
+                        p.X -= BAR_WIDTH_HALF;
+                        p.Y -= BAR_HEIGHT_HALF;
+                        if (p.X >= 0 && p.X <= camera.Bounds.Width - BAR_WIDTH && p.Y >= 0 && p.Y <= camera.Bounds.Height - BAR_HEIGHT)
+                        {
+                            DrawHealthLine(batcher, target, p.X, p.Y, offsetY, false, false);
+                        }
+                    }
+                }
+                return;
+            }
+
             foreach (Mobile mobile in _world.Mobiles.Values)
             {
                 if (mobile.IsDestroyed)

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
@@ -253,7 +253,7 @@ namespace ClassicUO.Game.UI.Gumps
                 new ComboBoxWithLabel
                 (World,
                     lang.GetGeneral.HPShowWhen, 0, ThemeSettings.COMBO_BOX_WIDTH,
-                    new string[] { lang.GetGeneral.HPShowWhen_Always, lang.GetGeneral.HPShowWhen_Less100, lang.GetGeneral.HPShowWhen_Smart }, profile.MobileHPShowWhen,
+                    new string[] { lang.GetGeneral.HPShowWhen_Always, lang.GetGeneral.HPShowWhen_Less100, lang.GetGeneral.HPShowWhen_Smart, "Target Only" }, profile.MobileHPShowWhen,
                     (s, n) => { profile.MobileHPShowWhen = s; }
                 ), true, page
             );

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
@@ -253,7 +253,7 @@ namespace ClassicUO.Game.UI.Gumps
                 new ComboBoxWithLabel
                 (World,
                     lang.GetGeneral.HPShowWhen, 0, ThemeSettings.COMBO_BOX_WIDTH,
-                    new string[] { lang.GetGeneral.HPShowWhen_Always, lang.GetGeneral.HPShowWhen_Less100, lang.GetGeneral.HPShowWhen_Smart, "Target Only" }, profile.MobileHPShowWhen,
+                    new string[] { lang.GetGeneral.HPShowWhen_Always, lang.GetGeneral.HPShowWhen_Less100, lang.GetGeneral.HPShowWhen_Smart, lang.GetGeneral.HPShowWhen_TargetOnly }, profile.MobileHPShowWhen,
                     (s, n) => { profile.MobileHPShowWhen = s; }
                 ), true, page
             );


### PR DESCRIPTION
Adds an additional 'Show when' option that places the mini hp bar under the current target only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Target Only” option to Mobiles HP display settings (Options > General > Mobiles HP).
  * When enabled, the UI displays a single health bar for your current target (last target/attack/selection), positioned near that target on screen.
  * Reduces on-screen clutter by skipping health bars for other mobiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->