### PR TITLE
Add ClearHands and EquipHands macros

### DIFF
--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -502,6 +502,9 @@ namespace ClassicUO.Configuration
 
         public uint SavedMountSerial { get; set; } = 0;
 
+        public uint SavedMainHandSerial { get; set; } = 0;
+        public uint SavedOffHandSerial { get; set; } = 0;
+
         public bool UseModernShopGump { get; set; } = false;
 
         public int MaxJournalEntries { get; set; } = 250;

--- a/src/ClassicUO.Client/Game/Managers/MacroManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/MacroManager.cs
@@ -1168,6 +1168,66 @@ namespace ClassicUO.Game.Managers
                     });
                     break;
 
+                case MacroType.ClearHands:
+                    var layersToClear = new List<Layer>();
+                    var mainHand = _world.Player.FindItemByLayer(Layer.OneHanded);
+                    var offHand = _world.Player.FindItemByLayer(Layer.TwoHanded);
+
+                    if (mainHand != null)
+                    {
+                        ProfileManager.CurrentProfile.SavedMainHandSerial = mainHand.Serial;
+                        layersToClear.Add(Layer.OneHanded);
+                    }
+                    else
+                    {
+                        ProfileManager.CurrentProfile.SavedMainHandSerial = 0;
+                    }
+
+                    if (offHand != null)
+                    {
+                        ProfileManager.CurrentProfile.SavedOffHandSerial = offHand.Serial;
+                        layersToClear.Add(Layer.TwoHanded);
+                    }
+                    else
+                    {
+                        ProfileManager.CurrentProfile.SavedOffHandSerial = 0;
+                    }
+
+                    if (layersToClear.Count > 0)
+                    {
+                        AsyncNetClient.Socket.Send_UnequipMacroKR(layersToClear.ToArray().AsSpan());
+                    }
+
+                    break;
+
+                case MacroType.EquipHands:
+                    var itemsToEquip = new List<uint>();
+
+                    if (ProfileManager.CurrentProfile.SavedMainHandSerial != 0)
+                    {
+                        var mainHandItem = _world.Items.Get(ProfileManager.CurrentProfile.SavedMainHandSerial);
+                        if (mainHandItem != null && mainHandItem.Container != _world.Player?.Serial)
+                        {
+                            itemsToEquip.Add(mainHandItem.Serial);
+                        }
+                    }
+
+                    if (ProfileManager.CurrentProfile.SavedOffHandSerial != 0)
+                    {
+                        var offHandItem = _world.Items.Get(ProfileManager.CurrentProfile.SavedOffHandSerial);
+                        if (offHandItem != null && offHandItem.Container != _world.Player?.Serial)
+                        {
+                            itemsToEquip.Add(offHandItem.Serial);
+                        }
+                    }
+
+                    if (itemsToEquip.Count > 0)
+                    {
+                        AsyncNetClient.Socket.Send_EquipMacroKR(itemsToEquip.ToArray().AsSpan());
+                    }
+
+                    break;
+
                 case MacroType.OpenDoor:
                     GameActions.OpenDoor();
 
@@ -2760,6 +2820,8 @@ namespace ClassicUO.Game.Managers
         RemoveFriend,
         ToggleHotkeys,
         ToggleMount,
+        ClearHands,
+        EquipHands,
     }
 
     public enum MacroSubType


### PR DESCRIPTION
## Summary
Implements two new macro types for quick hand equipment management:
- **ClearHands**: Unequips main and off-hand items, saving their serials to the profile
- **EquipHands**: Re-equips previously saved hand items (fails silently if none saved)

## Changes
- Added `SavedMainHandSerial` and `SavedOffHandSerial` properties to `Profile` class
- Added `ClearHands` and `EquipHands` to `MacroType` enum (appended at end to preserve existing macro compatibility)
- Implemented macro logic using KR equip/unequip packets (following DressAgent pattern)

## Implementation Details
- Uses efficient KR packet system (`Send_EquipMacroKR` and `Send_UnequipMacroKR`)
- Handles both Layer.OneHanded and Layer.TwoHanded
- Saves serials to profile for persistence across sessions
- EquipHands validates items still exist and aren't already equipped

## Test Plan
- [x] Verify ClearHands unequips both hand slots and saves serials
- [x] Verify EquipHands re-equips saved items correctly
- [x] Verify EquipHands fails silently when no items are saved
- [x] Verify saved serials persist across game sessions
- [x] Verify macros work with various weapon types (1H, 2H, dual-wield)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Clear Hands” macro to quickly unequip items from main and/or off-hand, simplifying inventory management.
  * Added “Equip Hands” macro to re-equip previously used main and off-hand items with one action, speeding recovery after swaps.
  * Profiles now remember last equipped main/off-hand items, enabling seamless re-equipping across sessions and reducing repetitive setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->