### PR TITLE
Update World Map when receiving map updates from Ultima Live

### DIFF
--- a/src/ClassicUO.Client/Game/GameActions.cs
+++ b/src/ClassicUO.Client/Game/GameActions.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: BSD-2-Clause
+// SPDX-License-Identifier: BSD-2-Clause
 using System;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
@@ -1058,22 +1058,24 @@ internal static class GameActions
         Socket.Send_RenameRequest(serial, name);
     }
 
-        public static void Logout(World world)
+    public static void Logout(World world)
+    {
+        if ((world.ClientFeatures.Flags & CharacterListFlags.CLF_OWERWRITE_CONFIGURATION_BUTTON) != 0)
         {
-            if ((world.ClientFeatures.Flags & CharacterListFlags.CLF_OWERWRITE_CONFIGURATION_BUTTON) != 0)
-            {
-                Client.Game.GetScene<GameScene>().DisconnectionRequested = true;
-                Socket.Send_LogoutNotification();
-            }
-            else
-            {
-                Client.Game.GetScene<GameScene>().DisconnectionRequested = true;
-                Client.Game.SetScene(new LoginScene(world));
-
-                Socket?.Disconnect();
-                Socket = new AsyncNetClient();
-            }
+            Client.Game.GetScene<GameScene>().DisconnectionRequested = true;
+            Socket.Send_LogoutNotification();
         }
+        else
+        {
+            Client.Game.GetScene<GameScene>().DisconnectionRequested = true;
+            Client.Game.SetScene(new LoginScene(world));
+
+            Socket?.Disconnect();
+            Socket = new AsyncNetClient();
+        }
+
+        WorldMapGump.ClearMapCache();
+    }
 
     internal static void UseSkill(int index)
     {

--- a/src/ClassicUO.Client/Game/Map/Chunk.cs
+++ b/src/ClassicUO.Client/Game/Map/Chunk.cs
@@ -1,13 +1,15 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
-using System.Collections.Generic;
-using System.Runtime.CompilerServices;
+using ClassicUO.Assets;
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.Managers;
-using ClassicUO.Assets;
+using ClassicUO.Game.UI.Gumps;
+using ClassicUO.Utility;
 using System;
-using System.Runtime.InteropServices;
 using System.Buffers;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace ClassicUO.Game.Map
 {
@@ -51,7 +53,7 @@ namespace ClassicUO.Game.Map
         }
 
 
-        public unsafe void Load(int index)
+        public unsafe void Load(int index, bool updateWorldMap = false)
         {
             IsDestroyed = false;
 
@@ -70,6 +72,10 @@ namespace ClassicUO.Game.Map
             var cells = block.Cells;
             int bx = X << 3;
             int by = Y << 3;
+
+            uint[] bufferBlock = new uint[64];
+            sbyte[] bufferBlockZ = new sbyte[64];
+            var huesLoader = Client.Game.UO.FileManager.Hues;
 
             for (int y = 0; y < 8; ++y)
             {
@@ -96,10 +102,20 @@ namespace ClassicUO.Game.Map
                         land.Hue = hue;
 
                     AddGameObject(land, x, y);
+
+                    if (updateWorldMap)
+                    {
+                        ushort color = (ushort)(0x8000 | huesLoader.GetRadarColorData(tileID & 0x3FFF));
+
+                        int blockIndex = y * 8 + x;
+                        bufferBlock[blockIndex] = HuesHelper.Color16To32(color) | 0xFF_00_00_00;
+                        bufferBlockZ[blockIndex] = z;
+                    }
                 }
             }
 
-            if (im.StaticAddress != 0 && im.StaticCount > 0)
+            //If Ultima Live is on, the statics of the first map block explored could be saved to StaticAdress 0, because the static file could be empty, so we can't check StaticAdress != 0
+            if (im.StaticAddress >= 0 && im.StaticCount > 0)
             {
                 var staticsBlockBuffer = ArrayPool<StaticsBlock>.Shared.Rent((int)im.StaticCount);
                 var staticsSpan = staticsBlockBuffer.AsSpan(0, (int)im.StaticCount);
@@ -127,10 +143,83 @@ namespace ClassicUO.Game.Map
                             staticObject.Hue = hue;
 
                         AddGameObject(staticObject, sb.X, sb.Y);
+
+                        if (updateWorldMap)
+                        {
+                            int blockIndex = (sb.Y << 3) + sb.X;
+                            if (GameObject.CanBeDrawn(_world, sb.Color) && sb.Z >= bufferBlockZ[blockIndex])
+                            {
+                                ushort color = (ushort)(0x8000 | (sb.Hue != 0 ? huesLoader.GetColor16(16384, sb.Hue) : huesLoader.GetRadarColorData(sb.Color + 0x4000)));
+
+                                bufferBlock[blockIndex] = HuesHelper.Color16To32(color) | 0xFF_00_00_00;
+                                bufferBlockZ[blockIndex] = sb.Z;
+                            }
+                        }
                     }
                 }
 
                 ArrayPool<StaticsBlock>.Shared.Return(staticsBlockBuffer);
+            }
+
+            if (updateWorldMap)
+            {
+                const float MAG_0 = 80f / 100f;
+                const float MAG_1 = 100f / 80f;
+
+                for (int y = 0; y < 8; ++y)
+                {
+                    for (int x = 0; x < 8; ++x)
+                    {
+                        int blockCurrent = y * 8 + x;
+                        int blockNext = (y + 1) * 8 + x;
+
+                        //Reached last line, nothing to compare with
+                        if (y == 7)
+                        {
+                            break;
+                        }
+
+                        sbyte z0 = bufferBlockZ[++blockCurrent];
+                        sbyte z1 = bufferBlockZ[blockNext];
+
+                        if (z0 == z1)
+                        {
+                            continue;
+                        }
+
+                        ref uint cc = ref bufferBlock[blockCurrent];
+
+                        if (cc == 0)
+                        {
+                            continue;
+                        }
+
+                        byte r = (byte)(cc & 0xFF);
+                        byte g = (byte)((cc >> 8) & 0xFF);
+                        byte b = (byte)((cc >> 16) & 0xFF);
+                        byte a = (byte)((cc >> 24) & 0xFF);
+
+                        if (r != 0 || g != 0 || b != 0)
+                        {
+                            if (z0 < z1)
+                            {
+                                r = (byte)Math.Min(0xFF, r * MAG_0);
+                                g = (byte)Math.Min(0xFF, g * MAG_0);
+                                b = (byte)Math.Min(0xFF, b * MAG_0);
+                            }
+                            else
+                            {
+                                r = (byte)Math.Min(0xFF, r * MAG_1);
+                                g = (byte)Math.Min(0xFF, g * MAG_1);
+                                b = (byte)Math.Min(0xFF, b * MAG_1);
+                            }
+
+                            cc = (uint)(r | (g << 8) | (b << 16) | (a << 24));
+                        }
+                    }
+                }
+
+                UIManager.GetGump<WorldMapGump>()?.UpdateWorldMapChunk(X, Y, bufferBlock);
             }
         }
 

--- a/src/ClassicUO.Client/Game/UltimaLive.cs
+++ b/src/ClassicUO.Client/Game/UltimaLive.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: BSD-2-Clause
+// SPDX-License-Identifier: BSD-2-Clause
 
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.Managers;
@@ -291,7 +291,7 @@ namespace ClassicUO.Game
 
                             mapChunk.Clear();
                             _UL._ULMap.ReloadBlock(mapId, block);
-                            mapChunk.Load(mapId);
+                            mapChunk.Load(mapId, true);
 
                             //linkedList?.AddLast(c.Node);
 
@@ -511,7 +511,7 @@ namespace ClassicUO.Game
                         }
 
                         mapChunk.Clear();
-                        mapChunk.Load(mapId);
+                        mapChunk.Load(mapId, true);
 
                         foreach (GameObject obj in gameObjects)
                         {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * World map updates incrementally per chunk for smoother, faster refreshes.
  * Automatic world map cache clearing on map changes and logout for accurate displays.

* **Bug Fixes**
  * Prevented issues when statics files are empty during world map processing.
  * Removed stale world map cache files to avoid outdated visuals.

* **Refactor**
  * Simplified logout flow, ensuring consistent disconnection and return to the login screen.

* **Chores**
  * Internal hooks added to trigger world map synchronization during terrain/static loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->