### PR TITLE
- Use OriginalGraphic when evaluating IsTree/IsCave state

### DIFF
--- a/src/ClassicUO.Client/LegionScripting/PyClasses/PyStatic.cs
+++ b/src/ClassicUO.Client/LegionScripting/PyClasses/PyStatic.cs
@@ -23,9 +23,9 @@ public class PyStatic : PyGameObject
     internal PyStatic(Static staticObj) : base(staticObj)
     {
         IsImpassible = staticObj.ItemData.IsImpassable;
-        IsTree = StaticFilters.IsTree(staticObj.Graphic, out _);
+        IsTree = StaticFilters.IsTree(staticObj.OriginalGraphic, out _);
         IsVegetation = staticObj.IsVegetation;
-        IsCave = StaticFilters.IsCave(staticObj.Graphic);
+        IsCave = StaticFilters.IsCave(staticObj.OriginalGraphic);
         Name = staticObj.Name;
     }
 


### PR DESCRIPTION
I update Tree graphics to Tree stumps after I've harvested them. Consequently, the next time the script runs, the IsTree check fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of tree and cave detection to ensure consistent object identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->