### PR TITLE
Fix thread safety issue in TextFileParser causing gump crashes

### DIFF
--- a/src/ClassicUO.Client/Network/PacketHandlers.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers.cs
@@ -33,18 +33,38 @@ sealed class PacketHandlers
 
     private static uint _requestedGridLoot;
 
-    private static readonly TextFileParser _parser = new TextFileParser(
-        string.Empty,
-        new[] { ' ' },
-        new char[] { },
-        new[] { '{', '}' }
-    );
-    private static readonly TextFileParser _cmdparser = new TextFileParser(
-        string.Empty,
-        new[] { ' ', ',' },
-        new char[] { },
-        new[] { '@', '@' }
-    );
+    [ThreadStatic]
+    private static TextFileParser _parser;
+    [ThreadStatic]
+    private static TextFileParser _cmdparser;
+
+    private static TextFileParser GetParser()
+    {
+        if (_parser == null)
+        {
+            _parser = new TextFileParser(
+                string.Empty,
+                new[] { ' ' },
+                new char[] { },
+                new[] { '{', '}' }
+            );
+        }
+        return _parser;
+    }
+
+    private static TextFileParser GetCmdParser()
+    {
+        if (_cmdparser == null)
+        {
+            _cmdparser = new TextFileParser(
+                string.Empty,
+                new[] { ' ', ',' },
+                new char[] { },
+                new[] { '@', '@' }
+            );
+        }
+        return _cmdparser;
+    }
 
     private List<uint> _clilocRequests = new List<uint>();
     private List<uint> _customHouseRequests = new List<uint>();
@@ -6806,7 +6826,7 @@ sealed class PacketHandlers
         if (string.IsNullOrEmpty(layout))
             return null;
 
-        List<string> cmdlist = _parser.GetTokens(layout);
+        List<string> cmdlist = GetParser().GetTokens(layout);
         int cmdlen = cmdlist.Count;
 
         if (cmdlen <= 0)
@@ -6868,7 +6888,7 @@ sealed class PacketHandlers
 
         for (int cnt = 0; cnt < cmdlen; cnt++)
         {
-            List<string> gparams = _cmdparser.GetTokens(cmdlist[cnt], false);
+            List<string> gparams = GetCmdParser().GetTokens(cmdlist[cnt], false);
 
             if (gparams.Count == 0)
             {


### PR DESCRIPTION
## Summary
- Fixed NullReferenceException in TextFileParser that caused crashes when opening compressed gumps
- Converted static TextFileParser instances to thread-local storage using `[ThreadStatic]`
- Added lazy initialization methods `GetParser()` and `GetCmdParser()` for thread-safe access

## Root Cause
The static `_parser` and `_cmdparser` fields were shared across all threads, causing race conditions when multiple threads parsed gump layouts simultaneously. The mutable internal state (`_string`, `_pos`, `_Size`) would get corrupted, leading to NullReferenceExceptions.

## Solution
Each thread now maintains its own TextFileParser instance via thread-local storage, eliminating race conditions while preserving the performance benefits of instance reuse within each thread.

## Test Plan
- [x] Build succeeds with no errors
- [ ] Manual testing: Open multiple gumps rapidly to verify no crashes occur
- [ ] Verify server gump interactions remain stable under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved responsiveness and reduced latency when processing network data, resulting in smoother gameplay under heavy load and on multi-core systems.

* **Refactor**
  * Internal adjustments to parser initialization to enhance thread-safety and scalability without changing user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->