### PR TITLE
Fix ArgumentOutOfRangeException in CleanUpDisposedChildren

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Controls/Control.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/Control.cs
@@ -534,8 +534,8 @@ namespace ClassicUO.Game.UI.Controls
             {
                 if (Children[i]?.IsDisposed == true)
                 {
-                    OnChildRemoved();
                     Children.RemoveAt(i);
+                    OnChildRemoved();
                 }
             }
         }


### PR DESCRIPTION
The issue occurred when OnChildRemoved() was called before removing the child from the Children collection. When OnChildRemoved() is overridden (e.g., in TableContainer, VBoxContainer, HBoxContainer), it calls Reposition() which may iterate over or modify the Children collection, causing the index to become invalid during iteration.

Fixed by swapping the order to remove from collection first, then call OnChildRemoved(), matching the pattern used in the Remove(Control c) method.

Fixes: Control.cs:539 ArgumentOutOfRangeException

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the sequence of operations during UI control cleanup to ensure proper handling of child element removal events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->