### PR TITLE
Add GlobalPriorityQueue for bandage actions with global cooldown inte…

### DIFF
--- a/src/ClassicUO.Client/Game/Managers/BandageManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/BandageManager.cs
@@ -88,6 +88,12 @@ namespace ClassicUO.Game.Managers
 
         private void AttemptHeal()
         {
+            // Enqueue the healing action into the global priority queue
+            GlobalPriorityQueue.Instance.Enqueue(() => ExecuteHeal());
+        }
+
+        private void ExecuteHeal()
+        {
             if (World.Instance.Player == null)
                 return;
 

--- a/src/ClassicUO.Client/Game/Managers/GlobalPriorityQueue.cs
+++ b/src/ClassicUO.Client/Game/Managers/GlobalPriorityQueue.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Concurrent;
+
+namespace ClassicUO.Game.Managers
+{
+    public sealed class GlobalPriorityQueue
+    {
+        public static GlobalPriorityQueue Instance { get; private set; } = new();
+
+        public bool IsEmpty => _isEmpty;
+
+        private bool _isEmpty = true;
+        private readonly ConcurrentQueue<Action> _actions = new();
+
+        private GlobalPriorityQueue()
+        {
+        }
+
+        public void Update()
+        {
+            if (_isEmpty) return;
+            if (GlobalActionCooldown.IsOnCooldown) return;
+
+            if (!_actions.TryDequeue(out var action))
+                return;
+
+            action?.Invoke();
+            GlobalActionCooldown.BeginCooldown();
+            _isEmpty = _actions.IsEmpty;
+        }
+
+        public void Enqueue(Action action)
+        {
+            if (action == null) return;
+
+            _actions.Enqueue(action);
+            _isEmpty = false;
+        }
+
+        public void Clear()
+        {
+            while (_actions.TryDequeue(out var _))
+            {
+            }
+            _isEmpty = true;
+        }
+    }
+}

--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -393,6 +393,7 @@ namespace ClassicUO.Game.Scenes
 
             SpellBarManager.Unload();
             _moveItemQueue.Clear();
+            GlobalPriorityQueue.Instance.Clear();
 
             GraphicsReplacement.Save();
             BuySellAgent.Unload();
@@ -462,6 +463,7 @@ namespace ClassicUO.Game.Scenes
             _world.DelayedObjectClickManager.Clear();
 
             _useItemQueue?.Clear();
+            GlobalPriorityQueue.Instance.Clear();
             EventSink.MessageReceived -= ChatOnMessageReceived;
 
             Settings.GlobalSettings.WindowSize = new Point(
@@ -899,6 +901,9 @@ namespace ClassicUO.Game.Scenes
             {
                 _useItemQueue.ClearCorpses();
             }
+
+            // Process priority queue first (for bandages and other high-priority actions)
+            GlobalPriorityQueue.Instance.Update();
 
             _useItemQueue.Update();
 


### PR DESCRIPTION
…gration

- Create GlobalPriorityQueue class for high-priority actions that respect global cooldown
- Update BandageManager to enqueue healing actions through priority queue instead of direct execution
- Integrate priority queue processing in GameScene.cs before existing item queues
- Ensure bandage actions have priority over move item and use object actions
- Maintain proper global cooldown timing across all action types

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a high-priority action queue that runs before regular actions, improving responsiveness for time-sensitive actions (e.g., bandaging).
  - Bandage/healing now executes via the queue with cooldown gating for more consistent timing.

- Bug Fixes
  - Clearing of pending high-priority actions on scene unload to prevent unintended actions after switching or exiting scenes.

- Refactor
  - Restructured healing flow to use the new queued execution path without changing existing behavior or conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->