### PR TITLE
fix: implement audio device recovery and fallback system

### DIFF
--- a/src/ClassicUO.Client/GameController.cs
+++ b/src/ClassicUO.Client/GameController.cs
@@ -578,10 +578,12 @@ namespace ClassicUO
             {
                 case SDL_EventType.SDL_EVENT_AUDIO_DEVICE_ADDED:
                     Log.Trace($"AUDIO ADDED: {sdlEvent->adevice.which}");
+                    Audio?.OnAudioDeviceAdded();
                     break;
 
                 case SDL_EventType.SDL_EVENT_AUDIO_DEVICE_REMOVED:
                     Log.Trace($"AUDIO REMOVED: {sdlEvent->adevice.which}");
+                    Audio?.OnAudioDeviceRemoved();
                     break;
 
                 case SDL_EventType.SDL_EVENT_WINDOW_MOUSE_ENTER:


### PR DESCRIPTION
Add comprehensive audio device recovery system to handle device disconnections and automatic fallback to alternative audio devices.

Features:
- Immediate fallback when audio device is removed
- Automatic recovery when new devices are added
- Device health monitoring and error handling
- Music restoration after successful recovery
- Multi-attempt device connection with retry logic
- Enhanced window activation audio recovery

This fixes the issue where TazUO completely loses audio when display devices are disconnected or when the system enters power saving mode, eliminating the need for client restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatic detection of audio device changes with seamless fallback and recovery.
- Improvements
  - More resilient audio playback: reduced dropouts when devices are unplugged/replugged.
  - Restores current music and preserves volume/settings after recovery.
  - Smarter retry timing to avoid repeated interruptions.
- Bug Fixes
  - Prevents audio from staying muted or failing after device disconnection/removal.
  - Avoids errors when switching or adding audio devices during gameplay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->