### PR TITLE
Add ToggleMount macro functionality

### DIFF
--- a/src/ClassicUO.Client/Game/Managers/MacroManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/MacroManager.cs
@@ -1118,6 +1118,40 @@ namespace ClassicUO.Game.Managers
                     _world.TargetManager.SetTargeting(CursorTarget.SetMount, 0, TargetType.Neutral);
                     break;
 
+                case MacroType.ToggleMount:
+                    var mountItem = _world.Player.FindItemByLayer(Layer.Mount);
+                    if (mountItem != null)
+                    {
+                        // Player is mounted, dismount
+                        GameActions.DoubleClickQueued(_world.Player);
+                        ClassicUO.LegionScripting.ScriptRecorder.Instance.RecordDismount();
+                    }
+                    else
+                    {
+                        // Player is not mounted, try to mount
+                        if (ProfileManager.CurrentProfile.SavedMountSerial != 0)
+                        {
+                            Entity mount = _world.Get(ProfileManager.CurrentProfile.SavedMountSerial);
+                            if (mount != null)
+                            {
+                                GameActions.DoubleClickQueued(ProfileManager.CurrentProfile.SavedMountSerial);
+                                ClassicUO.LegionScripting.ScriptRecorder.Instance.RecordMount(mount);
+                            }
+                            else
+                            {
+                                GameActions.Print(_world, "Saved mount not found. Target a new mount.", 32);
+                                _world.TargetManager.SetTargeting(CursorTarget.SetMount, 0, TargetType.Neutral);
+                            }
+                        }
+                        else
+                        {
+                            GameActions.Print(_world, "No mount set. Target a mount to save it.", 48);
+                            _world.TargetManager.SetTargeting(CursorTarget.SetMount, 0, TargetType.Neutral);
+                            result = 1;
+                        }
+                    }
+                    break;
+
                 case MacroType.AddFriend:
                     GameActions.Print(_world, "Target a player to add as a friend.", 62);
                     _world.TargetManager.SetTargeting(targeted =>
@@ -2744,6 +2778,7 @@ namespace ClassicUO.Game.Managers
         AddFriend,
         RemoveFriend,
         ToggleHotkeys,
+        ToggleMount,
     }
 
     public enum MacroSubType


### PR DESCRIPTION
Adds MacroType.ToggleMount enum value and implementation that automatically:
- Dismounts if player is currently mounted
- Attempts to mount using saved mount if player is not mounted
- Prompts to set mount if no saved mount is configured

Added ToggleMount at end of enum to preserve existing macro indices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Toggle Mount” macro action to mount or dismount with a single trigger.
  * Automatically uses your previously saved mount when available; if not saved or found, prompts you to target and save one.
  * Shows clear on-screen messages and targeting prompts to guide selection.
  * Available in the macro editor alongside existing mount-related actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->