### PR TITLE
feat: SpellVisualRangeManager rework to take into account FC and FCR and show a recovery progress bar

### DIFF
--- a/src/ClassicUO.Client/Game/GameObjects/PlayerMobile.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/PlayerMobile.cs
@@ -38,8 +38,8 @@ namespace ClassicUO.Game.GameObjects
                 }
             };
 
-            if(ProfileManager.CurrentProfile != null && ProfileManager.CurrentProfile.EnableSpellIndicators)
-                UIManager.Add(new SpellVisualRangeManager.CastTimerProgressBar(world));
+            if (ProfileManager.CurrentProfile != null && ProfileManager.CurrentProfile.EnableSpellIndicators)
+                UIManager.Add(new CastTimerProgressBar(world));
 
             IsPlayer = true;
         }
@@ -121,6 +121,7 @@ namespace ClassicUO.Game.GameObjects
         public uint TithingPoints;
         public ushort Weight;
         public ushort WeightMax;
+        public bool IsCasting;
 
         public Item FindBandage(ushort graphic = 0x0E21)
         {
@@ -136,6 +137,24 @@ namespace ClassicUO.Game.GameObjects
                 item = FindItemByLayer(Layer.Waist)?.FindItem(graphic);
 
             return item;
+        }
+
+        public void AttachCastingEventHandlers()
+        {
+            EventSink.SpellCastBegin += OnSpellCastBegin;
+            EventSink.SpellCastEnd += OnSpellCastEnd;
+        }
+
+        private void OnSpellCastBegin(object sender, int spellID)
+        {
+            if (World?.Player == this)
+                IsCasting = true; Log.Debug("IsCasting");
+        }
+
+        private void OnSpellCastEnd(object sender, int spellID)
+        {
+            if (World?.Player == this)
+                IsCasting = false;
         }
 
         public Item FindItemByGraphic(ushort graphic)
@@ -566,7 +585,7 @@ namespace ClassicUO.Game.GameObjects
         //}
         // #############################################
 
-         public bool Walk(Direction direction, bool run)
+        public bool Walk(Direction direction, bool run)
         {
             if (!ProfileManager.CurrentProfile.AutoAvoidObstacules || Pathfinder.AutoWalking)
             {
@@ -806,7 +825,7 @@ namespace ClassicUO.Game.GameObjects
                 x = walkStep.X;
                 y = walkStep.Y;
                 z = walkStep.Z;
-                oldDirection = (Direction) walkStep.Direction;
+                oldDirection = (Direction)walkStep.Direction;
             }
 
             sbyte oldZ = z;
@@ -835,7 +854,7 @@ namespace ClassicUO.Game.GameObjects
                     y = newY;
                     z = newZ;
 
-                    walkTime = (ushort) MovementSpeed.TimeToCompleteMovement(run, IsMounted || SpeedMode == CharacterSpeedType.FastUnmount || SpeedMode == CharacterSpeedType.FastUnmountAndCantRun || IsFlying);
+                    walkTime = (ushort)MovementSpeed.TimeToCompleteMovement(run, IsMounted || SpeedMode == CharacterSpeedType.FastUnmount || SpeedMode == CharacterSpeedType.FastUnmountAndCantRun || IsFlying);
                 }
             }
             else
@@ -859,7 +878,7 @@ namespace ClassicUO.Game.GameObjects
                     y = newY;
                     z = newZ;
 
-                    walkTime = (ushort) MovementSpeed.TimeToCompleteMovement(run, IsMounted || SpeedMode == CharacterSpeedType.FastUnmount || SpeedMode == CharacterSpeedType.FastUnmountAndCantRun || IsFlying);
+                    walkTime = (ushort)MovementSpeed.TimeToCompleteMovement(run, IsMounted || SpeedMode == CharacterSpeedType.FastUnmount || SpeedMode == CharacterSpeedType.FastUnmountAndCantRun || IsFlying);
                 }
 
                 direction = newDir;
@@ -881,13 +900,13 @@ namespace ClassicUO.Game.GameObjects
             step.Sequence = Walker.WalkSequence;
             step.Accepted = false;
             step.Running = run;
-            step.OldDirection = (byte) (oldDirection & Direction.Mask);
-            step.Direction = (byte) direction;
+            step.OldDirection = (byte)(oldDirection & Direction.Mask);
+            step.Direction = (byte)direction;
             step.Timer = Time.Ticks;
-            step.X = (ushort) x;
-            step.Y = (ushort) y;
+            step.X = (ushort)x;
+            step.Y = (ushort)y;
             step.Z = z;
-            step.NoRotation = step.OldDirection == (byte) direction && oldZ - z >= 11;
+            step.NoRotation = step.OldDirection == (byte)direction && oldZ - z >= 11;
 
             Walker.StepsCount++;
 
@@ -898,7 +917,7 @@ namespace ClassicUO.Game.GameObjects
                     X = x,
                     Y = y,
                     Z = z,
-                    Direction = (byte) direction,
+                    Direction = (byte)direction,
                     Run = run
                 }
             );

--- a/src/ClassicUO.Client/Game/GameObjects/PlayerMobile.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/PlayerMobile.cs
@@ -10,6 +10,7 @@ using ClassicUO.Network;
 using ClassicUO.Utility;
 using ClassicUO.Utility.Logging;
 using ClassicUO.Assets;
+using ClassicUO.Game.Managers.SpellVisualRange;
 
 namespace ClassicUO.Game.GameObjects
 {
@@ -19,6 +20,7 @@ namespace ClassicUO.Game.GameObjects
 
         public PlayerMobile(World world, uint serial) : base(world, serial)
         {
+            AttachCastingEventHandlers();
             Skills = new Skill[Client.Game.UO.FileManager.Skills.SkillsCount];
 
             for (int i = 0; i < Skills.Length; i++)
@@ -121,7 +123,7 @@ namespace ClassicUO.Game.GameObjects
         public uint TithingPoints;
         public ushort Weight;
         public ushort WeightMax;
-        public bool IsCasting;
+        public bool IsCasting { get; private set; }
 
         public Item FindBandage(ushort graphic = 0x0E21)
         {
@@ -145,16 +147,26 @@ namespace ClassicUO.Game.GameObjects
             EventSink.SpellCastEnd += OnSpellCastEnd;
         }
 
+        public void DetachCastingEventHandlers()
+        {
+            EventSink.SpellCastBegin -= OnSpellCastBegin;
+            EventSink.SpellCastEnd -= OnSpellCastEnd;
+        }
+
         private void OnSpellCastBegin(object sender, int spellID)
         {
             if (World?.Player == this)
-                IsCasting = true; Log.Debug("IsCasting");
+            {
+                IsCasting = true;
+            }
         }
 
         private void OnSpellCastEnd(object sender, int spellID)
         {
             if (World?.Player == this)
+            {
                 IsCasting = false;
+            }
         }
 
         public Item FindItemByGraphic(ushort graphic)
@@ -399,6 +411,7 @@ namespace ClassicUO.Game.GameObjects
             }
 
             DeathScreenTimer = 0;
+            DetachCastingEventHandlers();
 
             Log.Warn("PlayerMobile disposed!");
             base.Destroy();

--- a/src/ClassicUO.Client/Game/Managers/EventSink.cs
+++ b/src/ClassicUO.Client/Game/Managers/EventSink.cs
@@ -148,6 +148,9 @@ namespace ClassicUO.Game.Managers
         /// </summary>
         public static event EventHandler<int> SpellCastBegin;
         public static void InvokeSpellCastBegin(int spell) => SpellCastBegin?.Invoke(null, spell);
+        public static event EventHandler<int> SpellCastEnd;
+        public static void InvokeSpellCastEnd(int spell) => SpellCastEnd?.Invoke(null, spell);
+
     }
 
     public class OPLEventArgs : EventArgs

--- a/src/ClassicUO.Client/Game/Managers/SpellVisualRange/CastTimerProgressBar.cs
+++ b/src/ClassicUO.Client/Game/Managers/SpellVisualRange/CastTimerProgressBar.cs
@@ -40,9 +40,12 @@ public class CastTimerProgressBar : Gump
     /// </summary>
     public void OnSpellCastBegin()
     {
-        phaseStartTime = DateTime.Now;
-        inCastingPhase = true;
-        IsVisible = true;
+        MainThreadQueue.InvokeOnMainThread(() =>
+        {
+            phaseStartTime = DateTime.Now;
+            inCastingPhase = true;
+            IsVisible = true;
+        });
     }
 
     public override bool Draw(UltimaBatcher2D batcher, int x, int y)
@@ -63,6 +66,11 @@ public class CastTimerProgressBar : Gump
         IsVisible = true;
 
         double totalTime = inCastingPhase ? spell.GetEffectiveCastTime() : spell.GetEffectiveRecoveryTime();
+        if (totalTime <= 0)
+        {
+            if (!inCastingPhase) IsVisible = false;
+            return false;
+        }
         double elapsed = (DateTime.Now - phaseStartTime).TotalSeconds;
         double percent = Math.Min(elapsed / totalTime, 1.0);
 
@@ -86,11 +94,14 @@ public class CastTimerProgressBar : Gump
     /// Initiates the recovery phase progress visualization after a spell cast completes.
     /// </summary>
     /// <param name="spell">The spell that just finished casting.</param>
-    public void OnRecoveryBegin(SpellRangeInfo spell)
+    public void OnRecoveryBegin()
     {
-        phaseStartTime = DateTime.Now;
-        inCastingPhase = false;
-        IsVisible = true;
+        MainThreadQueue.InvokeOnMainThread(() =>
+        {
+            phaseStartTime = DateTime.Now;
+            inCastingPhase = false;
+            IsVisible = true;
+        });
     }
 
     private void DrawProgressBar(UltimaBatcher2D batcher, int x, int y, double percent, Vector3 fillHue)

--- a/src/ClassicUO.Client/Game/Managers/SpellVisualRange/CastTimerProgressBar.cs
+++ b/src/ClassicUO.Client/Game/Managers/SpellVisualRange/CastTimerProgressBar.cs
@@ -35,6 +35,9 @@ public class CastTimerProgressBar : Gump
         IsVisible = false;
     }
 
+    /// <summary>
+    /// Initiates the casting phase progress visualization.
+    /// </summary>
     public void OnSpellCastBegin()
     {
         phaseStartTime = DateTime.Now;
@@ -79,6 +82,10 @@ public class CastTimerProgressBar : Gump
         return base.Draw(batcher, x, y);
     }
 
+    /// <summary>
+    /// Initiates the recovery phase progress visualization after a spell cast completes.
+    /// </summary>
+    /// <param name="spell">The spell that just finished casting.</param>
     public void OnRecoveryBegin(SpellRangeInfo spell)
     {
         phaseStartTime = DateTime.Now;

--- a/src/ClassicUO.Client/Game/Managers/SpellVisualRange/CastTimerProgressBar.cs
+++ b/src/ClassicUO.Client/Game/Managers/SpellVisualRange/CastTimerProgressBar.cs
@@ -1,0 +1,115 @@
+using ClassicUO;
+using ClassicUO.Game;
+using ClassicUO.Game.GameObjects;
+using ClassicUO.Game.Managers;
+using ClassicUO.Game.UI.Gumps;
+using ClassicUO.Renderer;
+using ClassicUO.Utility.Logging;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using System;
+using static ClassicUO.Game.Managers.SpellVisualRangeManager;
+
+public class CastTimerProgressBar : Gump
+{
+    private Rectangle barBounds, barBoundsF;
+    private Texture2D background;
+    private Texture2D foreground;
+    private bool inCastingPhase = true;
+    private DateTime phaseStartTime;
+
+    public CastTimerProgressBar(World world) : base(world, 0, 0)
+    {
+        CanMove = false;
+        AcceptMouseInput = false;
+        CanCloseWithEsc = false;
+        CanCloseWithRightClick = false;
+
+        ref readonly var gi = ref Client.Game.UO.Gumps.GetGump(0x0805);
+        background = gi.Texture;
+        barBounds = gi.UV;
+
+        gi = ref Client.Game.UO.Gumps.GetGump(0x0806);
+        foreground = gi.Texture;
+        barBoundsF = gi.UV;
+
+        inCastingPhase = false;
+        IsVisible = false;
+    }
+
+    public void OnSpellCastBegin()
+    {
+        phaseStartTime = DateTime.Now;
+        inCastingPhase = true;
+        IsVisible = true;
+    }
+
+    public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+    {
+        SpellRangeInfo spell = Instance.GetCurrentSpell();
+        if (spell == null)
+        {
+            IsVisible = false;
+            return false;
+        }
+
+        IsVisible = true;
+
+        double totalTime = inCastingPhase ? spell.GetEffectiveCastTime() : spell.GetEffectiveRecoveryTime();
+        double elapsed = (DateTime.Now - phaseStartTime).TotalSeconds;
+        double percent = Math.Min(elapsed / totalTime, 1.0);
+
+        if (percent >= 1.0)
+        {
+            if (!inCastingPhase)
+                IsVisible = false;
+
+            return false;
+        }
+
+        Vector3 drawHue = inCastingPhase
+            ? ShaderHueTranslator.GetHueVector(0x005F)
+            : ShaderHueTranslator.GetHueVector(0x0035);
+        DrawProgressBar(batcher, x, y, percent, drawHue);
+
+        return base.Draw(batcher, x, y);
+    }
+
+    public void OnRecoveryBegin(SpellRangeInfo spell)
+    {
+        phaseStartTime = DateTime.Now;
+        inCastingPhase = false;
+        IsVisible = true;
+    }
+
+    private void DrawProgressBar(UltimaBatcher2D batcher, int x, int y, double percent, Vector3 fillHue)
+    {
+        Mobile m = World.Player;
+        Client.Game.UO.Animations.GetAnimationDimensions(
+            m.AnimIndex, m.GetGraphicForAnimation(), 0, 0, m.IsMounted, 0,
+            out int centerX, out int centerY, out int width, out int height
+        );
+
+        WorldViewportGump vp = UIManager.GetGump<WorldViewportGump>();
+        x = vp.Location.X + (int)(m.RealScreenPosition.X - (m.Offset.X + 22 + 5));
+        y = vp.Location.Y + (int)(m.RealScreenPosition.Y - ((m.Offset.Y - m.Offset.Z) - (height + centerY + 15) +
+            (m.IsGargoyle && m.IsFlying ? -22 : !m.IsMounted ? 22 : 0)));
+
+        if (background == null || foreground == null)
+            return;
+
+        Vector3 emptyHue = ShaderHueTranslator.GetHueVector(0x0026);
+        batcher.Draw(background, new Rectangle(x, y, barBounds.Width, barBounds.Height), barBounds, emptyHue);
+
+        int widthFromPercent = (int)(barBounds.Width * percent);
+        if (widthFromPercent > 0)
+        {
+            batcher.DrawTiled(
+                foreground,
+                new Rectangle(x, y, widthFromPercent, barBoundsF.Height),
+                barBoundsF,
+                fillHue
+            );
+        }
+    }
+}

--- a/src/ClassicUO.Client/Game/Managers/SpellVisualRange/CastTimerProgressBar.cs
+++ b/src/ClassicUO.Client/Game/Managers/SpellVisualRange/CastTimerProgressBar.cs
@@ -1,14 +1,12 @@
-using ClassicUO;
-using ClassicUO.Game;
 using ClassicUO.Game.GameObjects;
-using ClassicUO.Game.Managers;
 using ClassicUO.Game.UI.Gumps;
 using ClassicUO.Renderer;
-using ClassicUO.Utility.Logging;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
 using static ClassicUO.Game.Managers.SpellVisualRangeManager;
+
+namespace ClassicUO.Game.Managers.SpellVisualRange;
 
 public class CastTimerProgressBar : Gump
 {
@@ -25,13 +23,13 @@ public class CastTimerProgressBar : Gump
         CanCloseWithEsc = false;
         CanCloseWithRightClick = false;
 
-        ref readonly var gi = ref Client.Game.UO.Gumps.GetGump(0x0805);
-        background = gi.Texture;
-        barBounds = gi.UV;
+        ref readonly var giBg = ref Client.Game.UO.Gumps.GetGump(0x0805);
+        background = giBg.Texture;
+        barBounds = giBg.UV;
 
-        gi = ref Client.Game.UO.Gumps.GetGump(0x0806);
-        foreground = gi.Texture;
-        barBoundsF = gi.UV;
+        ref readonly var giFg = ref Client.Game.UO.Gumps.GetGump(0x0806);
+        foreground = giFg.Texture;
+        barBoundsF = giFg.UV;
 
         inCastingPhase = false;
         IsVisible = false;
@@ -46,6 +44,12 @@ public class CastTimerProgressBar : Gump
 
     public override bool Draw(UltimaBatcher2D batcher, int x, int y)
     {
+        if (World?.Player == null)
+        {
+            IsVisible = false;
+            return false;
+        }
+
         SpellRangeInfo spell = Instance.GetCurrentSpell();
         if (spell == null)
         {
@@ -91,6 +95,9 @@ public class CastTimerProgressBar : Gump
         );
 
         WorldViewportGump vp = UIManager.GetGump<WorldViewportGump>();
+        if (vp == null)
+            return;
+
         x = vp.Location.X + (int)(m.RealScreenPosition.X - (m.Offset.X + 22 + 5));
         y = vp.Location.Y + (int)(m.RealScreenPosition.Y - ((m.Offset.Y - m.Offset.Z) - (height + centerY + 15) +
             (m.IsGargoyle && m.IsFlying ? -22 : !m.IsMounted ? 22 : 0)));

--- a/src/ClassicUO.Client/Game/Managers/SpellVisualRange/CastTimerProgressBar.cs
+++ b/src/ClassicUO.Client/Game/Managers/SpellVisualRange/CastTimerProgressBar.cs
@@ -8,6 +8,9 @@ using static ClassicUO.Game.Managers.SpellVisualRangeManager;
 
 namespace ClassicUO.Game.Managers.SpellVisualRange;
 
+/// <summary>
+/// Displays a progress bar tracking spell casting and recovery phases.
+/// </summary>
 public class CastTimerProgressBar : Gump
 {
     private Rectangle barBounds, barBoundsF;
@@ -16,6 +19,13 @@ public class CastTimerProgressBar : Gump
     private bool inCastingPhase = true;
     private DateTime phaseStartTime;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastTimerProgressBar"/> class.
+    /// Creates a non-interactive cast timer progress bar associated with the specified game world.
+    /// </summary>
+    /// <param name="world">
+    /// The <see cref="World"/> instance representing the current game world context used by this progress bar.
+    /// </param>
     public CastTimerProgressBar(World world) : base(world, 0, 0)
     {
         CanMove = false;

--- a/src/ClassicUO.Client/Game/Managers/SpellVisualRange/SpellRangeInfo.cs
+++ b/src/ClassicUO.Client/Game/Managers/SpellVisualRange/SpellRangeInfo.cs
@@ -1,0 +1,61 @@
+using ClassicUO;
+using ClassicUO.Game;
+using ClassicUO.Game.Data;
+using System;
+using System.Linq;
+
+public class SpellRangeInfo
+{
+    public int ID { get; set; } = -1;
+    public string Name { get; set; } = "";
+    public string PowerWords { get; set; } = "";
+    public int CursorSize { get; set; } = 0;
+    public int CastRange { get; set; } = 1;
+    public ushort Hue { get; set; } = 32;
+    public ushort CursorHue { get; set; } = 10;
+    public int MaxDuration { get; set; } = 10;
+    public bool IsLinear { get; set; } = false;
+    public double CastTime { get; set; } = 0.0;
+    public bool ShowCastRangeDuringCasting { get; set; } = false;
+    public bool FreezeCharacterWhileCasting { get; set; } = false;
+    public bool ExpectTargetCursor { get; set; } = false;
+    public double RecoveryTime { get; set; } = 0.0;
+    public string School { get; set; } = "";
+    public int MaxFasterCasting { get; set; } = 0;
+    public int MaxFasterCastRecovery { get; set; } = 0;
+    public bool? CapChivalryFasterCasting { get; set; } = null;
+
+    private World World;
+
+    public SpellRangeInfo()
+    {
+        World = Client.Game.UO.World;
+    }
+
+    public static SpellRangeInfo FromSpellDef(SpellDefinition spell)
+    {
+        return new SpellRangeInfo() { ID = spell.ID, Name = spell.Name, PowerWords = spell.PowerWords };
+    }
+
+    public double GetEffectiveCastTime()
+    {
+        int maxFasterCasting = MaxFasterCasting;
+        if (School == "Chivalry" && CapChivalryFasterCasting == true)
+        {
+            float mageryValue = World.Player.Skills.FirstOrDefault(x => x.Name == "Magery")?.Value ?? 0;
+            float mysticismValue = World.Player.Skills.FirstOrDefault(x => x.Name == "Mysticism")?.Value ?? 0;
+            maxFasterCasting = mageryValue > 70 || mysticismValue > 70 ? 2 : 4;
+        }
+
+        int fasterCasting = Math.Min(World.Player.FasterCasting, maxFasterCasting);
+        double time = CastTime - (0.25 * fasterCasting);
+        return time < 0.25 ? 0.25 : time;
+    }
+
+    public double GetEffectiveRecoveryTime()
+    {
+        int fasterCastRecovery = Math.Min(World.Player.FasterCastRecovery, MaxFasterCastRecovery);
+        double time = RecoveryTime - (0.25 * fasterCastRecovery);
+        return time < 0 ? 0 : time;
+    }
+}

--- a/src/ClassicUO.Client/Game/Managers/SpellVisualRange/SpellRangeInfo.cs
+++ b/src/ClassicUO.Client/Game/Managers/SpellVisualRange/SpellRangeInfo.cs
@@ -1,8 +1,8 @@
-using ClassicUO;
-using ClassicUO.Game;
 using ClassicUO.Game.Data;
 using System;
 using System.Linq;
+
+namespace ClassicUO.Game.Managers.SpellVisualRange;
 
 public class SpellRangeInfo
 {

--- a/src/ClassicUO.Client/Game/Managers/SpellVisualRange/SpellRangeInfo.cs
+++ b/src/ClassicUO.Client/Game/Managers/SpellVisualRange/SpellRangeInfo.cs
@@ -4,6 +4,9 @@ using System.Linq;
 
 namespace ClassicUO.Game.Managers.SpellVisualRange;
 
+/// <summary>
+/// Encapsulates spell range, cast time, recovery time, and visual indicator configuration for a spell.
+/// </summary>
 public class SpellRangeInfo
 {
     public int ID { get; set; } = -1;
@@ -37,6 +40,11 @@ public class SpellRangeInfo
         return new SpellRangeInfo() { ID = spell.ID, Name = spell.Name, PowerWords = spell.PowerWords };
     }
 
+    /// <summary>
+    /// Calculates the effective cast time for this spell, accounting for the player's Faster Casting stat
+    /// and any school-specific caps (e.g., Chivalry with Magery/Mysticism requirements).
+    /// </summary>
+    /// <returns>The effective cast time in seconds, with a minimum of 0.25 seconds.</returns>
     public double GetEffectiveCastTime()
     {
         int maxFasterCasting = MaxFasterCasting;
@@ -52,6 +60,10 @@ public class SpellRangeInfo
         return time < 0.25 ? 0.25 : time;
     }
 
+    /// <summary>
+    /// Calculates the effective recovery time for this spell, accounting for the player's Faster Cast Recovery stat.
+    /// </summary>
+    /// <returns>The effective recovery time in seconds, with a minimum of 0 seconds.</returns>
     public double GetEffectiveRecoveryTime()
     {
         int fasterCastRecovery = Math.Min(World.Player.FasterCastRecovery, MaxFasterCastRecovery);

--- a/src/ClassicUO.Client/Game/Managers/SpellVisualRange/SpellVisualRangeManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/SpellVisualRange/SpellVisualRangeManager.cs
@@ -1,16 +1,12 @@
 ﻿using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.GameObjects;
-using ClassicUO.Game.UI.Gumps;
-using ClassicUO.Renderer;
 using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
-using System.Threading;
 using System.Threading.Tasks;
 using Timer = System.Timers.Timer;
 
@@ -19,8 +15,8 @@ namespace ClassicUO.Game.Managers
     using System.Text.Json.Serialization;
     using ClassicUO.Utility.Logging;
 
-    [JsonSerializable(typeof(SpellVisualRangeManager.SpellRangeInfo))]
-    [JsonSerializable(typeof(SpellVisualRangeManager.SpellRangeInfo[]))]
+    [JsonSerializable(typeof(SpellRangeInfo))]
+    [JsonSerializable(typeof(SpellRangeInfo[]))]
     public partial class SpellVisualRangeJsonContext : JsonSerializerContext
     {
     }
@@ -64,7 +60,7 @@ namespace ClassicUO.Game.Managers
 
         private SpellVisualRangeManager()
         {
-            this.World = Client.Game.UO.World;
+            World = Client.Game.UO.World;
             Load();
         }
 
@@ -75,9 +71,7 @@ namespace ClassicUO.Game.Managers
                 if (loaded && e.Parent != null && ReferenceEquals(e.Parent, World.Player))
                 {
                     if (spellRangePowerWordCache.TryGetValue(e.Text.Trim(), out SpellRangeInfo spell))
-                    {
                         SetCasting(spell);
-                    }
                 }
             });
         }
@@ -87,9 +81,7 @@ namespace ClassicUO.Game.Managers
             Task.Factory.StartNew(() =>
             {
                 if (isCasting && stopAtClilocs.Contains(cliloc))
-                {
                     ClearCasting();
-                }
             });
         }
 
@@ -98,19 +90,64 @@ namespace ClassicUO.Game.Managers
             LastSpellTime = DateTime.Now;
             currentSpell = spell;
             isCasting = true;
+
             if (currentSpell != null && currentSpell.FreezeCharacterWhileCasting)
-            {
                 World.Player.Flags |= Flags.Frozen;
-            }
+
+            var bar = UIManager.GetGump<CastTimerProgressBar>();
+            bar?.OnSpellCastBegin();
+
             EventSink.InvokeSpellCastBegin(spell.ID);
+
+            double castTime = spell.GetEffectiveCastTime();
+            Task.Run(async () =>
+            {
+                await Task.Delay(TimeSpan.FromSeconds(castTime));
+
+                if (isCasting && currentSpell == spell)
+                {
+                    if (spell.ExpectTargetCursor && World.TargetManager.IsTargeting)
+                        return;
+
+                    ClearCasting();
+                }
+            });
         }
 
         public void ClearCasting()
         {
-            isCasting = false;
+            if (currentSpell == null)
+                return;
+
+            if (currentSpell.RecoveryTime > 0)
+            {
+                StartRecovery(currentSpell);
+            }
+            else
+            {
+                EndRecovery(currentSpell);
+            }
+        }
+
+        private async void StartRecovery(SpellRangeInfo spell)
+        {
+            CastTimerProgressBar bar = UIManager.GetGump<CastTimerProgressBar>() ?? new CastTimerProgressBar(World);
+            if (bar.Parent == null)
+                UIManager.Add(bar);
+
+            bar.OnRecoveryBegin(spell);
+
+            double recTime = spell.GetEffectiveRecoveryTime();
+            await Task.Delay(TimeSpan.FromSeconds(recTime));
+            EndRecovery(spell);
+        }
+
+        private void EndRecovery(SpellRangeInfo spell)
+        {
             currentSpell = null;
-            LastSpellTime = DateTime.MinValue;
+            isCasting = false;
             World.Player.Flags &= ~Flags.Frozen;
+            EventSink.InvokeSpellCastEnd(currentSpell?.ID ?? 0);
         }
 
         public SpellRangeInfo GetCurrentSpell()
@@ -134,16 +171,12 @@ namespace ClassicUO.Game.Managers
         public bool IsTargetingAfterCasting()
         {
             if (!loaded || currentSpell == null || !isCasting || ProfileManager.CurrentProfile == null || !ProfileManager.CurrentProfile.EnableSpellIndicators)
-            {
                 return false;
-            }
 
             if (World.TargetManager.IsTargeting || (currentSpell.ShowCastRangeDuringCasting && IsCastingWithoutTarget()))
             {
                 if (LastSpellTime + TimeSpan.FromSeconds(currentSpell.MaxDuration) > DateTime.Now)
-                {
                     return true;
-                }
             }
 
             return false;
@@ -152,9 +185,7 @@ namespace ClassicUO.Game.Managers
         public bool IsCastingWithoutTarget()
         {
             if (!loaded || currentSpell == null || !isCasting || currentSpell.CastTime <= 0 || World.TargetManager.IsTargeting || ProfileManager.CurrentProfile == null || !ProfileManager.CurrentProfile.EnableSpellIndicators)
-            {
                 return false;
-            }
 
             if (LastSpellTime + TimeSpan.FromSeconds(currentSpell.MaxDuration) > DateTime.Now)
             {
@@ -177,12 +208,11 @@ namespace ClassicUO.Game.Managers
 
         public ushort ProcessHueForTile(ushort hue, GameObject o)
         {
-            if (!loaded || currentSpell == null) { return hue; }
+            if (!loaded || currentSpell == null)
+                return hue;
 
             if (currentSpell.CastRange > 0 && o.Distance <= currentSpell.CastRange)
-            {
                 hue = currentSpell.Hue;
-            }
 
             int cDistance = o.DistanceFrom(LastCursorTileLoc);
 
@@ -193,16 +223,12 @@ namespace ClassicUO.Game.Managers
                     if (GetDirection(new Vector2(World.Player.X, World.Player.Y), LastCursorTileLoc) == SpellDirection.EastWest)
                     { //X
                         if (o.Y == LastCursorTileLoc.Y)
-                        {
                             hue = currentSpell.CursorHue;
-                        }
                     }
                     else
                     { //Y
                         if (o.X == LastCursorTileLoc.X)
-                        {
                             hue = currentSpell.CursorHue;
-                        }
                     }
                 }
                 else
@@ -250,28 +276,33 @@ namespace ClassicUO.Game.Managers
             {
                 if (!File.Exists(savePath))
                 {
-                    //CreateAndLoadDataFile();
-                    var assembly = GetType().Assembly;
-
-                    var resourceName = "ClassicUO.Game.Managers.DefaultSpellIndicatorConfig.json";
+                    string defaultFilePath = Path.Combine(CUOEnviroment.ExecutablePath ?? "", "Data", "DefaultSpellIndicatorConfig.json");
 
                     try
                     {
-                        using Stream stream = assembly.GetManifestResourceStream(resourceName);
+                        if (File.Exists(defaultFilePath))
+                        {
+                            string json = File.ReadAllText(defaultFilePath);
+                            LoadFromString(json);
+                            Log.Trace($"Loaded default spell indicator config from {defaultFilePath}");
+                        }
+                        else
+                        {
+                            Log.Error($"Default spell indicator config not found at {defaultFilePath}");
+                            CreateAndLoadDataFile();
+                        }
 
-                        using StreamReader reader = new StreamReader(stream);
-
-                        LoadFromString(reader.ReadToEnd());
+                        AfterLoad();
+                        loaded = true;
+                        Save();
                     }
                     catch (Exception e)
                     {
-                        Log.Error(e.ToString());
+                        Log.Error($"Failed to load default spell indicator config: {e}");
                         CreateAndLoadDataFile();
+                        AfterLoad();
+                        loaded = true;
                     }
-
-                    AfterLoad();
-                    loaded = true;
-                    Save();
                 }
                 else
                 {
@@ -279,21 +310,19 @@ namespace ClassicUO.Game.Managers
                     {
                         string data = File.ReadAllText(savePath);
                         SpellRangeInfo[] fileData = JsonSerializer.Deserialize(data, SpellVisualRangeJsonContext.Default.SpellRangeInfoArray);
-
                         foreach (var entry in fileData)
-                        {
-                            spellRangeCache.Add(entry.ID, entry);
-                        }
+                            spellRangeCache[entry.ID] = entry;
+
                         AfterLoad();
                         loaded = true;
                     }
-                    catch
+                    catch (Exception e)
                     {
+                        Log.Error($"Failed to load profile spell range file: {e}");
                         CreateAndLoadDataFile();
                         AfterLoad();
                         loaded = true;
                     }
-
                 }
             });
         }
@@ -320,14 +349,10 @@ namespace ClassicUO.Game.Managers
                         {
                             SpellDefinition spellD = SpellDefinition.FullIndexGetSpell(entry.ID);
                             if (spellD == SpellDefinition.EmptySpell)
-                            {
                                 SpellDefinition.TryGetSpellFromName(entry.Name, out spellD);
-                            }
 
                             if (spellD != SpellDefinition.EmptySpell)
-                            {
                                 entry.PowerWords = spellD.PowerWords;
-                            }
                         }
                         if (!string.IsNullOrEmpty(entry.PowerWords))
                         {
@@ -365,6 +390,7 @@ namespace ClassicUO.Game.Managers
                 AfterLoad();
                 LoadOverrides();
                 loaded = true;
+
                 return true;
             }
             catch (Exception ex)
@@ -448,12 +474,11 @@ namespace ClassicUO.Game.Managers
             {
                 hasPendingChanges = true;
 
-                // Cancel existing timer if it's running
                 saveTimer?.Dispose();
 
                 saveTimer = new Timer();
                 saveTimer.Interval = 500;
-                saveTimer.Elapsed += (_,_) => { PerformSave(); };
+                saveTimer.Elapsed += (_, _) => { PerformSave(); };
                 saveTimer.Start();
             }
         }
@@ -508,109 +533,5 @@ namespace ClassicUO.Game.Managers
             EastWest,
             SouthNorth
         }
-
-        public class SpellRangeInfo
-        {
-            public int ID { get; set; } = -1;
-            public string Name { get; set; } = "";
-            public string PowerWords { get; set; } = "";
-            public int CursorSize { get; set; } = 0;
-            public int CastRange { get; set; } = 1;
-            public ushort Hue { get; set; } = 32;
-            public ushort CursorHue { get; set; } = 10;
-            public int MaxDuration { get; set; } = 10;
-            public bool IsLinear { get; set; } = false;
-            public double CastTime { get; set; } = 0.0;
-            public bool ShowCastRangeDuringCasting { get; set; } = false;
-            public bool FreezeCharacterWhileCasting { get; set; } = false;
-            public bool ExpectTargetCursor { get; set; } = false;
-
-            public static SpellRangeInfo FromSpellDef(SpellDefinition spell)
-            {
-                return new SpellRangeInfo() { ID = spell.ID, Name = spell.Name, PowerWords = spell.PowerWords };
-            }
-        }
-
-        #region Cast Timer Bar
-
-
-        public class CastTimerProgressBar : Gump
-        {
-            private Rectangle barBounds, barBoundsF;
-            private Texture2D background;
-            private Texture2D foreground;
-            private Vector3 hue = ShaderHueTranslator.GetHueVector(0);
-
-
-            public CastTimerProgressBar(World world) : base(world, 0, 0)
-            {
-                CanMove = false;
-                AcceptMouseInput = false;
-                CanCloseWithEsc = false;
-                CanCloseWithRightClick = false;
-
-                ref readonly var gi = ref Client.Game.UO.Gumps.GetGump(0x0805);
-                background = gi.Texture;
-                barBounds = gi.UV;
-
-                gi = ref Client.Game.UO.Gumps.GetGump(0x0806);
-                foreground = gi.Texture;
-                barBoundsF = gi.UV;
-            }
-
-            public override bool Draw(UltimaBatcher2D batcher, int x, int y)
-            {
-                if (SpellVisualRangeManager.Instance.IsCastingWithoutTarget())
-                {
-                    SpellRangeInfo i = SpellVisualRangeManager.Instance.GetCurrentSpell();
-                    if (i != null)
-                    {
-                        if (i.CastTime > 0)
-                        {
-                            if (background != null && foreground != null)
-                            {
-                                Mobile m = World.Player;
-                                Client.Game.UO.Animations.GetAnimationDimensions(
-                                    m.AnimIndex,
-                                    m.GetGraphicForAnimation(),
-                                    0,
-                                    0,
-                                    m.IsMounted,
-                                    0,
-                                    out int centerX,
-                                    out int centerY,
-                                    out int width,
-                                    out int height
-                                );
-
-                                WorldViewportGump vp = UIManager.GetGump<WorldViewportGump>();
-
-                                x = vp.Location.X + (int)(m.RealScreenPosition.X - (m.Offset.X + 22 + 5));
-                                y = vp.Location.Y + (int)(m.RealScreenPosition.Y - ((m.Offset.Y - m.Offset.Z) - (height + centerY + 15) + (m.IsGargoyle && m.IsFlying ? -22 : !m.IsMounted ? 22 : 0)));
-
-                                batcher.Draw(background, new Rectangle(x, y, barBounds.Width, barBounds.Height), barBounds, hue);
-
-                                double percent = (DateTime.Now - SpellVisualRangeManager.Instance.LastSpellTime).TotalSeconds / i.CastTime;
-
-                                int widthFromPercent = (int)(barBounds.Width * percent);
-                                widthFromPercent = widthFromPercent > barBounds.Width ? barBounds.Width : widthFromPercent; //Max width is the bar width
-
-                                if (widthFromPercent > 0)
-                                {
-                                    batcher.DrawTiled(foreground, new Rectangle(x, y, widthFromPercent, barBoundsF.Height), barBoundsF, hue);
-                                }
-
-                                if (percent <= 0 && i.FreezeCharacterWhileCasting)
-                                {
-                                    World.Player.Flags &= ~Flags.Frozen;
-                                }
-                            }
-                        }
-                    }
-                }
-                return base.Draw(batcher, x, y);
-            }
-        }
-        #endregion
     }
 }

--- a/src/ClassicUO.Client/Game/Managers/SpellVisualRange/SpellVisualRangeManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/SpellVisualRange/SpellVisualRangeManager.cs
@@ -136,7 +136,7 @@ namespace ClassicUO.Game.Managers
             if (bar.Parent == null)
                 UIManager.Add(bar);
 
-            bar.OnRecoveryBegin(spell);
+            bar.OnRecoveryBegin();
 
             double recTime = spell.GetEffectiveRecoveryTime();
             await Task.Delay(TimeSpan.FromSeconds(recTime));

--- a/src/ClassicUO.Client/Game/Managers/SpellVisualRange/SpellVisualRangeManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/SpellVisualRange/SpellVisualRangeManager.cs
@@ -13,6 +13,7 @@ using Timer = System.Timers.Timer;
 namespace ClassicUO.Game.Managers
 {
     using System.Text.Json.Serialization;
+    using ClassicUO.Game.Managers.SpellVisualRange;
     using ClassicUO.Utility.Logging;
 
     [JsonSerializable(typeof(SpellRangeInfo))]
@@ -144,10 +145,11 @@ namespace ClassicUO.Game.Managers
 
         private void EndRecovery(SpellRangeInfo spell)
         {
+            int endedSpellId = currentSpell?.ID ?? spell?.ID ?? 0;
             currentSpell = null;
             isCasting = false;
             World.Player.Flags &= ~Flags.Frozen;
-            EventSink.InvokeSpellCastEnd(currentSpell?.ID ?? 0);
+            EventSink.InvokeSpellCastEnd(endedSpellId);
         }
 
         public SpellRangeInfo GetCurrentSpell()

--- a/src/ClassicUO.Client/Game/UI/Gumps/SpellBar/SpellBar.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/SpellBar/SpellBar.cs
@@ -411,7 +411,7 @@ public class SpellBar : Gump
                     return true;
                 }
 
-                SpellVisualRangeManager.SpellRangeInfo i = SpellVisualRangeManager.Instance.GetCurrentSpell();
+                SpellRangeInfo i = SpellVisualRangeManager.Instance.GetCurrentSpell();
 
                 if (i == null)
                 {

--- a/src/ClassicUO.Client/Game/UI/Gumps/SpellBar/SpellBar.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/SpellBar/SpellBar.cs
@@ -3,6 +3,7 @@ using ClassicUO.Assets;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.Managers;
+using ClassicUO.Game.Managers.SpellVisualRange;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Game.UI.ImGuiControls;
 using ClassicUO.Input;

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/Agents/SpellIndicatorWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/Agents/SpellIndicatorWindow.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Numerics;
 using System.Linq;
+using ClassicUO.Game.Managers.SpellVisualRange;
 
 namespace ClassicUO.Game.UI.ImGuiControls
 {

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/Agents/SpellIndicatorWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/Agents/SpellIndicatorWindow.cs
@@ -21,7 +21,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
         private Dictionary<int, string> spellCastRangeInputs = new Dictionary<int, string>();
         private Dictionary<int, string> spellCastTimeInputs = new Dictionary<int, string>();
         private Dictionary<int, string> spellMaxDurationInputs = new Dictionary<int, string>();
-        private SpellVisualRangeManager.SpellRangeInfo selectedSpell = null;
+        private SpellRangeInfo selectedSpell = null;
 
         private SpellIndicatorWindow() : base("Spell Indicators")
         {
@@ -58,7 +58,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
                 }
                 else if (SpellDefinition.TryGetSpellFromName(spellSearchInput, out SpellDefinition spell))
                 {
-                    if (SpellVisualRangeManager.Instance.SpellRangeCache.TryGetValue(spell.ID, out SpellVisualRangeManager.SpellRangeInfo info))
+                    if (SpellVisualRangeManager.Instance.SpellRangeCache.TryGetValue(spell.ID, out SpellRangeInfo info))
                     {
                         selectedSpell = info;
                         InitializeInputs(info);
@@ -89,7 +89,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
             }
         }
 
-        private void InitializeInputs(SpellVisualRangeManager.SpellRangeInfo spell)
+        private void InitializeInputs(SpellRangeInfo spell)
         {
             if (!spellNameInputs.ContainsKey(spell.ID))
                 spellNameInputs[spell.ID] = spell.Name;
@@ -105,7 +105,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
                 spellMaxDurationInputs[spell.ID] = spell.MaxDuration.ToString();
         }
 
-        private void DrawSpellEditor(SpellVisualRangeManager.SpellRangeInfo spell)
+        private void DrawSpellEditor(SpellRangeInfo spell)
         {
             InitializeInputs(spell);
 

--- a/src/ClassicUO.Client/Game/World.cs
+++ b/src/ClassicUO.Client/Game/World.cs
@@ -231,6 +231,7 @@ namespace ClassicUO.Game
             }
 
             Player = new PlayerMobile(this, serial);
+            Player.AttachCastingEventHandlers();
             Mobiles.Add(Player);
             EventSink.InvokeOnPlayerCreated();
             Log.Trace($"Player [0x{serial:X8}] created");

--- a/src/ClassicUO.Client/Game/World.cs
+++ b/src/ClassicUO.Client/Game/World.cs
@@ -9,14 +9,12 @@ using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.Map;
 using ClassicUO.Game.UI.Gumps;
-using ClassicUO.Utility.Platforms;
 using Microsoft.Xna.Framework;
 using MathHelper = ClassicUO.Utility.MathHelper;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Scenes;
 using ClassicUO.Utility.Logging;
 using ClassicUO.Assets;
-using ClassicUO.Network;
 using ClassicUO.Game.UI;
 
 namespace ClassicUO.Game
@@ -231,7 +229,6 @@ namespace ClassicUO.Game
             }
 
             Player = new PlayerMobile(this, serial);
-            Player.AttachCastingEventHandlers();
             Mobiles.Add(Player);
             EventSink.InvokeOnPlayerCreated();
             Log.Trace($"Player [0x{serial:X8}] created");


### PR DESCRIPTION
https://github.com/user-attachments/assets/cf9bcb98-9119-4e3c-84fe-7a4c69aaa939

Take FC and FCR into account when showing the progress bars.
Added IsCasting to PlayerMobile

API.Player.IsCasting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * On-screen cast and recovery progress bar for spells with dynamic positioning and phase-specific coloring.

* **Improvements**
  * Client reliably tracks casting state, shows recovery phase, and freezes/unfreezes the character during casts.
  * Clearer end-of-cast handling so spell timing and UI update consistently.

* **Chores**
  * More robust loading and merging of default spell-indicator configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->