### PR TITLE
Fix PyMobile.cs GetMobile() error by using GetMobileUnsafe()

### DIFF
--- a/src/ClassicUO.Client/LegionScripting/PyClasses/PyMobile.cs
+++ b/src/ClassicUO.Client/LegionScripting/PyClasses/PyMobile.cs
@@ -41,15 +41,12 @@ public class PyMobile : PyEntity
     /// <summary>
     /// Get the mobile's Mount item (if mounted)
     /// </summary>
-    public PyItem Mount
+    public PyItem Mount => MainThreadQueue.InvokeOnMainThread(() =>
     {
-        get
-        {
-            Item mount = GetMobile()?.Mount;
+        Item mount = GetMobileUnsafe()?.Mount;
 
-            return mount != null ? new PyItem(mount) : null;
-        }
-    }
+        return mount != null ? new PyItem(mount) : null;
+    });
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PyMobile"/> class from a <see cref="Mobile"/>.


### PR DESCRIPTION
Changed the Mount property to use GetMobileUnsafe() wrapped in MainThreadQueue.InvokeOnMainThread() to match the pattern used by other properties in the class and resolve the CS0103 compilation error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal thread safety handling for mount-related operations, ensuring operations execute reliably on the main thread with optimized resource retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->