### PR TITLE
Fixed layering for parrot graphic (0xA2CA) on ServUO

### DIFF
--- a/src/ClassicUO.Client/Game/GameObjects/Views/MobileView.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Views/MobileView.cs
@@ -1223,7 +1223,8 @@ namespace ClassicUO.Game.GameObjects
                             && robe.Graphic != 0x9985
                             && robe.Graphic != 0x9986
                             && robe.Graphic != 0xA412
-                            && robe.Graphic != 0xA2CB;
+                            && robe.Graphic != 0xA2CB
+                            && robe.Graphic != 0xA2CA;
                     }
 
                     break;
@@ -1238,6 +1239,7 @@ namespace ClassicUO.Game.GameObjects
                         && robe.Graphic != 0x9986
                         && robe.Graphic != 0xA412
                         && robe.Graphic != 0xA2CB
+                        && robe.Graphic != 0xA2CA
                     )
                     {
                         return true;
@@ -1270,7 +1272,8 @@ namespace ClassicUO.Game.GameObjects
                         && robe.Graphic != 0x9985
                         && robe.Graphic != 0x9986
                         && robe.Graphic != 0xA412
-                        && robe.Graphic != 0xA2CB;
+                        && robe.Graphic != 0xA2CB
+                        && robe.Graphic != 0xA2CA;
 
                 case Layer.Helmet:
                 case Layer.Hair:

--- a/src/ClassicUO.Client/Game/UI/Controls/PaperDollInteractable.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/PaperDollInteractable.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: BSD-2-Clause
+// SPDX-License-Identifier: BSD-2-Clause
 
 using System.Collections.Generic;
 using ClassicUO.Assets;
@@ -233,7 +233,7 @@ namespace ClassicUO.Game.UI.Controls
 
             if (equipItem != null)
             {
-                if (robe != null && robe.Graphic == 0xA2CB) // parrot
+                if (robe != null && (robe.Graphic == 0xA2CB || robe.Graphic != 0xA2CA)) // parrot
                 {
                     layers = _layerOrder_parrot_fix;
                 }

--- a/src/ClassicUO.Client/Game/UI/Controls/PaperDollInteractable.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/PaperDollInteractable.cs
@@ -233,7 +233,7 @@ namespace ClassicUO.Game.UI.Controls
 
             if (equipItem != null)
             {
-                if (robe != null && (robe.Graphic == 0xA2CB || robe.Graphic != 0xA2CA)) // parrot
+                if (robe != null && (robe.Graphic == 0xA2CB || robe.Graphic == 0xA2CA)) // parrot
                 {
                     layers = _layerOrder_parrot_fix;
                 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected equipment coverage detection for specific robe variants so tunic, torso, and arms items are no longer incorrectly marked as covered.
  * Adjusted paperdoll layer ordering so parrots display correctly when worn with those robes.
  * Harmonized behavior across robe variants to reduce visual glitches and mismatches in character views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->