### PR TITLE
Fix timezone mismatch in GetJournalEntries API method

### DIFF
--- a/src/ClassicUO.Client/LegionScripting/API.cs
+++ b/src/ClassicUO.Client/LegionScripting/API.cs
@@ -2635,7 +2635,7 @@ namespace ClassicUO.LegionScripting
         {
             var entries = new PythonList();
 
-            DateTime cutoff = DateTime.UtcNow - TimeSpan.FromSeconds(seconds);
+            DateTime cutoff = DateTime.Now - TimeSpan.FromSeconds(seconds);
 
             bool checkMatches = !string.IsNullOrEmpty(matchingText);
 


### PR DESCRIPTION
Changed DateTime.UtcNow to DateTime.Now when calculating the cutoff time for filtering journal entries. This fixes an issue where recent entries were incorrectly filtered out due to comparing local timestamps (from JournalEntry.Time) against UTC timestamps.

The journal entries are timestamped with DateTime.Now in JournalManager, so the cutoff calculation should also use local time for consistent comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)