### PR TITLE
Fix ArgumentOutOfRangeException in CleanUpDisposedChildren

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Controls/Control.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/Control.cs
@@ -532,7 +532,8 @@ namespace ClassicUO.Game.UI.Controls
         {
             for (int i = Children.Count - 1; i >= 0; i--)
             {
-                if (Children[i]?.IsDisposed == true)
+                // Check bounds in case the list was modified during iteration
+                if (i < Children.Count && Children[i]?.IsDisposed == true)
                 {
                     OnChildRemoved();
                     Children.RemoveAt(i);


### PR DESCRIPTION
Adds bounds check before accessing Children list to prevent crash when the list is modified during recursive PreDraw() calls. This fixes the crash that was occurring at login on macOS.

Fixes crash in Control.cs:line 538 during UIManager.PreDraw()

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a stability issue that could occur during resource cleanup and disposal processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->