### PR TITLE
updated spiked whip graphic to match 0xA292

### DIFF
--- a/src/ClassicUO.Client/Game/Data/Ability.cs
+++ b/src/ClassicUO.Client/Game/Data/Ability.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: BSD-2-Clause
+// SPDX-License-Identifier: BSD-2-Clause
 
 using System;
 using System.Collections.Generic;
@@ -307,6 +307,7 @@ namespace ClassicUO.Game.Data
             { 0x48D0, new (0x48D0, Ability.Feint, Ability.DoubleStrike) },             // Gargish Daisho
             { 0xA289, new (0xA289, Ability.ConcussionBlow, Ability.WhirlwindAttack) }, // Barbed Whip
             { 0xA28A, new (0xA28A, Ability.ArmorPierce, Ability.WhirlwindAttack) },    // Spiked Whip
+            { 0xA292, new (0xA292, Ability.ArmorPierce, Ability.WhirlwindAttack) },    // Spiked Whip
             { 0xA28B, new (0xA28B, Ability.BleedAttack, Ability.WhirlwindAttack) },    // Bladed Whip
             { 0x08FF, new (0x08FF, Ability.MysticArc, Ability.ConcussionBlow) },       // Boomerang
             { 0x0900, new (0x0900, Ability.ArmorIgnore, Ability.ParalyzingBlow) },     // Stone War Sword


### PR DESCRIPTION
## Description
Added an alternate graphic for spiked whip.

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing
Verified on my shard with the new graphic and abilities.

## Additional Notes
None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Fixed recognition of a previously unmapped ability icon, ensuring Armor Pierce and Whirlwind Attack are properly identified.
  - Restores correct activation via hotkeys and UI, with accurate tooltips and status indications.
  - Improves consistency across action bars and combat feedback where these abilities are used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->