### PR TITLE
Fix NullReferenceException in StopScript for Python scripts

### DIFF
--- a/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
@@ -523,9 +523,15 @@ namespace ClassicUO.LegionScripting
                 {
                     if (script.PythonThread is { IsAlive: true })
                     {
-                        script.scopedAPI.StopRequested = true;
-                        script.scopedAPI.CancellationToken.Cancel();
-                        script.pythonEngine.Runtime.Shutdown();
+                        if (script.scopedAPI != null)
+                        {
+                            script.scopedAPI.StopRequested = true;
+                            script.scopedAPI.CancellationToken.Cancel();
+                        }
+
+                        if (script.pythonEngine != null)
+                            script.pythonEngine.Runtime.Shutdown();
+
                         script.PythonThread.Interrupt();
                     }
                     else


### PR DESCRIPTION
## Summary
- Fixed NullReferenceException crash when stopping Python scripts
- Added null checks for `scopedAPI` and `pythonEngine` before accessing them in the `StopScript` method
- Prevents crashes when stopping Python scripts that may not have these objects properly initialized

## Changes
- Modified `src/ClassicUO.Client/LegionScripting/LegionScripting.cs:521-543`
- Added null check for `script.scopedAPI` before accessing `StopRequested` and `CancellationToken.Cancel()`
- Added null check for `script.pythonEngine` before calling `Runtime.Shutdown()`

## Issue
Fixes the crash reported in the stack trace:
```
System.NullReferenceException: Arg_NullReferenceException
   at ClassicUO.LegionScripting.LegionScripting.StopScript(ScriptFile script) in D:\a\TazUO\TazUO\src\ClassicUO.Client\LegionScripting\LegionScripting.cs:line 525
   at ClassicUO.LegionScripting.LegionScripting.<>c__DisplayClass17_0.<Init>b__2(String[] a) in D:\a\TazUO\TazUO\src\ClassicUO.Client\LegionScripting\LegionScripting.cs:line 131
```

## Test plan
- [x] Build succeeds with no compilation errors
- [ ] Test stopping Python scripts via the togglelscript command
- [ ] Test stopping Python scripts that fail during initialization
- [ ] Verify no regressions in script stopping functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when stopping Python scripts by adding safety checks to prevent potential crashes.

* **Documentation**
  * Updated API documentation timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->