### PR TITLE
Fix ObjectDisposedException when rendering with disposed textures

### DIFF
--- a/src/ClassicUO.Renderer/Batcher2D.cs
+++ b/src/ClassicUO.Renderer/Batcher2D.cs
@@ -1341,6 +1341,11 @@ namespace ClassicUO.Renderer
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void InternalDraw(Texture texture, int baseSprite, int batchSize)
         {
+            if (texture == null || texture.IsDisposed)
+            {
+                return;
+            }
+
             GraphicsDevice.Textures[0] = texture;
 
             if (_customEffect != null)


### PR DESCRIPTION
Added null and IsDisposed check in InternalDraw method to prevent crashes when textures are disposed between being added to the batch and being flushed. This follows the same pattern used in PushSprite at line 1245.

Fixes issue where StbTextBox rendering would crash with: System.ObjectDisposedException: ObjectDisposed_Generic at Microsoft.Xna.Framework.Graphics.TextureCollection.set_Item

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved texture handling to prevent rendering errors when invalid textures are encountered. The renderer now safely skips rendering batches with invalid or disposed textures, preventing potential crashes and rendering issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->