### PR TITLE
Fix close corpse macro to also close GridContainer corpses

### DIFF
--- a/src/ClassicUO.Client/Game/Managers/MacroManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/MacroManager.cs
@@ -2038,6 +2038,18 @@ namespace ClassicUO.Game.Managers
                             gridLootGump.Dispose();
                         }
                     }
+
+                    // Close GridContainer corpses
+                    IEnumerable<GridContainer> gridContainerCorpses = UIManager.Gumps.OfType<GridContainer>().Where(gc =>
+                    {
+                        var item = _world.Items.Get(gc.LocalSerial);
+                        return item != null && item.IsCorpse;
+                    });
+
+                    foreach (var gridContainer in gridContainerCorpses)
+                    {
+                        gridContainer.Dispose();
+                    }
                     break;
 
                 case MacroType.ToggleDrawRoofs:


### PR DESCRIPTION
Added code to dispose GridContainer gumps for corpse items when the close corpse macro is executed, ensuring all corpse-related containers are properly closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Automatically closes lingering corpse container grids after related loot windows are closed, preventing orphaned UI panels.
  - Ensures corpse-related containers are fully disposed during macro processing, improving stability and resource usage.
  - Users should see fewer leftover container windows and smoother interactions when looting or closing corpse containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->