### PR TITLE
Add ImGui-based ScriptManagerWindow alongside existing ScriptManagerGump

### DIFF
--- a/src/ClassicUO.Client/Game/Managers/BandageManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/BandageManager.cs
@@ -88,6 +88,12 @@ namespace ClassicUO.Game.Managers
 
         private void AttemptHeal()
         {
+            // Enqueue the healing action into the global priority queue
+            GlobalPriorityQueue.Instance.Enqueue(() => ExecuteHeal());
+        }
+
+        private void ExecuteHeal()
+        {
             if (World.Instance.Player == null)
                 return;
 

--- a/src/ClassicUO.Client/Game/Managers/GlobalPriorityQueue.cs
+++ b/src/ClassicUO.Client/Game/Managers/GlobalPriorityQueue.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Concurrent;
+
+namespace ClassicUO.Game.Managers
+{
+    public sealed class GlobalPriorityQueue
+    {
+        public static GlobalPriorityQueue Instance { get; private set; } = new();
+
+        public bool IsEmpty => _isEmpty;
+
+        private bool _isEmpty = true;
+        private readonly ConcurrentQueue<Action> _actions = new();
+
+        private GlobalPriorityQueue()
+        {
+        }
+
+        public void Update()
+        {
+            if (_isEmpty) return;
+            if (GlobalActionCooldown.IsOnCooldown) return;
+
+            if (!_actions.TryDequeue(out var action))
+                return;
+
+            action?.Invoke();
+            GlobalActionCooldown.BeginCooldown();
+            _isEmpty = _actions.IsEmpty;
+        }
+
+        public void Enqueue(Action action)
+        {
+            if (action == null) return;
+
+            _actions.Enqueue(action);
+            _isEmpty = false;
+        }
+
+        public void Clear()
+        {
+            while (_actions.TryDequeue(out var _))
+            {
+            }
+            _isEmpty = true;
+        }
+    }
+}

--- a/src/ClassicUO.Client/Game/Managers/MacroManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/MacroManager.cs
@@ -1118,6 +1118,40 @@ namespace ClassicUO.Game.Managers
                     _world.TargetManager.SetTargeting(CursorTarget.SetMount, 0, TargetType.Neutral);
                     break;
 
+                case MacroType.ToggleMount:
+                    var mountItem = _world.Player.FindItemByLayer(Layer.Mount);
+                    if (mountItem != null)
+                    {
+                        // Player is mounted, dismount
+                        GameActions.DoubleClickQueued(_world.Player);
+                        ClassicUO.LegionScripting.ScriptRecorder.Instance.RecordDismount();
+                    }
+                    else
+                    {
+                        // Player is not mounted, try to mount
+                        if (ProfileManager.CurrentProfile.SavedMountSerial != 0)
+                        {
+                            Entity mount = _world.Get(ProfileManager.CurrentProfile.SavedMountSerial);
+                            if (mount != null)
+                            {
+                                GameActions.DoubleClickQueued(ProfileManager.CurrentProfile.SavedMountSerial);
+                                ClassicUO.LegionScripting.ScriptRecorder.Instance.RecordMount(mount);
+                            }
+                            else
+                            {
+                                GameActions.Print(_world, "Saved mount not found. Target a new mount.", 32);
+                                _world.TargetManager.SetTargeting(CursorTarget.SetMount, 0, TargetType.Neutral);
+                            }
+                        }
+                        else
+                        {
+                            GameActions.Print(_world, "No mount set. Target a mount to save it.", 48);
+                            _world.TargetManager.SetTargeting(CursorTarget.SetMount, 0, TargetType.Neutral);
+                            result = 1;
+                        }
+                    }
+                    break;
+
                 case MacroType.AddFriend:
                     GameActions.Print(_world, "Target a player to add as a friend.", 62);
                     _world.TargetManager.SetTargeting(targeted =>
@@ -2756,6 +2790,7 @@ namespace ClassicUO.Game.Managers
         AddFriend,
         RemoveFriend,
         ToggleHotkeys,
+        ToggleMount,
     }
 
     public enum MacroSubType

--- a/src/ClassicUO.Client/Game/Managers/SpellVisualRangeManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/SpellVisualRangeManager.cs
@@ -454,6 +454,7 @@ namespace ClassicUO.Game.Managers
                 saveTimer = new Timer();
                 saveTimer.Interval = 500;
                 saveTimer.Elapsed += (_,_) => { PerformSave(); };
+                saveTimer.Start();
             }
         }
 

--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -393,6 +393,7 @@ namespace ClassicUO.Game.Scenes
 
             SpellBarManager.Unload();
             _moveItemQueue.Clear();
+            GlobalPriorityQueue.Instance.Clear();
 
             GraphicsReplacement.Save();
             BuySellAgent.Unload();
@@ -462,6 +463,7 @@ namespace ClassicUO.Game.Scenes
             _world.DelayedObjectClickManager.Clear();
 
             _useItemQueue?.Clear();
+            GlobalPriorityQueue.Instance.Clear();
             EventSink.MessageReceived -= ChatOnMessageReceived;
 
             Settings.GlobalSettings.WindowSize = new Point(
@@ -899,6 +901,9 @@ namespace ClassicUO.Game.Scenes
             {
                 _useItemQueue.ClearCorpses();
             }
+
+            // Process priority queue first (for bandages and other high-priority actions)
+            GlobalPriorityQueue.Instance.Update();
 
             _useItemQueue.Update();
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/AssistantGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/AssistantGump.cs
@@ -281,30 +281,17 @@ public class AssistantGump : BaseOptionsGump
 
     private void BuildSpellIndicator()
     {
-        var page = (int)PAGE.SpellIndicator;
-        MainContent.AddToLeft(CategoryButton("Spell Indicators", page, MainContent.LeftWidth));
-        MainContent.ResetRightSide();
-
-        ScrollArea scroll = new(0, 0, MainContent.RightWidth, MainContent.Height);
-        MainContent.AddToRight(scroll, false, page);
-
-        PositionHelper.Reset();
-
-        SpellRangeEditor editor = new (scroll.Width - 20);
-
-        InputFieldWithLabel search = new ("Spell search", ThemeSettings.INPUT_WIDTH, string.Empty, false, (s, e) =>
+        ModernButton button = new(0, 0, MainContent.LeftWidth, 40, ButtonAction.Default, "Spell Indicators", ThemeSettings.BUTTON_FONT_COLOR);
+        button.MouseUp += (_, e) =>
         {
-            if (SpellDefinition.TryGetSpellFromName(((BaseOptionsGump.InputField.StbTextBox)s).Text, out SpellDefinition spell))
+            if(e.Button == MouseButtonType.Left)
             {
-                if(SpellVisualRangeManager.Instance.SpellRangeCache.TryGetValue(spell.ID, out SpellVisualRangeManager.SpellRangeInfo info))
-                    editor.SetSpellRangeInfo(info);
+                AssistantWindow.Show();
+                AssistantWindow.Instance.SelectTab(PAGE.SpellIndicator);
             }
-        });
+        };
 
-        scroll.Add(PositionHelper.PositionControl(search));
-        PositionHelper.BlankLine();
-        PositionHelper.BlankLine();
-        scroll.Add(PositionHelper.PositionControl(editor));
+        MainContent.AddToLeft(button);
     }
 
     private void BuildJournalFilter()

--- a/src/ClassicUO.Client/Game/UI/Gumps/AssistantGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/AssistantGump.cs
@@ -296,70 +296,17 @@ public class AssistantGump : BaseOptionsGump
 
     private void BuildJournalFilter()
     {
-        var page = (int)PAGE.JournalFilter;
-        MainContent.AddToLeft(CategoryButton("Journal Filter", page, MainContent.LeftWidth));
-        MainContent.ResetRightSide();
-
-        ScrollArea scroll = new(0, 0, MainContent.RightWidth, MainContent.Height);
-        MainContent.AddToRight(scroll, false, page);
-
-        PositionHelper.Reset();
-
-        scroll.Add(PositionHelper.PositionControl(new HttpClickableLink("Journal Filter Wiki", "https://github.com/PlayTazUO/TazUO/wiki/Journal-Filters", Color.White)));
-
-        VBoxContainer vbox = new(scroll.Width - 18);
-
-        ModernButton addButton = new(0, 0, 150, ThemeSettings.CHECKBOX_SIZE, ButtonAction.Default, "Add entry", ThemeSettings.BUTTON_FONT_COLOR);
-        addButton.MouseUp += (s, e) =>
+        ModernButton button = new(0, 0, MainContent.LeftWidth, 40, ButtonAction.Default, "Journal Filter", ThemeSettings.BUTTON_FONT_COLOR);
+        button.MouseUp += (_, e) =>
         {
-            JournalFilterManager.Instance.AddFilter("Type your matching text here");
-            buildEntries();
+            if(e.Button == MouseButtonType.Left)
+            {
+                AssistantWindow.Show();
+                AssistantWindow.Instance.SelectTab(PAGE.JournalFilter);
+            }
         };
 
-        scroll.Add(PositionHelper.PositionControl(addButton));
-        scroll.Add(PositionHelper.PositionControl(vbox));
-        buildEntries();
-
-        void buildEntries()
-        {
-            vbox.Clear();
-
-            foreach (string filter in JournalFilterManager.Instance.Filters)
-            {
-                vbox.Add(entryArea(filter));
-            }
-        }
-
-        Area entryArea(string filter)
-        {
-            string currentFilter = filter;
-            Area area = new Area();
-
-            InputField input = new InputField(scroll.Width - 18 - 25, ThemeSettings.CHECKBOX_SIZE, text: filter);
-            input.SetTooltip("Must match the journal entry exactly. Partial matches not supported.");
-            input.TextChanged += (s, e) =>
-            {
-                var newText = ((InputField.StbTextBox)s).Text;
-                JournalFilterManager.Instance.RemoveFilter(currentFilter);
-                JournalFilterManager.Instance.AddFilter(newText);
-                currentFilter = newText;
-            };
-
-            ModernButton del = new(scroll.Width-18-25, 0, 25, ThemeSettings.CHECKBOX_SIZE, ButtonAction.Default, "X", ThemeSettings.BUTTON_FONT_COLOR);
-            del.SetTooltip("Delete entry");
-            del.MouseUp += (s, e) =>
-            {
-                JournalFilterManager.Instance.RemoveFilter(currentFilter);
-                buildEntries();
-            };
-
-            area.Add(input);
-            area.Add(del);
-
-            area.ForceSizeUpdate();
-
-            return area;
-        }
+        MainContent.AddToLeft(button);
     }
 
     private void BuildTitleBar()

--- a/src/ClassicUO.Client/Game/UI/Gumps/TopBarGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/TopBarGump.cs
@@ -13,6 +13,7 @@ using ClassicUO.Utility.Logging;
 using Microsoft.Xna.Framework;
 using System.Collections.Generic;
 using ClassicUO.Game.UI.Gumps.SpellBar;
+using ClassicUO.Game.UI.ImGuiControls;
 
 namespace ClassicUO.Game.UI.Gumps
 {
@@ -166,7 +167,10 @@ namespace ClassicUO.Game.UI.Gumps
                 Y = 1,
                 FontCenter = true
             }, 1);
-            lscript.MouseUp += (s, e) => { UIManager.Add(new LegionScripting.ScriptManagerGump()); };
+            lscript.MouseUp += (s, e) => {
+                UIManager.Add(new LegionScripting.ScriptManagerGump());
+                ScriptManagerWindow.Show();
+            };
             startX += largeWidth + 1;
 
             RighClickableButton moreMenu;

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/Agents/AgentsWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/Agents/AgentsWindow.cs
@@ -17,6 +17,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
         private void DrawAutoSell() => AutoSellWindow.GetInstance()?.DrawContent();
         private void DrawAutoBuy() => AutoBuyWindow.GetInstance()?.DrawContent();
         private void DrawBandageAgent() => BandageAgentWindow.GetInstance()?.DrawContent();
+        private void DrawJournalFilter() => JournalFilterWindow.GetInstance()?.DrawContent();
         public override void DrawContent()
         {
             if (_profile == null)
@@ -55,6 +56,12 @@ namespace ClassicUO.Game.UI.ImGuiControls
                 if (ImGui.BeginTabItem("Dress"))
                 {
                     ImGui.Text("Dress Agent Will go here.");
+                    ImGui.EndTabItem();
+                }
+
+                if (ImGui.BeginTabItem("Journal Filter"))
+                {
+                    DrawJournalFilter();
                     ImGui.EndTabItem();
                 }
                 ImGui.EndTabBar();

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/Agents/AutoBuyWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/Agents/AutoBuyWindow.cs
@@ -54,36 +54,42 @@ namespace ClassicUO.Game.UI.ImGuiControls
             }
 
             // Main settings
-            if (ImGui.Checkbox("Enable auto buy", ref _enableAutoBuy))
+            ImGui.Spacing();
+            if (ImGui.Checkbox("Enable Auto Buy", ref _enableAutoBuy))
             {
                 _profile.BuyAgentEnabled = _enableAutoBuy;
             }
 
-            if (ImGui.SliderInt("Max total items (0 = unlimited)", ref _maxItems, 0, 100))
+            ImGui.SeparatorText("Options:");
+            ImGui.Spacing();
+
+            ImGui.SetNextItemWidth(150);
+            if (ImGui.SliderInt("Max total items", ref _maxItems, 0, 1000))
             {
                 _profile.BuyAgentMaxItems = _maxItems;
             }
-            if (ImGui.IsItemHovered())
-                ImGui.SetTooltip("Maximum total items to buy in a single transaction. Set to 0 for unlimited.");
+            ImGuiComponents.Tooltip("Maximum total items to buy in a single transaction. Set to 0 for unlimited.");
 
+            ImGui.SetNextItemWidth(150);
             if (ImGui.SliderInt("Max unique items", ref _maxUniques, 0, 100))
             {
                 _profile.BuyAgentMaxUniques = _maxUniques;
             }
-            if (ImGui.IsItemHovered())
-                ImGui.SetTooltip("Maximum number of different items to buy in a single transaction.");
+                ImGuiComponents.Tooltip("Maximum number of different items to buy in a single transaction.");
 
-            ImGui.Separator();
+            ImGui.Spacing();
 
+            ImGui.SeparatorText("Entries:");
             // Add entry section
-            if (ImGui.Button("Add Entry"))
+            if (ImGui.Button("Add Manual Entry"))
             {
                 _showAddEntry = !_showAddEntry;
             }
 
             ImGui.SameLine();
-            if (ImGui.Button("Target Item to Add"))
+            if (ImGui.Button("Add from Target"))
             {
+                GameActions.Print(Client.Game.UO.World, "Target item to add");
                 World.Instance.TargetManager.SetTargeting((targetedItem) =>
                 {
                     if (targetedItem != null && targetedItem is Entity targetedEntity)
@@ -101,26 +107,42 @@ namespace ClassicUO.Game.UI.ImGuiControls
 
             if (_showAddEntry)
             {
-                ImGui.Separator();
-                ImGui.Text("Add New Entry:");
+                ImGui.SeparatorText("Add New Entry:");
+                ImGui.Spacing();
 
+                ImGui.BeginGroup();
+                ImGui.AlignTextToFramePadding();
                 ImGui.Text("Graphic:");
-                ImGui.SameLine();
+                ImGui.SetNextItemWidth(70);
                 ImGui.InputText("##NewGraphic", ref _newGraphicInput, 10);
+                ImGui.EndGroup();
 
+                ImGui.SameLine();
+
+                ImGui.BeginGroup();
+                ImGui.AlignTextToFramePadding();
                 ImGui.Text("Hue (-1 for any):");
-                ImGui.SameLine();
+                ImGui.SetNextItemWidth(50);
                 ImGui.InputText("##NewHue", ref _newHueInput, 10);
+                ImGui.EndGroup();
 
+                ImGui.BeginGroup();
+                ImGui.AlignTextToFramePadding();
                 ImGui.Text("Max Amount:");
-                ImGui.SameLine();
+                ImGui.SetNextItemWidth(100);
                 ImGui.InputText("##NewMaxAmount", ref _newMaxAmountInput, 10);
+                ImGui.EndGroup();
 
-                ImGui.Text("Restock Up To:");
                 ImGui.SameLine();
+
+                ImGui.BeginGroup();
+                ImGui.AlignTextToFramePadding();
+                ImGui.Text("Restock Up To:");
+                ImGui.SetNextItemWidth(100);
                 ImGui.InputText("##NewRestock", ref _newRestockInput, 10);
-                if (ImGui.IsItemHovered())
-                    ImGui.SetTooltip("Amount to restock up to when buying (0 = disabled)");
+                ImGuiComponents.Tooltip("Amount to restock up to when buying (0 = disabled)");
+
+                ImGui.EndGroup();
 
                 if (ImGui.Button("Add##AddEntry"))
                 {

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/Agents/AutoLootWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/Agents/AutoLootWindow.cs
@@ -53,47 +53,54 @@ namespace ClassicUO.Game.UI.ImGuiControls
                 ImGui.Text("Profile not loaded");
                 return;
             }
-
-            ImGui.TextWrapped("Auto Loot allows you to automatically pick up items from corpses based on configured criteria.");
-            ImGui.Separator();
-
             // Main settings
-            if (ImGui.Checkbox("Enable auto loot", ref enableAutoLoot))
+            ImGui.Spacing();
+            if (ImGui.Checkbox("Enable Auto Loot", ref enableAutoLoot))
             {
                 profile.EnableAutoLoot = enableAutoLoot;
             }
+            ImGuiComponents.Tooltip("Auto Loot allows you to automatically pick up items from corpses based on configured criteria.");
 
-            if (ImGui.InputInt("Action Delay", ref actionDelay))
-            {
-                actionDelay = Math.Clamp(actionDelay, 10, 30000);
-                profile.MoveMultiObjectDelay = actionDelay;
-            }
+            ImGui.SameLine();
 
-            if (ImGui.Checkbox("Enable scavenger", ref enableScavenger))
-            {
-                profile.EnableScavenger = enableScavenger;
-            }
-
-            if (ImGui.Checkbox("Enable progress bar", ref enableProgressBar))
-            {
-                profile.EnableAutoLootProgressBar = enableProgressBar;
-            }
-
-            if (ImGui.Checkbox("Auto loot human corpses", ref autoLootHumanCorpses))
-            {
-                profile.AutoLootHumanCorpses = autoLootHumanCorpses;
-            }
-
-            ImGui.Separator();
-
-            // Buttons for grab bag and import/export
             if (ImGui.Button("Set Grab Bag"))
             {
                 GameActions.Print(Client.Game.UO.World, "Target container to grab items into");
                 Client.Game.UO.World.TargetManager.SetTargeting(CursorTarget.SetGrabBag, 0, TargetType.Neutral);
             }
-
             ImGui.SameLine();
+
+            ImGuiComponents.Tooltip("Choose a container to grab items into");
+
+            ImGui.SeparatorText("Options:");
+
+            if (ImGui.Checkbox("Enable Scavenger", ref enableScavenger))
+            {
+                profile.EnableScavenger = enableScavenger;
+            }
+            ImGui.SameLine();
+
+            ImGuiComponents.Tooltip("Scavenger option allows to pick objects from ground.");
+
+            if (ImGui.Checkbox("Enable progress bar", ref enableProgressBar))
+            {
+                profile.EnableAutoLootProgressBar = enableProgressBar;
+            }
+            ImGui.SameLine();
+
+            ImGuiComponents.Tooltip("Shows a progress bar gump.");
+
+
+            if (ImGui.Checkbox("Auto loot human corpses", ref autoLootHumanCorpses))
+            {
+                profile.AutoLootHumanCorpses = autoLootHumanCorpses;
+            }
+            ImGui.SameLine();
+
+            ImGuiComponents.Tooltip("Auto loots human corpses.");
+
+            // Buttons for grab bag and import/export
+            ImGui.SeparatorText("Import & Export:");
             if (ImGui.Button("Export JSON"))
             {
                 FileSelector.ShowFileBrowser(Client.Game.UO.World, FileSelectorType.Directory, null, null, (selectedPath) =>
@@ -126,22 +133,21 @@ namespace ClassicUO.Game.UI.ImGuiControls
                 showCharacterImportPopup = true;
             }
 
-            ImGui.Separator();
-
             // Add entry section
-            if (ImGui.Button("Add Entry"))
+            ImGui.SeparatorText("Entries:");
+
+            if (ImGui.Button("Add Manual Entry"))
             {
                 showAddEntry = !showAddEntry;
             }
-
             ImGui.SameLine();
-            if (ImGui.Button("Target Item to Add"))
+            if (ImGui.Button("Add from Target"))
             {
                 World.Instance.TargetManager.SetTargeting((targetedItem) =>
                 {
                     if (targetedItem != null && targetedItem is Entity targetedEntity)
                     {
-                        if(SerialHelper.IsItem(targetedEntity))
+                        if (SerialHelper.IsItem(targetedEntity))
                         {
                             AutoLootManager.Instance.AddAutoLootEntry(targetedEntity.Graphic, targetedEntity.Hue, targetedEntity.Name);
                             lootEntries = AutoLootManager.Instance.AutoLootList;
@@ -152,20 +158,34 @@ namespace ClassicUO.Game.UI.ImGuiControls
 
             if (showAddEntry)
             {
-                ImGui.Separator();
-                ImGui.Text("Add New Entry:");
+                ImGui.SeparatorText("Add New Entry:");
+                ImGui.Spacing();
 
+                ImGui.BeginGroup();
+                ImGui.AlignTextToFramePadding();
                 ImGui.Text("Graphic:");
                 ImGui.SameLine();
+                ImGuiComponents.Tooltip("Item Graphic");
+                ImGui.SetNextItemWidth(70);
                 ImGui.InputText("##NewGraphic", ref newGraphicInput, 10);
+                ImGui.EndGroup();
 
-                ImGui.Text("Hue (-1 for any):");
                 ImGui.SameLine();
+
+                ImGui.BeginGroup();
+                ImGui.AlignTextToFramePadding();
+                ImGui.Text("Hue:");
+                ImGui.SameLine();
+
+                ImGuiComponents.Tooltip("Set -1 to match any Hue");
+                ImGui.SetNextItemWidth(70);
                 ImGui.InputText("##NewHue", ref newHueInput, 10);
+                ImGui.EndGroup();
 
                 ImGui.Text("Regex:");
-                ImGui.SameLine();
-                ImGui.InputText("##NewRegex", ref newRegexInput, 100);
+                ImGui.InputText("##NewRegex", ref newRegexInput, 500);
+
+                ImGui.Spacing();
 
                 if (ImGui.Button("Add##AddEntry"))
                 {
@@ -197,10 +217,8 @@ namespace ClassicUO.Game.UI.ImGuiControls
                 }
             }
 
-            ImGui.Separator();
-
+            ImGui.SeparatorText("Current Auto Loot Entries:");
             // List of current entries
-            ImGui.Text("Current Auto Loot Entries:");
 
             if (lootEntries.Count == 0)
             {
@@ -213,7 +231,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
                 ImGui.TableSetupColumn(string.Empty, ImGuiTableColumnFlags.WidthFixed, 52);
                 ImGui.TableSetupColumn("Graphic", ImGuiTableColumnFlags.WidthFixed, ImGuiTheme.Dimensions.STANDARD_INPUT_WIDTH);
                 ImGui.TableSetupColumn("Hue", ImGuiTableColumnFlags.WidthFixed, ImGuiTheme.Dimensions.STANDARD_INPUT_WIDTH);
-                ImGui.TableSetupColumn("Regex", ImGuiTableColumnFlags.WidthStretch);
+                ImGui.TableSetupColumn("Regex", ImGuiTableColumnFlags.WidthFixed, 100);
                 ImGui.TableSetupColumn("Actions", ImGuiTableColumnFlags.WidthFixed, ImGuiTheme.Dimensions.STANDARD_INPUT_WIDTH);
                 ImGui.TableHeadersRow();
 
@@ -269,11 +287,30 @@ namespace ClassicUO.Game.UI.ImGuiControls
                         entryRegexInputs[entry.UID] = entry.RegexSearch ?? "";
                     }
                     string regexStr = entryRegexInputs[entry.UID];
-                    if (ImGui.InputText($"##Regex{i}", ref regexStr, 200))
+
+
+                    if (ImGui.Button($"Edit##{i}"))
                     {
-                        entryRegexInputs[entry.UID] = regexStr;
-                        entry.RegexSearch = regexStr;
+                        ImGui.OpenPopup($"RegexEditor##{i}");
                     }
+
+                    if (ImGui.BeginPopup($"RegexEditor##{i}"))
+                    {
+                        ImGui.TextColored(ImGuiTheme.Colors.Primary, "Regex Editor:");
+
+                        if (ImGui.InputTextMultiline($"##Regex{i}", ref regexStr, 500, new Vector2(300, 100)))
+                        {
+                            entryRegexInputs[entry.UID] = regexStr;
+                            entry.RegexSearch = regexStr;
+                        }
+
+                        if (ImGui.Button("Close"))
+                            ImGui.CloseCurrentPopup();
+
+                        ImGui.EndPopup();
+                    }
+
+
 
                     ImGui.TableNextColumn();
                     if (ImGui.Button($"Delete##Delete{i}"))

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/Agents/AutoSellWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/Agents/AutoSellWindow.cs
@@ -54,36 +54,38 @@ namespace ClassicUO.Game.UI.ImGuiControls
             }
 
             // Main settings
-            if (ImGui.Checkbox("Enable auto sell", ref _enableAutoSell))
+            ImGui.Spacing();
+            if (ImGui.Checkbox("Enable Auto Sell", ref _enableAutoSell))
             {
                 _profile.SellAgentEnabled = _enableAutoSell;
             }
 
-            if (ImGui.SliderInt("Max total items (0 = unlimited)", ref _maxItems, 0, 100))
+            ImGui.SeparatorText("Options:");
+
+            ImGui.SetNextItemWidth(150);
+            if (ImGui.SliderInt("Max total items", ref _maxItems, 0, 1000))
             {
                 _profile.SellAgentMaxItems = _maxItems;
             }
-            if (ImGui.IsItemHovered())
-                ImGui.SetTooltip("Maximum total items to sell in a single transaction. Set to 0 for unlimited.");
-
+                ImGuiComponents.Tooltip("Maximum total items to sell in a single transaction. Set to 0 for unlimited.");
+            ImGui.SetNextItemWidth(150);
             if (ImGui.SliderInt("Max unique items", ref _maxUniques, 0, 100))
             {
                 _profile.SellAgentMaxUniques = _maxUniques;
             }
-            if (ImGui.IsItemHovered())
-                ImGui.SetTooltip("Maximum number of different items to sell in a single transaction.");
+            ImGuiComponents.Tooltip("Maximum number of different items to sell in a single transaction.");
 
-            ImGui.Separator();
-
+            ImGui.SeparatorText("Entries:");
             // Add entry section
-            if (ImGui.Button("Add Entry"))
+            if (ImGui.Button("Add Manual Entry"))
             {
                 _showAddEntry = !_showAddEntry;
             }
 
             ImGui.SameLine();
-            if (ImGui.Button("Target Item to Add"))
+            if (ImGui.Button("Add from Target"))
             {
+                GameActions.Print(Client.Game.UO.World, "Target item to add");
                 World.Instance.TargetManager.SetTargeting((targetedItem) =>
                 {
                     if (targetedItem != null && targetedItem is Entity targetedEntity)
@@ -101,26 +103,45 @@ namespace ClassicUO.Game.UI.ImGuiControls
 
             if (_showAddEntry)
             {
-                ImGui.Separator();
-                ImGui.Text("Add New Entry:");
+                ImGui.SeparatorText("Add New Entry:");
+                ImGui.Spacing();
 
+                ImGui.BeginGroup();
+                ImGui.AlignTextToFramePadding();
                 ImGui.Text("Graphic:");
-                ImGui.SameLine();
+                ImGui.SetNextItemWidth(70);
                 ImGui.InputText("##NewGraphic", ref _newGraphicInput, 10);
+                ImGui.EndGroup();
 
+                ImGui.SameLine();
+
+                ImGui.BeginGroup();
+                ImGui.AlignTextToFramePadding();
                 ImGui.Text("Hue (-1 for any):");
-                ImGui.SameLine();
+                ImGui.SetNextItemWidth(50);
                 ImGui.InputText("##NewHue", ref _newHueInput, 10);
+                ImGui.EndGroup();
 
+                ImGui.BeginGroup();
+                ImGui.AlignTextToFramePadding();
                 ImGui.Text("Max Amount:");
-                ImGui.SameLine();
+                ImGui.SetNextItemWidth(100);
                 ImGui.InputText("##NewMaxAmount", ref _newMaxAmountInput, 10);
+                ImGuiComponents.Tooltip("Set to 0 for unlimited.");
+                ImGui.EndGroup();
 
-                ImGui.Text("Min on Hand:");
                 ImGui.SameLine();
+
+                ImGui.BeginGroup();
+                ImGui.AlignTextToFramePadding();
+                ImGui.Text("Min on Hand:");
+                ImGui.SetNextItemWidth(100);
                 ImGui.InputText("##NewRestock", ref _newRestockInput, 10);
-                if (ImGui.IsItemHovered())
-                    ImGui.SetTooltip("Minimum amount to keep on hand (0 = disabled)");
+                    ImGuiComponents.Tooltip("Minimum amount to keep on hand (0 = disabled)");
+                ImGui.EndGroup();
+
+                ImGui.Spacing();
+                ImGui.Separator();
 
                 if (ImGui.Button("Add##AddEntry"))
                 {

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/Agents/BandageAgentWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/Agents/BandageAgentWindow.cs
@@ -64,14 +64,14 @@ namespace ClassicUO.Game.UI.ImGuiControls
                     profile.BandageAgentDelay = Math.Clamp(delay, 50, 30000);
                 }
             }
-            SetTooltip("Delay between bandage attempts in milliseconds (50-30000)");
+            ImGuiComponents.Tooltip("Delay between bandage attempts in milliseconds (50-30000)");
 
             // HP percentage threshold slider
             if (ImGui.SliderInt("HP percentage threshold", ref hpPercentage, 10, 95))
             {
                 profile.BandageAgentHPPercentage = hpPercentage;
             }
-            SetTooltip("Heal when HP drops below this percentage");
+            ImGuiComponents.Tooltip("Heal when HP drops below this percentage");
 
             ImGui.Separator();
 
@@ -117,7 +117,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
                     profile.BandageAgentGraphic = graphic;
                 }
             }
-            SetTooltip("Graphic ID of bandages to use (default: 0x0E21). Accepts hex (0x0E21) or decimal (3617)");
+            ImGuiComponents.Tooltip("Graphic ID of bandages to use (default: 0x0E21). Accepts hex (0x0E21) or decimal (3617)");
         }
 
         private bool TryParseBandageGraphic(string text, out ushort graphic)

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/Agents/FriendsListWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/Agents/FriendsListWindow.cs
@@ -1,0 +1,173 @@
+using ImGuiNET;
+using ClassicUO.Game.Managers;
+using ClassicUO.Game.GameObjects;
+using ClassicUO.Game.UI.Gumps;
+using System;
+using System.Numerics;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ClassicUO.Game.UI.ImGuiControls
+{
+    public class FriendsListWindow : SingletonImGuiWindow<FriendsListWindow>
+    {
+        private List<FriendEntry> friendEntries;
+        private bool showAddFriendPopup = false;
+        private string newFriendName = "";
+
+        private FriendsListWindow() : base("Friends List")
+        {
+            WindowFlags = ImGuiWindowFlags.AlwaysAutoResize;
+            RefreshFriendsList();
+        }
+
+        private void RefreshFriendsList()
+        {
+            friendEntries = FriendsListManager.Instance.GetFriends();
+        }
+
+        public override void DrawContent()
+        {
+            ImGui.Spacing();
+
+            // Header information
+            ImGui.Text("Manage your friends list.");
+            ImGui.Spacing();
+
+            // Add friend buttons
+            if (ImGui.Button("Add by Target"))
+            {
+                GameActions.Print(World.Instance, "Target a player to add to friends list");
+                World.Instance.TargetManager.SetTargeting(targeted =>
+                {
+                    if (targeted != null && targeted is Mobile mobile)
+                    {
+                        if (FriendsListManager.Instance.AddFriend(mobile))
+                        {
+                            GameActions.Print(World.Instance, $"Added {mobile.Name} to friends list");
+                            RefreshFriendsList();
+                        }
+                        else
+                        {
+                            GameActions.Print(World.Instance, $"Could not add {mobile.Name} - already in friends list");
+                        }
+                    }
+                    else
+                    {
+                        GameActions.Print(World.Instance, "Invalid target - must be a player");
+                    }
+                });
+            }
+
+            ImGui.SameLine();
+
+            if (ImGui.Button("Add by Name"))
+            {
+                showAddFriendPopup = true;
+            }
+
+            ImGui.Spacing();
+            ImGui.SeparatorText("Current Friends:");
+
+            // Display friends list
+            if (friendEntries.Count == 0)
+            {
+                ImGui.Text("No friends added yet.");
+            }
+            else
+            {
+                // Table for friends list
+                if (ImGui.BeginTable("FriendsTable", 4, ImGuiTableFlags.Borders | ImGuiTableFlags.RowBg | ImGuiTableFlags.ScrollY, new Vector2(0, ImGuiTheme.Dimensions.STANDARD_TABLE_SCROLL_HEIGHT)))
+                {
+                    ImGui.TableSetupColumn("Name", ImGuiTableColumnFlags.WidthStretch);
+                    ImGui.TableSetupColumn("Serial", ImGuiTableColumnFlags.WidthFixed, 100);
+                    ImGui.TableSetupColumn("Date Added", ImGuiTableColumnFlags.WidthFixed, 120);
+                    ImGui.TableSetupColumn("Actions", ImGuiTableColumnFlags.WidthFixed, 80);
+                    ImGui.TableHeadersRow();
+
+                    for (int i = friendEntries.Count - 1; i >= 0; i--)
+                    {
+                        var friend = friendEntries[i];
+                        ImGui.TableNextRow();
+
+                        ImGui.TableNextColumn();
+                        ImGui.Text(friend.Name ?? "Unknown");
+
+                        ImGui.TableNextColumn();
+                        if (friend.Serial != 0)
+                        {
+                            ImGui.Text(friend.Serial.ToString());
+                        }
+                        else
+                        {
+                            ImGui.TextColored(new Vector4(0.5f, 0.5f, 0.5f, 1.0f), "N/A");
+                        }
+
+                        ImGui.TableNextColumn();
+                        ImGui.Text(friend.DateAdded.ToString("yyyy-MM-dd"));
+
+                        ImGui.TableNextColumn();
+                        if (ImGui.Button($"Remove##{i}"))
+                        {
+                            bool removed = friend.Serial != 0
+                                ? FriendsListManager.Instance.RemoveFriend(friend.Serial)
+                                : FriendsListManager.Instance.RemoveFriend(friend.Name);
+
+                            if (removed)
+                            {
+                                GameActions.Print(World.Instance, $"Removed {friend.Name} from friends list");
+                                RefreshFriendsList();
+                            }
+                        }
+                    }
+
+                    ImGui.EndTable();
+                }
+            }
+
+            // Add friend by name popup
+            if (showAddFriendPopup)
+            {
+                ImGui.OpenPopup("Add Friend by Name");
+                showAddFriendPopup = false;
+            }
+
+            if (ImGui.BeginPopupModal("Add Friend by Name"))
+            {
+                ImGui.Text("Enter friend's name:");
+                ImGui.SetNextItemWidth(200);
+                ImGui.InputText("##FriendName", ref newFriendName, 100);
+
+                ImGui.Spacing();
+
+                if (ImGui.Button("Add"))
+                {
+                    if (!string.IsNullOrWhiteSpace(newFriendName))
+                    {
+                        if (FriendsListManager.Instance.AddFriend(0, newFriendName.Trim()))
+                        {
+                            GameActions.Print(World.Instance, $"Added {newFriendName.Trim()} to friends list");
+                            RefreshFriendsList();
+                            newFriendName = "";
+                            ImGui.CloseCurrentPopup();
+                        }
+                        else
+                        {
+                            GameActions.Print(World.Instance, $"Could not add {newFriendName.Trim()} - already in friends list or invalid name");
+                        }
+                    }
+                }
+
+                ImGui.SameLine();
+
+                if (ImGui.Button("Cancel"))
+                {
+                    newFriendName = "";
+                    ImGui.CloseCurrentPopup();
+                }
+
+                ImGui.EndPopup();
+            }
+        }
+    }
+}

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/Agents/JournalFilterWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/Agents/JournalFilterWindow.cs
@@ -1,0 +1,195 @@
+using ImGuiNET;
+using ClassicUO.Configuration;
+using ClassicUO.Game.Managers;
+using ClassicUO.Game.UI.Gumps;
+using ClassicUO.Utility;
+using System;
+using System.IO;
+using System.Numerics;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ClassicUO.Game.UI.ImGuiControls
+{
+    public class JournalFilterWindow : SingletonImGuiWindow<JournalFilterWindow>
+    {
+        private Profile profile;
+        private string newFilterInput = "";
+        private bool showAddFilter = false;
+        private Dictionary<string, string> filterInputs = new Dictionary<string, string>();
+        private List<string> filterList;
+
+        private JournalFilterWindow() : base("Journal Filter")
+        {
+            WindowFlags = ImGuiWindowFlags.AlwaysAutoResize;
+            profile = ProfileManager.CurrentProfile;
+            RefreshFilterList();
+        }
+
+        private void RefreshFilterList()
+        {
+            filterList = JournalFilterManager.Instance.Filters.ToList();
+
+            // Initialize input dictionaries for existing filters
+            foreach (var filter in filterList)
+            {
+                if (!filterInputs.ContainsKey(filter))
+                {
+                    filterInputs[filter] = filter;
+                }
+            }
+        }
+
+        public override void DrawContent()
+        {
+            if (profile == null)
+            {
+                ImGui.Text("Profile not loaded");
+                return;
+            }
+
+            ImGui.Spacing();
+            ImGui.TextWrapped("Journal Filter allows you to hide specific messages from the journal. Messages that match exactly will be filtered out.");
+
+            // Wiki link
+            if (ImGui.Button("Journal Filter Wiki"))
+            {
+                Utility.Platforms.PlatformHelper.LaunchBrowser("https://github.com/PlayTazUO/TazUO/wiki/Journal-Filters");
+            }
+
+            ImGui.SeparatorText("Import & Export:");
+
+            if (ImGui.Button("Export JSON"))
+            {
+                FileSelector.ShowFileBrowser(Client.Game.UO.World, FileSelectorType.Directory, null, null, (selectedPath) =>
+                {
+                    if (string.IsNullOrWhiteSpace(selectedPath)) return;
+                    string fileName = $"JournalFilters_{DateTime.Now:yyyyMMdd_HHmmss}.json";
+                    string fullPath = Path.Combine(selectedPath, fileName);
+                    JsonHelper.SaveAndBackup(JournalFilterManager.Instance.Filters, fullPath, HashSetContext.Default.HashSetString);
+                }, "Export Journal Filter Configuration");
+            }
+
+            ImGui.SameLine();
+            if (ImGui.Button("Import JSON"))
+            {
+                FileSelector.ShowFileBrowser(Client.Game.UO.World, FileSelectorType.File, null, new[] { "json" }, (selectedFile) =>
+                {
+                    if (string.IsNullOrWhiteSpace(selectedFile)) return;
+                    if (JsonHelper.Load(selectedFile, HashSetContext.Default.HashSetString, out HashSet<string> importedFilters))
+                    {
+                        foreach (var filter in importedFilters)
+                        {
+                            JournalFilterManager.Instance.AddFilter(filter);
+                        }
+                        JournalFilterManager.Instance.Save(false);
+                        RefreshFilterList();
+                    }
+                }, "Import Journal Filter Configuration");
+            }
+
+            // Add filter section
+            ImGui.SeparatorText("Filters:");
+
+            if (ImGui.Button("Add Filter Entry"))
+            {
+                showAddFilter = !showAddFilter;
+            }
+
+            if (showAddFilter)
+            {
+                ImGui.SeparatorText("Add New Filter:");
+                ImGui.Spacing();
+
+                ImGui.Text("Filter Text:");
+                ImGuiComponents.Tooltip("Must match the journal entry exactly. Partial matches not supported.");
+                ImGui.InputText("##NewFilter", ref newFilterInput, 500);
+
+                ImGui.Spacing();
+
+                if (ImGui.Button("Add##AddFilter"))
+                {
+                    if (!string.IsNullOrWhiteSpace(newFilterInput))
+                    {
+                        JournalFilterManager.Instance.AddFilter(newFilterInput);
+                        JournalFilterManager.Instance.Save(false);
+                        newFilterInput = "";
+                        showAddFilter = false;
+                        RefreshFilterList();
+                    }
+                }
+                ImGui.SameLine();
+                if (ImGui.Button("Cancel##AddFilter"))
+                {
+                    showAddFilter = false;
+                    newFilterInput = "";
+                }
+            }
+
+            ImGui.SeparatorText("Current Journal Filters:");
+
+            if (filterList.Count == 0)
+            {
+                ImGui.Text("No filters configured");
+            }
+            else
+            {
+                // Table for filters
+                if (ImGui.BeginTable("JournalFilterTable", 2, ImGuiTableFlags.Borders | ImGuiTableFlags.RowBg | ImGuiTableFlags.ScrollY, new Vector2(0, ImGuiTheme.Dimensions.STANDARD_TABLE_SCROLL_HEIGHT)))
+                {
+                    ImGui.TableSetupColumn("Filter Text", ImGuiTableColumnFlags.WidthStretch);
+                    ImGui.TableSetupColumn("Actions", ImGuiTableColumnFlags.WidthFixed, 80);
+                    ImGui.TableHeadersRow();
+
+                    for (int i = filterList.Count - 1; i >= 0; i--)
+                    {
+                        var filter = filterList[i];
+                        ImGui.TableNextRow();
+
+                        ImGui.TableNextColumn();
+
+                        // Get or initialize input string for this filter
+                        if (!filterInputs.ContainsKey(filter))
+                        {
+                            filterInputs[filter] = filter;
+                        }
+
+                        string filterStr = filterInputs[filter];
+                        ImGui.InputText($"##Filter{i}", ref filterStr, 500);
+
+                        // Update the local input string
+                        filterInputs[filter] = filterStr;
+
+                        // Only commit changes on Enter or blur, and avoid no-ops/empty values
+                        if (ImGui.IsItemDeactivatedAfterEdit() && !string.IsNullOrWhiteSpace(filterStr) && filterStr != filter)
+                        {
+                            // Update the filter
+                            string oldFilter = filter;
+                            JournalFilterManager.Instance.RemoveFilter(oldFilter);
+                            JournalFilterManager.Instance.AddFilter(filterStr);
+                            JournalFilterManager.Instance.Save(false);
+
+                            // Update our tracking - remove old key, add new one
+                            filterInputs.Remove(oldFilter);
+                            filterInputs[filterStr] = filterStr;
+
+                            RefreshFilterList();
+                            break; // Break out of loop after successful mutation to avoid iterating refreshed list
+                        }
+
+                        ImGui.TableNextColumn();
+                        if (ImGui.Button($"Delete##Delete{i}"))
+                        {
+                            JournalFilterManager.Instance.RemoveFilter(filter);
+                            JournalFilterManager.Instance.Save(false);
+                            filterInputs.Remove(filter);
+                            RefreshFilterList();
+                        }
+                    }
+
+                    ImGui.EndTable();
+                }
+            }
+        }
+    }
+}

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/Agents/SpellIndicatorWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/Agents/SpellIndicatorWindow.cs
@@ -1,0 +1,356 @@
+using ImGuiNET;
+using ClassicUO.Configuration;
+using ClassicUO.Game.Managers;
+using ClassicUO.Game.Data;
+using ClassicUO.Utility;
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Linq;
+
+namespace ClassicUO.Game.UI.ImGuiControls
+{
+    public class SpellIndicatorWindow : SingletonImGuiWindow<SpellIndicatorWindow>
+    {
+        private Profile profile;
+        private bool enableSpellIndicators;
+        private string spellSearchInput = "";
+        private Dictionary<int, string> spellNameInputs = new Dictionary<int, string>();
+        private Dictionary<int, string> spellPowerWordsInputs = new Dictionary<int, string>();
+        private Dictionary<int, string> spellCursorSizeInputs = new Dictionary<int, string>();
+        private Dictionary<int, string> spellCastRangeInputs = new Dictionary<int, string>();
+        private Dictionary<int, string> spellCastTimeInputs = new Dictionary<int, string>();
+        private Dictionary<int, string> spellMaxDurationInputs = new Dictionary<int, string>();
+        private SpellVisualRangeManager.SpellRangeInfo selectedSpell = null;
+
+        private SpellIndicatorWindow() : base("Spell Indicators")
+        {
+            WindowFlags = ImGuiWindowFlags.AlwaysAutoResize;
+            profile = ProfileManager.CurrentProfile;
+            enableSpellIndicators = profile?.EnableSpellIndicators ?? false;
+        }
+
+        public override void DrawContent()
+        {
+            if (profile == null)
+            {
+                ImGui.Text("Profile not loaded");
+                return;
+            }
+
+            ImGui.Spacing();
+
+            if (ImGui.Checkbox("Enable Spell Indicators", ref enableSpellIndicators))
+            {
+                profile.EnableSpellIndicators = enableSpellIndicators;
+            }
+            ImGuiComponents.Tooltip("Enable visual spell range indicators that show casting range and area of effect for spells.");
+
+            ImGui.SeparatorText("Spell Search:");
+
+            ImGui.Text("Spell search:");
+            ImGui.SetNextItemWidth(250);
+            if (ImGui.InputText("##SpellSearch", ref spellSearchInput, 100))
+            {
+                if (string.IsNullOrWhiteSpace(spellSearchInput))
+                {
+                    selectedSpell = null;
+                }
+                else if (SpellDefinition.TryGetSpellFromName(spellSearchInput, out SpellDefinition spell))
+                {
+                    if (SpellVisualRangeManager.Instance.SpellRangeCache.TryGetValue(spell.ID, out SpellVisualRangeManager.SpellRangeInfo info))
+                    {
+                        selectedSpell = info;
+                        InitializeInputs(info);
+                    }
+                }
+                else
+                {
+                    selectedSpell = null;
+                }
+            }
+            ImGui.SameLine();
+            if (ImGui.Button("Clear"))
+            {
+                spellSearchInput = "";
+                selectedSpell = null;
+            }
+            ImGuiComponents.Tooltip("Type a spell name to search and edit its spell indicator settings.");
+
+            if (selectedSpell != null)
+            {
+                ImGui.SeparatorText("Spell Configuration:");
+                DrawSpellEditor(selectedSpell);
+            }
+            else if (string.IsNullOrWhiteSpace(spellSearchInput))
+            {
+                ImGui.SeparatorText("All Spell Indicators:");
+                DrawSpellTable();
+            }
+        }
+
+        private void InitializeInputs(SpellVisualRangeManager.SpellRangeInfo spell)
+        {
+            if (!spellNameInputs.ContainsKey(spell.ID))
+                spellNameInputs[spell.ID] = spell.Name;
+            if (!spellPowerWordsInputs.ContainsKey(spell.ID))
+                spellPowerWordsInputs[spell.ID] = spell.PowerWords ?? "";
+            if (!spellCursorSizeInputs.ContainsKey(spell.ID))
+                spellCursorSizeInputs[spell.ID] = spell.CursorSize.ToString();
+            if (!spellCastRangeInputs.ContainsKey(spell.ID))
+                spellCastRangeInputs[spell.ID] = spell.CastRange.ToString();
+            if (!spellCastTimeInputs.ContainsKey(spell.ID))
+                spellCastTimeInputs[spell.ID] = spell.CastTime.ToString();
+            if (!spellMaxDurationInputs.ContainsKey(spell.ID))
+                spellMaxDurationInputs[spell.ID] = spell.MaxDuration.ToString();
+        }
+
+        private void DrawSpellEditor(SpellVisualRangeManager.SpellRangeInfo spell)
+        {
+            InitializeInputs(spell);
+
+            if (ImGui.BeginTable("SpellEditorTable", 2, ImGuiTableFlags.SizingFixedFit))
+            {
+                ImGui.TableSetupColumn("Property", ImGuiTableColumnFlags.WidthFixed, 120);
+                ImGui.TableSetupColumn("Value", ImGuiTableColumnFlags.WidthStretch);
+
+                // Name
+                ImGui.TableNextRow();
+                ImGui.TableNextColumn();
+                ImGui.Text("Name:");
+                ImGui.TableNextColumn();
+                string nameStr = spellNameInputs[spell.ID];
+                ImGui.SetNextItemWidth(200);
+                if (ImGui.InputText($"##Name{spell.ID}", ref nameStr, 100))
+                {
+                    spellNameInputs[spell.ID] = nameStr;
+                    spell.Name = nameStr;
+                    SaveSpell();
+                }
+
+                // Power Words
+                ImGui.TableNextRow();
+                ImGui.TableNextColumn();
+                ImGui.Text("Power Words:");
+                ImGui.TableNextColumn();
+                string powerWordsStr = spellPowerWordsInputs[spell.ID];
+                ImGui.SetNextItemWidth(200);
+                if (ImGui.InputText($"##PowerWords{spell.ID}", ref powerWordsStr, 100))
+                {
+                    spellPowerWordsInputs[spell.ID] = powerWordsStr;
+                    spell.PowerWords = powerWordsStr;
+                    SaveSpell();
+                }
+                ImGuiComponents.Tooltip("Power words must be exact, this is the best way we can detect spells.");
+
+                // Cursor Size
+                ImGui.TableNextRow();
+                ImGui.TableNextColumn();
+                ImGui.Text("Cursor Size:");
+                ImGui.TableNextColumn();
+                string cursorSizeStr = spellCursorSizeInputs[spell.ID];
+                ImGui.SetNextItemWidth(100);
+                if (ImGui.InputText($"##CursorSize{spell.ID}", ref cursorSizeStr, 10))
+                {
+                    spellCursorSizeInputs[spell.ID] = cursorSizeStr;
+                    if (int.TryParse(cursorSizeStr, out int cursorSize))
+                    {
+                        spell.CursorSize = cursorSize;
+                        SaveSpell();
+                    }
+                }
+                ImGuiComponents.Tooltip("This is the area to show around the cursor, intended for area spells that affect the area near your target.");
+
+                // Cast Range
+                ImGui.TableNextRow();
+                ImGui.TableNextColumn();
+                ImGui.Text("Cast Range:");
+                ImGui.TableNextColumn();
+                string castRangeStr = spellCastRangeInputs[spell.ID];
+                ImGui.SetNextItemWidth(100);
+                if (ImGui.InputText($"##CastRange{spell.ID}", ref castRangeStr, 10))
+                {
+                    spellCastRangeInputs[spell.ID] = castRangeStr;
+                    if (int.TryParse(castRangeStr, out int castRange))
+                    {
+                        spell.CastRange = castRange;
+                        SaveSpell();
+                    }
+                }
+
+                // Cast Time
+                ImGui.TableNextRow();
+                ImGui.TableNextColumn();
+                ImGui.Text("Cast Time:");
+                ImGui.TableNextColumn();
+                string castTimeStr = spellCastTimeInputs[spell.ID];
+                ImGui.SetNextItemWidth(100);
+                if (ImGui.InputText($"##CastTime{spell.ID}", ref castTimeStr, 10))
+                {
+                    spellCastTimeInputs[spell.ID] = castTimeStr;
+                    if (double.TryParse(castTimeStr, out double castTime))
+                    {
+                        spell.CastTime = castTime;
+                        SaveSpell();
+                    }
+                }
+
+                // Max Duration
+                ImGui.TableNextRow();
+                ImGui.TableNextColumn();
+                ImGui.Text("Max Duration:");
+                ImGui.TableNextColumn();
+                string maxDurationStr = spellMaxDurationInputs[spell.ID];
+                ImGui.SetNextItemWidth(100);
+                if (ImGui.InputText($"##MaxDuration{spell.ID}", ref maxDurationStr, 10))
+                {
+                    spellMaxDurationInputs[spell.ID] = maxDurationStr;
+                    if (int.TryParse(maxDurationStr, out int maxDuration))
+                    {
+                        spell.MaxDuration = maxDuration;
+                        SaveSpell();
+                    }
+                }
+                ImGuiComponents.Tooltip("This is a fallback in-case the spell detection fails.");
+
+                // Cursor Hue
+                ImGui.TableNextRow();
+                ImGui.TableNextColumn();
+                ImGui.Text("Cursor Hue:");
+                ImGui.TableNextColumn();
+                int cursorHueInt = spell.CursorHue;
+                ImGui.SetNextItemWidth(100);
+                if (ImGui.InputInt($"##CursorHue{spell.ID}", ref cursorHueInt, 1, 10))
+                {
+                    if (cursorHueInt >= 0 && cursorHueInt <= ushort.MaxValue)
+                    {
+                        spell.CursorHue = (ushort)cursorHueInt;
+                        SaveSpell();
+                    }
+                }
+
+                // Range Hue
+                ImGui.TableNextRow();
+                ImGui.TableNextColumn();
+                ImGui.Text("Range Hue:");
+                ImGui.TableNextColumn();
+                int rangeHueInt = spell.Hue;
+                ImGui.SetNextItemWidth(100);
+                if (ImGui.InputInt($"##RangeHue{spell.ID}", ref rangeHueInt, 1, 10))
+                {
+                    if (rangeHueInt >= 0 && rangeHueInt <= ushort.MaxValue)
+                    {
+                        spell.Hue = (ushort)rangeHueInt;
+                        SaveSpell();
+                    }
+                }
+
+                // Checkboxes
+                ImGui.TableNextRow();
+                ImGui.TableNextColumn();
+                ImGui.Text("Is Linear:");
+                ImGui.TableNextColumn();
+                bool isLinear = spell.IsLinear;
+                if (ImGui.Checkbox($"##IsLinear{spell.ID}", ref isLinear))
+                {
+                    spell.IsLinear = isLinear;
+                    SaveSpell();
+                }
+                ImGuiComponents.Tooltip("Used for spells like wall of stone that create a line.");
+
+                ImGui.TableNextRow();
+                ImGui.TableNextColumn();
+                ImGui.Text("Show Range During Cast:");
+                ImGui.TableNextColumn();
+                bool showRange = spell.ShowCastRangeDuringCasting;
+                if (ImGui.Checkbox($"##ShowRange{spell.ID}", ref showRange))
+                {
+                    spell.ShowCastRangeDuringCasting = showRange;
+                    SaveSpell();
+                }
+
+                ImGui.TableNextRow();
+                ImGui.TableNextColumn();
+                ImGui.Text("Freeze While Casting:");
+                ImGui.TableNextColumn();
+                bool freezeWhileCasting = spell.FreezeCharacterWhileCasting;
+                if (ImGui.Checkbox($"##FreezeWhileCasting{spell.ID}", ref freezeWhileCasting))
+                {
+                    spell.FreezeCharacterWhileCasting = freezeWhileCasting;
+                    SaveSpell();
+                }
+                ImGuiComponents.Tooltip("Prevent yourself from moving and disrupting your spell.");
+
+                ImGui.TableNextRow();
+                ImGui.TableNextColumn();
+                ImGui.Text("Expect Target Cursor:");
+                ImGui.TableNextColumn();
+                bool expectTargetCursor = spell.ExpectTargetCursor;
+                if (ImGui.Checkbox($"##ExpectTargetCursor{spell.ID}", ref expectTargetCursor))
+                {
+                    spell.ExpectTargetCursor = expectTargetCursor;
+                    SaveSpell();
+                }
+
+                ImGui.EndTable();
+            }
+        }
+
+        private void DrawSpellTable()
+        {
+            var spells = SpellVisualRangeManager.Instance.SpellRangeCache.Values.OrderBy(s => s.Name).ToList();
+
+            if (spells.Count == 0)
+            {
+                ImGui.Text("No spell indicators configured");
+                return;
+            }
+
+            if (ImGui.BeginTable("SpellIndicatorTable", 6, ImGuiTableFlags.Borders | ImGuiTableFlags.RowBg | ImGuiTableFlags.ScrollY, new Vector2(0, ImGuiTheme.Dimensions.STANDARD_TABLE_SCROLL_HEIGHT)))
+            {
+                ImGui.TableSetupColumn("Name", ImGuiTableColumnFlags.WidthFixed, 150);
+                ImGui.TableSetupColumn("Power Words", ImGuiTableColumnFlags.WidthFixed, 120);
+                ImGui.TableSetupColumn("Cast Range", ImGuiTableColumnFlags.WidthFixed, 80);
+                ImGui.TableSetupColumn("Cursor Size", ImGuiTableColumnFlags.WidthFixed, 80);
+                ImGui.TableSetupColumn("Cast Time", ImGuiTableColumnFlags.WidthFixed, 80);
+                ImGui.TableSetupColumn("Actions", ImGuiTableColumnFlags.WidthFixed, 80);
+                ImGui.TableHeadersRow();
+
+                foreach (var spell in spells)
+                {
+                    ImGui.TableNextRow();
+
+                    ImGui.TableNextColumn();
+                    ImGui.Text(spell.Name);
+
+                    ImGui.TableNextColumn();
+                    ImGui.Text(spell.PowerWords ?? "");
+
+                    ImGui.TableNextColumn();
+                    ImGui.Text(spell.CastRange.ToString());
+
+                    ImGui.TableNextColumn();
+                    ImGui.Text(spell.CursorSize.ToString());
+
+                    ImGui.TableNextColumn();
+                    ImGui.Text(spell.CastTime.ToString("F1"));
+
+                    ImGui.TableNextColumn();
+                    if (ImGui.Button($"Edit##{spell.ID}"))
+                    {
+                        selectedSpell = spell;
+                        spellSearchInput = spell.Name;
+                        InitializeInputs(spell);
+                    }
+                }
+
+                ImGui.EndTable();
+            }
+        }
+
+        private void SaveSpell()
+        {
+            SpellVisualRangeManager.Instance.DelayedSave();
+        }
+    }
+}

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/AssistantWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/AssistantWindow.cs
@@ -45,6 +45,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
                     _preSelectIndex = 0; // General tab since spell indicators are now in General window
                     break;
                 case AssistantGump.PAGE.JournalFilter:
+                    _preSelectIndex = 1; // Agents tab since Journal Filter is in Agents Window
                     break;
                 case AssistantGump.PAGE.TitleBar:
                     break;

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/AssistantWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/AssistantWindow.cs
@@ -42,6 +42,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
                 case AssistantGump.PAGE.HUD:
                     break;
                 case AssistantGump.PAGE.SpellIndicator:
+                    _preSelectIndex = 0; // General tab since spell indicators are now in General window
                     break;
                 case AssistantGump.PAGE.JournalFilter:
                     break;

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/General/GeneralWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/General/GeneralWindow.cs
@@ -71,7 +71,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
         {
             // Group: Visual Config
             ImGui.BeginGroup();
-            ImGui.Spacing();
+            ImGui.AlignTextToFramePadding();
             ImGui.TextColored(ImGuiTheme.Colors.BaseContent, "Visual Config");
 
             if (ImGui.Checkbox("Highlight game objects", ref _highlightObjects))
@@ -83,17 +83,14 @@ namespace ClassicUO.Game.UI.ImGuiControls
             {
                 _profile.NameOverheadToggled = _showNames;
             }
-
-            ImGui.SameLine();
-            ImGui.TextDisabled("(?)");
-            if (ImGui.IsItemHovered())
-                ImGui.SetTooltip("Toggle the display of names above characters and NPCs in the game world.");
+                ImGuiComponents.Tooltip("Toggle the display of names above characters and NPCs in the game world.");
             ImGui.EndGroup();
 
             ImGui.SameLine();
 
             // Group: Delay Config
             ImGui.BeginGroup();
+            ImGui.AlignTextToFramePadding();
             ImGui.TextColored(ImGuiTheme.Colors.BaseContent, "Delay Config");
 
             int tempTurnDelay = _turnDelay;

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/General/GeneralWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/General/GeneralWindow.cs
@@ -68,6 +68,12 @@ namespace ClassicUO.Game.UI.ImGuiControls
                     TitleBarWindow.GetInstance()?.DrawContent();
                     ImGui.EndTabItem();
                 }
+
+                if (ImGui.BeginTabItem("Spell Indicators"))
+                {
+                    SpellIndicatorWindow.GetInstance()?.DrawContent();
+                    ImGui.EndTabItem();
+                }
                 ImGui.EndTabBar();
             }
         }

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/General/GeneralWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/General/GeneralWindow.cs
@@ -74,6 +74,12 @@ namespace ClassicUO.Game.UI.ImGuiControls
                     SpellIndicatorWindow.GetInstance()?.DrawContent();
                     ImGui.EndTabItem();
                 }
+
+                if (ImGui.BeginTabItem("Friends List"))
+                {
+                    FriendsListWindow.GetInstance()?.DrawContent();
+                    ImGui.EndTabItem();
+                }
                 ImGui.EndTabBar();
             }
         }

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/General/GeneralWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/General/GeneralWindow.cs
@@ -62,6 +62,12 @@ namespace ClassicUO.Game.UI.ImGuiControls
                     GraphicReplacementWindow.GetInstance()?.DrawContent();
                     ImGui.EndTabItem();
                 }
+
+                if (ImGui.BeginTabItem("Title Bar"))
+                {
+                    TitleBarWindow.GetInstance()?.DrawContent();
+                    ImGui.EndTabItem();
+                }
                 ImGui.EndTabBar();
             }
         }

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/General/GeneralWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/General/GeneralWindow.cs
@@ -53,7 +53,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
 
                 if (ImGui.BeginTabItem("Journal Filter"))
                 {
-                    ImGui.Text("Journal Filter Settings will go here.");
+                    JournalFilterWindow.GetInstance()?.DrawContent();
                     ImGui.EndTabItem();
                 }
 

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/General/GeneralWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/General/GeneralWindow.cs
@@ -47,7 +47,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
 
                 if (ImGui.BeginTabItem("HUD"))
                 {
-                    ImGui.Text("HUD Settings will go here.");
+                    HudWindow.GetInstance()?.DrawContent();
                     ImGui.EndTabItem();
                 }
 

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/General/GraphicReplacementWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/General/GraphicReplacementWindow.cs
@@ -26,10 +26,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
         public override void DrawContent()
         {
             ImGui.Text("Info:");
-            ImGui.SameLine();
-            ImGui.TextDisabled("(?)");
-            if (ImGui.IsItemHovered())
-                ImGui.SetTooltip("This can be used to replace graphics of mobiles with other graphics (For example if dragons are too big, replace them with wyverns).");
+            ImGuiComponents.Tooltip("This can be used to replace graphics of mobiles with other graphics (For example if dragons are too big, replace them with wyverns).");
 
             ImGui.Separator();
 

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/General/HudWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/General/HudWindow.cs
@@ -1,0 +1,244 @@
+using ImGuiNET;
+using ClassicUO.Configuration;
+using ClassicUO.Game.Data;
+using ClassicUO.Game.Managers;
+using ClassicUO.Utility;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ClassicUO.Game.UI.ImGuiControls
+{
+    public class HudWindow : SingletonImGuiWindow<HudWindow>
+    {
+        private Profile profile;
+        private Dictionary<HideHudFlags, bool> hudFlagStates;
+
+        private HudWindow() : base("HUD Settings")
+        {
+            WindowFlags = ImGuiWindowFlags.AlwaysAutoResize;
+            profile = ProfileManager.CurrentProfile;
+
+            // Initialize HUD flag states
+            hudFlagStates = new Dictionary<HideHudFlags, bool>();
+            InitializeHudStates();
+        }
+
+        private void InitializeHudStates()
+        {
+            if (profile == null) return;
+
+            foreach (HideHudFlags flag in Enum.GetValues(typeof(HideHudFlags)))
+            {
+                if (flag == HideHudFlags.None) continue;
+                hudFlagStates[flag] = ByteFlagHelper.HasFlag(profile.HideHudGumpFlags, (ulong)flag);
+            }
+        }
+
+        public override void DrawContent()
+        {
+            if (profile == null)
+            {
+                ImGui.Text("Profile not loaded");
+                return;
+            }
+
+            ImGui.Spacing();
+
+            // Header text
+            ImGui.TextWrapped("Check the types of gumps you would like to toggle visibility when using the Toggle Hud Visible macro.");
+            ImGui.Spacing();
+            ImGui.Separator();
+            ImGui.Spacing();
+
+            // Quick actions
+            if (ImGui.Button("Select All"))
+            {
+                SetAllFlags(true);
+            }
+            ImGui.SameLine();
+            if (ImGui.Button("Deselect All"))
+            {
+                SetAllFlags(false);
+            }
+            ImGui.SameLine();
+            if (ImGui.Button("Toggle HUD Now"))
+            {
+                HideHudManager.ToggleHidden(profile.HideHudGumpFlags);
+            }
+            ImGuiComponents.Tooltip("Immediately toggle the visibility of selected HUD elements");
+
+            ImGui.Spacing();
+            ImGui.Separator();
+            ImGui.Spacing();
+
+            // Draw HUD options in a table format for better organization
+            if (ImGui.BeginTable("HudOptionsTable", 2, ImGuiTableFlags.SizingStretchSame))
+            {
+                ImGui.TableSetupColumn("Column1", ImGuiTableColumnFlags.WidthStretch);
+                ImGui.TableSetupColumn("Column2", ImGuiTableColumnFlags.WidthStretch);
+
+                bool isFirstColumn = true;
+                foreach (var kvp in hudFlagStates.ToList())
+                {
+                    HideHudFlags flag = kvp.Key;
+                    if (flag == HideHudFlags.None) continue;
+
+                    if (isFirstColumn)
+                    {
+                        ImGui.TableNextRow();
+                        ImGui.TableNextColumn();
+                    }
+                    else
+                    {
+                        ImGui.TableNextColumn();
+                    }
+
+                    bool currentState = kvp.Value;
+                    string flagName = HideHudManager.GetFlagName(flag);
+
+                    if (ImGui.Checkbox(flagName, ref currentState))
+                    {
+                        hudFlagStates[flag] = currentState;
+                        UpdateProfileFlags(flag, currentState);
+
+                        // Handle special case for "All" flag
+                        if (flag == HideHudFlags.All)
+                        {
+                            if (currentState)
+                            {
+                                SetAllFlags(true);
+                            }
+                            else
+                            {
+                                // When "All" is unchecked, uncheck everything
+                                SetAllFlags(false);
+                            }
+                        }
+                    }
+
+                    // Add tooltip for some flags
+                    AddTooltipForFlag(flag);
+
+                    isFirstColumn = !isFirstColumn;
+                }
+
+                ImGui.EndTable();
+            }
+
+            ImGui.Spacing();
+            ImGui.Separator();
+            ImGui.Spacing();
+
+            // Additional information
+            ImGui.TextColored(ImGuiTheme.Colors.Primary, "Current Configuration:");
+            ImGui.Text($"Active flags: {CountActiveFlags()} / {hudFlagStates.Count - 2}"); // -2 to exclude None and All
+
+            if (ImGui.CollapsingHeader("Advanced"))
+            {
+                ImGui.Text($"Raw flag value: {profile.HideHudGumpFlags}");
+                if (ImGui.Button("Reset to Default"))
+                {
+                    profile.HideHudGumpFlags = 0;
+                    InitializeHudStates();
+                }
+                ImGuiComponents.Tooltip("Reset all HUD visibility settings to default (everything visible)");
+            }
+        }
+
+        private void SetAllFlags(bool state)
+        {
+            foreach (var flag in hudFlagStates.Keys.ToList())
+            {
+                if (flag == HideHudFlags.None) continue;
+                hudFlagStates[flag] = state;
+                UpdateProfileFlags(flag, state);
+            }
+        }
+
+        private void UpdateProfileFlags(HideHudFlags flag, bool enabled)
+        {
+            if (enabled)
+            {
+                profile.HideHudGumpFlags = ByteFlagHelper.AddFlag(profile.HideHudGumpFlags, (ulong)flag);
+
+                // If "All" is selected, select everything
+                if (flag == HideHudFlags.All)
+                {
+                    foreach (var otherFlag in hudFlagStates.Keys.ToList())
+                    {
+                        if (otherFlag == HideHudFlags.None) continue;
+                        hudFlagStates[otherFlag] = true;
+                        if (otherFlag != HideHudFlags.All)
+                            profile.HideHudGumpFlags = ByteFlagHelper.AddFlag(profile.HideHudGumpFlags, (ulong)otherFlag);
+                    }
+                }
+            }
+            else
+            {
+                if (flag == HideHudFlags.All)
+                {
+                    // When "All" is unchecked, clear everything
+                    profile.HideHudGumpFlags = 0;
+                    foreach (var otherFlag in hudFlagStates.Keys.ToList())
+                    {
+                        hudFlagStates[otherFlag] = false;
+                    }
+                }
+                else
+                {
+                    profile.HideHudGumpFlags = ByteFlagHelper.RemoveFlag(profile.HideHudGumpFlags, (ulong)flag);
+                    // If any individual flag is unchecked, also uncheck "All"
+                    hudFlagStates[HideHudFlags.All] = false;
+                    profile.HideHudGumpFlags = ByteFlagHelper.RemoveFlag(profile.HideHudGumpFlags, (ulong)HideHudFlags.All);
+                }
+            }
+        }
+
+        private int CountActiveFlags()
+        {
+            return hudFlagStates.Count(kvp => kvp.Key != HideHudFlags.None && kvp.Key != HideHudFlags.All && kvp.Value);
+        }
+
+        private void AddTooltipForFlag(HideHudFlags flag)
+        {
+            string tooltip = flag switch
+            {
+                HideHudFlags.Paperdoll => "Character paperdoll windows",
+                HideHudFlags.WorldMap => "World map window",
+                HideHudFlags.GridContainers => "Grid-style container windows",
+                HideHudFlags.Containers => "Traditional container windows",
+                HideHudFlags.Healthbars => "Health bar windows",
+                HideHudFlags.StatusBar => "Character status windows",
+                HideHudFlags.SpellBar => "Spell bar windows",
+                HideHudFlags.Journal => "Journal/chat windows",
+                HideHudFlags.XMLGumps => "Server-sent XML gump windows",
+                HideHudFlags.NearbyCorpseLoot => "Nearby corpse loot windows",
+                HideHudFlags.MacroButtons => "Macro button windows",
+                HideHudFlags.SkillButtons => "Skill button windows",
+                HideHudFlags.SkillsMenus => "Skills menu windows",
+                HideHudFlags.TopMenuBar => "Top menu bar",
+                HideHudFlags.DurabilityTracker => "Item durability tracker",
+                HideHudFlags.BuffBar => "Buff/debuff status bars",
+                HideHudFlags.CounterBar => "Item counter bars",
+                HideHudFlags.InfoBar => "Information bars",
+                HideHudFlags.SpellIcons => "Spell icon buttons",
+                HideHudFlags.NameOverheadGump => "Name overhead displays",
+                HideHudFlags.ScriptManagerGump => "Script manager window",
+                HideHudFlags.All => "Select/deselect all HUD elements at once",
+                _ => null
+            };
+
+            if (!string.IsNullOrEmpty(tooltip))
+            {
+                ImGuiComponents.Tooltip(tooltip);
+            }
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+            hudFlagStates?.Clear();
+        }
+    }
+}

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/General/TitleBarWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/General/TitleBarWindow.cs
@@ -1,0 +1,113 @@
+using ImGuiNET;
+using ClassicUO.Configuration;
+using ClassicUO.Game.Managers;
+using System.Numerics;
+
+namespace ClassicUO.Game.UI.ImGuiControls
+{
+    public class TitleBarWindow : SingletonImGuiWindow<TitleBarWindow>
+    {
+        private Profile profile;
+        private bool enableTitleBarStats;
+        private int updateInterval;
+        private TitleBarStatsMode statsMode;
+
+        private TitleBarWindow() : base("Title Bar Settings")
+        {
+            WindowFlags = ImGuiWindowFlags.AlwaysAutoResize;
+            profile = ProfileManager.CurrentProfile;
+
+            if (profile != null)
+            {
+                enableTitleBarStats = profile.EnableTitleBarStats;
+                updateInterval = profile.TitleBarUpdateInterval;
+                statsMode = profile.TitleBarStatsMode;
+            }
+        }
+
+        public override void DrawContent()
+        {
+            if (profile == null)
+            {
+                ImGui.Text("Profile not loaded");
+                return;
+            }
+
+            ImGui.Spacing();
+
+            // Main description
+            ImGui.TextWrapped("Configure window title bar to show HP, Mana, and Stamina information.");
+            ImGui.Spacing();
+
+            // Wiki link (placeholder - would need proper link handling)
+            if (ImGui.Button("Title Bar Status Wiki"))
+            {
+                // Would open wiki link here
+                GameActions.Print(Client.Game.UO.World, "Wiki: https://github.com/PlayTazUO/TazUO/wiki/Title-Bar-Status");
+            }
+            ImGui.Spacing();
+
+            // Enable title bar stats
+            if (ImGui.Checkbox("Enable title bar stats", ref enableTitleBarStats))
+            {
+                profile.EnableTitleBarStats = enableTitleBarStats;
+                if (enableTitleBarStats)
+                {
+                    TitleBarStatsManager.ForceUpdate();
+                }
+                else
+                {
+                    Client.Game.SetWindowTitle(string.IsNullOrEmpty(World.Instance.Player?.Name) ? string.Empty : World.Instance.Player.Name);
+                }
+            }
+            ImGui.Spacing();
+
+            // Update interval slider
+            ImGui.Text("Update interval (ms):");
+            ImGui.SetNextItemWidth(300);
+            if (ImGui.SliderInt("##UpdateInterval", ref updateInterval, 500, 5000))
+            {
+                profile.TitleBarUpdateInterval = updateInterval;
+                TitleBarStatsManager.ForceUpdate();
+            }
+            ImGuiComponents.Tooltip("How often to update the title bar (500ms - 5000ms)");
+            ImGui.Spacing();
+
+            // Display mode section
+            ImGui.SeparatorText("Display Mode:");
+            ImGui.Spacing();
+
+            // Radio buttons for display mode
+            if (ImGui.RadioButton("Text (HP 85/100, MP 42/50, SP 95/100)", statsMode == TitleBarStatsMode.Text))
+            {
+                statsMode = TitleBarStatsMode.Text;
+                profile.TitleBarStatsMode = statsMode;
+                TitleBarStatsManager.ForceUpdate();
+            }
+
+            if (ImGui.RadioButton("Percent (HP 85%, MP 84%, SP 95%)", statsMode == TitleBarStatsMode.Percent))
+            {
+                statsMode = TitleBarStatsMode.Percent;
+                profile.TitleBarStatsMode = statsMode;
+                TitleBarStatsManager.ForceUpdate();
+            }
+
+            if (ImGui.RadioButton("Progress Bar (HP [||||||    ] MP [||||||    ] SP [||||||    ])", statsMode == TitleBarStatsMode.ProgressBar))
+            {
+                statsMode = TitleBarStatsMode.ProgressBar;
+                profile.TitleBarStatsMode = statsMode;
+                TitleBarStatsManager.ForceUpdate();
+            }
+
+            ImGui.Spacing();
+
+            // Preview section
+            ImGui.SeparatorText("Preview:");
+            ImGui.TextWrapped(TitleBarStatsManager.GetPreviewText());
+            ImGui.Spacing();
+
+            // Note about Unicode characters
+            ImGui.TextWrapped("Note: Progress bars use Unicode block characters (█▓▒░) and may not display correctly on all systems.");
+        }
+    }
+}

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/ImGUIComponents.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/ImGUIComponents.cs
@@ -1,0 +1,25 @@
+using ImGuiNET;
+
+/// <summary>
+/// Provides reusable ImGui UI components with consistent styling.
+/// </summary>
+public static class ImGuiComponents
+{
+    /// <summary>
+    /// Displays a "(?)" help icon that shows a tooltip with the specified text when hovered.
+    /// </summary>
+    /// <param name="text">The tooltip text to display.</param>
+    public static void Tooltip(string text)
+    {
+        ImGui.SameLine();
+        ImGui.TextDisabled("(?)");
+        if (ImGui.IsItemHovered())
+        {
+            ImGui.BeginTooltip();
+            ImGui.PushTextWrapPos(400); // Limita el ancho del texto
+            ImGui.TextUnformatted(text);
+            ImGui.PopTextWrapPos();
+            ImGui.EndTooltip();
+        }
+    }
+}

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/ScriptManagerWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/ScriptManagerWindow.cs
@@ -229,7 +229,7 @@ while True:
 
         private void DrawScript(ScriptFile script)
         {
-            ImGui.PushID(script.FileName);
+            ImGui.PushID(script.FullPath);
 
             // Get script display name (without extension)
             string displayName = script.FileName;
@@ -304,6 +304,13 @@ while True:
                 if (ImGui.Begin("ContextMenu", ref _showContextMenu,
                     ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.AlwaysAutoResize))
                 {
+                    // Check for outside click or Escape key to dismiss menu
+                    if ((ImGui.IsMouseClicked(ImGuiMouseButton.Left) && !ImGui.IsWindowHovered(ImGuiHoveredFlags.RootAndChildWindows)) ||
+                        ImGui.IsKeyPressed(ImGuiKey.Escape))
+                    {
+                        _showContextMenu = false;
+                    }
+
                     if (_contextMenuScript != null)
                     {
                         DrawScriptContextMenu(_contextMenuScript);

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/ScriptManagerWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/ScriptManagerWindow.cs
@@ -168,14 +168,16 @@ while True:
             // Group header with expand/collapse button and context menu
             ImGui.PushID(fullGroupPath);
 
-            bool headerClicked = false;
-            if (isCollapsed)
+            // Call TreeNode and store the open state
+            bool nodeOpen = ImGui.TreeNode(groupName);
+
+            // Only toggle collapsed state when left-clicked
+            if (ImGui.IsItemClicked(ImGuiMouseButton.Left))
             {
-                headerClicked = ImGui.TreeNode($"+ {groupName}");
-            }
-            else
-            {
-                headerClicked = ImGui.TreeNode($"- {groupName}");
+                if (isCollapsed)
+                    _collapsedGroups.Remove(fullGroupPath);
+                else
+                    _collapsedGroups.Add(fullGroupPath);
             }
 
             // Right-click context menu for group
@@ -188,15 +190,8 @@ while True:
                 _contextMenuPosition = ImGui.GetMousePos();
             }
 
-            if (headerClicked)
-            {
-                if (isCollapsed)
-                    _collapsedGroups.Remove(fullGroupPath);
-                else
-                    _collapsedGroups.Add(fullGroupPath);
-            }
-
-            if (!isCollapsed)
+            // If node is open, render children and call TreePop
+            if (nodeOpen)
             {
                 ImGui.Indent();
 
@@ -220,6 +215,7 @@ while True:
                 }
 
                 ImGui.Unindent();
+                ImGui.TreePop();
             }
 
             ImGui.PopID();
@@ -428,9 +424,13 @@ while True:
                             {
                                 try
                                 {
-                                    string gPath = _contextMenuGroup == NOGROUPTEXT ? "" :
-                                        string.IsNullOrEmpty(_contextMenuGroup) ? _contextMenuSubGroup :
-                                        Path.Combine(_contextMenuGroup, _contextMenuSubGroup);
+                                    // Normalize sentinels by replacing NOGROUPTEXT with empty string
+                                    string normalizedGroup = _contextMenuGroup == NOGROUPTEXT ? "" : _contextMenuGroup;
+                                    string normalizedSubGroup = _contextMenuSubGroup == NOGROUPTEXT ? "" : _contextMenuSubGroup;
+
+                                    string gPath = string.IsNullOrEmpty(normalizedGroup) ? normalizedSubGroup :
+                                        string.IsNullOrEmpty(normalizedSubGroup) ? normalizedGroup :
+                                        Path.Combine(normalizedGroup, normalizedSubGroup);
 
                                     string filePath = Path.Combine(LegionScripting.LegionScripting.ScriptPath, gPath, _newScriptName);
                                     if (!File.Exists(filePath))
@@ -487,8 +487,15 @@ while True:
 
                             try
                             {
-                                string gname = _contextMenuSubGroup == NOGROUPTEXT ? "" : _contextMenuSubGroup;
-                                string path = Path.Combine(LegionScripting.LegionScripting.ScriptPath, gname, _newGroupName);
+                                // Build full path including parent group
+                                string normalizedGroup = _contextMenuGroup == NOGROUPTEXT ? "" : _contextMenuGroup;
+                                string normalizedSubGroup = _contextMenuSubGroup == NOGROUPTEXT ? "" : _contextMenuSubGroup;
+
+                                string path = Path.Combine(LegionScripting.LegionScripting.ScriptPath,
+                                    normalizedGroup ?? "",
+                                    normalizedSubGroup ?? "",
+                                    _newGroupName);
+
                                 if (!Directory.Exists(path))
                                 {
                                     Directory.CreateDirectory(path);

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/ScriptManagerWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/ScriptManagerWindow.cs
@@ -237,21 +237,41 @@ while True:
             if (lastDotIndex != -1)
                 displayName = displayName.Substring(0, lastDotIndex);
 
+            // Check if script is playing
+            bool isPlaying = script.IsPlaying || (script.GetScript != null && script.GetScript.IsPlaying);
+
             // Script status color
-            Vector4 scriptColor = script.IsPlaying || (script.GetScript != null && script.GetScript.IsPlaying)
+            Vector4 scriptColor = isPlaying
                 ? new Vector4(0.0f, 1.0f, 0.0f, 1.0f)  // Green for running
                 : new Vector4(1.0f, 1.0f, 1.0f, 1.0f);  // White for stopped
 
-            // Draw script item
+            // Draw play/stop button
+            string buttonText = isPlaying ? "Stop" : "Play";
+            Vector4 buttonColor = isPlaying
+                ? new Vector4(1.0f, 0.3f, 0.3f, 1.0f)  // Red for stop
+                : new Vector4(0.3f, 1.0f, 0.3f, 1.0f); // Green for play
+
+            ImGui.PushStyleColor(ImGuiCol.Button, buttonColor);
+            ImGui.PushStyleColor(ImGuiCol.ButtonHovered, buttonColor * 1.2f);
+            ImGui.PushStyleColor(ImGuiCol.ButtonActive, buttonColor * 0.8f);
+
+            if (ImGui.Button(buttonText, new Vector2(50, 0)))
+            {
+                if (isPlaying)
+                    LegionScripting.LegionScripting.StopScript(script);
+                else
+                    LegionScripting.LegionScripting.PlayScript(script);
+            }
+
+            ImGui.PopStyleColor(3);
+
+            // Draw script name next to the button
+            ImGui.SameLine();
             ImGui.PushStyleColor(ImGuiCol.Text, scriptColor);
             bool isSelected = false;
             if (ImGui.Selectable($"  {displayName}", isSelected))
             {
-                // Toggle script play/stop on click
-                if (script.IsPlaying || (script.GetScript != null && script.GetScript.IsPlaying))
-                    LegionScripting.LegionScripting.StopScript(script);
-                else
-                    LegionScripting.LegionScripting.PlayScript(script);
+                // Optional: Could add double-click behavior here for editing
             }
             ImGui.PopStyleColor();
 
@@ -261,7 +281,7 @@ while True:
                 ImGui.SetTooltip(script.FileName);
             }
 
-            // Right-click context menu for script
+            // Right-click context menu for script (works on both button and name)
             if (ImGui.IsItemClicked(ImGuiMouseButton.Right))
             {
                 _showContextMenu = true;

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/ScriptManagerWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/ScriptManagerWindow.cs
@@ -41,7 +41,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
             "# See examples at" +
             "\n#   https://github.com/PlayTazUO/PublicLegionScripts/" +
             "\n# Or documentation at" +
-            "\n#   https://github.com/PlayTazUO/TazUO/wiki/TazUO.Legion-Scripting";
+            "\n#   https://tazuo.org/legion/api/";
 
         private const string EXAMPLE_LSCRIPT =
             SCRIPT_HEADER +
@@ -180,10 +180,25 @@ while True:
         private void DrawGroup(string groupName, Dictionary<string, List<ScriptFile>> subGroups, string parentGroup)
         {
             string fullGroupPath = string.IsNullOrEmpty(parentGroup) ? groupName : Path.Combine(parentGroup, groupName);
+
+            // Initialize collapsed state from settings if not already in our set
+            string normalizedGroupName = groupName == NOGROUPTEXT ? "" : groupName;
+            string normalizedParentGroup = parentGroup == NOGROUPTEXT ? "" : parentGroup;
+
+            bool isCollapsedInSettings = string.IsNullOrEmpty(normalizedParentGroup)
+                ? LegionScripting.LegionScripting.IsGroupCollapsed(normalizedGroupName)
+                : LegionScripting.LegionScripting.IsGroupCollapsed(normalizedParentGroup, normalizedGroupName);
+
+            if (isCollapsedInSettings && !_collapsedGroups.Contains(fullGroupPath))
+                _collapsedGroups.Add(fullGroupPath);
+
             bool isCollapsed = _collapsedGroups.Contains(fullGroupPath);
 
             // Group header with expand/collapse button and context menu
             ImGui.PushID(fullGroupPath);
+
+            // Set the default open state based on collapsed state
+            ImGui.SetNextItemOpen(!isCollapsed, ImGuiCond.Once);
 
             // Call TreeNode and store the open state
             bool nodeOpen = ImGui.TreeNode(groupName);
@@ -192,9 +207,21 @@ while True:
             if (ImGui.IsItemClicked(ImGuiMouseButton.Left))
             {
                 if (isCollapsed)
+                {
                     _collapsedGroups.Remove(fullGroupPath);
+                    if (string.IsNullOrEmpty(normalizedParentGroup))
+                        LegionScripting.LegionScripting.SetGroupCollapsed(normalizedGroupName, "", false);
+                    else
+                        LegionScripting.LegionScripting.SetGroupCollapsed(normalizedParentGroup, normalizedGroupName, false);
+                }
                 else
+                {
                     _collapsedGroups.Add(fullGroupPath);
+                    if (string.IsNullOrEmpty(normalizedParentGroup))
+                        LegionScripting.LegionScripting.SetGroupCollapsed(normalizedGroupName, "", true);
+                    else
+                        LegionScripting.LegionScripting.SetGroupCollapsed(normalizedParentGroup, normalizedGroupName, true);
+                }
             }
 
             // Right-click context menu for group
@@ -252,15 +279,14 @@ while True:
             bool isPlaying = script.IsPlaying || (script.GetScript != null && script.GetScript.IsPlaying);
 
             // Script status color
-            Vector4 scriptColor = isPlaying
-                ? new Vector4(0.0f, 1.0f, 0.0f, 1.0f)  // Green for running
-                : new Vector4(1.0f, 1.0f, 1.0f, 1.0f);  // White for stopped
+            //Vector4 scriptColor = new Vector4(1.0f, 1.0f, 1.0f, 1.0f);
 
             // Draw play/stop button
             string buttonText = isPlaying ? "Stop" : "Play";
             Vector4 buttonColor = isPlaying
-                ? new Vector4(1.0f, 0.3f, 0.3f, 1.0f)  // Red for stop
-                : new Vector4(0.3f, 1.0f, 0.3f, 1.0f); // Green for play
+                ? new Vector4(0.2f, 0.6f, 0.2f, 1.0f) // Green for play
+                : ImGuiTheme.Colors.Primary;
+
 
             ImGui.PushStyleColor(ImGuiCol.Button, buttonColor);
             ImGui.PushStyleColor(ImGuiCol.ButtonHovered, buttonColor * 1.2f);
@@ -301,7 +327,7 @@ while True:
             }
 
             // Draw script name or rename input
-            ImGui.PushStyleColor(ImGuiCol.Text, scriptColor);
+            //ImGui.PushStyleColor(ImGuiCol.Text, scriptColor);
 
             if (_renamingScript == script)
             {
@@ -344,7 +370,7 @@ while True:
                 }
             }
 
-            ImGui.PopStyleColor();
+            //ImGui.PopStyleColor();
 
             // Tooltip with full filename (only when not renaming)
             if (_renamingScript != script && ImGui.IsItemHovered())
@@ -391,14 +417,14 @@ while True:
                 string newPath = Path.Combine(directory, newName);
 
                 // Check if the new file name already exists
-                if (File.Exists(newPath) && !string.Equals(script.FullPath, newPath, StringComparison.OrdinalIgnoreCase))
+                if (File.Exists(newPath) && !string.Equals(script.FullPath, newPath))
                 {
                     GameActions.Print(World.Instance, $"A file with the name '{newName}' already exists.", 32);
                     return;
                 }
 
                 // Perform the rename
-                if (!string.Equals(script.FullPath, newPath, StringComparison.OrdinalIgnoreCase))
+                if (!string.Equals(script.FullPath, newPath))
                 {
                     File.Move(script.FullPath, newPath);
 
@@ -592,6 +618,10 @@ while True:
                                         Path.Combine(normalizedGroup, normalizedSubGroup);
 
                                     string filePath = Path.Combine(LegionScripting.LegionScripting.ScriptPath, gPath, _newScriptName);
+
+                                    if (!Directory.Exists(Path.Combine(LegionScripting.LegionScripting.ScriptPath, gPath)))
+                                        Directory.CreateDirectory(Path.Combine(LegionScripting.LegionScripting.ScriptPath, gPath));
+
                                     if (!File.Exists(filePath))
                                     {
                                         File.WriteAllText(filePath, SCRIPT_HEADER);

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/ScriptManagerWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/ScriptManagerWindow.cs
@@ -32,6 +32,10 @@ namespace ClassicUO.Game.UI.ImGuiControls
         private Vector2 _contextMenuPosition;
         private bool _showMainMenu = false;
         private bool _pendingReload = false;
+        private ScriptFile _renamingScript = null;
+        private string _renameBuffer = "";
+        private double _lastClickTime = 0.0;
+        private ScriptFile _lastClickedScript = null;
 
         private const string SCRIPT_HEADER =
             "# See examples at" +
@@ -71,6 +75,13 @@ while True:
             {
                 LegionScripting.LegionScripting.LoadScriptsFromFile();
                 _pendingReload = false;
+            }
+
+            // Cancel rename if user clicks outside
+            if (_renamingScript != null && ImGui.IsMouseClicked(ImGuiMouseButton.Left) && !ImGui.IsAnyItemActive())
+            {
+                _renamingScript = null;
+                _renameBuffer = "";
             }
 
             // Top menu bar
@@ -265,18 +276,78 @@ while True:
 
             ImGui.PopStyleColor(3);
 
-            // Draw script name next to the button
+            // Autostart indicator
             ImGui.SameLine();
-            ImGui.PushStyleColor(ImGuiCol.Text, scriptColor);
-            bool isSelected = false;
-            if (ImGui.Selectable($"  {displayName}", isSelected))
+            bool hasGlobalAutostart = LegionScripting.LegionScripting.AutoLoadEnabled(script, true);
+            bool hasCharacterAutostart = LegionScripting.LegionScripting.AutoLoadEnabled(script, false);
+
+            if (hasGlobalAutostart || hasCharacterAutostart)
             {
-                // Optional: Could add double-click behavior here for editing
+                Vector4 autostartColor = hasGlobalAutostart
+                    ? new Vector4(1.0f, 0.8f, 0.0f, 1.0f)  // Gold for global autostart
+                    : new Vector4(0.0f, 0.8f, 1.0f, 1.0f); // Cyan for character autostart
+
+                ImGui.PushStyleColor(ImGuiCol.Text, autostartColor);
+                string indicator = hasGlobalAutostart ? "[G]" : "[C]";
+                ImGui.Text(indicator);
+                ImGui.PopStyleColor();
+
+                if (ImGui.IsItemHovered())
+                {
+                    string tooltip = hasGlobalAutostart ? "Autostart: All characters" : "Autostart: This character";
+                    ImGui.SetTooltip(tooltip);
+                }
+                ImGui.SameLine();
             }
+
+            // Draw script name or rename input
+            ImGui.PushStyleColor(ImGuiCol.Text, scriptColor);
+
+            if (_renamingScript == script)
+            {
+                // Show rename input and save button
+                ImGui.SetKeyboardFocusHere();
+                if (ImGui.InputText("##rename", ref _renameBuffer, 256, ImGuiInputTextFlags.EnterReturnsTrue))
+                {
+                    PerformRename(script);
+                }
+
+                ImGui.SameLine();
+                if (ImGui.Button("Save##rename"))
+                {
+                    PerformRename(script);
+                }
+
+                ImGui.SameLine();
+                if (ImGui.Button("Cancel##rename"))
+                {
+                    _renamingScript = null;
+                    _renameBuffer = "";
+                }
+            }
+            else
+            {
+                // Normal script display with double-click detection
+                bool isSelected = false;
+                if (ImGui.Selectable($"  {displayName}", isSelected))
+                {
+                    // Handle double-click for rename
+                    double currentTime = ImGui.GetTime();
+                    if (_lastClickedScript == script && (currentTime - _lastClickTime) < 0.5) // 500ms for double-click
+                    {
+                        // Start renaming
+                        _renamingScript = script;
+                        _renameBuffer = displayName;
+                    }
+                    _lastClickedScript = script;
+                    _lastClickTime = currentTime;
+                }
+            }
+
             ImGui.PopStyleColor();
 
-            // Tooltip with full filename
-            if (ImGui.IsItemHovered())
+            // Tooltip with full filename (only when not renaming)
+            if (_renamingScript != script && ImGui.IsItemHovered())
             {
                 ImGui.SetTooltip(script.FileName);
             }
@@ -292,6 +363,61 @@ while True:
             }
 
             ImGui.PopID();
+        }
+
+        private void PerformRename(ScriptFile script)
+        {
+            if (string.IsNullOrWhiteSpace(_renameBuffer))
+            {
+                _renamingScript = null;
+                _renameBuffer = "";
+                return;
+            }
+
+            try
+            {
+                // Get the original extension
+                string originalExtension = Path.GetExtension(script.FileName);
+
+                // Ensure the new name has the correct extension
+                string newName = _renameBuffer;
+                if (!newName.EndsWith(originalExtension, StringComparison.OrdinalIgnoreCase))
+                {
+                    newName += originalExtension;
+                }
+
+                // Build new file path
+                string directory = Path.GetDirectoryName(script.FullPath);
+                string newPath = Path.Combine(directory, newName);
+
+                // Check if the new file name already exists
+                if (File.Exists(newPath) && !string.Equals(script.FullPath, newPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    GameActions.Print(World.Instance, $"A file with the name '{newName}' already exists.", 32);
+                    return;
+                }
+
+                // Perform the rename
+                if (!string.Equals(script.FullPath, newPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    File.Move(script.FullPath, newPath);
+
+                    // Update the script object
+                    script.FullPath = newPath;
+                    script.FileName = newName;
+
+                    _pendingReload = true;
+                }
+            }
+            catch (Exception ex)
+            {
+                GameActions.Print(World.Instance, $"Error renaming script: {ex.Message}", 32);
+            }
+            finally
+            {
+                _renamingScript = null;
+                _renameBuffer = "";
+            }
         }
 
         private void DrawContextMenus()
@@ -587,6 +713,9 @@ while True:
             _showContextMenu = false;
             _showNewScriptDialog = false;
             _showNewGroupDialog = false;
+            _renamingScript = null;
+            _renameBuffer = "";
+            _lastClickedScript = null;
             base.Dispose();
         }
     }

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/ScriptManagerWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/ScriptManagerWindow.cs
@@ -31,6 +31,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
         private ScriptFile _contextMenuScript = null;
         private Vector2 _contextMenuPosition;
         private bool _showMainMenu = false;
+        private bool _pendingReload = false;
 
         private const string SCRIPT_HEADER =
             "# See examples at" +
@@ -60,12 +61,17 @@ while True:
         private ScriptManagerWindow() : base("Script Manager")
         {
             WindowFlags = ImGuiWindowFlags.None;
+            _pendingReload = true;
         }
 
         public override void DrawContent()
         {
             // Load scripts if needed
-            LegionScripting.LegionScripting.LoadScriptsFromFile();
+            if (_pendingReload)
+            {
+                LegionScripting.LegionScripting.LoadScriptsFromFile();
+                _pendingReload = false;
+            }
 
             // Top menu bar
             DrawMenuBar();
@@ -98,7 +104,7 @@ while True:
                 {
                     if (ImGui.MenuItem("Refresh"))
                     {
-                        LegionScripting.LegionScripting.LoadScriptsFromFile();
+                        _pendingReload = true;
                         _showMainMenu = false;
                     }
 
@@ -390,7 +396,7 @@ while True:
                                 string gPath = string.IsNullOrEmpty(parentGroup) ? groupName : Path.Combine(parentGroup, groupName);
                                 gPath = Path.Combine(LegionScripting.LegionScripting.ScriptPath, gPath);
                                 Directory.Delete(gPath, true);
-                                LegionScripting.LegionScripting.LoadScriptsFromFile();
+                                _pendingReload = true;
                             }
                             catch (Exception) { }
                         }
@@ -436,7 +442,7 @@ while True:
                                     if (!File.Exists(filePath))
                                     {
                                         File.WriteAllText(filePath, SCRIPT_HEADER);
-                                        LegionScripting.LegionScripting.LoadScriptsFromFile();
+                                        _pendingReload = true;
                                     }
                                 }
                                 catch (Exception e)
@@ -501,7 +507,7 @@ while True:
                                     Directory.CreateDirectory(path);
                                 }
                                 File.WriteAllText(Path.Combine(path, "Example.py"), EXAMPLE_LSCRIPT);
-                                LegionScripting.LegionScripting.LoadScriptsFromFile();
+                                _pendingReload = true;
                             }
                             catch (Exception e)
                             {

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/ScriptManagerWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/ScriptManagerWindow.cs
@@ -1,0 +1,553 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using ClassicUO.Configuration;
+using ClassicUO.Game;
+using ClassicUO.Game.Managers;
+using ClassicUO.Game.UI.Gumps;
+using ClassicUO.Input;
+using ClassicUO.LegionScripting;
+using ClassicUO.Utility.Logging;
+using ImGuiNET;
+using Microsoft.Xna.Framework;
+using Vector2 = System.Numerics.Vector2;
+using Vector4 = System.Numerics.Vector4;
+
+namespace ClassicUO.Game.UI.ImGuiControls
+{
+    public class ScriptManagerWindow : SingletonImGuiWindow<ScriptManagerWindow>
+    {
+        private readonly HashSet<string> _collapsedGroups = new HashSet<string>();
+        private string _newScriptName = "";
+        private string _newGroupName = "";
+        private bool _showContextMenu = false;
+        private string _contextMenuGroup = "";
+        private string _contextMenuSubGroup = "";
+        private bool _showNewScriptDialog = false;
+        private bool _showNewGroupDialog = false;
+        private ScriptFile _contextMenuScript = null;
+        private Vector2 _contextMenuPosition;
+        private bool _showMainMenu = false;
+
+        private const string SCRIPT_HEADER =
+            "# See examples at" +
+            "\n#   https://github.com/PlayTazUO/PublicLegionScripts/" +
+            "\n# Or documentation at" +
+            "\n#   https://github.com/PlayTazUO/TazUO/wiki/TazUO.Legion-Scripting";
+
+        private const string EXAMPLE_LSCRIPT =
+            SCRIPT_HEADER +
+            @"
+player = API.Player
+delay = 8
+diffhits = 10
+
+while True:
+    if player.HitsMax - player.Hits > diffhits or player.IsPoisoned:
+        if API.BandageSelf():
+            API.CreateCooldownBar(delay, 'Bandaging...', 21)
+            API.Pause(delay)
+        else:
+            API.SysMsg('WARNING: No bandages!', 32)
+            break
+    API.Pause(0.5)";
+
+        private const string NOGROUPTEXT = "No group";
+
+        private ScriptManagerWindow() : base("Script Manager")
+        {
+            WindowFlags = ImGuiWindowFlags.None;
+        }
+
+        public override void DrawContent()
+        {
+            // Load scripts if needed
+            LegionScripting.LegionScripting.LoadScriptsFromFile();
+
+            // Top menu bar
+            DrawMenuBar();
+
+            ImGui.Separator();
+
+            // Organize scripts by groups
+            var groupsMap = OrganizeScripts();
+
+            // Draw script groups
+            DrawScriptGroups(groupsMap);
+
+            // Handle context menus and dialogs
+            DrawContextMenus();
+            DrawDialogs();
+        }
+
+        private void DrawMenuBar()
+        {
+            if (ImGui.Button("Menu"))
+            {
+                _showMainMenu = !_showMainMenu;
+            }
+
+            if (_showMainMenu)
+            {
+                ImGui.SetNextWindowPos(ImGui.GetCursorScreenPos());
+                if (ImGui.Begin("ScriptManagerMenu", ref _showMainMenu,
+                    ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.AlwaysAutoResize))
+                {
+                    if (ImGui.MenuItem("Refresh"))
+                    {
+                        LegionScripting.LegionScripting.LoadScriptsFromFile();
+                        _showMainMenu = false;
+                    }
+
+                    if (ImGui.MenuItem("Public Script Browser"))
+                    {
+                        UIManager.Add(new ScriptBrowser(World.Instance));
+                        _showMainMenu = false;
+                    }
+
+                    if (ImGui.MenuItem("Script Recording"))
+                    {
+                        UIManager.Add(new ScriptRecordingGump());
+                        _showMainMenu = false;
+                    }
+
+                    if (ImGui.MenuItem("Scripting Info"))
+                    {
+                        ScriptingInfoGump.Show();
+                        _showMainMenu = false;
+                    }
+
+                    bool disableCache = LegionScripting.LegionScripting.LScriptSettings.DisableModuleCache;
+                    if (ImGui.Checkbox("Disable Module Cache", ref disableCache))
+                    {
+                        LegionScripting.LegionScripting.LScriptSettings.DisableModuleCache = disableCache;
+                    }
+                }
+                ImGui.End();
+            }
+        }
+
+        private Dictionary<string, Dictionary<string, List<ScriptFile>>> OrganizeScripts()
+        {
+            var groupsMap = new Dictionary<string, Dictionary<string, List<ScriptFile>>>
+            {
+                { "", new Dictionary<string, List<ScriptFile>> { { "", new List<ScriptFile>() } } }
+            };
+
+            foreach (ScriptFile sf in LegionScripting.LegionScripting.LoadedScripts)
+            {
+                if (!groupsMap.ContainsKey(sf.Group))
+                    groupsMap[sf.Group] = new Dictionary<string, List<ScriptFile>>();
+
+                if (!groupsMap[sf.Group].ContainsKey(sf.SubGroup))
+                    groupsMap[sf.Group][sf.SubGroup] = new List<ScriptFile>();
+
+                groupsMap[sf.Group][sf.SubGroup].Add(sf);
+            }
+
+            return groupsMap;
+        }
+
+        private void DrawScriptGroups(Dictionary<string, Dictionary<string, List<ScriptFile>>> groupsMap)
+        {
+            foreach (var group in groupsMap)
+            {
+                string groupName = string.IsNullOrEmpty(group.Key) ? NOGROUPTEXT : group.Key;
+                DrawGroup(groupName, group.Value, "");
+            }
+        }
+
+        private void DrawGroup(string groupName, Dictionary<string, List<ScriptFile>> subGroups, string parentGroup)
+        {
+            string fullGroupPath = string.IsNullOrEmpty(parentGroup) ? groupName : Path.Combine(parentGroup, groupName);
+            bool isCollapsed = _collapsedGroups.Contains(fullGroupPath);
+
+            // Group header with expand/collapse button and context menu
+            ImGui.PushID(fullGroupPath);
+
+            bool headerClicked = false;
+            if (isCollapsed)
+            {
+                headerClicked = ImGui.TreeNode($"+ {groupName}");
+            }
+            else
+            {
+                headerClicked = ImGui.TreeNode($"- {groupName}");
+            }
+
+            // Right-click context menu for group
+            if (ImGui.IsItemClicked(ImGuiMouseButton.Right))
+            {
+                _showContextMenu = true;
+                _contextMenuGroup = parentGroup;
+                _contextMenuSubGroup = groupName;
+                _contextMenuScript = null;
+                _contextMenuPosition = ImGui.GetMousePos();
+            }
+
+            if (headerClicked)
+            {
+                if (isCollapsed)
+                    _collapsedGroups.Remove(fullGroupPath);
+                else
+                    _collapsedGroups.Add(fullGroupPath);
+            }
+
+            if (!isCollapsed)
+            {
+                ImGui.Indent();
+
+                // Draw subgroups and scripts
+                foreach (var subGroup in subGroups)
+                {
+                    if (!string.IsNullOrEmpty(subGroup.Key))
+                    {
+                        // This is a subgroup
+                        var subGroupData = new Dictionary<string, List<ScriptFile>> { { "", subGroup.Value } };
+                        DrawGroup(subGroup.Key, subGroupData, groupName);
+                    }
+                    else
+                    {
+                        // These are scripts directly in this group
+                        foreach (var script in subGroup.Value)
+                        {
+                            DrawScript(script);
+                        }
+                    }
+                }
+
+                ImGui.Unindent();
+            }
+
+            ImGui.PopID();
+        }
+
+        private void DrawScript(ScriptFile script)
+        {
+            ImGui.PushID(script.FileName);
+
+            // Get script display name (without extension)
+            string displayName = script.FileName;
+            int lastDotIndex = displayName.LastIndexOf('.');
+            if (lastDotIndex != -1)
+                displayName = displayName.Substring(0, lastDotIndex);
+
+            // Script status color
+            Vector4 scriptColor = script.IsPlaying || (script.GetScript != null && script.GetScript.IsPlaying)
+                ? new Vector4(0.0f, 1.0f, 0.0f, 1.0f)  // Green for running
+                : new Vector4(1.0f, 1.0f, 1.0f, 1.0f);  // White for stopped
+
+            // Draw script item
+            ImGui.PushStyleColor(ImGuiCol.Text, scriptColor);
+            bool isSelected = false;
+            if (ImGui.Selectable($"  {displayName}", isSelected))
+            {
+                // Toggle script play/stop on click
+                if (script.IsPlaying || (script.GetScript != null && script.GetScript.IsPlaying))
+                    LegionScripting.LegionScripting.StopScript(script);
+                else
+                    LegionScripting.LegionScripting.PlayScript(script);
+            }
+            ImGui.PopStyleColor();
+
+            // Tooltip with full filename
+            if (ImGui.IsItemHovered())
+            {
+                ImGui.SetTooltip(script.FileName);
+            }
+
+            // Right-click context menu for script
+            if (ImGui.IsItemClicked(ImGuiMouseButton.Right))
+            {
+                _showContextMenu = true;
+                _contextMenuScript = script;
+                _contextMenuGroup = "";
+                _contextMenuSubGroup = "";
+                _contextMenuPosition = ImGui.GetMousePos();
+            }
+
+            ImGui.PopID();
+        }
+
+        private void DrawContextMenus()
+        {
+            if (_showContextMenu)
+            {
+                ImGui.SetNextWindowPos(_contextMenuPosition);
+                ImGui.SetNextWindowSize(new Vector2(200, 0));
+
+                if (ImGui.Begin("ContextMenu", ref _showContextMenu,
+                    ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.AlwaysAutoResize))
+                {
+                    if (_contextMenuScript != null)
+                    {
+                        DrawScriptContextMenu(_contextMenuScript);
+                    }
+                    else
+                    {
+                        DrawGroupContextMenu(_contextMenuGroup, _contextMenuSubGroup);
+                    }
+                }
+                ImGui.End();
+            }
+        }
+
+        private void DrawScriptContextMenu(ScriptFile script)
+        {
+            ImGui.Text(script.FileName);
+            ImGui.Separator();
+
+            if (ImGui.MenuItem("Edit"))
+            {
+                UIManager.Add(new ScriptEditor(World.Instance, script));
+                _showContextMenu = false;
+            }
+
+            if (ImGui.MenuItem("Edit Externally"))
+            {
+                OpenFileWithDefaultApp(script.FullPath);
+                _showContextMenu = false;
+            }
+
+            if (ImGui.BeginMenu("Autostart"))
+            {
+                bool globalAutostart = LegionScripting.LegionScripting.AutoLoadEnabled(script, true);
+                bool characterAutostart = LegionScripting.LegionScripting.AutoLoadEnabled(script, false);
+
+                if (ImGui.Checkbox("All characters", ref globalAutostart))
+                {
+                    LegionScripting.LegionScripting.SetAutoPlay(script, true, globalAutostart);
+                }
+
+                if (ImGui.Checkbox("This character", ref characterAutostart))
+                {
+                    LegionScripting.LegionScripting.SetAutoPlay(script, false, characterAutostart);
+                }
+
+                ImGui.EndMenu();
+            }
+
+            if (ImGui.MenuItem("Create macro button"))
+            {
+                var mm = MacroManager.TryGetMacroManager(World.Instance);
+                if (mm != null)
+                {
+                    Macro mac = new Macro(script.FileName);
+                    mac.Items = new MacroObjectString(MacroType.ClientCommand, MacroSubType.MSC_NONE, "togglelscript " + script.FileName);
+                    mm.PushToBack(mac);
+
+                    MacroButtonGump bg = new MacroButtonGump(World.Instance, mac, Mouse.Position.X, Mouse.Position.Y);
+                    UIManager.Add(bg);
+                }
+                _showContextMenu = false;
+            }
+
+            if (ImGui.MenuItem("Delete"))
+            {
+                QuestionGump g = new QuestionGump(World.Instance, "Are you sure?", (r) =>
+                {
+                    if (r)
+                    {
+                        try
+                        {
+                            File.Delete(script.FullPath);
+                            LegionScripting.LegionScripting.LoadedScripts.Remove(script);
+                        }
+                        catch (Exception) { }
+                    }
+                });
+                UIManager.Add(g);
+                _showContextMenu = false;
+            }
+        }
+
+        private void DrawGroupContextMenu(string parentGroup, string groupName)
+        {
+            if (ImGui.MenuItem("New script"))
+            {
+                _showNewScriptDialog = true;
+                _showContextMenu = false;
+            }
+
+            if (string.IsNullOrEmpty(parentGroup))
+            {
+                if (ImGui.MenuItem("New group"))
+                {
+                    _showNewGroupDialog = true;
+                    _showContextMenu = false;
+                }
+            }
+
+            if (groupName != NOGROUPTEXT && !string.IsNullOrEmpty(groupName))
+            {
+                if (ImGui.MenuItem("Delete group"))
+                {
+                    QuestionGump g = new QuestionGump(World.Instance, "Delete group?", (r) =>
+                    {
+                        if (r)
+                        {
+                            try
+                            {
+                                string gPath = string.IsNullOrEmpty(parentGroup) ? groupName : Path.Combine(parentGroup, groupName);
+                                gPath = Path.Combine(LegionScripting.LegionScripting.ScriptPath, gPath);
+                                Directory.Delete(gPath, true);
+                                LegionScripting.LegionScripting.LoadScriptsFromFile();
+                            }
+                            catch (Exception) { }
+                        }
+                    });
+                    UIManager.Add(g);
+                    _showContextMenu = false;
+                }
+            }
+        }
+
+        private void DrawDialogs()
+        {
+            // New Script Dialog
+            if (_showNewScriptDialog)
+            {
+                ImGui.SetNextWindowPos(ImGui.GetMainViewport().GetCenter(), ImGuiCond.Appearing, new Vector2(0.5f, 0.5f));
+                if (ImGui.Begin("New Script", ref _showNewScriptDialog, ImGuiWindowFlags.AlwaysAutoResize))
+                {
+                    ImGui.Text("Enter a name for this script.");
+                    ImGui.Text("Use .lscript or .py extension");
+
+                    ImGui.InputText("Script Name", ref _newScriptName, 100);
+
+                    ImGui.Separator();
+
+                    if (ImGui.Button("Create"))
+                    {
+                        if (!string.IsNullOrEmpty(_newScriptName))
+                        {
+                            if (_newScriptName.EndsWith(".lscript") || _newScriptName.EndsWith(".py"))
+                            {
+                                try
+                                {
+                                    string gPath = _contextMenuGroup == NOGROUPTEXT ? "" :
+                                        string.IsNullOrEmpty(_contextMenuGroup) ? _contextMenuSubGroup :
+                                        Path.Combine(_contextMenuGroup, _contextMenuSubGroup);
+
+                                    string filePath = Path.Combine(LegionScripting.LegionScripting.ScriptPath, gPath, _newScriptName);
+                                    if (!File.Exists(filePath))
+                                    {
+                                        File.WriteAllText(filePath, SCRIPT_HEADER);
+                                        LegionScripting.LegionScripting.LoadScriptsFromFile();
+                                    }
+                                }
+                                catch (Exception e)
+                                {
+                                    GameActions.Print(World.Instance, e.ToString(), 32);
+                                }
+                            }
+                            else
+                            {
+                                GameActions.Print(World.Instance, "Script files must end with .lscript or .py", 32);
+                            }
+                        }
+
+                        _newScriptName = "";
+                        _showNewScriptDialog = false;
+                    }
+
+                    ImGui.SameLine();
+
+                    if (ImGui.Button("Cancel"))
+                    {
+                        _newScriptName = "";
+                        _showNewScriptDialog = false;
+                    }
+                }
+                ImGui.End();
+            }
+
+            // New Group Dialog
+            if (_showNewGroupDialog)
+            {
+                ImGui.SetNextWindowPos(ImGui.GetMainViewport().GetCenter(), ImGuiCond.Appearing, new Vector2(0.5f, 0.5f));
+                if (ImGui.Begin("New Group", ref _showNewGroupDialog, ImGuiWindowFlags.AlwaysAutoResize))
+                {
+                    ImGui.Text("Enter a name for this group.");
+
+                    ImGui.InputText("Group Name", ref _newGroupName, 100);
+
+                    ImGui.Separator();
+
+                    if (ImGui.Button("Create"))
+                    {
+                        if (!string.IsNullOrEmpty(_newGroupName))
+                        {
+                            int p = _newGroupName.IndexOf('.');
+                            if (p != -1)
+                                _newGroupName = _newGroupName.Substring(0, p);
+
+                            try
+                            {
+                                string gname = _contextMenuSubGroup == NOGROUPTEXT ? "" : _contextMenuSubGroup;
+                                string path = Path.Combine(LegionScripting.LegionScripting.ScriptPath, gname, _newGroupName);
+                                if (!Directory.Exists(path))
+                                {
+                                    Directory.CreateDirectory(path);
+                                }
+                                File.WriteAllText(Path.Combine(path, "Example.py"), EXAMPLE_LSCRIPT);
+                                LegionScripting.LegionScripting.LoadScriptsFromFile();
+                            }
+                            catch (Exception e)
+                            {
+                                Log.Error(e.ToString());
+                            }
+                        }
+
+                        _newGroupName = "";
+                        _showNewGroupDialog = false;
+                    }
+
+                    ImGui.SameLine();
+
+                    if (ImGui.Button("Cancel"))
+                    {
+                        _newGroupName = "";
+                        _showNewGroupDialog = false;
+                    }
+                }
+                ImGui.End();
+            }
+        }
+
+        private static void OpenFileWithDefaultApp(string filePath)
+        {
+            try
+            {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    Process.Start(new ProcessStartInfo(filePath) { UseShellExecute = true });
+                }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    Process.Start("xdg-open", filePath);
+                }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                {
+                    Process.Start("open", filePath);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error("Error opening file: " + ex.Message);
+            }
+        }
+
+        public override void Dispose()
+        {
+            _showMainMenu = false;
+            _showContextMenu = false;
+            _showNewScriptDialog = false;
+            _showNewGroupDialog = false;
+            base.Dispose();
+        }
+    }
+}

--- a/src/ClassicUO.Client/Game/UI/ImGuiManager.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiManager.cs
@@ -82,7 +82,7 @@ namespace ClassicUO.Game.UI
             // Primary background
             colors[(int)ImGuiCol.WindowBg] = ImGuiTheme.Colors.Base100;
             colors[(int)ImGuiCol.MenuBarBg] = ImGuiTheme.Colors.Primary;
-            colors[(int)ImGuiCol.PopupBg] = ImGuiTheme.Colors.Primary;
+            colors[(int)ImGuiCol.PopupBg] = ImGuiTheme.Colors.Base100;
 
             // Headers
             colors[(int)ImGuiCol.Header] = ImGuiTheme.Colors.Base100;

--- a/src/ClassicUO.Client/LegionScripting/IPyGump.cs
+++ b/src/ClassicUO.Client/LegionScripting/IPyGump.cs
@@ -1,0 +1,9 @@
+using ClassicUO.Game.Managers;
+using ClassicUO.Game.UI.Gumps;
+
+namespace ClassicUO.LegionScripting;
+
+public interface IPyGump
+{
+    public Gump Gump { get; }
+}

--- a/src/ClassicUO.Client/LegionScripting/PyClasses/PyBaseControl.cs
+++ b/src/ClassicUO.Client/LegionScripting/PyClasses/PyBaseControl.cs
@@ -7,6 +7,7 @@ namespace ClassicUO.LegionScripting.PyClasses;
 
 public class PyBaseControl(Control control)
 {
+    protected Control Control => control;
     /// <summary>
     /// Adds a child control to this control. Works with gumps too (gump.Add(control)).
     /// Used in python API
@@ -17,6 +18,8 @@ public class PyBaseControl(Control control)
         if (childControl != null && VerifyIntegrity())
             MainThreadQueue.EnqueueAction(() => control?.Add(childControl));
     }
+
+    public void Add(PyBaseControl childControl) => Add(childControl.Control);
 
     /// <summary>
     /// Returns the control's X position.

--- a/src/ClassicUO.Client/LegionScripting/PyClasses/PyNineSliceGump.cs
+++ b/src/ClassicUO.Client/LegionScripting/PyClasses/PyNineSliceGump.cs
@@ -1,0 +1,159 @@
+using System;
+using ClassicUO.Game.Data;
+using ClassicUO.Game.Managers;
+using ClassicUO.Game.UI.Gumps;
+
+namespace ClassicUO.LegionScripting.PyClasses;
+
+public class PyNineSliceGump : PyBaseControl, IPyGump
+{
+    private readonly NineSliceGump _nineSliceGump;
+    private readonly API _api;
+    private object _onResizedCallback;
+    public NineSliceGump NineSliceGump => _nineSliceGump;
+
+    /// <summary>
+    /// Creates a modern nine-slice gump using ModernUIConstants
+    /// </summary>
+    /// <param name="x">X position</param>
+    /// <param name="y">Y position</param>
+    /// <param name="width">Initial width</param>
+    /// <param name="height">Initial height</param>
+    /// <param name="resizable">Whether the gump can be resized by dragging corners</param>
+    /// <param name="minWidth">Minimum width</param>
+    /// <param name="minHeight">Minimum height</param>
+    /// <param name="onResized">Optional callback function called when the gump is resized</param>
+    public PyNineSliceGump(API api, int x, int y, int width, int height, bool resizable = true, int minWidth = 50, int minHeight = 50, object onResized = null)
+        : base(CreateNineSliceGump(api, x, y, width, height, resizable, minWidth, minHeight))
+    {
+        _nineSliceGump = (NineSliceGump)Control;
+        _api = api;
+        _onResizedCallback = onResized;
+
+        // Override the OnResize method if callback is provided
+        if (_onResizedCallback != null)
+        {
+            SetupResizeCallback();
+        }
+    }
+
+    private static NineSliceGump CreateNineSliceGump(API api, int x, int y, int width, int height, bool resizable, int minWidth, int minHeight)
+    {
+        return new ModernNineSliceGump(api, x, y, width, height, resizable, minWidth, minHeight);
+    }
+
+    private void SetupResizeCallback()
+    {
+        if (_nineSliceGump is ModernNineSliceGump modernGump)
+        {
+            modernGump.SetResizeCallback(_onResizedCallback);
+        }
+    }
+
+    /// <summary>
+    /// Gets the current hue of the nine-slice gump
+    /// </summary>
+    /// <returns>The current hue value</returns>
+    public ushort GetHue()
+    {
+        if (!VerifyIntegrity())
+            return 0;
+        return _nineSliceGump.Hue;
+    }
+
+    /// <summary>
+    /// Sets the hue of the nine-slice gump
+    /// </summary>
+    /// <param name="hue">The hue value to set</param>
+    public void SetHue(ushort hue)
+    {
+        if (VerifyIntegrity())
+            MainThreadQueue.EnqueueAction(() => _nineSliceGump.Hue = hue);
+    }
+
+    /// <summary>
+    /// Gets whether the gump is resizable
+    /// </summary>
+    /// <returns>True if resizable, false otherwise</returns>
+    public bool GetResizable()
+    {
+        if (!VerifyIntegrity())
+            return false;
+        return _nineSliceGump.Resizable;
+    }
+
+    /// <summary>
+    /// Sets whether the gump is resizable
+    /// </summary>
+    /// <param name="resizable">True to make resizable, false otherwise</param>
+    public void SetResizable(bool resizable)
+    {
+        if (VerifyIntegrity())
+            MainThreadQueue.EnqueueAction(() => _nineSliceGump.Resizable = resizable);
+    }
+
+    /// <summary>
+    /// Gets the border size of the nine-slice
+    /// </summary>
+    /// <returns>The border size in pixels</returns>
+    public int GetBorderSize()
+    {
+        if (!VerifyIntegrity())
+            return 0;
+        return _nineSliceGump.BorderSize;
+    }
+
+    /// <summary>
+    /// Sets the border size of the nine-slice
+    /// </summary>
+    /// <param name="borderSize">The border size in pixels</param>
+    public void SetBorderSize(int borderSize)
+    {
+        if (VerifyIntegrity())
+            MainThreadQueue.EnqueueAction(() => _nineSliceGump.BorderSize = borderSize);
+    }
+
+    public Gump Gump => _nineSliceGump;
+}
+
+/// <summary>
+/// Internal class that extends NineSliceGump to provide callback support
+/// </summary>
+internal class ModernNineSliceGump : NineSliceGump
+{
+    private readonly API _api;
+    private object _resizeCallback;
+
+    public ModernNineSliceGump(API api, int x, int y, int width, int height, bool resizable, int minWidth, int minHeight)
+        : base(Game.World.Instance, x, y, width, height, ModernUIConstants.ModernUIPanel, ModernUIConstants.ModernUIPanel_BoderSize, resizable, minWidth, minHeight)
+    {
+        _api = api;
+    }
+
+    public void SetResizeCallback(object callback)
+    {
+        _resizeCallback = callback;
+    }
+
+    protected override void OnResize(int oldWidth, int oldHeight, int newWidth, int newHeight)
+    {
+        base.OnResize(oldWidth, oldHeight, newWidth, newHeight);
+
+        if (_resizeCallback != null)
+        {
+            _api.ScheduleCallback
+            (() =>
+                {
+                    try
+                    {
+                        _api.engine.Operations.Invoke(_resizeCallback);
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine($"Script callback error: {ex}");
+                    }
+                }
+            );
+        }
+    }
+}


### PR DESCRIPTION
- Created ScriptManagerWindow.cs as SingletonImGuiWindow in ImGuiControls folder
- Replicates all ScriptManagerGump functionality including context menus, script management, and hierarchical display
- Updated TopBarGump to open both original and ImGui versions when clicking Legion Script button
- Not part of AssistantWindow as requested, standalone ImGui window
- Maintains existing ScriptManagerGump for comparison and backward compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Script Manager window for Legion scripting with group/tree view, play/stop, context actions (edit, external edit, autostart, macro buttons, create/delete) and safe-delete confirmations.
  * New in-game windows: Friends List, Journal Filter, Spell Indicators, HUD Settings, Title Bar config.
  * Tooltip helper for inline help icons.

* **Improvements**
  * Top-bar Legion button opens the Script Manager; ImGui popup styling tweaked.
  * Added queued action processing and a mount-toggle macro; various UI refinements and import/export support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->