### PR TITLE
Fix InvalidOperationException in GetFirstControlAcceptKeyboardInput

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Controls/Control.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/Control.cs
@@ -664,7 +664,7 @@ namespace ClassicUO.Game.UI.Controls
                 return null;
             }
 
-            foreach (Control c in Children)
+            foreach (Control c in Children.ToArray())
             {
                 Control a = c.GetFirstControlAcceptKeyboardInput();
 


### PR DESCRIPTION
Changed iteration over Children collection to use ToArray() to create a snapshot before enumeration. This prevents the InvalidOperationException that occurs when the UI control collection is modified during keyboard input handling.

Fixes issue where "InvalidOperation_EnumFailedVersion" exception was thrown in Control.cs:667 during UIManager keyboard input processing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of control input handling during UI interactions by preventing potential race conditions that could cause unexpected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->