### PR TITLE
Add Hide Player Char and Hide Mouse options to Hide HUD system

### DIFF
--- a/src/ClassicUO.Client/Game/Data/HideHudFlags.cs
+++ b/src/ClassicUO.Client/Game/Data/HideHudFlags.cs
@@ -27,6 +27,8 @@ public enum HideHudFlags : ulong //Up to 63 gump types for ulong
     SpellIcons = 1 << 18,
     NameOverheadGump = 1 << 19,
     ScriptManagerGump = 1 << 20,
+    PlayerChar = 1 << 21,
+    Mouse = 1 << 22,
 
-    All = (1UL << 21) - 1 //Update 21 if more are added
+    All = (1UL << 23) - 1 //Update 23 if more are added
 }

--- a/src/ClassicUO.Client/Game/GameCursor.cs
+++ b/src/ClassicUO.Client/Game/GameCursor.cs
@@ -138,6 +138,7 @@ namespace ClassicUO.Game
         public bool IsLoading { get; set; }
         public bool IsDraggingCursorForced { get; set; }
         public bool AllowDrawSDLCursor { get; set; } = true;
+        public bool IsVisible { get; set; } = true;
 
         public ItemHold ItemHold { get; } = new ItemHold();
 
@@ -259,6 +260,12 @@ namespace ClassicUO.Game
 
         public void Draw(UltimaBatcher2D sb)
         {
+            // Check if mouse should be hidden via Hide HUD system
+            if (!IsVisible)
+            {
+                return;
+            }
+
             if (_world.InGame && _world.TargetManager.IsTargeting && ProfileManager.CurrentProfile != null)
             {
                 if (_world.TargetManager.TargetingState == CursorTarget.MultiPlacement)

--- a/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
@@ -113,6 +113,7 @@ namespace ClassicUO.Game.GameObjects
 
         public Mobile(World world) : base(world, 0) { }
 
+        public bool IsVisible { get; set; } = true;
         public Deque<Step> Steps { get; } = new Deque<Step>(Constants.MAX_STEP_COUNT);
         public bool IsParalyzed => (Flags & Flags.Frozen) != 0;
         public bool IsYellowHits => (Flags & Flags.YellowBar) != 0;

--- a/src/ClassicUO.Client/Game/GameObjects/PlayerMobile.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/PlayerMobile.cs
@@ -44,6 +44,8 @@ namespace ClassicUO.Game.GameObjects
             IsPlayer = true;
         }
 
+        public bool IsVisible { get; set; } = true;
+
         public Skill[] Skills { get; }
         public override bool InWarMode { get; set; }
         public IReadOnlyDictionary<BuffIconType, BuffIcon> BuffIcons => _buffIcons;

--- a/src/ClassicUO.Client/Game/GameObjects/Views/MobileView.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Views/MobileView.cs
@@ -23,7 +23,13 @@ namespace ClassicUO.Game.GameObjects
 
         public override bool Draw(UltimaBatcher2D batcher, int posX, int posY, float depth)
         {
-            if (IsDestroyed || !AllowedToDraw)
+            if (IsDestroyed || !AllowedToDraw || !IsVisible)
+            {
+                return false;
+            }
+
+            // Check if player character should be hidden via Hide HUD system
+            if (this is PlayerMobile player && !player.IsVisible)
             {
                 return false;
             }

--- a/src/ClassicUO.Client/Game/Managers/HideHudManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/HideHudManager.cs
@@ -4,6 +4,7 @@ using ClassicUO.Game.UI;
 using ClassicUO.Game.UI.Gumps;
 using ClassicUO.Game.UI.Gumps.SpellBar;
 using ClassicUO.Utility;
+using SDL3;
 
 namespace ClassicUO.Game.Managers;
 
@@ -19,6 +20,29 @@ public static class HideHudManager
     public static void ToggleHidden(ulong flags)
     {
         isVisible = !isVisible;
+
+        // Toggle player character visibility
+        if (ByteFlagHelper.HasFlag(flags, (ulong)HideHudFlags.PlayerChar))
+        {
+            if (UIManager.World?.Player != null)
+            {
+                UIManager.World.Player.IsVisible = isVisible;
+            }
+        }
+
+        // Toggle mouse cursor visibility
+        if (ByteFlagHelper.HasFlag(flags, (ulong)HideHudFlags.Mouse))
+        {
+            if (Client.Game.UO?.GameCursor != null)
+            {
+                Client.Game.UO.GameCursor.IsVisible = isVisible;
+
+                if (!isVisible)
+                    SDL.SDL_HideCursor();
+                else
+                    SDL.SDL_ShowCursor();
+            }
+        }
 
         foreach (Gump gump in UIManager.Gumps)
         {

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/General/HudWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/General/HudWindow.cs
@@ -190,6 +190,8 @@ namespace ClassicUO.Game.UI.ImGuiControls
                 HideHudFlags.SpellIcons => "Spell icon buttons",
                 HideHudFlags.NameOverheadGump => "Name overhead displays",
                 HideHudFlags.ScriptManagerGump => "Script manager window",
+                HideHudFlags.PlayerChar => "Player character (your avatar in the game world)",
+                HideHudFlags.Mouse => "Mouse cursor",
                 HideHudFlags.All => "Select/deselect all HUD elements at once",
                 _ => null
             };


### PR DESCRIPTION
## Summary
- Added **Hide Player Char** option to hide the player character avatar
- Added **Hide Mouse** option to hide the mouse cursor  
- Both options integrate with the existing Hide HUD toggle system

## Changes Made
- `HideHudFlags.cs`: Added `PlayerChar` and `Mouse` flags to the enum
- `MobileView.cs`: Added check to prevent player character rendering when flag is set
- `GameCursor.cs`: Added check to prevent cursor rendering when flag is set
- `HudWindow.cs`: Added descriptive tooltips for the new options

## Test Plan
- [x] Build succeeds without errors
- [x] New options appear in HUD Settings window
- [ ] Toggle functionality works with Hide HUD macro
- [ ] Player character hides when PlayerChar flag is enabled
- [ ] Mouse cursor hides when Mouse flag is enabled

## Additional Notes
These options are useful for creating clean screenshots or recordings without UI elements, player character, or cursor visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Hide HUD options to hide the player character and the mouse cursor.
  * Mouse cursor now respects visibility toggles and hides the system cursor accordingly.
  * Player character (and other mobiles) no longer render when hidden, enabling cleaner screenshots/streams.
  * HUD window includes tooltips describing the new options.
  * Toggles can be switched on/off independently without affecting other UI elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->