### PR TITLE
Add pull_request trigger to build-test workflow

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -2,7 +2,16 @@ name: Build-Test
 
 on:
   push:
-    branches: "*"
+    branches:
+      - dev
+      - main
+    paths-ignore:
+      - '**/build-release.yml'
+      - 'appveyor.yml'
+      - '**/README.md'
+  pull_request:
+    branches:
+      - dev
     paths-ignore:
       - '**/build-release.yml'
       - 'appveyor.yml'


### PR DESCRIPTION
- Configure workflow to build on PR pushes targeting dev branch
- Limit push trigger to dev and main branches to avoid duplicate builds
- When pushing to a PR branch, only the pull_request event triggers (no duplicate)
- Direct pushes to dev/main still trigger builds as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)