### PR TITLE
Display Graphics and Container values in hexadecimal format in InspectorGump

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/InspectorGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/InspectorGump.cs
@@ -232,7 +232,7 @@ namespace ClassicUO.Game.UI.Gumps
         {
             Dictionary<string, string> dict = new Dictionary<string, string>();
 
-            dict["Graphics"] = $"{obj.Graphic}";
+            dict["Graphics"] = $"0x{obj.Graphic:X4}";
             dict["Hue"] = $"{obj.Hue}";
             dict["Position"] = $"X={obj.X}, Y={obj.Y}, Z={obj.Z}";
             dict["PriorityZ"] = obj.PriorityZ.ToString();
@@ -272,7 +272,7 @@ namespace ClassicUO.Game.UI.Gumps
                     dict["HP"] = $"{it.Hits}/{it.HitsMax}";
                     dict["IsCoins"] = it.IsCoin.ToString();
                     dict["Amount"] = it.Amount.ToString();
-                    dict["Container"] = it.Container.ToString();
+                    dict["Container"] = $"0x{it.Container:X8}";
                     dict["Layer"] = it.Layer.ToString();
                     dict["Price"] = it.Price.ToString();
                     dict["Direction"] = it.Direction.ToString();

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/General/GeneralWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/General/GeneralWindow.cs
@@ -130,7 +130,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
 
         private readonly string _version = "TazUO Version: " + CUOEnviroment.Version; //Pre-cache to prevent reading var and string concatenation every frame
         private uint _lastObject = 0;
-        private string _lastObjectString = "Last Object:";
+        private string _lastObjectString = "Last Object: 0x00000000";
         private void DrawInfoTab()
         {
             if (World.Instance != null)
@@ -138,7 +138,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
                 if (_lastObject != World.Instance.LastObject)
                 {
                     _lastObject = World.Instance.LastObject;
-                    _lastObjectString = "Last Object: " + _lastObject;
+                    _lastObjectString = $"Last Object: 0x{_lastObject:X8}";
                 }
             }
 
@@ -149,7 +149,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
             ImGui.Text(_lastObjectString);
             if(ImGui.IsItemClicked())
             {
-                SDL3.SDL.SDL_SetClipboardText(_lastObject.ToString());
+                SDL3.SDL.SDL_SetClipboardText($"0x{_lastObject:X8}");
                 GameActions.Print("Copied last object to clipboard.", 62);
             }
             ImGui.Spacing();


### PR DESCRIPTION
## Summary
- Changed Graphics display from decimal to hexadecimal format (0x0000)
- Changed Container serial from decimal to hexadecimal format (0x00000000)
- Improves consistency with other serial/ID displays in the inspector (Serial, MultiGraphic)
- Makes values easier to reference in standard UO documentation

## Changes
- `Graphics` field now displays as `0x0A3C` instead of `2620`
- `Container` field now displays as `0x40001234` instead of `1073746484`

## Test plan
- [x] Build completes successfully
- [ ] Open InspectorGump on various game objects and verify hex formatting
- [ ] Verify clicking values still copies them to clipboard correctly
- [ ] Check dump functionality still works with hex values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Unified ID formatting to hexadecimal across the UI: Graphics IDs and Container IDs in the Inspector now display as 0x-prefixed hex (readable cross-reference format).  
  * "Last Object" display and clipboard copy now show the object ID as 0x-prefixed hex.  
  * No behavioral changes; only display/clipboard formatting updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->