### PR TITLE
feat: add SpellBar ImGui window with hotkey assignment

### DIFF
--- a/src/ClassicUO.Client/Game/Managers/SpellBarManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/SpellBarManager.cs
@@ -97,8 +97,6 @@ public class SpellBarManager
             var hotKey = (SDL.SDL_Keycode)spellBarSettings.HotKeys[i];
             var hotMod = (SDL.SDL_Keymod)spellBarSettings.KeyMod[i];
 
-            Log.Info($"Checking {key} {mod} against {hotKey} {hotMod}");
-
             if (key != hotKey)
                 continue;
 

--- a/src/ClassicUO.Client/Game/Managers/SpellBarManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/SpellBarManager.cs
@@ -69,6 +69,26 @@ public class SpellBarManager
         if (!enabled || !spellBarSettings.Enabled || ProfileManager.CurrentProfile.DisableHotkeys)
             return;
 
+        // Remove NUM lock from modifier checks
+        mod &= ~SDL.SDL_Keymod.SDL_KMOD_NUM;
+
+        // Normalize left/right modifiers to generic modifiers
+        if ((mod & (SDL.SDL_Keymod.SDL_KMOD_LCTRL | SDL.SDL_Keymod.SDL_KMOD_RCTRL)) != 0)
+        {
+            mod &= ~(SDL.SDL_Keymod.SDL_KMOD_LCTRL | SDL.SDL_Keymod.SDL_KMOD_RCTRL);
+            mod |= SDL.SDL_Keymod.SDL_KMOD_CTRL;
+        }
+        if ((mod & (SDL.SDL_Keymod.SDL_KMOD_LSHIFT | SDL.SDL_Keymod.SDL_KMOD_RSHIFT)) != 0)
+        {
+            mod &= ~(SDL.SDL_Keymod.SDL_KMOD_LSHIFT | SDL.SDL_Keymod.SDL_KMOD_RSHIFT);
+            mod |= SDL.SDL_Keymod.SDL_KMOD_SHIFT;
+        }
+        if ((mod & (SDL.SDL_Keymod.SDL_KMOD_LALT | SDL.SDL_Keymod.SDL_KMOD_RALT)) != 0)
+        {
+            mod &= ~(SDL.SDL_Keymod.SDL_KMOD_LALT | SDL.SDL_Keymod.SDL_KMOD_RALT);
+            mod |= SDL.SDL_Keymod.SDL_KMOD_ALT;
+        }
+
         for (int i = 0; i < 10; i++)
         {
             if (i >= spellBarSettings.HotKeys.Length)
@@ -76,6 +96,8 @@ public class SpellBarManager
 
             var hotKey = (SDL.SDL_Keycode)spellBarSettings.HotKeys[i];
             var hotMod = (SDL.SDL_Keymod)spellBarSettings.KeyMod[i];
+
+            Log.Info($"Checking {key} {mod} against {hotKey} {hotMod}");
 
             if (key != hotKey)
                 continue;

--- a/src/ClassicUO.Client/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameSceneInputHandler.cs
@@ -15,6 +15,7 @@ using Microsoft.Xna.Framework;
 using SDL3;
 using MathHelper = ClassicUO.Utility.MathHelper;
 using ClassicUO.Assets;
+using ClassicUO.Utility.Logging;
 
 namespace ClassicUO.Game.Scenes
 {

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/AssistantWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/AssistantWindow.cs
@@ -38,6 +38,8 @@ namespace ClassicUO.Game.UI.ImGuiControls
                     _preSelectIndex = 4;
                     break;
                 case AssistantGump.PAGE.SpellBar:
+                    SpellBarWindow.Show();
+                    Dispose(); // Close the assistant window since we're opening the dedicated window
                     break;
                 case AssistantGump.PAGE.HUD:
                     break;

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/General/GeneralWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/General/GeneralWindow.cs
@@ -57,6 +57,12 @@ namespace ClassicUO.Game.UI.ImGuiControls
                     ImGui.EndTabItem();
                 }
 
+                if (ImGui.BeginTabItem("Spell Bar"))
+                {
+                    SpellBarWindow.GetInstance()?.DrawContent();
+                    ImGui.EndTabItem();
+                }
+
                 if (ImGui.BeginTabItem("Graphics"))
                 {
                     GraphicReplacementWindow.GetInstance()?.DrawContent();

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/General/SpellBarWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/General/SpellBarWindow.cs
@@ -146,9 +146,6 @@ namespace ClassicUO.Game.UI.ImGuiControls
         private void CaptureCurrentInput()
         {
             if (listeningSlot < 0) return;
-            // For now, we'll use a simplified approach
-            // The full SDL3 keyboard state polling has API compatibility issues
-            // Instead, we'll rely on ImGui's key detection for basic keys
 
             // Capture modifier keys from ImGui
             capturedMod = SDL.SDL_Keymod.SDL_KMOD_NONE;
@@ -159,6 +156,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
             if (ImGui.GetIO().KeyShift)
                 capturedMod |= SDL.SDL_Keymod.SDL_KMOD_SHIFT;
 
+            // Capture keyboard input
             foreach (var kvp in keyMap)
             {
                 if (ImGui.IsKeyPressed(kvp.Key))
@@ -168,8 +166,13 @@ namespace ClassicUO.Game.UI.ImGuiControls
                 }
             }
 
-            // TODO: Add gamepad button capture using TazUO's existing controller system
-            // For now, focusing on keyboard capture
+            // Capture gamepad button input using TazUO's existing controller system
+            var pressedButtons = Controller.PressedButtons();
+            if (pressedButtons.Length > 0)
+            {
+                capturedButtons.Clear();
+                capturedButtons.AddRange(pressedButtons);
+            }
         }
 
         private void ApplyCapturedHotkey()

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/General/SpellBarWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/General/SpellBarWindow.cs
@@ -1,0 +1,452 @@
+using ImGuiNET;
+using ClassicUO.Configuration;
+using ClassicUO.Game.Managers;
+using ClassicUO.Game.UI.Gumps;
+using ClassicUO.Game.UI.Controls;
+using ClassicUO.Input;
+using System.Numerics;
+using System.Collections.Generic;
+using System;
+using Microsoft.Xna.Framework.Input;
+using SDL3;
+
+namespace ClassicUO.Game.UI.ImGuiControls
+{
+    public class SpellBarWindow : SingletonImGuiWindow<SpellBarWindow>
+    {
+        private Profile profile;
+        private bool enableSpellBar;
+        private bool showHotkeys;
+        private bool[] showHotkeyEdit = new bool[10];
+        private string[] hotkeyLabels = new string[10];
+        private bool[] isListeningForHotkey = new bool[10];
+        private string newPresetName = "";
+        private bool showPresetSaveDialog = false;
+        private bool showPresetLoadDialog = false;
+        private int listeningSlot = -1;
+        private SDL.SDL_Keycode capturedKey = SDL.SDL_Keycode.SDLK_UNKNOWN;
+        private SDL.SDL_Keymod capturedMod = SDL.SDL_Keymod.SDL_KMOD_NONE;
+        private List<SDL.SDL_GamepadButton> capturedButtons = new List<SDL.SDL_GamepadButton>();
+
+        private SpellBarWindow() : base("Spell Bar")
+        {
+            WindowFlags = ImGuiWindowFlags.AlwaysAutoResize;
+            profile = ProfileManager.CurrentProfile;
+
+            enableSpellBar = SpellBarManager.IsEnabled();
+            showHotkeys = profile.SpellBar_ShowHotkeys;
+
+            UpdateHotkeyLabels();
+        }
+
+        private void UpdateHotkeyLabels()
+        {
+            var controllerHotkeys = SpellBarManager.GetControllerButtons();
+            var hotkeys = SpellBarManager.GetHotKeys();
+            var keymods = SpellBarManager.GetModKeys();
+
+            for (int i = 0; i < 10; i++)
+            {
+                string hotkeyDisplay = "";
+                if (i < hotkeys.Length && i < keymods.Length)
+                {
+                    hotkeyDisplay = KeysTranslator.TryGetKey(hotkeys[i], keymods[i]);
+                }
+                if (i < controllerHotkeys.Length)
+                {
+                    string controllerDisplay = Controller.GetButtonNames(controllerHotkeys[i]);
+                    if (!string.IsNullOrEmpty(controllerDisplay))
+                    {
+                        if (!string.IsNullOrEmpty(hotkeyDisplay))
+                            hotkeyDisplay += " / ";
+                        hotkeyDisplay += controllerDisplay;
+                    }
+                }
+
+                hotkeyLabels[i] = string.IsNullOrEmpty(hotkeyDisplay) ? "None" : hotkeyDisplay;
+            }
+        }
+
+        private void StartListeningForHotkey(int slot)
+        {
+            // Reset all listening states
+            for (int i = 0; i < 10; i++)
+            {
+                isListeningForHotkey[i] = false;
+            }
+
+            isListeningForHotkey[slot] = true;
+            listeningSlot = slot;
+            capturedKey = SDL.SDL_Keycode.SDLK_UNKNOWN;
+            capturedMod = SDL.SDL_Keymod.SDL_KMOD_NONE;
+            capturedButtons.Clear();
+        }
+
+        private void StopListeningForHotkey()
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                isListeningForHotkey[i] = false;
+            }
+            listeningSlot = -1;
+        }
+
+        private static Dictionary<ImGuiKey, SDL.SDL_Keycode> keyMap = new()
+        {
+            { ImGuiKey.F1, SDL.SDL_Keycode.SDLK_F1 },
+            { ImGuiKey.F2, SDL.SDL_Keycode.SDLK_F2 },
+            { ImGuiKey.F3, SDL.SDL_Keycode.SDLK_F3 },
+            { ImGuiKey.F4, SDL.SDL_Keycode.SDLK_F4 },
+            { ImGuiKey.F5, SDL.SDL_Keycode.SDLK_F5 },
+            { ImGuiKey.F6, SDL.SDL_Keycode.SDLK_F6 },
+            { ImGuiKey.F7, SDL.SDL_Keycode.SDLK_F7 },
+            { ImGuiKey.F8, SDL.SDL_Keycode.SDLK_F8 },
+            { ImGuiKey.F9, SDL.SDL_Keycode.SDLK_F9 },
+            { ImGuiKey.F10, SDL.SDL_Keycode.SDLK_F10 },
+            { ImGuiKey.F11, SDL.SDL_Keycode.SDLK_F11 },
+            { ImGuiKey.F12, SDL.SDL_Keycode.SDLK_F12 },
+            { ImGuiKey.A, SDL.SDL_Keycode.SDLK_A },
+            { ImGuiKey.B, SDL.SDL_Keycode.SDLK_B },
+            { ImGuiKey.C, SDL.SDL_Keycode.SDLK_C },
+            { ImGuiKey.D, SDL.SDL_Keycode.SDLK_D },
+            { ImGuiKey.E, SDL.SDL_Keycode.SDLK_E },
+            { ImGuiKey.F, SDL.SDL_Keycode.SDLK_F },
+            { ImGuiKey.G, SDL.SDL_Keycode.SDLK_G },
+            { ImGuiKey.H, SDL.SDL_Keycode.SDLK_H },
+            { ImGuiKey.I, SDL.SDL_Keycode.SDLK_I },
+            { ImGuiKey.J, SDL.SDL_Keycode.SDLK_J },
+            { ImGuiKey.K, SDL.SDL_Keycode.SDLK_K },
+            { ImGuiKey.L, SDL.SDL_Keycode.SDLK_L },
+            { ImGuiKey.M, SDL.SDL_Keycode.SDLK_M },
+            { ImGuiKey.N, SDL.SDL_Keycode.SDLK_N },
+            { ImGuiKey.O, SDL.SDL_Keycode.SDLK_O },
+            { ImGuiKey.P, SDL.SDL_Keycode.SDLK_P },
+            { ImGuiKey.Q, SDL.SDL_Keycode.SDLK_Q },
+            { ImGuiKey.R, SDL.SDL_Keycode.SDLK_R },
+            { ImGuiKey.S, SDL.SDL_Keycode.SDLK_S },
+            { ImGuiKey.T, SDL.SDL_Keycode.SDLK_T },
+            { ImGuiKey.U, SDL.SDL_Keycode.SDLK_U },
+            { ImGuiKey.V, SDL.SDL_Keycode.SDLK_V },
+            { ImGuiKey.W, SDL.SDL_Keycode.SDLK_W },
+            { ImGuiKey.X, SDL.SDL_Keycode.SDLK_X },
+            { ImGuiKey.Y, SDL.SDL_Keycode.SDLK_Y },
+            { ImGuiKey.Z, SDL.SDL_Keycode.SDLK_Z },
+            { ImGuiKey._1, SDL.SDL_Keycode.SDLK_1 },
+            { ImGuiKey._2, SDL.SDL_Keycode.SDLK_2 },
+            { ImGuiKey._3, SDL.SDL_Keycode.SDLK_3 },
+            { ImGuiKey._4, SDL.SDL_Keycode.SDLK_4 },
+            { ImGuiKey._5, SDL.SDL_Keycode.SDLK_5 },
+            { ImGuiKey._6, SDL.SDL_Keycode.SDLK_6 },
+            { ImGuiKey._7, SDL.SDL_Keycode.SDLK_7 },
+            { ImGuiKey._8, SDL.SDL_Keycode.SDLK_8 },
+            { ImGuiKey._9, SDL.SDL_Keycode.SDLK_9 },
+            { ImGuiKey._0, SDL.SDL_Keycode.SDLK_0 }
+        };
+
+        private void CaptureCurrentInput()
+        {
+            if (listeningSlot < 0) return;
+            // For now, we'll use a simplified approach
+            // The full SDL3 keyboard state polling has API compatibility issues
+            // Instead, we'll rely on ImGui's key detection for basic keys
+
+            // Capture modifier keys from ImGui
+            capturedMod = SDL.SDL_Keymod.SDL_KMOD_NONE;
+            if (ImGui.GetIO().KeyCtrl)
+                capturedMod |= SDL.SDL_Keymod.SDL_KMOD_CTRL;
+            if (ImGui.GetIO().KeyAlt)
+                capturedMod |= SDL.SDL_Keymod.SDL_KMOD_ALT;
+            if (ImGui.GetIO().KeyShift)
+                capturedMod |= SDL.SDL_Keymod.SDL_KMOD_SHIFT;
+
+            foreach (var kvp in keyMap)
+            {
+                if (ImGui.IsKeyPressed(kvp.Key))
+                {
+                    capturedKey = kvp.Value;
+                    break;
+                }
+            }
+
+            // TODO: Add gamepad button capture using TazUO's existing controller system
+            // For now, focusing on keyboard capture
+        }
+
+        private void ApplyCapturedHotkey()
+        {
+            if (listeningSlot < 0) return;
+
+            // Apply if we have either a keyboard key or controller buttons
+            if (capturedKey != SDL.SDL_Keycode.SDLK_UNKNOWN || capturedButtons.Count > 0)
+            {
+                // Apply the captured hotkey
+                SpellBarManager.SetButtons(listeningSlot, capturedMod, capturedKey, capturedButtons.ToArray());
+                UpdateHotkeyLabels();
+
+                // Refresh the actual SpellBar gump instances to update their hotkey labels
+                Game.UI.Gumps.SpellBar.SpellBar.Instance?.SetupHotkeyLabels();
+
+                StopListeningForHotkey();
+            }
+        }
+
+        public override void DrawContent()
+        {
+            if (profile == null)
+            {
+                ImGui.Text("Profile not loaded");
+                return;
+            }
+
+            // Handle key capture if we're listening for hotkeys
+            if (listeningSlot >= 0)
+            {
+                CaptureCurrentInput();
+            }
+
+            ImGui.Spacing();
+
+            // Main enable checkbox
+            if (ImGui.Checkbox("Enable spellbar", ref enableSpellBar))
+            {
+                if (SpellBarManager.ToggleEnabled())
+                {
+                    UIManager.Add(new Game.UI.Gumps.SpellBar.SpellBar(Client.Game.UO.World));
+                }
+                else
+                {
+                    Game.UI.Gumps.SpellBar.SpellBar.Instance?.Dispose();
+                }
+            }
+            ImGuiComponents.Tooltip("Enable or disable the spell bar feature");
+
+            ImGui.Spacing();
+
+            // Show hotkeys checkbox
+            if (ImGui.Checkbox("Display hotkeys on spellbar", ref showHotkeys))
+            {
+                profile.SpellBar_ShowHotkeys = showHotkeys;
+                Game.UI.Gumps.SpellBar.SpellBar.Instance?.SetupHotkeyLabels();
+            }
+            ImGuiComponents.Tooltip("Show hotkey assignments on the spell bar buttons");
+
+            ImGui.Spacing();
+            ImGui.SeparatorText("Row Management:");
+
+            // Row management buttons
+            if (ImGui.Button("Add Row"))
+            {
+                SpellBarManager.SpellBarRows.Add(new SpellBarRow());
+                Game.UI.Gumps.SpellBar.SpellBar.Instance?.Build();
+            }
+            ImGuiComponents.Tooltip("Add a new spell bar row");
+
+            ImGui.SameLine();
+
+            if (ImGui.Button("Remove Row"))
+            {
+                if (SpellBarManager.SpellBarRows.Count > 1) // Make sure to always leave one row
+                    SpellBarManager.SpellBarRows.RemoveAt(SpellBarManager.SpellBarRows.Count - 1);
+                Game.UI.Gumps.SpellBar.SpellBar.Instance?.Build();
+            }
+            ImGuiComponents.Tooltip("Remove the last row. If you have 5 rows, row 5 will be removed.");
+
+            ImGui.Spacing();
+            ImGui.SeparatorText("Hotkey Configuration:");
+
+            // Create a table for better layout
+            if (ImGui.BeginTable("HotkeyTable", 3, ImGuiTableFlags.Borders | ImGuiTableFlags.RowBg))
+            {
+                ImGui.TableSetupColumn("Slot", ImGuiTableColumnFlags.WidthFixed, 60);
+                ImGui.TableSetupColumn("Current Hotkey", ImGuiTableColumnFlags.WidthFixed, 150);
+                ImGui.TableSetupColumn("Actions", ImGuiTableColumnFlags.WidthFixed, 120);
+                ImGui.TableHeadersRow();
+
+                for (int i = 0; i < 10; i++)
+                {
+                    ImGui.TableNextRow();
+
+                    ImGui.TableNextColumn();
+                    ImGui.Text($"Slot {i}");
+
+                    ImGui.TableNextColumn();
+                    if (isListeningForHotkey[i])
+                    {
+                        // Show what we've captured so far
+                        string captureText = "Press a key or controller button...";
+                        if (capturedKey != SDL.SDL_Keycode.SDLK_UNKNOWN || capturedButtons.Count > 0)
+                        {
+                            string parts = "";
+
+                            // Add keyboard part
+                            if (capturedKey != SDL.SDL_Keycode.SDLK_UNKNOWN)
+                            {
+                                string modText = "";
+                                if ((capturedMod & SDL.SDL_Keymod.SDL_KMOD_CTRL) != 0) modText += "Ctrl+";
+                                if ((capturedMod & SDL.SDL_Keymod.SDL_KMOD_ALT) != 0) modText += "Alt+";
+                                if ((capturedMod & SDL.SDL_Keymod.SDL_KMOD_SHIFT) != 0) modText += "Shift+";
+                                parts = $"{modText}{capturedKey}";
+                            }
+
+                            // Add controller part
+                            if (capturedButtons.Count > 0)
+                            {
+                                string buttonNames = Controller.GetButtonNames(capturedButtons.ToArray());
+                                if (!string.IsNullOrEmpty(parts)) parts += " / ";
+                                parts += buttonNames;
+                            }
+
+                            captureText = $"Captured: {parts}";
+                        }
+
+                        ImGui.TextColored(new Vector4(1, 1, 0, 1), captureText);
+
+                        // Escape cancels
+                        if (ImGui.IsKeyPressed(ImGuiKey.Escape))
+                        {
+                            StopListeningForHotkey();
+                        }
+                    }
+                    else
+                    {
+                        ImGui.Text(hotkeyLabels[i]);
+                    }
+
+                    ImGui.TableNextColumn();
+                    if (isListeningForHotkey[i])
+                    {
+                        if (ImGui.Button($"Apply##slot{i}"))
+                        {
+                            ApplyCapturedHotkey();
+                        }
+                        ImGui.SameLine();
+                        if (ImGui.Button($"Cancel##slot{i}"))
+                        {
+                            StopListeningForHotkey();
+                        }
+                    }
+                    else
+                    {
+                        if (ImGui.Button($"Set##slot{i}"))
+                        {
+                            StartListeningForHotkey(i);
+                        }
+                        ImGui.SameLine();
+                        if (ImGui.Button($"Clear##slot{i}"))
+                        {
+                            // Clear the hotkey assignment (pass empty array instead of null to clear controller bindings)
+                            SpellBarManager.SetButtons(i, SDL.SDL_Keymod.SDL_KMOD_NONE, SDL.SDL_Keycode.SDLK_UNKNOWN, new SDL.SDL_GamepadButton[0]);
+                            UpdateHotkeyLabels();
+
+                            // Refresh the actual SpellBar gump instances to update their hotkey labels
+                            Game.UI.Gumps.SpellBar.SpellBar.Instance?.SetupHotkeyLabels();
+                        }
+                    }
+                }
+
+                ImGui.EndTable();
+            }
+
+            ImGui.Spacing();
+            ImGui.SeparatorText("Preset Management:");
+
+            // Preset management
+            if (ImGui.Button("Save Current Row as Preset"))
+            {
+                showPresetSaveDialog = true;
+            }
+            ImGuiComponents.Tooltip("Save the current spell bar row as a preset");
+
+            ImGui.SameLine();
+
+            if (ImGui.Button("Load Preset"))
+            {
+                showPresetLoadDialog = true;
+            }
+            ImGuiComponents.Tooltip("Load a saved preset");
+
+            // Save preset dialog
+            if (showPresetSaveDialog)
+            {
+                ImGui.OpenPopup("Save Preset");
+                showPresetSaveDialog = false;
+            }
+
+            if (ImGui.BeginPopupModal("Save Preset", ref showPresetSaveDialog))
+            {
+                ImGui.Text("Enter preset name:");
+                ImGui.InputText("##PresetName", ref newPresetName, 50);
+
+                if (ImGui.Button("Save"))
+                {
+                    if (!string.IsNullOrEmpty(newPresetName))
+                    {
+                        SpellBarManager.SaveCurrentRowPreset(newPresetName);
+                        newPresetName = "";
+                        ImGui.CloseCurrentPopup();
+                    }
+                }
+                ImGui.SameLine();
+                if (ImGui.Button("Cancel"))
+                {
+                    newPresetName = "";
+                    ImGui.CloseCurrentPopup();
+                }
+
+                ImGui.EndPopup();
+            }
+
+            // Load preset dialog
+            if (showPresetLoadDialog)
+            {
+                ImGui.OpenPopup("Load Preset");
+                showPresetLoadDialog = false;
+            }
+
+            if (ImGui.BeginPopupModal("Load Preset", ref showPresetLoadDialog))
+            {
+                string[] presets = SpellBarManager.ListPresets();
+
+                if (presets.Length == 0)
+                {
+                    ImGui.Text("No presets available.");
+                }
+                else
+                {
+                    ImGui.Text("Select a preset to load:");
+                    ImGui.Separator();
+
+                    foreach (string preset in presets)
+                    {
+                        if (ImGui.Button(preset))
+                        {
+                            SpellBarManager.ImportPreset(preset);
+                            ImGui.CloseCurrentPopup();
+                        }
+                    }
+                }
+
+                ImGui.Separator();
+                if (ImGui.Button("Cancel"))
+                {
+                    ImGui.CloseCurrentPopup();
+                }
+
+                ImGui.EndPopup();
+            }
+
+            ImGui.Spacing();
+
+            // Wiki link
+            if (ImGui.Button("SpellBar Wiki"))
+            {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = "https://github.com/PlayTazUO/TazUO/wiki/TazUO.SpellBar",
+                    UseShellExecute = true
+                });
+            }
+            ImGuiComponents.Tooltip("Open the SpellBar wiki page in your browser");
+        }
+    }
+}


### PR DESCRIPTION
- Create SpellBarWindow similar to AutoLootWindow pattern
- Add to GeneralWindow as dedicated tab
- Implement real-time SDL key capture with modifier support
- Maintain all original functionality: enable/disable, row management, presets
- Update AssistantGump to use button that opens dedicated window
- Support F1-F12, A-Z, 0-9 keys with Ctrl/Alt/Shift modifiers
- Provide live feedback during hotkey assignment
- Include preset save/load functionality with modal dialogs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Spell Bar settings window accessible from the General tab.
  * Enable/disable the spell bar, manage rows, and configure per-slot hotkeys with Set/Clear and live capture.
  * Save/load hotkey presets and quickly access documentation via a Wiki button.
  * Selecting Spell Bar now opens the dedicated window and closes the assistant window.

* **Bug Fixes**
  * Improved hotkey reliability by normalizing modifier keys (left/right CTRL/SHIFT/ALT) and ignoring Num Lock state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->