### PR TITLE
Add null safety checks for gump decompression failures

### DIFF
--- a/src/ClassicUO.Client/Network/PacketHandlers.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers.cs
@@ -5586,12 +5586,17 @@ sealed class PacketHandlers
         }
 
         byte[] layoutBuffer = System.Buffers.ArrayPool<byte>.Shared.Rent(layoutDecompressedLen);
-        string layout;
+        string layout = null;
 
         try
         {
             ZLib.Decompress(p.Buffer.Slice(p.Position, (int)layoutCompressedLen), layoutBuffer.AsSpan(0, layoutDecompressedLen));
             layout = Encoding.UTF8.GetString(layoutBuffer.AsSpan(0, layoutDecompressedLen));
+        }
+        catch (Exception ex)
+        {
+            Log.Error($"Failed to decompress or decode gump layout: {ex.Message}");
+            return;
         }
         finally
         {

--- a/src/ClassicUO.Utility/TextFileParser.cs
+++ b/src/ClassicUO.Utility/TextFileParser.cs
@@ -163,6 +163,11 @@ namespace ClassicUO.Utility
 
         public List<string> GetTokens(string str, bool trim = true)
         {
+            if (str == null)
+            {
+                return new List<string>();
+            }
+
             _string = str;
             _Size = str.Length;
             _pos = 0;


### PR DESCRIPTION
## Summary
- Added exception handling in `PacketHandlers.cs` to catch and log gump layout decompression errors
- Added null check in `TextFileParser.GetTokens()` to prevent crashes when processing null layout strings
- Fixes rare server gump crashes when malformed or corrupted gump data is received

## Test Plan
- [x] Test with corrupted gump layout data
- [x] Verify error logging works correctly
- [x] Test TextFileParser with null inputs
- [x] Verify existing gumps still work properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when loading compressed UI data: errors during decompression/decoding are now handled gracefully, preventing crashes and stopping invalid layouts from rendering.
  * Added safeguards in text token parsing to handle null input, avoiding null-reference errors and improving stability in edge cases.
  * These fixes enhance overall reliability and reduce unexpected interruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->