### PR TITLE
Add dropdown box to API

### DIFF
--- a/src/APIToMarkdown/Program.cs
+++ b/src/APIToMarkdown/Program.cs
@@ -287,7 +287,7 @@ public static class GenDoc
                 if (pyReturn == classDeclaration.Identifier.Text)
                     pyReturn = $"\"{pyReturn}\"";
 
-                python.AppendLine($"{pySpace}def {method.Identifier.Text}({GetPythonParameters(method.ParameterList.Parameters)})"
+                python.AppendLine($"{pySpace}def {method.Identifier.Text}({GetPythonParameters(method.ParameterList.Parameters, !isMainAPI)})"
                  + $" -> {pyReturn}:");
                 if (!string.IsNullOrWhiteSpace(methodSummary))
                 {
@@ -420,11 +420,15 @@ public static class GenDoc
         sb.Append(")`");
     }
 
-    private static string GetPythonParameters(SeparatedSyntaxList<ParameterSyntax> parameters)
+    private static string GetPythonParameters(SeparatedSyntaxList<ParameterSyntax> parameters, bool inClass)
     {
-        if (parameters.Count == 0) return "";
+        if (parameters.Count == 0) return inClass ? "self" : string.Empty;
 
         var sb = new StringBuilder();
+
+        if(inClass)
+            sb.Append("self, ");
+
         foreach (var param in parameters)
         {
             string pythonType = MapCSharpTypeToPython(param.Type!.ToString());
@@ -567,6 +571,7 @@ public static class GenDoc
             "Notoriety" => "Notoriety",
             "GameObject" or "PyGameObject" => "PyGameObject",
             "PyProfile" => "PyProfile",
+            "PyControlDropDown" => "PyControlDropDown",
 
             // Fallback for unknown types
             _ => noMatch

--- a/src/ClassicUO.Client/LegionScripting/API.cs
+++ b/src/ClassicUO.Client/LegionScripting/API.cs
@@ -3294,6 +3294,18 @@ namespace ClassicUO.LegionScripting
         }
 
         /// <summary>
+        /// Creates a dropdown control (combobox) with the specified width and items.
+        /// </summary>
+        /// <param name="width">The width of the dropdown control</param>
+        /// <param name="items">Array of strings to display as dropdown options</param>
+        /// <param name="selectedIndex">The initially selected item index (default: 0)</param>
+        /// <returns>A PyControlDropDown wrapper containing the combobox control</returns>
+        public PyControlDropDown CreateDropDown(int width, string[] items, int selectedIndex = 0)
+        {
+            return new PyControlDropDown(new Combobox(0, 0, width, items, selectedIndex));
+        }
+
+        /// <summary>
         /// Add an onClick callback to a control.
         /// Example:
         /// ```py

--- a/src/ClassicUO.Client/LegionScripting/PyClasses/PyBaseControl.cs
+++ b/src/ClassicUO.Client/LegionScripting/PyClasses/PyBaseControl.cs
@@ -1,0 +1,161 @@
+using ClassicUO.Game.Managers;
+using ClassicUO.Game.Scenes;
+using ClassicUO.Game.UI.Controls;
+using ClassicUO.Game.UI.Gumps;
+
+namespace ClassicUO.LegionScripting.PyClasses;
+
+public class PyBaseControl(Control control)
+{
+    /// <summary>
+    /// Adds a child control to this control. Works with gumps too (gump.Add(control)).
+    /// Used in python API
+    /// </summary>
+    /// <param name="childControl">The control to add as a child</param>
+    public void Add(Control childControl)
+    {
+        if (childControl != null && VerifyIntegrity())
+            MainThreadQueue.EnqueueAction(() => control?.Add(childControl));
+    }
+
+    /// <summary>
+    /// Returns the control's X position.
+    /// Used in python API
+    /// </summary>
+    /// <returns>The X coordinate of the control</returns>
+    public int GetX()
+    {
+        if (!VerifyIntegrity())
+            return 0;
+        return control.X;
+    }
+
+    /// <summary>
+    /// Returns the control's Y position.
+    /// Used in python API
+    /// </summary>
+    /// <returns>The Y coordinate of the control</returns>
+    public int GetY()
+    {
+        if (!VerifyIntegrity())
+            return 0;
+        return control.Y;
+    }
+
+    /// <summary>
+    /// Sets the control's X position.
+    /// Used in python API
+    /// </summary>
+    /// <param name="x">The new X coordinate</param>
+    public void SetX(int x)
+    {
+        if (VerifyIntegrity())
+            MainThreadQueue.EnqueueAction(() => control.X = x);
+    }
+
+    /// <summary>
+    /// Sets the control's Y position.
+    /// Used in python API
+    /// </summary>
+    /// <param name="y">The new Y coordinate</param>
+    public void SetY(int y)
+    {
+        if (VerifyIntegrity())
+            MainThreadQueue.EnqueueAction(() => control.Y = y);
+    }
+
+    /// <summary>
+    /// Sets the control's X and Y positions.
+    /// Used in python API
+    /// </summary>
+    /// <param name="x">The new X coordinate</param>
+    /// <param name="y">The new Y coordinate</param>
+    public void SetPos(int x, int y)
+    {
+        if (VerifyIntegrity())
+            MainThreadQueue.EnqueueAction(() =>
+            {
+                control.X = x;
+                control.Y = y;
+            });
+    }
+
+    /// <summary>
+    /// Sets the control's width.
+    /// Used in python API
+    /// </summary>
+    /// <param name="width">The new width in pixels</param>
+    public void SetWidth(int width)
+    {
+        if (VerifyIntegrity())
+            MainThreadQueue.EnqueueAction(() => control.Width = width);
+    }
+
+    /// <summary>
+    /// Sets the control's height.
+    /// Used in python API
+    /// </summary>
+    /// <param name="height">The new height in pixels</param>
+    public void SetHeight(int height)
+    {
+        if (VerifyIntegrity())
+            MainThreadQueue.EnqueueAction(() => control.Height = height);
+    }
+
+    /// <summary>
+    /// Sets the control's position and size in one operation.
+    /// Used in python API
+    /// </summary>
+    /// <param name="x">The new X coordinate</param>
+    /// <param name="y">The new Y coordinate</param>
+    /// <param name="width">The new width in pixels</param>
+    /// <param name="height">The new height in pixels</param>
+    public void SetRect(int x, int y, int width, int height)
+    {
+        if (VerifyIntegrity())
+            MainThreadQueue.EnqueueAction(() =>
+            {
+                control.X = x;
+                control.Y = y;
+                control.Width = width;
+                control.Height = height;
+            });
+    }
+
+    /// <summary>
+    /// Centers a GUMP horizontally in the viewport. Only works on Gump instances.
+    /// Used in python API
+    /// </summary>
+    public void CenterXInViewPort()
+    {
+        if (VerifyIntegrity() && control is Gump g)
+            MainThreadQueue.EnqueueAction(() => g.CenterXInViewPort());
+    }
+
+    /// <summary>
+    /// Centers a GUMP vertically in the viewport. Only works on Gump instances.
+    /// Used in python API
+    /// </summary>
+    public void CenterYInViewPort()
+    {
+        if (VerifyIntegrity() && control is Gump g)
+            MainThreadQueue.EnqueueAction(() => g.CenterYInViewPort());
+    }
+
+    /// <summary>
+    /// Close/Destroy the control
+    /// </summary>
+    public void Dispose()
+    {
+        if (VerifyIntegrity())
+            MainThreadQueue.EnqueueAction(() => control?.Dispose());
+    }
+
+    protected bool VerifyIntegrity()
+    {
+        if (control == null)
+            return false;
+
+        return !control.IsDisposed;
+    }
+}

--- a/src/ClassicUO.Client/LegionScripting/PyClasses/PyControlComboBox.cs
+++ b/src/ClassicUO.Client/LegionScripting/PyClasses/PyControlComboBox.cs
@@ -1,0 +1,24 @@
+using ClassicUO.Game.Managers;
+using ClassicUO.Game.UI.Controls;
+
+namespace ClassicUO.LegionScripting.PyClasses;
+
+public class PyControlDropDown(Combobox combobox) : PyBaseControl(combobox)
+{
+    /// <summary>
+    /// Get the selected index of the dropdown. The first entry is 0.
+    /// </summary>
+    /// <returns></returns>
+    public int GetSelectedIndex()
+    {
+        if (!VerifyIntegrity()) return 0;
+
+        return MainThreadQueue.InvokeOnMainThread(() =>
+        {
+            if(combobox != null)
+                return combobox.SelectedIndex;
+
+            return 0;
+        });
+    }
+}


### PR DESCRIPTION
Better fake py api gen
Begin conversion to Pywrapper for controls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support to create and use a dropdown UI control from scripts, including reading the current selection.
  - Introduced a base control wrapper for scripts to add children, move/resize controls, set rectangles, and center controls in the viewport.
  - Improved Python scripting ergonomics: instance methods now correctly include self in non-root API classes.
  - Expanded type mapping to consistently recognize dropdown controls.

- Bug Fixes
  - More reliable parameter handling in generated Python method signatures, ensuring correct behavior when no explicit parameters are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->