### PR TITLE
Add Clear method to PyBaseControl and Mount to player

### DIFF
--- a/src/ClassicUO.Client/LegionScripting/PyClasses/PyBaseControl.cs
+++ b/src/ClassicUO.Client/LegionScripting/PyClasses/PyBaseControl.cs
@@ -154,6 +154,16 @@ public class PyBaseControl(Control control)
     }
 
     /// <summary>
+    /// Clears all child controls from this control.
+    /// Used in python API
+    /// </summary>
+    public void Clear()
+    {
+        if (VerifyIntegrity())
+            MainThreadQueue.EnqueueAction(() => control?.Clear());
+    }
+
+    /// <summary>
     /// Close/Destroy the control
     /// </summary>
     public void Dispose()

--- a/src/ClassicUO.Client/LegionScripting/PyClasses/PyMobile.cs
+++ b/src/ClassicUO.Client/LegionScripting/PyClasses/PyMobile.cs
@@ -38,6 +38,19 @@ public class PyMobile : PyEntity
     }
 
     /// <summary>
+    /// Get the mobile's Mount item (if mounted)
+    /// </summary>
+    public PyItem Mount
+    {
+        get
+        {
+            Item mount = GetMobile()?.Mount;
+
+            return mount != null ? new PyItem(mount) : null;
+        }
+    }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="PyMobile"/> class from a <see cref="Mobile"/>.
     /// </summary>
     /// <param name="mobile">The mobile to wrap.</param>


### PR DESCRIPTION
This adds a Clear() method to PyBaseControl that calls the underlying Control.Clear() method, allowing Python scripts to clear all child controls from a control instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a one-step control clearing action to remove all child elements from a UI control via the Python API, simplifying interface management and scripting.
  * Exposed a mobile's mounted item through the Python API, allowing scripts to detect and interact with an entity's mount more easily.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->