### PR TITLE
Restore ability to get/set gump.CanCloseWithRightClick

### DIFF
--- a/src/ClassicUO.Client/LegionScripting/PyClasses/PyBaseGump.cs
+++ b/src/ClassicUO.Client/LegionScripting/PyClasses/PyBaseGump.cs
@@ -43,6 +43,27 @@ public class PyBaseGump(Gump gump) : PyBaseControl(gump), IPyGump
     }
 
     /// <summary>
+    /// Gets or Sets the ability to close the gump with a right click
+    /// </summary>
+    public bool CanCloseWithRightClick
+    {
+        get
+        {
+            if (!VerifyIntegrity())
+                return false;
+
+            return MainThreadQueue.InvokeOnMainThread(() => Gump.CanCloseWithRightClick);
+        }
+        set
+        {
+            if (!VerifyIntegrity())
+                return;
+
+            MainThreadQueue.EnqueueAction(() => Gump.CanCloseWithRightClick = value);
+        }
+    }
+
+    /// <summary>
     /// Gets the underlying Gump instance that this wrapper represents.
     /// Used internally by the scripting system to access the actual game object.
     /// </summary>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability for UI windows (gumps) to be closed with a right-click when enabled.
  * Exposed a scripting option to get and set the right-click-to-close behavior per gump, allowing finer control in custom scripts.
  * Improves usability for quick dismissal of windows; default behavior remains unchanged unless explicitly enabled by scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->