### PR TITLE
Add character name to journal log filenames

### DIFF
--- a/src/ClassicUO.Client/Game/Managers/JournalManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/JournalManager.cs
@@ -84,7 +84,7 @@ namespace ClassicUO.Game.Managers
                     string path = FileSystemHelper.CreateFolderIfNotExists(Path.Combine(CUOEnviroment.ExecutablePath, "Data"), "Client", "JournalLogs");
 
                     // Get character name and sanitize it for use in filename
-                    string characterName = World.Player?.Name ?? "Unknown";
+                    string characterName = World.Instance.Player?.Name ?? "Unknown";
                     characterName = SanitizeFilename(characterName);
 
                     string filename = $"{DateTime.Now:yyyy_MM_dd_HH_mm_ss}_{characterName}_journal.txt";

--- a/src/ClassicUO.Client/Game/Managers/JournalManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/JournalManager.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.IO;
+using System.Text.RegularExpressions;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Utility;
@@ -82,7 +83,12 @@ namespace ClassicUO.Game.Managers
                 {
                     string path = FileSystemHelper.CreateFolderIfNotExists(Path.Combine(CUOEnviroment.ExecutablePath, "Data"), "Client", "JournalLogs");
 
-                    _fileWriter = new StreamWriter(File.Open(Path.Combine(path, $"{DateTime.Now:yyyy_MM_dd_HH_mm_ss}_journal.txt"), FileMode.Create, FileAccess.Write, FileShare.Read))
+                    // Get character name and sanitize it for use in filename
+                    string characterName = World.Player?.Name ?? "Unknown";
+                    characterName = SanitizeFilename(characterName);
+
+                    string filename = $"{DateTime.Now:yyyy_MM_dd_HH_mm_ss}_{characterName}_journal.txt";
+                    _fileWriter = new StreamWriter(File.Open(Path.Combine(path, filename), FileMode.Create, FileAccess.Write, FileShare.Read))
                     {
                         AutoFlush = true
                     };
@@ -109,6 +115,14 @@ namespace ClassicUO.Game.Managers
                     _writerHasException = true;
                 }
             }
+        }
+
+        private static string SanitizeFilename(string filename)
+        {
+            // Replace invalid filename characters with underscore
+            string invalid = new string(Path.GetInvalidFileNameChars());
+            string pattern = $"[{Regex.Escape(invalid)}]";
+            return Regex.Replace(filename, pattern, "_");
         }
 
         public void CloseWriter()


### PR DESCRIPTION
Journal log files now include the character name in the filename format: yyyy_MM_dd_HH_mm_ss_CharacterName_journal.txt

This allows players running multiple clients to easily identify which journal logs belong to which character. Invalid filename characters in character names are automatically replaced with underscores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Journal files now include the character name in their filenames, making logs easier to identify per character.

* **Bug Fixes**
  * Character names with special or invalid filename characters are now sanitized so journal files are created reliably across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->