### PR TITLE
Fix NullReferenceException in TextFileParser for gump parsing

### DIFF
--- a/src/ClassicUO.Utility/TextFileParser.cs
+++ b/src/ClassicUO.Utility/TextFileParser.cs
@@ -37,6 +37,12 @@ namespace ClassicUO.Utility
 
         private void GetEOL()
         {
+            if (_string == null)
+            {
+                _eol = 0;
+                return;
+            }
+
             for (int i = _pos; i < _Size; i++)
             {
                 if (_string[i] == '\n')
@@ -51,6 +57,9 @@ namespace ClassicUO.Utility
 
         private void SkipToData()
         {
+            if (_string == null)
+                return;
+
             while (_pos < _eol && IsDelimiter(_string[_pos]))
                 _pos++;
         }
@@ -65,6 +74,9 @@ namespace ClassicUO.Utility
 
         private bool IsComment()
         {
+            if (_string == null || _pos >= _Size)
+                return false;
+
             foreach (char c in _comments)
                 if (_string[_pos] == c)
                     return true;
@@ -73,6 +85,11 @@ namespace ClassicUO.Utility
 
         private bool TryGetQuotePair(out char startQuote, out char endQuote)
         {
+            startQuote = endQuote = '\0';
+
+            if (_string == null || _pos >= _Size)
+                return false;
+
             for (int i = 0; i + 1 < _quotes.Length; i += 2)
             {
                 if (_string[_pos] == _quotes[i])
@@ -83,12 +100,14 @@ namespace ClassicUO.Utility
                 }
             }
 
-            startQuote = endQuote = '\0';
             return false;
         }
 
         private void ObtainQuotedData(char endQuote, bool areTheSame)
         {
+            if (_string == null)
+                return;
+
             _pos++; // skip opening quote
 
             while (_pos < _eol)
@@ -107,6 +126,9 @@ namespace ClassicUO.Utility
 
         private void ObtainUnquotedData()
         {
+            if (_string == null)
+                return;
+
             while (_pos < _eol)
             {
                 if (IsDelimiter(_string[_pos]) || IsComment() || TryGetQuotePair(out _, out _))
@@ -122,7 +144,7 @@ namespace ClassicUO.Utility
             _trim = trim;
             List<string> result = new List<string>();
 
-            if (_pos >= _Size)
+            if (_string == null || _pos >= _Size)
                 return result;
 
             GetEOL(); // sets _eol to the end of the current line


### PR DESCRIPTION
## Summary
Fixes a critical NullReferenceException crash that occurs when opening compressed gumps from the server. This crash happens in the TextFileParser when the `_string` field is accessed while null.

## Root Cause
The TextFileParser uses a ThreadStatic `_parser` field that persists across method calls. The internal `_string` field could be accessed in a null state during gump layout parsing, causing crashes in multiple private methods.

## Changes
Added comprehensive null safety checks throughout TextFileParser:
- ✅ `ReadTokens()` - Early return if string is null
- ✅ `GetEOL()` - Null check with safe default
- ✅ `SkipToData()` - Null check before iteration
- ✅ `IsComment()` - Null and bounds checking
- ✅ `TryGetQuotePair()` - Null and bounds checking with safe defaults
- ✅ `ObtainQuotedData()` - Null check before processing
- ✅ `ObtainUnquotedData()` - Null check before processing

## Test Plan
- [x] Build completes successfully
- [ ] Launch client and open various server gumps
- [ ] Verify no NullReferenceExceptions in crash logs
- [ ] Test with different gump types (containers, vendor gumps, quest gumps, etc.)

## Related Issues
Resolves crashes in `PacketHandlers.CreateGump()` at line 6829 when processing compressed gump packets from the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents rare crashes when parsing text by gracefully handling empty or missing input.
  * Improves reliability during loading and processing of text-based data (e.g., configs or imports).

* **Refactor**
  * Hardened input parsing with additional safeguards to avoid null-related errors, with no change to normal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->