### PR TITLE
feat: modernize journal filter with ImGui window

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/AssistantGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/AssistantGump.cs
@@ -296,70 +296,17 @@ public class AssistantGump : BaseOptionsGump
 
     private void BuildJournalFilter()
     {
-        var page = (int)PAGE.JournalFilter;
-        MainContent.AddToLeft(CategoryButton("Journal Filter", page, MainContent.LeftWidth));
-        MainContent.ResetRightSide();
-
-        ScrollArea scroll = new(0, 0, MainContent.RightWidth, MainContent.Height);
-        MainContent.AddToRight(scroll, false, page);
-
-        PositionHelper.Reset();
-
-        scroll.Add(PositionHelper.PositionControl(new HttpClickableLink("Journal Filter Wiki", "https://github.com/PlayTazUO/TazUO/wiki/Journal-Filters", Color.White)));
-
-        VBoxContainer vbox = new(scroll.Width - 18);
-
-        ModernButton addButton = new(0, 0, 150, ThemeSettings.CHECKBOX_SIZE, ButtonAction.Default, "Add entry", ThemeSettings.BUTTON_FONT_COLOR);
-        addButton.MouseUp += (s, e) =>
+        ModernButton button = new(0, 0, MainContent.LeftWidth, 40, ButtonAction.Default, "Journal Filter", ThemeSettings.BUTTON_FONT_COLOR);
+        button.MouseUp += (_, e) =>
         {
-            JournalFilterManager.Instance.AddFilter("Type your matching text here");
-            buildEntries();
+            if(e.Button == MouseButtonType.Left)
+            {
+                AssistantWindow.Show();
+                AssistantWindow.Instance.SelectTab(PAGE.JournalFilter);
+            }
         };
 
-        scroll.Add(PositionHelper.PositionControl(addButton));
-        scroll.Add(PositionHelper.PositionControl(vbox));
-        buildEntries();
-
-        void buildEntries()
-        {
-            vbox.Clear();
-
-            foreach (string filter in JournalFilterManager.Instance.Filters)
-            {
-                vbox.Add(entryArea(filter));
-            }
-        }
-
-        Area entryArea(string filter)
-        {
-            string currentFilter = filter;
-            Area area = new Area();
-
-            InputField input = new InputField(scroll.Width - 18 - 25, ThemeSettings.CHECKBOX_SIZE, text: filter);
-            input.SetTooltip("Must match the journal entry exactly. Partial matches not supported.");
-            input.TextChanged += (s, e) =>
-            {
-                var newText = ((InputField.StbTextBox)s).Text;
-                JournalFilterManager.Instance.RemoveFilter(currentFilter);
-                JournalFilterManager.Instance.AddFilter(newText);
-                currentFilter = newText;
-            };
-
-            ModernButton del = new(scroll.Width-18-25, 0, 25, ThemeSettings.CHECKBOX_SIZE, ButtonAction.Default, "X", ThemeSettings.BUTTON_FONT_COLOR);
-            del.SetTooltip("Delete entry");
-            del.MouseUp += (s, e) =>
-            {
-                JournalFilterManager.Instance.RemoveFilter(currentFilter);
-                buildEntries();
-            };
-
-            area.Add(input);
-            area.Add(del);
-
-            area.ForceSizeUpdate();
-
-            return area;
-        }
+        MainContent.AddToLeft(button);
     }
 
     private void BuildTitleBar()

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/Agents/AgentsWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/Agents/AgentsWindow.cs
@@ -17,6 +17,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
         private void DrawAutoSell() => AutoSellWindow.GetInstance()?.DrawContent();
         private void DrawAutoBuy() => AutoBuyWindow.GetInstance()?.DrawContent();
         private void DrawBandageAgent() => BandageAgentWindow.GetInstance()?.DrawContent();
+        private void DrawJournalFilter() => JournalFilterWindow.GetInstance()?.DrawContent();
         public override void DrawContent()
         {
             if (_profile == null)
@@ -55,6 +56,12 @@ namespace ClassicUO.Game.UI.ImGuiControls
                 if (ImGui.BeginTabItem("Dress"))
                 {
                     ImGui.Text("Dress Agent Will go here.");
+                    ImGui.EndTabItem();
+                }
+
+                if (ImGui.BeginTabItem("Journal Filter"))
+                {
+                    DrawJournalFilter();
                     ImGui.EndTabItem();
                 }
                 ImGui.EndTabBar();

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/Agents/JournalFilterWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/Agents/JournalFilterWindow.cs
@@ -155,7 +155,13 @@ namespace ClassicUO.Game.UI.ImGuiControls
                         }
 
                         string filterStr = filterInputs[filter];
-                        if (ImGui.InputText($"##Filter{i}", ref filterStr, 500))
+                        ImGui.InputText($"##Filter{i}", ref filterStr, 500);
+
+                        // Update the local input string
+                        filterInputs[filter] = filterStr;
+
+                        // Only commit changes on Enter or blur, and avoid no-ops/empty values
+                        if (ImGui.IsItemDeactivatedAfterEdit() && !string.IsNullOrWhiteSpace(filterStr) && filterStr != filter)
                         {
                             // Update the filter
                             string oldFilter = filter;
@@ -163,11 +169,12 @@ namespace ClassicUO.Game.UI.ImGuiControls
                             JournalFilterManager.Instance.AddFilter(filterStr);
                             JournalFilterManager.Instance.Save(false);
 
-                            // Update our tracking
+                            // Update our tracking - remove old key, add new one
                             filterInputs.Remove(oldFilter);
                             filterInputs[filterStr] = filterStr;
 
                             RefreshFilterList();
+                            break; // Break out of loop after successful mutation to avoid iterating refreshed list
                         }
 
                         ImGui.TableNextColumn();

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/Agents/JournalFilterWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/Agents/JournalFilterWindow.cs
@@ -1,0 +1,188 @@
+using ImGuiNET;
+using ClassicUO.Configuration;
+using ClassicUO.Game.Managers;
+using ClassicUO.Game.UI.Gumps;
+using ClassicUO.Utility;
+using System;
+using System.IO;
+using System.Numerics;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ClassicUO.Game.UI.ImGuiControls
+{
+    public class JournalFilterWindow : SingletonImGuiWindow<JournalFilterWindow>
+    {
+        private Profile profile;
+        private string newFilterInput = "";
+        private bool showAddFilter = false;
+        private Dictionary<string, string> filterInputs = new Dictionary<string, string>();
+        private List<string> filterList;
+
+        private JournalFilterWindow() : base("Journal Filter")
+        {
+            WindowFlags = ImGuiWindowFlags.AlwaysAutoResize;
+            profile = ProfileManager.CurrentProfile;
+            RefreshFilterList();
+        }
+
+        private void RefreshFilterList()
+        {
+            filterList = JournalFilterManager.Instance.Filters.ToList();
+
+            // Initialize input dictionaries for existing filters
+            foreach (var filter in filterList)
+            {
+                if (!filterInputs.ContainsKey(filter))
+                {
+                    filterInputs[filter] = filter;
+                }
+            }
+        }
+
+        public override void DrawContent()
+        {
+            if (profile == null)
+            {
+                ImGui.Text("Profile not loaded");
+                return;
+            }
+
+            ImGui.Spacing();
+            ImGui.TextWrapped("Journal Filter allows you to hide specific messages from the journal. Messages that match exactly will be filtered out.");
+
+            // Wiki link
+            if (ImGui.Button("Journal Filter Wiki"))
+            {
+                Utility.Platforms.PlatformHelper.LaunchBrowser("https://github.com/PlayTazUO/TazUO/wiki/Journal-Filters");
+            }
+
+            ImGui.SeparatorText("Import & Export:");
+
+            if (ImGui.Button("Export JSON"))
+            {
+                FileSelector.ShowFileBrowser(Client.Game.UO.World, FileSelectorType.Directory, null, null, (selectedPath) =>
+                {
+                    if (string.IsNullOrWhiteSpace(selectedPath)) return;
+                    string fileName = $"JournalFilters_{DateTime.Now:yyyyMMdd_HHmmss}.json";
+                    string fullPath = Path.Combine(selectedPath, fileName);
+                    JsonHelper.SaveAndBackup(JournalFilterManager.Instance.Filters, fullPath, HashSetContext.Default.HashSetString);
+                }, "Export Journal Filter Configuration");
+            }
+
+            ImGui.SameLine();
+            if (ImGui.Button("Import JSON"))
+            {
+                FileSelector.ShowFileBrowser(Client.Game.UO.World, FileSelectorType.File, null, new[] { "json" }, (selectedFile) =>
+                {
+                    if (string.IsNullOrWhiteSpace(selectedFile)) return;
+                    if (JsonHelper.Load(selectedFile, HashSetContext.Default.HashSetString, out HashSet<string> importedFilters))
+                    {
+                        foreach (var filter in importedFilters)
+                        {
+                            JournalFilterManager.Instance.AddFilter(filter);
+                        }
+                        JournalFilterManager.Instance.Save(false);
+                        RefreshFilterList();
+                    }
+                }, "Import Journal Filter Configuration");
+            }
+
+            // Add filter section
+            ImGui.SeparatorText("Filters:");
+
+            if (ImGui.Button("Add Filter Entry"))
+            {
+                showAddFilter = !showAddFilter;
+            }
+
+            if (showAddFilter)
+            {
+                ImGui.SeparatorText("Add New Filter:");
+                ImGui.Spacing();
+
+                ImGui.Text("Filter Text:");
+                ImGuiComponents.Tooltip("Must match the journal entry exactly. Partial matches not supported.");
+                ImGui.InputText("##NewFilter", ref newFilterInput, 500);
+
+                ImGui.Spacing();
+
+                if (ImGui.Button("Add##AddFilter"))
+                {
+                    if (!string.IsNullOrWhiteSpace(newFilterInput))
+                    {
+                        JournalFilterManager.Instance.AddFilter(newFilterInput);
+                        JournalFilterManager.Instance.Save(false);
+                        newFilterInput = "";
+                        showAddFilter = false;
+                        RefreshFilterList();
+                    }
+                }
+                ImGui.SameLine();
+                if (ImGui.Button("Cancel##AddFilter"))
+                {
+                    showAddFilter = false;
+                    newFilterInput = "";
+                }
+            }
+
+            ImGui.SeparatorText("Current Journal Filters:");
+
+            if (filterList.Count == 0)
+            {
+                ImGui.Text("No filters configured");
+            }
+            else
+            {
+                // Table for filters
+                if (ImGui.BeginTable("JournalFilterTable", 2, ImGuiTableFlags.Borders | ImGuiTableFlags.RowBg | ImGuiTableFlags.ScrollY, new Vector2(0, ImGuiTheme.Dimensions.STANDARD_TABLE_SCROLL_HEIGHT)))
+                {
+                    ImGui.TableSetupColumn("Filter Text", ImGuiTableColumnFlags.WidthStretch);
+                    ImGui.TableSetupColumn("Actions", ImGuiTableColumnFlags.WidthFixed, 80);
+                    ImGui.TableHeadersRow();
+
+                    for (int i = filterList.Count - 1; i >= 0; i--)
+                    {
+                        var filter = filterList[i];
+                        ImGui.TableNextRow();
+
+                        ImGui.TableNextColumn();
+
+                        // Get or initialize input string for this filter
+                        if (!filterInputs.ContainsKey(filter))
+                        {
+                            filterInputs[filter] = filter;
+                        }
+
+                        string filterStr = filterInputs[filter];
+                        if (ImGui.InputText($"##Filter{i}", ref filterStr, 500))
+                        {
+                            // Update the filter
+                            string oldFilter = filter;
+                            JournalFilterManager.Instance.RemoveFilter(oldFilter);
+                            JournalFilterManager.Instance.AddFilter(filterStr);
+                            JournalFilterManager.Instance.Save(false);
+
+                            // Update our tracking
+                            filterInputs.Remove(oldFilter);
+                            filterInputs[filterStr] = filterStr;
+
+                            RefreshFilterList();
+                        }
+
+                        ImGui.TableNextColumn();
+                        if (ImGui.Button($"Delete##Delete{i}"))
+                        {
+                            JournalFilterManager.Instance.RemoveFilter(filter);
+                            JournalFilterManager.Instance.Save(false);
+                            filterInputs.Remove(filter);
+                            RefreshFilterList();
+                        }
+                    }
+
+                    ImGui.EndTable();
+                }
+            }
+        }
+    }
+}

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/AssistantWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/AssistantWindow.cs
@@ -45,6 +45,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
                     _preSelectIndex = 0; // General tab since spell indicators are now in General window
                     break;
                 case AssistantGump.PAGE.JournalFilter:
+                    _preSelectIndex = 1; // Agents tab since Journal Filter is in Agents Window
                     break;
                 case AssistantGump.PAGE.TitleBar:
                     break;

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/General/GeneralWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/General/GeneralWindow.cs
@@ -53,7 +53,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
 
                 if (ImGui.BeginTabItem("Journal Filter"))
                 {
-                    ImGui.Text("Journal Filter Settings will go here.");
+                    JournalFilterWindow.GetInstance()?.DrawContent();
                     ImGui.EndTabItem();
                 }
 


### PR DESCRIPTION
- Extract journal filter functionality from AssistantGump legacy UI
- Create new JournalFilterWindow using modern ImGui components
- Add journal filter tab to both GeneralWindow and AgentsWindow
- Maintain all original functionality: add/edit/delete filters, import/export
- Update AssistantGump to use button that opens modern UI
- Integrate with existing JournalFilterManager for seamless operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dedicated Journal Filter window/tab with an organized table for managing filters.
  * Import and export journal filters to/from JSON.
  * Add, edit, delete, and reorder filters with inline validation.

* **Improvements**
  * Left-side “Journal Filter” button opens the Assistant and jumps to the Journal Filter tab.
  * Journal Filter content now renders dynamically in Agents and General for centralized management.
  * Auto-preselects the relevant tab when opening Journal Filter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->