### PR TITLE
Add null/empty check for gump layout before creation

### DIFF
--- a/src/ClassicUO.Client/Network/PacketHandlers.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers.cs
@@ -5681,6 +5681,12 @@ sealed class PacketHandlers
                 }
             }
 
+            if (string.IsNullOrEmpty(layout))
+            {
+                Log.Error("Gump layout is null or empty. Unable to create gump.");
+                return;
+            }
+
             CreateGump(world, sender, gumpID, (int)x, (int)y, layout, lines);
         }
         catch (Exception e)


### PR DESCRIPTION
## Summary
- Add validation to ensure gump layout string is not null or empty before calling CreateGump
- Prevent potential crashes from malformed gump packets with invalid layout data
- Log error message when invalid layout is detected

## Test plan
- [x] Code compiles successfully
- [ ] Test with various gump packets to ensure validation works correctly
- [ ] Verify error logging occurs for malformed packets
- [ ] Confirm no regressions with normal gump creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents errors or crashes when opening certain compressed UI windows with missing or invalid layout data by validating input and safely skipping creation.
  * Improves robustness of UI loading with early checks on decompressed data to avoid unexpected failures.
  * Adds clear error logging when invalid layout data is encountered to aid diagnosis and stability.
  * Enhances overall reliability when interacting with compressed UI elements that may contain incomplete or malformed data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->