### PR TITLE
feat: add friend bandaging with timer-based retry system

### DIFF
--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -143,6 +143,7 @@ namespace ClassicUO.Configuration
         public bool BandageAgentCheckPoisoned { get; set; } = false;
         public int BandageAgentHPPercentage { get; set; } = 80;
         public bool BandageAgentCheckInvul { get; set; } = true;
+        public bool BandageAgentBandageFriends { get; set; } = false;
 
         public bool EnableDeathScreen { get; set; } = true;
         public bool EnableBlackWhiteEffect { get; set; } = true;

--- a/src/ClassicUO.Client/Game/Managers/BandageManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/BandageManager.cs
@@ -2,22 +2,31 @@ using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.Managers;
+using ClassicUO.Network;
 using ClassicUO.Utility;
 using System;
+using System.Collections.Generic;
+using System.Threading;
+using ClassicUO.Utility.Logging;
 
 namespace ClassicUO.Game.Managers
 {
-    internal class BandageManager
+    internal class BandageManager : IDisposable
     {
-        public static BandageManager Instance { get; private set; } = new();
+        public static Lazy<BandageManager> Instance { get; private set; } = new(() => new BandageManager());
 
-        private long nextBandageTime = 0;
-        private bool isEnabled => ProfileManager.CurrentProfile?.EnableBandageAgent ?? false;
-        private int healDelayMs => ProfileManager.CurrentProfile?.BandageAgentDelay ?? 3000;
-        private bool checkForBuff => ProfileManager.CurrentProfile?.BandageAgentCheckForBuff ?? false;
-        private ushort bandageGraphic => ProfileManager.CurrentProfile?.BandageAgentGraphic ?? 0x0E21;
-        private bool useNewBandagePacket => ProfileManager.CurrentProfile?.BandageAgentUseNewPacket ?? true;
-        private int hpPercentageThreshold => ProfileManager.CurrentProfile?.BandageAgentHPPercentage ?? 80;
+        private long _nextBandageTime = 0;
+        private readonly LinkedList<uint> _pendingHeals = new();
+        private Timer _retryTimer;
+        private const int RETRY_INTERVAL_MS = 100;
+
+        private bool IsEnabled => ProfileManager.CurrentProfile?.EnableBandageAgent ?? false;
+        private bool FriendBandagingEnabled => ProfileManager.CurrentProfile?.BandageAgentBandageFriends ?? false;
+        private int HealDelayMs => ProfileManager.CurrentProfile?.BandageAgentDelay ?? 3000;
+        private bool CheckForBuff => ProfileManager.CurrentProfile?.BandageAgentCheckForBuff ?? false;
+        private ushort BandageGraphic => ProfileManager.CurrentProfile?.BandageAgentGraphic ?? 0x0E21;
+        private bool UseNewBandagePacket => ProfileManager.CurrentProfile?.BandageAgentUseNewPacket ?? true;
+        private int HpPercentageThreshold => ProfileManager.CurrentProfile?.BandageAgentHPPercentage ?? 80;
         public bool UseOnPoisoned => ProfileManager.CurrentProfile?.BandageAgentCheckPoisoned ?? false;
         public bool CheckHidden => ProfileManager.CurrentProfile?.BandageAgentCheckHidden ?? false;
         public bool CheckInvul => ProfileManager.CurrentProfile?.BandageAgentCheckInvul ?? false;
@@ -25,17 +34,8 @@ namespace ClassicUO.Game.Managers
 
         private BandageManager()
         {
-            EventSink.OnPlayerStatChange += OnPlayerStatChanged;
             EventSink.OnBuffAdded += OnBuffAdded;
             EventSink.OnBuffRemoved += OnBuffRemoved;
-        }
-
-        private void OnPlayerStatChanged(object sender, PlayerStatChangedArgs e)
-        {
-            if (!isEnabled || e.Stat != PlayerStatChangedArgs.PlayerStat.Hits)
-                return;
-
-            OnHpChanged(e.OldValue, e.NewValue);
         }
 
         private void OnBuffAdded(object sender, BuffEventArgs e)
@@ -54,76 +54,189 @@ namespace ClassicUO.Game.Managers
             }
         }
 
-        private void OnHpChanged(int oldHp, int newHp)
+        /// <summary>
+        /// Called from packet handlers when mobile HP changes
+        /// </summary>
+        public void OnMobileHpChanged(Mobile mobile, int oldHp, int newHp)
+        {
+            if (!IsEnabled || mobile == null)
+                return;
+
+            // Check if we should heal this mobile
+            if (ShouldAttemptHeal(mobile))
+            {
+                AttemptHealMobile(mobile);
+            }
+        }
+
+        /// <summary>
+        /// Schedules a retry
+        /// </summary>
+        private void ScheduleRetry(uint mobileSerial = 0)
+        {
+            if(!_pendingHeals.Contains(mobileSerial))
+            {
+                if (mobileSerial == World.Instance.Player)
+                    _pendingHeals.AddFirst(mobileSerial);
+                else
+                    _pendingHeals.AddLast(mobileSerial);
+            }
+
+            VerifyTimer();
+        }
+
+        private void VerifyTimer()
+        {
+            if (_pendingHeals.Count == 0)
+            {
+                DestroyTimer();
+                return;
+            }
+            _retryTimer ??= new Timer(ProcessRetryQueue, null, RETRY_INTERVAL_MS, RETRY_INTERVAL_MS);
+        }
+
+        private void DestroyTimer()
+        {
+            _retryTimer?.Dispose();
+            _retryTimer = null;
+        }
+
+        /// <summary>
+        /// Timer callback to process the retry queue
+        /// </summary>
+        private void ProcessRetryQueue(object state)
+        {
+            if (_pendingHeals.Count == 0) return;
+
+            if (_pendingHeals.First == null)
+            {
+                _pendingHeals.RemoveFirst();
+                ProcessRetryQueue(state);
+                return;
+            }
+
+            uint serial = _pendingHeals.First.Value;
+            _pendingHeals.RemoveFirst();
+            Mobile mobile = World.Instance?.Mobiles?.Get(serial);
+            if (ShouldAttemptHeal(mobile))
+            {
+                AttemptHealMobile(mobile);
+            }
+
+            VerifyTimer();
+        }
+
+        private bool ShouldAttemptHeal(Mobile mobile)
         {
             var player = World.Instance.Player;
-            if (player == null || !isEnabled)
-                return;
+            if (player == null || mobile == null)
+                return false;
+
+            // Check if this is the player or a friend
+            bool isPlayer = mobile == player;
+            bool isFriend = !isPlayer && FriendBandagingEnabled && FriendsListManager.Instance.IsFriend(mobile.Serial);
+            if (!isPlayer && !isFriend)
+                return false;
+
+            // Check distance for friends (within 3 tiles)
+            if (isFriend && mobile.Distance > 3)
+                return false;
 
             // Guard against divide-by-zero and invul
-            if (player.HitsMax <= 0 || (CheckInvul && player.IsYellowHits))
-                return;
+            if (mobile.HitsMax <= 0)
+                return false;
 
-            var currentHpPercentage = (int)((double)newHp / player.HitsMax * 100);
+            // Check for invul if enabled
+            if (CheckInvul && mobile.IsYellowHits)
+                return false;
 
-            // Check for hidden status
-            if (CheckHidden && player.IsHidden)
-                return;
+            // Check for hidden status if enabled
+            if (CheckHidden && mobile.IsHidden)
+                return false;
 
-            // Check for poison status #thanks taz
-            if ((!UseOnPoisoned || !player.IsPoisoned) &&
-                currentHpPercentage >= hpPercentageThreshold)
-                return;
+            var currentHpPercentage = (int)((double)mobile.Hits / mobile.HitsMax * 100);
 
+            // Check for poison status or HP threshold
+            if ((!UseOnPoisoned || !mobile.IsPoisoned) &&
+                currentHpPercentage >= HpPercentageThreshold)
+                return false;
+
+            return true;
+        }
+
+        private void AttemptHealMobile(Mobile mobile)
+        {
             // If using buff checking, only prevent healing if buff is present
-            if (checkForBuff && HasBandagingBuff)
+            if (CheckForBuff && HasBandagingBuff)
+            {
+                ScheduleRetry(mobile.Serial);
                 return;
+            }
 
             // If using delay checking (not buff checking), check time delay
-            if (!checkForBuff && Time.Ticks < nextBandageTime)
-                return;
-
-            AttemptHeal();
-        }
-
-        private void AttemptHeal()
-        {
-            // Enqueue the healing action into the global priority queue
-            GlobalPriorityQueue.Instance.Enqueue(() => ExecuteHeal());
-        }
-
-        private void ExecuteHeal()
-        {
-            if (World.Instance.Player == null)
-                return;
-
-            if (useNewBandagePacket)
+            if (!CheckForBuff && Time.Ticks < _nextBandageTime)
             {
-                if (GameActions.BandageSelf(World.Instance))
-                {
-                    nextBandageTime = Time.Ticks + healDelayMs;
-                }
+                ScheduleRetry(mobile.Serial);
+                return;
+            }
+
+            // Enqueue the healing action into the global priority queue
+            GlobalPriorityQueue.Instance.Enqueue(() => ExecuteHealMobile(mobile));
+        }
+
+        private void ExecuteHealMobile(Mobile mobile)
+        {
+            if (World.Instance.Player == null || mobile == null)
+                return;
+
+            Item bandage = FindBandage();
+            if (bandage == null)
+                return;
+
+            if (UseNewBandagePacket)
+            {
+                // Use the same pattern as BandageSelf but target the mobile
+                AsyncNetClient.Socket.Send_TargetSelectedObject(bandage.Serial, mobile.Serial);
+                _nextBandageTime = Time.Ticks + HealDelayMs;
             }
             else
             {
-                Item bandage = FindBandage();
-                if (bandage == null)
-                    return;
-
                 // Set up auto-target before double-clicking
-                TargetManager.SetAutoTarget(World.Instance.Player.Serial, TargetType.Beneficial, CursorTarget.Object);
+                TargetManager.SetAutoTarget(mobile.Serial, TargetType.Beneficial, CursorTarget.Object);
 
                 GameActions.DoubleClick(World.Instance, bandage.Serial);
-                nextBandageTime = Time.Ticks + healDelayMs;
+                _nextBandageTime = Time.Ticks + HealDelayMs;
             }
+
+            Log.Debug("Tried to heal someone");
+
+            ScheduleRetry(mobile.Serial); // Schedule recheck in case heal failed and hp stayed the same
         }
 
         private Item FindBandage()
         {
-            if (World.Instance.Player?.FindItemByGraphic(bandageGraphic) is Item bandage)
+            if (World.Instance.Player?.FindItemByGraphic(BandageGraphic) is { } bandage)
                 return bandage;
 
             return World.Instance.Player?.FindBandage();
+        }
+
+        /// <summary>
+        /// Clears all pending healing requests
+        /// </summary>
+        private void ClearAllPendingHeals()
+        {
+            _pendingHeals.Clear();
+            DestroyTimer();
+        }
+
+        public void Dispose()
+        {
+            DestroyTimer();
+            ClearAllPendingHeals();
+            EventSink.OnBuffAdded -= OnBuffAdded;
+            EventSink.OnBuffRemoved -= OnBuffRemoved;
+            Instance = null;
         }
     }
 }

--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -222,7 +222,6 @@ namespace ClassicUO.Game.Scenes
             AutoLootManager.Instance.OnSceneLoad();
             DressAgentManager.Instance.Load();
             FriendsListManager.Instance.OnSceneLoad();
-            var _ = BandageManager.Instance;
 
             foreach (var xml in ProfileManager.CurrentProfile.AutoOpenXmlGumps)
             {
@@ -401,6 +400,7 @@ namespace ClassicUO.Game.Scenes
 
             PersistentVars.Unload();
             LegionScripting.LegionScripting.Unload();
+            BandageManager.Instance.Value.Dispose();
 
             ProfileManager.CurrentProfile.GameWindowPosition = new Point(
                 Camera.Bounds.X,

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/Agents/BandageAgentWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/Agents/BandageAgentWindow.cs
@@ -17,6 +17,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
         private bool checkPoisoned;
         private bool checkHidden;
         private bool checkInvul;
+        private bool healfriends;
 
         private BandageAgentWindow() : base("Bandage Agent")
         {
@@ -33,6 +34,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
             checkPoisoned = profile.BandageAgentCheckPoisoned;
             checkHidden = profile.BandageAgentCheckHidden;
             checkInvul = profile.BandageAgentCheckInvul;
+            healfriends = profile.BandageAgentBandageFriends;
         }
 
         public override void DrawContent()
@@ -48,9 +50,11 @@ namespace ClassicUO.Game.UI.ImGuiControls
 
             // Enable bandage agent checkbox
             if (ImGui.Checkbox("Enable bandage agent", ref enabled))
-            {
                 profile.EnableBandageAgent = enabled;
-            }
+
+            ImGui.SameLine();
+            if (ImGui.Checkbox("Bandage friends", ref healfriends))
+                profile.BandageAgentBandageFriends = healfriends;
 
             ImGui.Separator();
 

--- a/src/ClassicUO.Client/Network/PacketHandlers.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers.cs
@@ -512,6 +512,7 @@ sealed class PacketHandlers
         }
 
         string oldName = entity.Name;
+        ushort oldHits = entity.Hits;
         entity.Name = p.ReadASCII(30);
         entity.Hits = p.ReadUInt16BE();
         entity.HitsMax = p.ReadUInt16BE();
@@ -715,6 +716,12 @@ sealed class PacketHandlers
             if (mobile == world.Player)
             {
                 TitleBarStatsManager.UpdateTitleBar();
+            }
+
+            // Check for bandage healing
+            if (oldHits != mobile.Hits)
+            {
+                BandageManager.Instance.Value.OnMobileHpChanged(mobile, oldHits, mobile.Hits);
             }
         }
     }
@@ -1857,6 +1864,7 @@ sealed class PacketHandlers
             return;
         }
 
+        ushort oldHits = entity.Hits;
         entity.HitsMax = p.ReadUInt16BE();
         entity.Hits = p.ReadUInt16BE();
 
@@ -1882,6 +1890,12 @@ sealed class PacketHandlers
             if (mobile == world.Player)
             {
                 TitleBarStatsManager.UpdateTitleBar();
+            }
+
+            // Check for bandage healing
+            if (oldHits != mobile.Hits)
+            {
+                BandageManager.Instance.Value.OnMobileHpChanged(mobile, oldHits, mobile.Hits);
             }
         }
     }
@@ -3600,6 +3614,7 @@ sealed class PacketHandlers
             return;
         }
 
+        ushort oldHits = entity.Hits;
         entity.HitsMax = p.ReadUInt16BE();
         entity.Hits = p.ReadUInt16BE();
 
@@ -3612,6 +3627,16 @@ sealed class PacketHandlers
         {
             SpellVisualRangeManager.Instance.ClearCasting();
             TitleBarStatsManager.UpdateTitleBar();
+        }
+
+        // Check for bandage healing for all mobiles
+        if (SerialHelper.IsMobile(entity.Serial) && oldHits != entity.Hits)
+        {
+            Mobile mobile = entity as Mobile;
+            if (mobile != null)
+            {
+                BandageManager.Instance.Value.OnMobileHpChanged(mobile, oldHits, entity.Hits);
+            }
         }
     }
 


### PR DESCRIPTION
- Add BandageAgentBandageFriends toggle to Profile settings
- Implement event-driven healing from packet handlers (CharacterStatus, MobileAttributes, UpdateHitpoints)
- Use mobile.Distance property for accurate 3-tile range checking
- Support both self and friend healing with unified logic and shared cooldowns
- Respects all existing bandage agent settings (HP threshold, buffs, hidden, invul checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added “Bandage friends” option in Bandage Agent settings/UI.
  * Bandage Agent can now heal friends/party automatically when eligible (HP, distance, status).

* Improvements
  * More reliable bandaging with per-target scheduling and automatic retries.
  * Faster reaction to HP changes for timely healing.
  * Improved cleanup on scene unload to reduce lingering state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->