### PR TITLE
Move graphic replacement to new assistant window

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/AssistantGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/AssistantGump.cs
@@ -52,7 +52,6 @@ public class AssistantGump : BaseOptionsGump
 
     private void BuildAutoLoot()
     {
-        int page = (int)PAGE.AutoLoot;
 
         ModernButton button = new(0, 0, MainContent.LeftWidth, 40, ButtonAction.Default, "Auto loot", ThemeSettings.BUTTON_FONT_COLOR);
         button.MouseUp += (_, e) =>
@@ -69,7 +68,6 @@ public class AssistantGump : BaseOptionsGump
 
     private void BuildAutoSell()
     {
-        int page = (int)PAGE.AutoSell;
 
         ModernButton button = new(0, 0, MainContent.LeftWidth, 40, ButtonAction.Default, "Auto sell", ThemeSettings.BUTTON_FONT_COLOR);
         button.MouseUp += (_, e) =>
@@ -86,7 +84,6 @@ public class AssistantGump : BaseOptionsGump
 
     private void BuildAutoBuy()
     {
-        int page = (int)PAGE.AutoBuy;
 
         ModernButton button = new(0, 0, MainContent.LeftWidth, 40, ButtonAction.Default, "Auto buy", ThemeSettings.BUTTON_FONT_COLOR);
         button.MouseUp += (_, e) =>
@@ -131,18 +128,18 @@ public class AssistantGump : BaseOptionsGump
 
     private void BuildMobileGraphicFilter()
     {
-        var page = (int)PAGE.MobileGraphicFilter;
-        MainContent.AddToLeft(CategoryButton("Mobile Graphics", page, MainContent.LeftWidth));
-        MainContent.ResetRightSide();
 
-        ScrollArea scroll = new(0, 0, MainContent.RightWidth, MainContent.Height);
-        MainContent.AddToRight(scroll, false, page);
-        PositionHelper.Reset();
+        ModernButton button = new(0, 0, MainContent.LeftWidth, 40, ButtonAction.Default, "Mobile Graphics", ThemeSettings.BUTTON_FONT_COLOR);
+        button.MouseUp += (_, e) =>
+        {
+            if(e.Button == MouseButtonType.Left)
+            {
+                AssistantWindow.Show();
+                AssistantWindow.Instance.SelectTab(PAGE.MobileGraphicFilter);
+            }
+        };
 
-        scroll.Add(PositionHelper.PositionControl(new HttpClickableLink("Mobile Graphic Filter Wiki", "https://github.com/PlayTazUO/TazUO/wiki/TazUO.Mobile-Graphics-Filter", ThemeSettings.TEXT_FONT_COLOR)));
-        scroll.Add(PositionHelper.PositionControl(TextBox.GetOne("This can be used to replace graphics of mobiles with other graphics(For example if dragons are too big, replace them with wyverns).", ThemeSettings.FONT, ThemeSettings.STANDARD_TEXT_SIZE, ThemeSettings.TEXT_FONT_COLOR, TextBox.RTLOptions.Default(MainContent.RightWidth - 20))));
-        PositionHelper.BlankLine();
-        scroll.Add(PositionHelper.PositionControl(new GraphicFilterConfigs(World, MainContent.RightWidth - ThemeSettings.SCROLL_BAR_WIDTH - 10)));
+        MainContent.AddToLeft(button);
     }
 
     private void BuildSpellBar()
@@ -596,7 +593,6 @@ public class AssistantGump : BaseOptionsGump
 
     private void BuildBandageAgent()
     {
-        var page = (int)PAGE.BandageAgent;
 
         ModernButton button = new(0, 0, MainContent.LeftWidth, 40, ButtonAction.Default, "Auto Bandage", ThemeSettings.BUTTON_FONT_COLOR);
         button.MouseUp += (_, e) =>
@@ -716,7 +712,6 @@ public class AssistantGump : BaseOptionsGump
 
     private void BuildOrganizer()
     {
-        const int page = (int)PAGE.Organizer;
         ModernButton orgButton = new(0, 0, MainContent.LeftWidth, 40, ButtonAction.Default, "Organizer", ThemeSettings.BUTTON_FONT_COLOR);
         orgButton.MouseUp += (_, e) =>
         {
@@ -1107,191 +1102,6 @@ public class AssistantGump : BaseOptionsGump
             Height = _container.Height;
         }
     }
-    private class GraphicFilterConfigs : Control
-        {
-            private DataBox _dataBox;
-
-            public GraphicFilterConfigs(World world, int width)
-            {
-                AcceptMouseInput = true;
-                CanMove = true;
-                Width = width;
-
-                Add(_dataBox = new DataBox(0, 0, width, 0));
-
-                ModernButton b;
-                _dataBox.Add(b = new ModernButton(0, 0, 150, ThemeSettings.CHECKBOX_SIZE, ButtonAction.Default, "+ Add blank entry", ThemeSettings.BUTTON_FONT_COLOR));
-
-                b.MouseUp += (s, e) =>
-                {
-                    var newConfig = GraphicsReplacement.NewFilter(0, 0);
-
-                    if (newConfig != null)
-                    {
-                        _dataBox.Insert(3, GenConfigEntry(newConfig, width));
-                        RearrangeDataBox();
-                    }
-                };
-
-                _dataBox.Add(b = new ModernButton(0, 0, 150, ThemeSettings.CHECKBOX_SIZE, ButtonAction.Default, "+ Target entity", ThemeSettings.BUTTON_FONT_COLOR));
-
-                b.MouseUp += (s, e) =>
-                {
-                    world.TargetManager.SetTargeting((e) =>
-                        {
-                            if (e == null || !(e is Entity entity))
-                                return;
-
-                            // if (e == null || !SerialHelper.IsMobile(e)) return;
-                            var sc = GraphicsReplacement.NewFilter(entity.Graphic, entity.Graphic, entity.Hue);
-
-                            if (sc != null && _dataBox != null)
-                            {
-                                _dataBox.Insert(3, GenConfigEntry(sc, width));
-                                RearrangeDataBox();
-                            }
-                        }
-                    );
-                };
-
-                Area titles = new Area(false);
-
-                Control c;
-                titles.Add(TextBox.GetOne("Graphic", ThemeSettings.FONT, ThemeSettings.STANDARD_TEXT_SIZE, ThemeSettings.TEXT_FONT_COLOR, TextBox.RTLOptions.Default()));
-                titles.Add(c = TextBox.GetOne("New Graphic", ThemeSettings.FONT, ThemeSettings.STANDARD_TEXT_SIZE, ThemeSettings.TEXT_FONT_COLOR, TextBox.RTLOptions.Default()));
-                c.X = ((width - 90 - 5) / 3) + 5;
-                titles.Add(c = TextBox.GetOne("New Hue", ThemeSettings.FONT, ThemeSettings.STANDARD_TEXT_SIZE, ThemeSettings.TEXT_FONT_COLOR, TextBox.RTLOptions.Default()));
-                c.X = (((width - 90 - 5) / 3) * 2) + 10;
-                titles.ForceSizeUpdate();
-                _dataBox.Add(titles);
-
-                foreach (var item in GraphicsReplacement.GraphicFilters)
-                {
-                    _dataBox.Add(GenConfigEntry(item.Value, width));
-                }
-
-                RearrangeDataBox();
-            }
-
-            private Control GenConfigEntry(GraphicChangeFilter filter, int width)
-            {
-                int ewidth = (width - 90) / 3;
-
-                Area area = new Area()
-                {
-                    Width = width,
-                    Height = 50
-                };
-
-                int x = 0;
-
-                InputField graphicInput = new InputField
-                (
-                    ewidth, 50, 100, -1, filter.OriginalGraphic.ToString(), false, (s, e) =>
-                    {
-                        InputField.StbTextBox graphicInput = (InputField.StbTextBox)s;
-
-                        if (graphicInput.Text.StartsWith("0x") && ushort.TryParse(graphicInput.Text.Substring(2), NumberStyles.AllowHexSpecifier, null, out var ngh))
-                        {
-                            filter.OriginalGraphic = ngh;
-                            GraphicsReplacement.ResetLists();
-                        }
-                        else if (ushort.TryParse(graphicInput.Text, out var ng))
-                        {
-                            filter.OriginalGraphic = ng;
-                            GraphicsReplacement.ResetLists();
-                        }
-                    }
-                )
-                {
-                    X = x
-                };
-
-                graphicInput.SetTooltip("Original Graphic");
-                area.Add(graphicInput);
-                x += graphicInput.Width + 5;
-
-                InputField newgraphicInput = new InputField
-                (
-                    ewidth, 50, 100, -1, filter.ReplacementGraphic.ToString(), false, (s, e) =>
-                    {
-                        InputField.StbTextBox graphicInput = (InputField.StbTextBox)s;
-
-                        if (graphicInput.Text.StartsWith("0x") && ushort.TryParse(graphicInput.Text.Substring(2), NumberStyles.AllowHexSpecifier, null, out var ngh))
-                        {
-                            filter.ReplacementGraphic = ngh;
-                        }
-                        else if (ushort.TryParse(graphicInput.Text, out var ng))
-                        {
-                            filter.ReplacementGraphic = ng;
-                        }
-                    }
-                )
-                {
-                    X = x
-                };
-
-                newgraphicInput.SetTooltip("Replacement Graphic");
-                area.Add(newgraphicInput);
-                x += newgraphicInput.Width + 5;
-
-                InputField hueInput = new InputField
-                (
-                    ewidth, 50, 100, -1, filter.NewHue == ushort.MaxValue ? "-1" : filter.NewHue.ToString(), false, (s, e) =>
-                    {
-                        InputField.StbTextBox hueInput = (InputField.StbTextBox)s;
-
-                        if (hueInput.Text == "-1")
-                        {
-                            filter.NewHue = ushort.MaxValue;
-                        }
-                        else if (ushort.TryParse(hueInput.Text, out var ng))
-                        {
-                            filter.NewHue = ng;
-                        }
-                    }
-                )
-                {
-                    X = x
-                };
-
-                hueInput.SetTooltip("Hue (-1 to leave original)");
-                area.Add(hueInput);
-                x += hueInput.Width + 5;
-
-                NiceButton delete;
-
-                area.Add
-                (
-                    delete = new NiceButton(x, 0, area.Width - x, 49, ButtonAction.Activate, "X")
-                    {
-                        IsSelectable = false,
-                        DisplayBorder = true
-                    }
-                );
-
-                delete.SetTooltip("Delete this entry");
-
-                delete.MouseUp += (s, e) =>
-                {
-                    if (e.Button == Input.MouseButtonType.Left)
-                    {
-                        GraphicsReplacement.DeleteFilter(filter.OriginalGraphic);
-                        area.Dispose();
-                        RearrangeDataBox();
-                    }
-                };
-
-                return area;
-            }
-
-            private void RearrangeDataBox()
-            {
-                _dataBox.ReArrangeChildren();
-                _dataBox.ForceSizeUpdate();
-                Height = _dataBox.Height;
-            }
-        }
 
     #endregion
 }

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/AssistantWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/AssistantWindow.cs
@@ -18,6 +18,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
             AddTab("Auto Loot", DrawAutoLoot, AutoLootWindow.Show, () => AutoLootWindow.Instance?.Dispose() );
             AddTab("Auto Sell", DrawAutoSell, AutoSellWindow.Show, () => AutoSellWindow.Instance?.Dispose() );
             AddTab("Auto Buy", DrawAutoBuy, AutoBuyWindow.Show, () => AutoBuyWindow.Instance?.Dispose() );
+            AddTab("Mobile Graphics", DrawGraphicReplacement, GraphicReplacementWindow.Show, () => GraphicReplacementWindow.Instance?.Dispose() );
             AddTab("Organizer", DrawOrganizer, OrganizerWindow.Show, () => OrganizerWindow.Instance?.Dispose() );
             AddTab("Bandage Agent", DrawBandageAgent, BandageAgentWindow.Show, () => BandageAgentWindow.Instance?.Dispose() );
         }
@@ -38,6 +39,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
                     _preSelectIndex = 3;
                     break;
                 case AssistantGump.PAGE.MobileGraphicFilter:
+                    _preSelectIndex = 4;
                     break;
                 case AssistantGump.PAGE.SpellBar:
                     break;
@@ -52,12 +54,12 @@ namespace ClassicUO.Game.UI.ImGuiControls
                 case AssistantGump.PAGE.DressAgent:
                     break;
                 case AssistantGump.PAGE.BandageAgent:
-                    _preSelectIndex = 5;
+                    _preSelectIndex = 6;
                     break;
                 case AssistantGump.PAGE.FriendsList:
                     break;
                 case AssistantGump.PAGE.Organizer:
-                    _preSelectIndex = 4;
+                    _preSelectIndex = 5;
                     break;
             }
         }
@@ -127,6 +129,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
         private void DrawAutoLoot() => AutoLootWindow.GetInstance()?.DrawContent();
         private void DrawAutoSell() => AutoSellWindow.GetInstance()?.DrawContent();
         private void DrawAutoBuy() => AutoBuyWindow.GetInstance()?.DrawContent();
+        private void DrawGraphicReplacement() => GraphicReplacementWindow.GetInstance()?.DrawContent();
         private void DrawOrganizer() => OrganizerWindow.GetInstance()?.DrawContent();
         private void DrawBandageAgent() => BandageAgentWindow.GetInstance()?.DrawContent();
 

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/GraphicReplacementWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/GraphicReplacementWindow.cs
@@ -1,0 +1,222 @@
+using ImGuiNET;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Numerics;
+using ClassicUO.Game.Managers;
+using ClassicUO.Game.GameObjects;
+
+namespace ClassicUO.Game.UI.ImGuiControls
+{
+    public class GraphicReplacementWindow : SingletonImGuiWindow<GraphicReplacementWindow>
+    {
+        private string newOriginalGraphicInput = "";
+        private string newReplacementGraphicInput = "";
+        private string newHueInput = "";
+        private bool showAddEntry = false;
+        private Dictionary<ushort, string> entryOriginalInputs = new Dictionary<ushort, string>();
+        private Dictionary<ushort, string> entryReplacementInputs = new Dictionary<ushort, string>();
+        private Dictionary<ushort, string> entryHueInputs = new Dictionary<ushort, string>();
+
+        private GraphicReplacementWindow() : base("Mobile Graphics Replacement")
+        {
+            WindowFlags = ImGuiWindowFlags.AlwaysAutoResize;
+        }
+
+        public override void DrawContent()
+        {
+            ImGui.TextWrapped("This can be used to replace graphics of mobiles with other graphics (For example if dragons are too big, replace them with wyverns).");
+
+            ImGui.Separator();
+
+            // Add entry section
+            if (ImGui.Button("Add Entry"))
+            {
+                showAddEntry = !showAddEntry;
+            }
+
+            ImGui.SameLine();
+            if (ImGui.Button("Target Entity"))
+            {
+                World.Instance.TargetManager.SetTargeting((targetedEntity) =>
+                {
+                    if (targetedEntity != null && targetedEntity is Entity entity)
+                    {
+                        var filter = GraphicsReplacement.NewFilter(entity.Graphic, entity.Graphic, entity.Hue);
+                        if (filter != null)
+                        {
+                            // Initialize input strings for the new entry
+                            entryOriginalInputs[filter.OriginalGraphic] = filter.OriginalGraphic.ToString();
+                            entryReplacementInputs[filter.OriginalGraphic] = filter.ReplacementGraphic.ToString();
+                            entryHueInputs[filter.OriginalGraphic] = filter.NewHue == ushort.MaxValue ? "-1" : filter.NewHue.ToString();
+                        }
+                    }
+                });
+            }
+
+            if (showAddEntry)
+            {
+                ImGui.Separator();
+                ImGui.Text("Add New Entry:");
+
+                ImGui.Text("Original Graphic:");
+                ImGui.SameLine();
+                ImGui.InputText("##NewOriginalGraphic", ref newOriginalGraphicInput, 10);
+
+                ImGui.Text("Replacement Graphic:");
+                ImGui.SameLine();
+                ImGui.InputText("##NewReplacementGraphic", ref newReplacementGraphicInput, 10);
+
+                ImGui.Text("New Hue (-1 to leave original):");
+                ImGui.SameLine();
+                ImGui.InputText("##NewHue", ref newHueInput, 10);
+
+                if (ImGui.Button("Add##AddEntry"))
+                {
+                    if (TryParseGraphic(newOriginalGraphicInput, out int originalGraphic) &&
+                        TryParseGraphic(newReplacementGraphicInput, out int replacementGraphic))
+                    {
+                        ushort newHue = ushort.MaxValue;
+                        if (!string.IsNullOrEmpty(newHueInput) && newHueInput != "-1")
+                        {
+                            ushort.TryParse(newHueInput, out newHue);
+                        }
+
+                        var filter = GraphicsReplacement.NewFilter((ushort)originalGraphic, (ushort)replacementGraphic, newHue);
+                        if (filter != null)
+                        {
+                            // Initialize input strings for the new entry
+                            entryOriginalInputs[filter.OriginalGraphic] = filter.OriginalGraphic.ToString();
+                            entryReplacementInputs[filter.OriginalGraphic] = filter.ReplacementGraphic.ToString();
+                            entryHueInputs[filter.OriginalGraphic] = filter.NewHue == ushort.MaxValue ? "-1" : filter.NewHue.ToString();
+                        }
+
+                        newOriginalGraphicInput = "";
+                        newReplacementGraphicInput = "";
+                        newHueInput = "";
+                        showAddEntry = false;
+                    }
+                }
+                ImGui.SameLine();
+                if (ImGui.Button("Cancel##AddEntry"))
+                {
+                    showAddEntry = false;
+                    newOriginalGraphicInput = "";
+                    newReplacementGraphicInput = "";
+                    newHueInput = "";
+                }
+            }
+
+            ImGui.Separator();
+
+            // List of current filters
+            ImGui.Text("Current Graphic Replacements:");
+
+            var filters = GraphicsReplacement.GraphicFilters;
+            if (filters.Count == 0)
+            {
+                ImGui.Text("No replacements configured");
+            }
+            else
+            {
+                // Table headers
+                if (ImGui.BeginTable("GraphicReplacementTable", 4, ImGuiTableFlags.Borders | ImGuiTableFlags.RowBg | ImGuiTableFlags.ScrollY, new Vector2(0, 200)))
+                {
+                    ImGui.TableSetupColumn("Original Graphic", ImGuiTableColumnFlags.WidthFixed, 80);
+                    ImGui.TableSetupColumn("Replacement Graphic", ImGuiTableColumnFlags.WidthFixed, 80);
+                    ImGui.TableSetupColumn("New Hue", ImGuiTableColumnFlags.WidthFixed, 80);
+                    ImGui.TableSetupColumn("Actions", ImGuiTableColumnFlags.WidthFixed, 80);
+                    ImGui.TableHeadersRow();
+
+                    var filterList = filters.Values.ToList();
+                    for (int i = filterList.Count - 1; i >= 0; i--)
+                    {
+                        var filter = filterList[i];
+                        ImGui.TableNextRow();
+
+                        ImGui.TableNextColumn();
+                        // Initialize input string if not exists
+                        if (!entryOriginalInputs.ContainsKey(filter.OriginalGraphic))
+                        {
+                            entryOriginalInputs[filter.OriginalGraphic] = filter.OriginalGraphic.ToString();
+                        }
+                        string originalStr = entryOriginalInputs[filter.OriginalGraphic];
+                        if (ImGui.InputText($"##Original{i}", ref originalStr, 10))
+                        {
+                            entryOriginalInputs[filter.OriginalGraphic] = originalStr;
+                            if (TryParseGraphic(originalStr, out int newOriginal))
+                            {
+                                filter.OriginalGraphic = (ushort)newOriginal;
+                                GraphicsReplacement.ResetLists();
+                            }
+                        }
+
+                        ImGui.TableNextColumn();
+                        // Initialize input string if not exists
+                        if (!entryReplacementInputs.ContainsKey(filter.OriginalGraphic))
+                        {
+                            entryReplacementInputs[filter.OriginalGraphic] = filter.ReplacementGraphic.ToString();
+                        }
+                        string replacementStr = entryReplacementInputs[filter.OriginalGraphic];
+                        if (ImGui.InputText($"##Replacement{i}", ref replacementStr, 10))
+                        {
+                            entryReplacementInputs[filter.OriginalGraphic] = replacementStr;
+                            if (TryParseGraphic(replacementStr, out int newReplacement))
+                            {
+                                filter.ReplacementGraphic = (ushort)newReplacement;
+                            }
+                        }
+
+                        ImGui.TableNextColumn();
+                        // Initialize input string if not exists
+                        if (!entryHueInputs.ContainsKey(filter.OriginalGraphic))
+                        {
+                            entryHueInputs[filter.OriginalGraphic] = filter.NewHue == ushort.MaxValue ? "-1" : filter.NewHue.ToString();
+                        }
+                        string hueStr = entryHueInputs[filter.OriginalGraphic];
+                        if (ImGui.InputText($"##Hue{i}", ref hueStr, 10))
+                        {
+                            entryHueInputs[filter.OriginalGraphic] = hueStr;
+                            if (hueStr == "-1")
+                            {
+                                filter.NewHue = ushort.MaxValue;
+                            }
+                            else if (ushort.TryParse(hueStr, out ushort newHue))
+                            {
+                                filter.NewHue = newHue;
+                            }
+                        }
+
+                        ImGui.TableNextColumn();
+                        if (ImGui.Button($"Delete##Delete{i}"))
+                        {
+                            GraphicsReplacement.DeleteFilter(filter.OriginalGraphic);
+                            // Clean up input dictionaries
+                            entryOriginalInputs.Remove(filter.OriginalGraphic);
+                            entryReplacementInputs.Remove(filter.OriginalGraphic);
+                            entryHueInputs.Remove(filter.OriginalGraphic);
+                        }
+                    }
+
+                    ImGui.EndTable();
+                }
+            }
+        }
+
+        private bool TryParseGraphic(string text, out int graphic)
+        {
+            graphic = 0;
+            if (string.IsNullOrEmpty(text)) return false;
+
+            if (text.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+            {
+                return int.TryParse(text.Substring(2), NumberStyles.AllowHexSpecifier, null, out graphic);
+            }
+            else
+            {
+                return int.TryParse(text, out graphic);
+            }
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a “Mobile Graphics” tab for managing graphic replacement rules.
  - Introduced an interactive window to add, edit, and delete rules, with hex/decimal inputs and in-game targeting to prefill values.
  - Provides a live, editable table of rules and user feedback when no rules exist.

- Refactor
  - Streamlined navigation: relevant buttons now open the Assistant window directly to the appropriate tab.
  - Updated tab pre-selection indexes for Mobile Graphics, Bandage Agent, and Organizer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->