### PR TITLE
feat: Grid highlight selects best matching rule and adds tooltip options

### DIFF
--- a/src/ClassicUO.Client/Configuration/Language.cs
+++ b/src/ClassicUO.Client/Configuration/Language.cs
@@ -448,6 +448,8 @@ namespace ClassicUO.Configuration
             public string DefaultGridColumns { get; set; } = "Default grid columns";
             public string GridHighlightSettings { get; set; } = "Grid highlight settings";
             public string GridHighlightSize { get; set; } = "Grid highlight size";
+            public string GridHighlightProperties { get; set; } = "Show highlighted item properties in tooltip";
+            public string GridHighlightShowRuleName { get; set; } = "Show matched rule name in tooltip";
             public string GridDisableTargeting { get; set; } = "Disable Targeting Grid Containers";
             #endregion
 

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -425,6 +425,8 @@ namespace ClassicUO.Configuration
         public List<List<int>> GridHighlight_PropMinVal { get; set; } = new List<List<int>>();
         public bool GridHighlight_CorpseOnly { get; set; } = false;
         public int GridHighlightSize { get; set; } = 1;
+        public bool GridHighlightProperties { get; set; } = true;
+        public bool GridHighlightShowRuleName { get; set; } = true;
         public List<bool> GridHighlight_AcceptExtraProperties { get; set; } = new List<bool>();
         public List<List<bool>> GridHighlight_IsOptionalProperties { get; set; } = new List<List<bool>>();
         public List<List<string>> GridHighlight_ExcludeNegatives { get; set; } = new List<List<string>>();

--- a/src/ClassicUO.Client/Game/GameObjects/Item.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Item.cs
@@ -80,7 +80,6 @@ namespace ClassicUO.Game.GameObjects
         public bool IsCoin => Graphic == 0x0EEA || Graphic == 0x0EED || Graphic == 0x0EF0;
 
         public bool MatchesHighlightData;
-        public ushort HighlightHue;
         public Color HighlightColor = Color.White;
         public ushort DisplayedGraphic
         {

--- a/src/ClassicUO.Client/Game/Managers/ToolTipOverrideManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/ToolTipOverrideManager.cs
@@ -263,10 +263,10 @@ namespace ClassicUO.Game.Managers
                 return null;
 
             var sb = new StringBuilder();
-            ToolTipOverrideData[] result = GetAllToolTipOverrides();
+            ToolTipOverrideData[] toolTipOverrides = GetAllToolTipOverrides();
 
             bool headerHandled = false;
-            foreach (var overrideData in FilteredOverrides(result, itemPropertiesData.item?.ItemData.Layer ?? 0))
+            foreach (var overrideData in FilteredOverrides(toolTipOverrides, itemPropertiesData.item?.ItemData.Layer ?? 0))
             {
                 if (MatchItemName(itemPropertiesData.Name, overrideData.SearchText))
                 {
@@ -288,24 +288,20 @@ namespace ClassicUO.Game.Managers
                 );
             }
 
-            var best = ProfileManager.CurrentProfile.GridHighlightProperties ? GridHighlightData.GetBestMatch(itemPropertiesData) : null;
+            var bestGridHighlightData = ProfileManager.CurrentProfile.GridHighlightProperties ? GridHighlightData.GetBestMatch(itemPropertiesData) : null;
 
             foreach (var property in itemPropertiesData.singlePropertyData)
             {
-                bool handled = false;
+                string cleanText = StripColorCodes(property.OriginalString);
 
-                // 1. Highlight check (only once per property)
-                if (best != null && best.DoesPropertyMatch(property))
-                {
-                    string cleanText = StripColorCodes(property.OriginalString);
-                    sb.AppendLine($"[o] {cleanText}/cd");
-                    handled = true;
-                }
+                // Find if this property is highlighted
+                bool isHighlighted = bestGridHighlightData != null && bestGridHighlightData.DoesPropertyMatch(property);
 
-                // 2. Overrides (if not highlighted)
-                if (!handled && result != null)
+                // Try to find an override
+                ToolTipOverrideData matchedOverride = null;
+                if (toolTipOverrides != null)
                 {
-                    foreach (var overrideData in FilteredOverrides(result, itemPropertiesData.item?.ItemData.Layer ?? 0))
+                    foreach (var overrideData in FilteredOverrides(toolTipOverrides, itemPropertiesData.item?.ItemData.Layer ?? 0))
                     {
                         if (!MatchPropertyName(World.Instance, property.OriginalString, overrideData.SearchText))
                             continue;
@@ -313,52 +309,65 @@ namespace ClassicUO.Game.Managers
                         if ((property.FirstValue == double.MinValue || (property.FirstValue >= overrideData.Min1 && property.FirstValue <= overrideData.Max1)) &&
                             (property.SecondValue == double.MinValue || (property.SecondValue >= overrideData.Min2 && property.SecondValue <= overrideData.Max2)))
                         {
-                            try
-                            {
-                                if (compareTo != uint.MinValue)
-                                {
-                                    sb.AppendLine(string.Format(
-                                        overrideData.FormattedText,
-                                        property.Name,
-                                        property.FirstValue.ToString(),
-                                        property.SecondValue.ToString(),
-                                        property.OriginalString,
-                                        property.FirstDiff != 0 ? $"({property.FirstDiff})" : "",
-                                        property.SecondDiff != 0 ? $"({property.SecondDiff})" : ""
-                                    ));
-                                }
-                                else
-                                {
-                                    sb.AppendLine(string.Format(
-                                        overrideData.FormattedText,
-                                        property.Name,
-                                        property.FirstValue.ToString(),
-                                        property.SecondValue.ToString(),
-                                        property.OriginalString, "", ""
-                                    ));
-                                }
-                                handled = true;
-                                break;
-                            }
-                            catch
-                            {
-                                GameActions.Print(World.Instance, $"Invalid format string in tooltip override: {overrideData.FormattedText}", 32);
-                            }
+                            matchedOverride = overrideData;
+                            break;
                         }
                     }
                 }
 
-                // 3. Fallback
-                if (!handled)
+                string finalLine;
+
+                // 1. If override exists, format it
+                if (matchedOverride != null)
                 {
-                    string cleanText = StripColorCodes(property.OriginalString);
-                    sb.AppendLine(cleanText);
+                    try
+                    {
+                        if (compareTo != uint.MinValue)
+                        {
+                            finalLine = string.Format(
+                                matchedOverride.FormattedText,
+                                property.Name,
+                                property.FirstValue.ToString(),
+                                property.SecondValue.ToString(),
+                                property.OriginalString,
+                                property.FirstDiff != 0 ? $"({property.FirstDiff})" : "",
+                                property.SecondDiff != 0 ? $"({property.SecondDiff})" : ""
+                            );
+                        }
+                        else
+                        {
+                            finalLine = string.Format(
+                                matchedOverride.FormattedText,
+                                property.Name,
+                                property.FirstValue.ToString(),
+                                property.SecondValue.ToString(),
+                                property.OriginalString, "", ""
+                            );
+                        }
+                    }
+                    catch
+                    {
+                        GameActions.Print(World.Instance, $"Invalid format string in tooltip override: {matchedOverride.FormattedText}", 32);
+                        finalLine = cleanText;
+                    }
                 }
+                else
+                {
+                    // 2. No override → fallback to original text
+                    finalLine = cleanText;
+                }
+
+                if (isHighlighted)
+                {
+                    finalLine = $"[o] {finalLine}/cd";
+                }
+
+                sb.AppendLine(finalLine);
             }
 
-            if (ProfileManager.CurrentProfile.GridHighlightShowRuleName && best != null && !string.IsNullOrEmpty(best.Name))
+            if (ProfileManager.CurrentProfile.GridHighlightShowRuleName && bestGridHighlightData != null && !string.IsNullOrEmpty(bestGridHighlightData.Name))
             {
-                sb.AppendLine($"/cdMatched Rule: {best.Name}/cd");
+                sb.AppendLine($"/c[gray]Matched Rule: {bestGridHighlightData.Name}/cd");
             }
 
             return sb.ToString();

--- a/src/ClassicUO.Client/Game/Managers/ToolTipOverrideManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/ToolTipOverrideManager.cs
@@ -11,6 +11,8 @@ using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using System.Threading;
 using ClassicUO.Utility.Logging;
+using Microsoft.Xna.Framework;
+using ClassicUO.Game.UI.Gumps.GridHighLight;
 
 namespace ClassicUO.Game.Managers
 {
@@ -255,36 +257,23 @@ namespace ClassicUO.Game.Managers
             }
         }
 
-        public static string ProcessTooltipText(World world, uint serial, uint compareTo = uint.MinValue)
+        private static string BuildTooltip(ItemPropertiesData itemPropertiesData, uint compareTo = uint.MinValue)
         {
-            string tooltip = "";
-            ItemPropertiesData itemPropertiesData;
-
-            if (compareTo != uint.MinValue)
-                itemPropertiesData = new ItemPropertiesData(world, world.Items.Get(serial), world.Items.Get(compareTo));
-            else
-                itemPropertiesData = new ItemPropertiesData(world, world.Items.Get(serial));
-
             if (!itemPropertiesData.HasData)
                 return null;
 
+            var sb = new StringBuilder();
             ToolTipOverrideData[] result = GetAllToolTipOverrides();
 
-
-            // --------------------------------
-            // Apply header override (item name)
-            // --------------------------------
             bool headerHandled = false;
-
-            foreach (var overrideData in FilteredOverrides(result, itemPropertiesData.item.ItemData.Layer))
+            foreach (var overrideData in FilteredOverrides(result, itemPropertiesData.item?.ItemData.Layer ?? 0))
             {
                 if (MatchItemName(itemPropertiesData.Name, overrideData.SearchText))
                 {
-                    tooltip += string.Format(
+                    sb.AppendLine(string.Format(
                         overrideData.FormattedText,
                         itemPropertiesData.Name, "", "", "", "", ""
-                    ) + "\n";
-
+                    ));
                     headerHandled = true;
                     break;
                 }
@@ -292,112 +281,109 @@ namespace ClassicUO.Game.Managers
 
             if (!headerHandled)
             {
-                tooltip += ProfileManager.CurrentProfile == null
-                    ? $"/c[yellow]{itemPropertiesData.Name}\n"
-                    : string.Format(ProfileManager.CurrentProfile.TooltipHeaderFormat + "\n", itemPropertiesData.Name);
+                sb.AppendLine(
+                    ProfileManager.CurrentProfile == null
+                        ? $"/c[yellow]{itemPropertiesData.Name}"
+                        : string.Format(ProfileManager.CurrentProfile.TooltipHeaderFormat, itemPropertiesData.Name)
+                );
             }
 
-            // --------------------------
-            // Apply property line overrides
-            // --------------------------
+            var best = ProfileManager.CurrentProfile.GridHighlightProperties ? GridHighlightData.GetBestMatch(itemPropertiesData) : null;
+
             foreach (var property in itemPropertiesData.singlePropertyData)
             {
                 bool handled = false;
 
-                foreach (var overrideData in FilteredOverrides(result, itemPropertiesData.item.ItemData.Layer))
+                // 1. Highlight check (only once per property)
+                if (best != null && best.DoesPropertyMatch(property))
                 {
-                    // Skip name-based overrides — they should never apply to properties
-                    if (!MatchPropertyName(world, property.OriginalString, overrideData.SearchText))
-                        continue;
+                    string cleanText = StripColorCodes(property.OriginalString);
+                    sb.AppendLine($"[o] {cleanText}/cd");
+                    handled = true;
+                }
 
-                    // Check value bounds
-                    if ((property.FirstValue == double.MinValue || (property.FirstValue >= overrideData.Min1 && property.FirstValue <= overrideData.Max1)) &&
-                        (property.SecondValue == double.MinValue || (property.SecondValue >= overrideData.Min2 && property.SecondValue <= overrideData.Max2)))
+                // 2. Overrides (if not highlighted)
+                if (!handled && result != null)
+                {
+                    foreach (var overrideData in FilteredOverrides(result, itemPropertiesData.item?.ItemData.Layer ?? 0))
                     {
-                        try
-                        {
-                            tooltip += (compareTo != uint.MinValue)
-                                ? string.Format(
-                                    overrideData.FormattedText,
-                                    property.Name,
-                                    property.FirstValue.ToString(),
-                                    property.SecondValue.ToString(),
-                                    property.OriginalString,
-                                    property.FirstDiff != 0 ? $"({property.FirstDiff})" : "",
-                                    property.SecondDiff != 0 ? $"({property.SecondDiff})" : ""
-                                )
-                                : string.Format(
-                                    overrideData.FormattedText,
-                                    property.Name,
-                                    property.FirstValue.ToString(),
-                                    property.SecondValue.ToString(),
-                                    property.OriginalString, "", ""
-                                );
+                        if (!MatchPropertyName(World.Instance, property.OriginalString, overrideData.SearchText))
+                            continue;
 
-                            tooltip += "\n";
-                            handled = true;
-                            break;
-                        }
-                        catch (FormatException e)
+                        if ((property.FirstValue == double.MinValue || (property.FirstValue >= overrideData.Min1 && property.FirstValue <= overrideData.Max1)) &&
+                            (property.SecondValue == double.MinValue || (property.SecondValue >= overrideData.Min2 && property.SecondValue <= overrideData.Max2)))
                         {
-                            GameActions.Print(World.Instance, $"Invalid format string in tooltip override: {overrideData.FormattedText}", 32);
+                            try
+                            {
+                                if (compareTo != uint.MinValue)
+                                {
+                                    sb.AppendLine(string.Format(
+                                        overrideData.FormattedText,
+                                        property.Name,
+                                        property.FirstValue.ToString(),
+                                        property.SecondValue.ToString(),
+                                        property.OriginalString,
+                                        property.FirstDiff != 0 ? $"({property.FirstDiff})" : "",
+                                        property.SecondDiff != 0 ? $"({property.SecondDiff})" : ""
+                                    ));
+                                }
+                                else
+                                {
+                                    sb.AppendLine(string.Format(
+                                        overrideData.FormattedText,
+                                        property.Name,
+                                        property.FirstValue.ToString(),
+                                        property.SecondValue.ToString(),
+                                        property.OriginalString, "", ""
+                                    ));
+                                }
+                                handled = true;
+                                break;
+                            }
+                            catch
+                            {
+                                GameActions.Print(World.Instance, $"Invalid format string in tooltip override: {overrideData.FormattedText}", 32);
+                            }
                         }
                     }
                 }
 
+                // 3. Fallback
                 if (!handled)
                 {
-                    tooltip += property.OriginalString + "\n";
+                    string cleanText = StripColorCodes(property.OriginalString);
+                    sb.AppendLine(cleanText);
                 }
             }
 
-            return tooltip;
+            if (ProfileManager.CurrentProfile.GridHighlightShowRuleName && best != null && !string.IsNullOrEmpty(best.Name))
+            {
+                sb.AppendLine($"/cdMatched Rule: {best.Name}/cd");
+            }
+
+            return sb.ToString();
+        }
+
+        private static string StripColorCodes(string input)
+        {
+            if (string.IsNullOrEmpty(input)) return input;
+            return Regex.Replace(input, @"\/c\[[^\]]*\]|\/cd", string.Empty, RegexOptions.IgnoreCase);
+        }
+
+        public static string ProcessTooltipText(World world, uint serial, uint compareTo = uint.MinValue)
+        {
+            ItemPropertiesData itemPropertiesData =
+                compareTo != uint.MinValue
+                ? new ItemPropertiesData(world, world.Items.Get(serial), world.Items.Get(compareTo))
+                : new ItemPropertiesData(world, world.Items.Get(serial));
+
+            return BuildTooltip(itemPropertiesData, compareTo);
         }
 
         public static string ProcessTooltipText(string text)
         {
-            string tooltip = "";
-
             ItemPropertiesData itemPropertiesData = new ItemPropertiesData(text);
-
-            ToolTipOverrideData[] result = GetAllToolTipOverrides();
-
-            if (itemPropertiesData.HasData && result != null && result.Length > 0)
-            {
-                tooltip += ProfileManager.CurrentProfile == null ? $"/c[yellow]{itemPropertiesData.Name}\n" : string.Format(ProfileManager.CurrentProfile.TooltipHeaderFormat + "\n", itemPropertiesData.Name);
-
-                //Loop through each property
-                foreach (ItemPropertiesData.SinglePropertyData property in itemPropertiesData.singlePropertyData)
-                {
-                    bool handled = false;
-                    //Loop though each override setting player created
-                    foreach (ToolTipOverrideData overrideData in result)
-                    {
-                        if (overrideData != null)
-                            if (overrideData.ItemLayer == TooltipLayers.Any)
-                            {
-                                if (property.OriginalString.ToLower().Contains(overrideData.SearchText.ToLower()))
-                                    if (property.FirstValue == double.MinValue || (property.FirstValue >= overrideData.Min1 && property.FirstValue <= overrideData.Max1))
-                                        if (property.SecondValue == double.MinValue || (property.SecondValue >= overrideData.Min2 && property.SecondValue <= overrideData.Max2))
-                                        {
-                                            try
-                                            {
-                                                tooltip += string.Format(overrideData.FormattedText, property.Name, property.FirstValue.ToString(), property.SecondValue.ToString()) + "\n";
-                                                handled = true;
-                                                break;
-                                            }
-                                            catch { }
-                                        }
-                            }
-                    }
-                    if (!handled) //Did not find a matching override, need to add the plain tooltip line still
-                        tooltip += $"{property.OriginalString}\n";
-
-                }
-
-                return tooltip;
-            }
-            return null;
+            return BuildTooltip(itemPropertiesData);
         }
 
         private static bool CheckLayers(TooltipLayers overrideLayer, byte itemLayer)

--- a/src/ClassicUO.Client/Game/UI/Controls/NiceButton.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/NiceButton.cs
@@ -13,7 +13,7 @@ namespace ClassicUO.Game.UI.Controls
         private readonly ButtonAction _action;
         private readonly int _groupnumber;
         private bool _isSelected;
-
+        public Color? BackgroundColor { get; set; } = null;
         public bool DisplayBorder;
 
         public NiceButton
@@ -137,6 +137,16 @@ namespace ClassicUO.Game.UI.Controls
 
         public override bool Draw(UltimaBatcher2D batcher, int x, int y)
         {
+            if (BackgroundColor.HasValue)
+            {
+                batcher.Draw
+                (
+                    SolidColorTextureCache.GetTexture(BackgroundColor.Value),
+                    new Rectangle(x, y, Width, Height),
+                    ShaderHueTranslator.GetHueVector(0, false, Alpha)
+                );
+            }
+
             if (IsSelected || AlwaysShowBackground)
             {
                 Vector3 hueVector = ShaderHueTranslator.GetHueVector(Hue, false, Alpha);

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightData.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightData.cs
@@ -20,7 +20,6 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
         private static readonly Queue<uint> _queue = new();
         private static bool hasQueuedItems;
 
-        private static readonly Regex HtmlTagRegex = new("<.*?>", RegexOptions.Compiled);
         private readonly Dictionary<string, string> _normalizeCache = new();
 
         public static GridHighlightData[] AllConfigs
@@ -111,12 +110,6 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
             set => _entry.LootOnMatch = value;
         }
 
-        public GridHighlightData()
-        {
-            _entry = new GridHighlightSetupEntry();
-            ProfileManager.CurrentProfile.GridHighlightSetup.Add(_entry);
-        }
-
         private GridHighlightData(GridHighlightSetupEntry entry)
         {
             _entry = entry;
@@ -163,22 +156,19 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
                     itemData.Add(new ItemPropertiesData(World, item));
             }
 
-            foreach (var config in AllConfigs)
+            foreach (var data in itemData)
             {
-                foreach (var data in itemData)
+                var bestMatch = GetBestMatch(data);
+                if (bestMatch != null)
                 {
-                    if (config.IsMatch(data))
-                    {
-                        data.item.MatchesHighlightData = true;
-                        data.item.HighlightHue = config.Hue;
-                        data.item.HighlightColor = config.HighlightColor;
+                    data.item.MatchesHighlightData = true;
+                    data.item.HighlightColor = bestMatch.HighlightColor;
 
-                        if (config.LootOnMatch)
-                        {
-                            var root = World.Items.Get(data.item.RootContainer);
-                            if (root != null && root.IsCorpse)
-                                AutoLootManager.Instance.LootItem(data.item);
-                        }
+                    if (bestMatch.LootOnMatch)
+                    {
+                        var root = World.Items.Get(data.item.RootContainer);
+                        if (root != null && root.IsCorpse)
+                            AutoLootManager.Instance.LootItem(data.item);
                     }
                 }
             }
@@ -212,12 +202,33 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
 
         public bool IsMatch(ItemPropertiesData itemData)
         {
-            if (!itemData.HasData)
-                return false;
-
             return AcceptExtraProperties
                 ? IsMatchFromProperties(itemData)
                 : IsMatchFromItemPropertiesData(itemData);
+        }
+
+        public bool DoesPropertyMatch(ItemPropertiesData.SinglePropertyData property)
+        {
+            foreach (var rule in Properties)
+            {
+                string nProp = Normalize(property.Name);
+                string nRule = Normalize(rule.Name);
+
+                bool nameMatch = nProp.Equals(nRule, StringComparison.OrdinalIgnoreCase) ||
+                                 nProp.Contains(nRule, StringComparison.OrdinalIgnoreCase) ||
+                                 Normalize(property.OriginalString).Contains(nRule, StringComparison.OrdinalIgnoreCase);
+
+                bool valueMatch = rule.MinValue == -1 || property.FirstValue >= rule.MinValue;
+
+                if (nameMatch && valueMatch)
+                    return true;
+            }
+
+            // rarities
+            if (RequiredRarities.Any(r => Normalize(property.Name).Equals(Normalize(r), StringComparison.OrdinalIgnoreCase)))
+                return true;
+
+            return false;
         }
 
         private bool IsMatchFromProperties(ItemPropertiesData itemData)
@@ -226,7 +237,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
                 return false;
 
             if (!MatchesSlot(itemData.item.ItemData.Layer))
-                    return false;
+                return false;
 
             if (Overweight && itemData.singlePropertyData.Any(prop =>
                     Normalize(prop.OriginalString).IndexOf("Weight: 50 Stones", StringComparison.OrdinalIgnoreCase) >= 0))
@@ -298,15 +309,11 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
                 GridHighlightRules.NegativeProperties.Any(rule =>
                     Normalize(rule).Equals(Normalize(p.Name), StringComparison.OrdinalIgnoreCase))).ToList();
 
-            var itemResistances = props.Where(p =>
-                GridHighlightRules.Resistances.Any(rule =>
-                    Normalize(rule).Equals(Normalize(p.Name), StringComparison.OrdinalIgnoreCase))).ToList();
-
             var itemRarities = props.Where(p =>
                 GridHighlightRules.RarityProperties.Any(rule =>
                     Normalize(rule).Equals(Normalize(p.Name), StringComparison.OrdinalIgnoreCase))).ToList();
 
-            if (!itemProperties.Any() && !itemNegatives.Any() && !itemResistances.Any() && !itemRarities.Any())
+            if (!itemProperties.Any() && !itemNegatives.Any() && !itemRarities.Any())
                 return false;
 
             if (Overweight && props.Any(prop =>
@@ -354,6 +361,53 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
 
             var isMatchingPropertyCount = IsMatchingPropertyCount(matchingPropertiesCount);
             return isMatchingPropertyCount;
+        }
+
+        public static GridHighlightData GetBestMatch(ItemPropertiesData itemData)
+        {
+            GridHighlightData best = null;
+            int bestScore = -1;
+            bool bestHasExact = false;
+
+            foreach (var config in AllConfigs)
+            {
+                if (!config.IsMatch(itemData))
+                    continue;
+
+                int score = 0;
+                bool hasExact = false;
+
+                foreach (var prop in itemData.singlePropertyData)
+                {
+                    foreach (var rule in config.Properties)
+                    {
+                        string nProp = config.Normalize(prop.Name);
+                        string nRule = config.Normalize(rule.Name);
+
+                        if (nProp.Equals(nRule, StringComparison.OrdinalIgnoreCase))
+                        {
+                            score += 2; // exact name match = stronger
+                            hasExact = true;
+                        }
+                        else if (nProp.Contains(nRule, StringComparison.OrdinalIgnoreCase) ||
+                                 config.Normalize(prop.OriginalString).Contains(nRule, StringComparison.OrdinalIgnoreCase))
+                        {
+                            score += 1;
+                        }
+                    }
+                }
+
+                // tie-breaker: prefer exact name matches, then higher score
+                if (best == null || (hasExact && !bestHasExact) ||
+                    (hasExact == bestHasExact && score > bestScore))
+                {
+                    best = config;
+                    bestScore = score;
+                    bestHasExact = hasExact;
+                }
+            }
+
+            return best;
         }
 
         private bool IsMatchingPropertyCount(int matchingPropertiesCount)
@@ -425,7 +479,8 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
 
         private bool MatchesSlot(byte layer)
         {
-            if (EquipmentSlots.Other) {
+            if (EquipmentSlots.Other)
+            {
                 return true;
             }
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightProfile.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightProfile.cs
@@ -25,6 +25,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
         public List<string> RequiredRarities { get; set; } = new();
         public GridHighlightSlot GridHighlightSlot { get; set; } = new();
         public bool LootOnMatch { get; set; } = false;
+        public bool IsHighlightProperties { get; set; } = true;
 
         public Color GetHighlightColor()
         {

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHightlightMenu.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHightlightMenu.cs
@@ -120,6 +120,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
                     {
                         data.HighlightColor = selectedColor;
                         data.Hue = (ushort)(selectedColor.R + (selectedColor.G << 8) + (selectedColor.B << 16));
+                        colorButton.BackgroundColor = selectedColor;
                         GridHighlightData.RecheckMatchStatus(); //Request new opl data and re-check item matches
                     });
                 }

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHightlightMenu.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHightlightMenu.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using ClassicUO.Game.Data;
-using ClassicUO.Utility;
 
 namespace ClassicUO.Game.UI.Gumps.GridHighLight
 {

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHightlightMenu.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHightlightMenu.cs
@@ -7,12 +7,13 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using ClassicUO.Game.Data;
+using ClassicUO.Utility;
 
 namespace ClassicUO.Game.UI.Gumps.GridHighLight
 {
     internal class GridHighlightMenu : NineSliceGump
     {
-        private const int WIDTH = 370, HEIGHT = 500;
+        private const int WIDTH = 420, HEIGHT = 500;
         private SettingsSection highlightSection;
         private ScrollArea highlightSectionScroll;
 
@@ -36,7 +37,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
             Clear();
             int y = 0;
             {
-                SettingsSection section = new SettingsSection("Grid highlighting settings", Width - (BorderSize*2));
+                SettingsSection section = new SettingsSection("Grid highlighting settings", Width - (BorderSize * 2));
                 section.X = BorderSize;
                 section.Y = BorderSize;
                 section.Add(new Label("You can add object properties that you would like the grid to be highlighted for here.", true, 0xffff, section.Width - 15));
@@ -109,7 +110,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
             int spaceBetween = 7;
 
             NiceButton colorButton;
-            area.Add(colorButton = new NiceButton(0, y, 60, 20, ButtonAction.Activate, "Color") { IsSelectable = false });
+            area.Add(colorButton = new NiceButton(0, y, 60, 20, ButtonAction.Activate, "Color") { BackgroundColor = data.HighlightColor, IsSelectable = false });
             colorButton.SetTooltip("Select grid highlight color");
             colorButton.MouseUp += (s, e) =>
             {
@@ -124,16 +125,16 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
                 }
             };
 
-            NiceButton  _propertiesButton;
-            area.Add( _propertiesButton = new NiceButton(0, y, 60, 20, ButtonAction.Activate, "Properties") { IsSelectable = false });
-             _propertiesButton.MouseUp += (s, e) =>
-            {
-                if (e.Button == Input.MouseButtonType.Left)
-                {
-                    UIManager.GetGump<GridHighlightProperties>()?.Dispose();
-                    UIManager.Add(new GridHighlightProperties(World, keyLoc, 100, 100));
-                }
-            };
+            NiceButton _propertiesButton;
+            area.Add(_propertiesButton = new NiceButton(0, y, 60, 20, ButtonAction.Activate, "Properties") { IsSelectable = false });
+            _propertiesButton.MouseUp += (s, e) =>
+           {
+               if (e.Button == Input.MouseButtonType.Left)
+               {
+                   UIManager.GetGump<GridHighlightProperties>()?.Dispose();
+                   UIManager.Add(new GridHighlightProperties(World, keyLoc, 100, 100));
+               }
+           };
 
             NiceButton _del;
             area.Add(_del = new NiceButton(0, y, 20, 20, ButtonAction.Activate, "X") { IsSelectable = false });
@@ -175,17 +176,17 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
             };
 
             pos.PositionLeftOf(_moveUp, _moveDown);
-            pos.PositionLeftOf( _del, _moveUp);
-            pos.PositionLeftOf( _propertiesButton, _del);
-            pos.PositionLeftOf(colorButton,  _propertiesButton);
+            pos.PositionLeftOf(_del, _moveUp);
+            pos.PositionLeftOf(_propertiesButton, _del);
+            pos.PositionLeftOf(colorButton, _propertiesButton);
 
             InputField _name;
             area.Add(_name = new InputField(0x0BB8, 0xFF, 0xFFFF, true, colorButton.X - spaceBetween, 20)
-                {
-                    X = 0,
-                    Y = y,
-                    AcceptKeyboardInput = true
-                }
+            {
+                X = 0,
+                Y = y,
+                AcceptKeyboardInput = true
+            }
             );
             _name.SetText(data.Name);
             _name.TextChanged += (s, e) => data.Name = _name.Text;
@@ -241,7 +242,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
                     var imported = JsonSerializer.Deserialize<List<GridHighlightSetupEntry>>(json);
                     if (imported != null)
                     {
-                        ProfileManager.CurrentProfile.GridHighlightSetup.AddRange(imported);;
+                        ProfileManager.CurrentProfile.GridHighlightSetup.AddRange(imported);
                         SaveProfile();
                         UIManager.GetGump<GridHighlightMenu>()?.Dispose();
                         UIManager.Add(new GridHighlightMenu(world));

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
@@ -2814,6 +2814,18 @@ namespace ClassicUO.Game.UI.Gumps
 
             content.AddToRight
             (
+                c = new CheckboxWithLabel(lang.GetTazUO.GridHighlightProperties, 0, profile.GridHighlightProperties, (b) => { profile.GridHighlightProperties = b; }),
+                true, page
+            );
+
+            content.AddToRight
+            (
+                c = new CheckboxWithLabel(lang.GetTazUO.GridHighlightShowRuleName, 0, profile.GridHighlightShowRuleName, (b) => { profile.GridHighlightShowRuleName = b; }),
+                true, page
+            );
+
+            content.AddToRight
+            (
                 c = new CheckboxWithLabel(lang.GetTazUO.GridDisableTargeting, 0, profile.DisableTargetingGridContainers, (b) => { profile.DisableTargetingGridContainers = b; }),
                 true, page
             );


### PR DESCRIPTION
- Items are now highlighted using the "best" matching rule (FIFO tie-breaking).
- Added option to highlight only the matching properties in the tooltip.
- Added option to display the matched rule name at the bottom of the tooltip.
<img width="277" height="252" alt="image" src="https://github.com/user-attachments/assets/1b2f2c06-9a5e-42f5-a742-af6915e11202" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Options to show highlighted item properties in tooltips and to display the matched rule name (enabled by default).
  - Grid highlighting now selects the best-matching rule for items, improving accuracy.

- **Improvements**
  - Tooltips show cleaner text (color codes stripped), clearer headers, and improved layout for highlighted properties and overrides.
  - UI: new toggles in Options > TazUO Grid Highlighting; grid menu widened; color buttons reflect selection and buttons support background color.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->