### PR TITLE
Add setter for Graphic property in Scripts

### DIFF
--- a/src/ClassicUO.Client/LegionScripting/PyClasses/PyGameObject.cs
+++ b/src/ClassicUO.Client/LegionScripting/PyClasses/PyGameObject.cs
@@ -54,7 +54,17 @@ public class PyGameObject
     /// <summary>
     /// The graphic ID of the object, representing its visual appearance.
     /// </summary>
-    public ushort Graphic;
+    public ushort Graphic { get => field;
+        set
+        {
+            if (_gameObject == null || _gameObject.IsDestroyed)
+                return;
+
+            MainThreadQueue.EnqueueAction(() => _gameObject.Graphic = value);
+
+            field = value;
+        }
+    }
 
     /// <summary>
     /// The hue (color tint) applied to the object.


### PR DESCRIPTION
Expose the ability to set the Graphic from scripts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when updating game object graphics via scripting.
  * Prevents errors when attempting to modify graphics on destroyed or missing objects.
  * Ensures graphic updates occur on the main thread to avoid race conditions and visual glitches.

* **Reliability**
  * More consistent behavior when scripts change object appearance, reducing unexpected failures and improving overall robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->