### PR TITLE
Add graphic to autoloot assistant window

### DIFF
--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/AutoLootWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/AutoLootWindow.cs
@@ -209,8 +209,9 @@ namespace ClassicUO.Game.UI.ImGuiControls
             }
             else
             // Table headers
-            if (ImGui.BeginTable("AutoLootTable", 4, ImGuiTableFlags.Borders | ImGuiTableFlags.RowBg | ImGuiTableFlags.ScrollY, new Vector2(0, 200)))
+            if (ImGui.BeginTable("AutoLootTable", 5, ImGuiTableFlags.Borders | ImGuiTableFlags.RowBg | ImGuiTableFlags.ScrollY, new Vector2(0, 200)))
             {
+                ImGui.TableSetupColumn(string.Empty, ImGuiTableColumnFlags.WidthFixed, 52);
                 ImGui.TableSetupColumn("Graphic", ImGuiTableColumnFlags.WidthFixed, 80);
                 ImGui.TableSetupColumn("Hue", ImGuiTableColumnFlags.WidthFixed, 80);
                 ImGui.TableSetupColumn("Regex", ImGuiTableColumnFlags.WidthStretch);
@@ -221,6 +222,10 @@ namespace ClassicUO.Game.UI.ImGuiControls
                 {
                     var entry = lootEntries[i];
                     ImGui.TableNextRow();
+
+                    ImGui.TableNextColumn();
+                    if (!DrawArt((ushort)entry.Graphic, new Vector2(50, 50)))
+                        ImGui.Text($"{entry.Graphic:X4}");
 
                     ImGui.TableNextColumn();
                     // Initialize input string if not exists


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto Loot window now includes an item thumbnail preview column, making it easier to recognize items at a glance.
  * Updated table layout to accommodate the new preview while keeping existing columns intact.
  * If a thumbnail can’t be shown, the item identifier is displayed instead for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->