### PR TITLE
Add auto buy to assistant window

### DIFF
--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>4.9.10</AssemblyVersion>
-    <FileVersion>4.9.10</FileVersion>
+    <AssemblyVersion>4.9.11</AssemblyVersion>
+    <FileVersion>4.9.11</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Gumps/AssistantGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/AssistantGump.cs
@@ -86,6 +86,23 @@ public class AssistantGump : BaseOptionsGump
 
     private void BuildAutoBuy()
     {
+        int page = (int)PAGE.AutoBuy;
+
+        ModernButton button = new(0, 0, MainContent.LeftWidth, 40, ButtonAction.Default, "Auto buy", ThemeSettings.BUTTON_FONT_COLOR);
+        button.MouseUp += (_, e) =>
+        {
+            if(e.Button == MouseButtonType.Left)
+            {
+                AssistantWindow.Show();
+                AssistantWindow.Instance.SelectTab(PAGE.AutoBuy);
+            }
+        };
+
+        MainContent.AddToLeft(button);
+    }
+
+    private void BuildAutoBuyLegacy()
+    {
         var page = (int)PAGE.AutoBuy;
         MainContent.AddToLeft(CategoryButton("Auto buy", page, MainContent.LeftWidth));
         MainContent.ResetRightSide();

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/AssistantWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/AssistantWindow.cs
@@ -17,6 +17,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
             AddTab("General", DrawGeneral, GeneralWindow.Show, () => GeneralWindow.Instance?.Dispose());
             AddTab("Auto Loot", DrawAutoLoot, AutoLootWindow.Show, () => AutoLootWindow.Instance?.Dispose() );
             AddTab("Auto Sell", DrawAutoSell, AutoSellWindow.Show, () => AutoSellWindow.Instance?.Dispose() );
+            AddTab("Auto Buy", DrawAutoBuy, AutoBuyWindow.Show, () => AutoBuyWindow.Instance?.Dispose() );
             AddTab("Organizer", DrawOrganizer, OrganizerWindow.Show, () => OrganizerWindow.Instance?.Dispose() );
             AddTab("Bandage Agent", DrawBandageAgent, BandageAgentWindow.Show, () => BandageAgentWindow.Instance?.Dispose() );
         }
@@ -34,6 +35,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
                     _preSelectIndex = 2;
                     break;
                 case AssistantGump.PAGE.AutoBuy:
+                    _preSelectIndex = 3;
                     break;
                 case AssistantGump.PAGE.MobileGraphicFilter:
                     break;
@@ -50,12 +52,12 @@ namespace ClassicUO.Game.UI.ImGuiControls
                 case AssistantGump.PAGE.DressAgent:
                     break;
                 case AssistantGump.PAGE.BandageAgent:
-                    _preSelectIndex = 4;
+                    _preSelectIndex = 5;
                     break;
                 case AssistantGump.PAGE.FriendsList:
                     break;
                 case AssistantGump.PAGE.Organizer:
-                    _preSelectIndex = 3;
+                    _preSelectIndex = 4;
                     break;
             }
         }
@@ -124,6 +126,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
         private void DrawGeneral() => GeneralWindow.GetInstance()?.DrawContent();
         private void DrawAutoLoot() => AutoLootWindow.GetInstance()?.DrawContent();
         private void DrawAutoSell() => AutoSellWindow.GetInstance()?.DrawContent();
+        private void DrawAutoBuy() => AutoBuyWindow.GetInstance()?.DrawContent();
         private void DrawOrganizer() => OrganizerWindow.GetInstance()?.DrawContent();
         private void DrawBandageAgent() => BandageAgentWindow.GetInstance()?.DrawContent();
 

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/AutoBuyWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/AutoBuyWindow.cs
@@ -1,0 +1,311 @@
+using ImGuiNET;
+using ClassicUO.Configuration;
+using ClassicUO.Game.Managers;
+using ClassicUO.Game.GameObjects;
+using System;
+using System.Numerics;
+using System.Globalization;
+using System.Collections.Generic;
+
+namespace ClassicUO.Game.UI.ImGuiControls
+{
+    public class AutoBuyWindow : SingletonImGuiWindow<AutoBuyWindow>
+    {
+        private Profile _profile;
+        private bool _enableAutoBuy;
+        private int _maxItems;
+        private int _maxUniques;
+
+        private string _newGraphicInput = "";
+        private string _newHueInput = "";
+        private string _newMaxAmountInput = "";
+        private string _newRestockInput = "";
+
+        private List<BuySellItemConfig> _buyEntries;
+        private bool _showAddEntry = false;
+        private Dictionary<BuySellItemConfig, string> _entryGraphicInputs = new Dictionary<BuySellItemConfig, string>();
+        private Dictionary<BuySellItemConfig, string> _entryHueInputs = new Dictionary<BuySellItemConfig, string>();
+        private Dictionary<BuySellItemConfig, string> _entryMaxAmountInputs = new Dictionary<BuySellItemConfig, string>();
+        private Dictionary<BuySellItemConfig, string> _entryRestockInputs = new Dictionary<BuySellItemConfig, string>();
+
+        private AutoBuyWindow() : base("Auto Buy")
+        {
+            WindowFlags = ImGuiWindowFlags.AlwaysAutoResize;
+            _profile = ProfileManager.CurrentProfile;
+
+            if (_profile == null)
+            {
+                Dispose();
+                return;
+            }
+
+            _enableAutoBuy = _profile.BuyAgentEnabled;
+            _maxItems = _profile.BuyAgentMaxItems;
+            _maxUniques = _profile.BuyAgentMaxUniques;
+
+            _buyEntries = BuySellAgent.Instance?.BuyConfigs ?? new List<BuySellItemConfig>();
+        }
+
+        public override void DrawContent()
+        {
+            if (_profile == null)
+            {
+                ImGui.Text("Profile not loaded");
+                return;
+            }
+
+            // Main settings
+            if (ImGui.Checkbox("Enable auto buy", ref _enableAutoBuy))
+            {
+                _profile.BuyAgentEnabled = _enableAutoBuy;
+            }
+
+            if (ImGui.SliderInt("Max total items (0 = unlimited)", ref _maxItems, 0, 100))
+            {
+                _profile.BuyAgentMaxItems = _maxItems;
+            }
+            if (ImGui.IsItemHovered())
+                ImGui.SetTooltip("Maximum total items to buy in a single transaction. Set to 0 for unlimited.");
+
+            if (ImGui.SliderInt("Max unique items", ref _maxUniques, 0, 100))
+            {
+                _profile.BuyAgentMaxUniques = _maxUniques;
+            }
+            if (ImGui.IsItemHovered())
+                ImGui.SetTooltip("Maximum number of different items to buy in a single transaction.");
+
+            ImGui.Separator();
+
+            // Add entry section
+            if (ImGui.Button("Add Entry"))
+            {
+                _showAddEntry = !_showAddEntry;
+            }
+
+            ImGui.SameLine();
+            if (ImGui.Button("Target Item to Add"))
+            {
+                World.Instance.TargetManager.SetTargeting((targetedItem) =>
+                {
+                    if (targetedItem != null && targetedItem is Entity targetedEntity)
+                    {
+                        if (SerialHelper.IsItem(targetedEntity))
+                        {
+                            var newConfig = BuySellAgent.Instance.NewBuyConfig();
+                            newConfig.Graphic = targetedEntity.Graphic;
+                            newConfig.Hue = targetedEntity.Hue;
+                            _buyEntries = BuySellAgent.Instance.BuyConfigs;
+                        }
+                    }
+                });
+            }
+
+            if (_showAddEntry)
+            {
+                ImGui.Separator();
+                ImGui.Text("Add New Entry:");
+
+                ImGui.Text("Graphic:");
+                ImGui.SameLine();
+                ImGui.InputText("##NewGraphic", ref _newGraphicInput, 10);
+
+                ImGui.Text("Hue (-1 for any):");
+                ImGui.SameLine();
+                ImGui.InputText("##NewHue", ref _newHueInput, 10);
+
+                ImGui.Text("Max Amount:");
+                ImGui.SameLine();
+                ImGui.InputText("##NewMaxAmount", ref _newMaxAmountInput, 10);
+
+                ImGui.Text("Restock Up To:");
+                ImGui.SameLine();
+                ImGui.InputText("##NewRestock", ref _newRestockInput, 10);
+                if (ImGui.IsItemHovered())
+                    ImGui.SetTooltip("Amount to restock up to when buying (0 = disabled)");
+
+                if (ImGui.Button("Add##AddEntry"))
+                {
+                    if (TryParseGraphic(_newGraphicInput, out int graphic))
+                    {
+                        var newConfig = BuySellAgent.Instance.NewBuyConfig();
+                        newConfig.Graphic = (ushort)graphic;
+
+                        if (!string.IsNullOrEmpty(_newHueInput) && _newHueInput != "-1")
+                        {
+                            if (ushort.TryParse(_newHueInput, out ushort hue))
+                                newConfig.Hue = hue;
+                        }
+                        else
+                        {
+                            newConfig.Hue = ushort.MaxValue;
+                        }
+
+                        if (!string.IsNullOrEmpty(_newMaxAmountInput) && ushort.TryParse(_newMaxAmountInput, out ushort maxAmount))
+                        {
+                            newConfig.MaxAmount = maxAmount == 0 ? ushort.MaxValue : maxAmount;
+                        }
+
+                        if (!string.IsNullOrEmpty(_newRestockInput) && ushort.TryParse(_newRestockInput, out ushort restock))
+                        {
+                            newConfig.RestockUpTo = restock;
+                        }
+
+                        _newGraphicInput = "";
+                        _newHueInput = "";
+                        _newMaxAmountInput = "";
+                        _newRestockInput = "";
+                        _showAddEntry = false;
+                        _buyEntries = BuySellAgent.Instance.BuyConfigs;
+                    }
+                }
+                ImGui.SameLine();
+                if (ImGui.Button("Cancel##AddEntry"))
+                {
+                    _showAddEntry = false;
+                    _newGraphicInput = "";
+                    _newHueInput = "";
+                    _newMaxAmountInput = "";
+                    _newRestockInput = "";
+                }
+            }
+
+            ImGui.Separator();
+
+            if (_buyEntries.Count == 0)
+            {
+                ImGui.Text("No entries configured");
+            }
+            else
+            {
+                // Table headers
+                if (ImGui.BeginTable("AutoBuyTable", 7, ImGuiTableFlags.Borders | ImGuiTableFlags.RowBg | ImGuiTableFlags.ScrollY, new Vector2(0, 200)))
+                {
+                    ImGui.TableSetupColumn(string.Empty, ImGuiTableColumnFlags.WidthFixed, 52);
+                    ImGui.TableSetupColumn("Graphic", ImGuiTableColumnFlags.WidthFixed, 80);
+                    ImGui.TableSetupColumn("Hue", ImGuiTableColumnFlags.WidthFixed, 80);
+                    ImGui.TableSetupColumn("Max Amount", ImGuiTableColumnFlags.WidthFixed, 80);
+                    ImGui.TableSetupColumn("Restock Up To", ImGuiTableColumnFlags.WidthFixed, 80);
+                    ImGui.TableSetupColumn("Enabled", ImGuiTableColumnFlags.WidthFixed, 60);
+                    ImGui.TableSetupColumn("Actions", ImGuiTableColumnFlags.WidthFixed, 50);
+                    ImGui.TableHeadersRow();
+
+                    for (int i = _buyEntries.Count - 1; i >= 0; i--)
+                    {
+                        var entry = _buyEntries[i];
+                        ImGui.TableNextRow();
+
+                        ImGui.TableNextColumn();
+                        if (!DrawArt(entry.Graphic, new Vector2(50, 50)))
+                            ImGui.Text($"{entry.Graphic:X4}");
+
+                        // Graphic
+                        ImGui.TableNextColumn();
+                        if (!_entryGraphicInputs.ContainsKey(entry))
+                        {
+                            _entryGraphicInputs[entry] = entry.Graphic.ToString();
+                        }
+                        string graphicStr = _entryGraphicInputs[entry];
+                        if (ImGui.InputText($"##Graphic{i}", ref graphicStr, 10))
+                        {
+                            _entryGraphicInputs[entry] = graphicStr;
+                            if (TryParseGraphic(graphicStr, out int newGraphic))
+                            {
+                                entry.Graphic = (ushort)newGraphic;
+                            }
+                        }
+
+                        // Hue
+                        ImGui.TableNextColumn();
+                        if (!_entryHueInputs.ContainsKey(entry))
+                        {
+                            _entryHueInputs[entry] = entry.Hue == ushort.MaxValue ? "-1" : entry.Hue.ToString();
+                        }
+                        string hueStr = _entryHueInputs[entry];
+                        if (ImGui.InputText($"##Hue{i}", ref hueStr, 10))
+                        {
+                            _entryHueInputs[entry] = hueStr;
+                            if (hueStr == "-1")
+                            {
+                                entry.Hue = ushort.MaxValue;
+                            }
+                            else if (ushort.TryParse(hueStr, out ushort newHue))
+                            {
+                                entry.Hue = newHue;
+                            }
+                        }
+
+                        // Max Amount
+                        ImGui.TableNextColumn();
+                        if (!_entryMaxAmountInputs.ContainsKey(entry))
+                        {
+                            _entryMaxAmountInputs[entry] = entry.MaxAmount == ushort.MaxValue ? "0" : entry.MaxAmount.ToString();
+                        }
+                        string maxAmountStr = _entryMaxAmountInputs[entry];
+                        if (ImGui.InputText($"##MaxAmount{i}", ref maxAmountStr, 10))
+                        {
+                            _entryMaxAmountInputs[entry] = maxAmountStr;
+                            if (ushort.TryParse(maxAmountStr, out ushort newMaxAmount))
+                            {
+                                entry.MaxAmount = newMaxAmount == 0 ? ushort.MaxValue : newMaxAmount;
+                            }
+                        }
+
+                        // Restock Up To
+                        ImGui.TableNextColumn();
+                        if (!_entryRestockInputs.ContainsKey(entry))
+                        {
+                            _entryRestockInputs[entry] = entry.RestockUpTo.ToString();
+                        }
+                        string restockStr = _entryRestockInputs[entry];
+                        if (ImGui.InputText($"##Restock{i}", ref restockStr, 10))
+                        {
+                            _entryRestockInputs[entry] = restockStr;
+                            if (ushort.TryParse(restockStr, out ushort newRestock))
+                            {
+                                entry.RestockUpTo = newRestock;
+                            }
+                        }
+
+                        // Enabled
+                        ImGui.TableNextColumn();
+                        bool enabled = entry.Enabled;
+                        if (ImGui.Checkbox($"##Enabled{i}", ref enabled))
+                        {
+                            entry.Enabled = enabled;
+                        }
+
+                        // Actions
+                        ImGui.TableNextColumn();
+                        if (ImGui.Button($"Delete##Delete{i}"))
+                        {
+                            BuySellAgent.Instance?.DeleteConfig(entry);
+                            // Clean up input dictionaries
+                            _entryGraphicInputs.Remove(entry);
+                            _entryHueInputs.Remove(entry);
+                            _entryMaxAmountInputs.Remove(entry);
+                            _entryRestockInputs.Remove(entry);
+                            _buyEntries = BuySellAgent.Instance.BuyConfigs;
+                        }
+                    }
+
+                    ImGui.EndTable();
+                }
+            }
+        }
+
+        private bool TryParseGraphic(string text, out int graphic)
+        {
+            graphic = 0;
+            if (string.IsNullOrEmpty(text)) return false;
+
+            if (text.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+            {
+                return int.TryParse(text.Substring(2), NumberStyles.AllowHexSpecifier, null, out graphic);
+            }
+            else
+            {
+                return int.TryParse(text, out graphic);
+            }
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added an “Auto Buy” tab in the Assistant window to configure automated buying.
  * Enable/disable Auto Buy, set max items/uniques, and manage a list of buy entries.
  * Add entries via manual input or targeting an in-game item to prefill details.
  * Edit, enable/disable, or delete existing entries; changes persist with profiles.
  * New button in the Assistant UI opens the Assistant window directly to Auto Buy.

* Chores
  * Bumped application version to 4.9.11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->