### PR TITLE
Add auto-open own corpse feature

### DIFF
--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -211,6 +211,7 @@ namespace ClassicUO.Configuration
         public int AutoOpenCorpseRange { get; set; } = 2;
         public int CorpseOpenOptions { get; set; } = 3;
         public bool SkipEmptyCorpse { get; set; }
+        public bool AutoOpenOwnCorpse { get; set; } = true;
         public bool DisableDefaultHotkeys { get; set; }
         public bool DisableArrowBtn { get; set; }
         public bool DisableTabBtn { get; set; }

--- a/src/ClassicUO.Client/Game/GameObjects/PlayerMobile.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/PlayerMobile.cs
@@ -386,22 +386,35 @@ namespace ClassicUO.Game.GameObjects
 
         public void TryOpenCorpses()
         {
-            if (ProfileManager.CurrentProfile.AutoOpenCorpses)
+            foreach (Item item in World.Items.Values)
             {
-                if ((ProfileManager.CurrentProfile.CorpseOpenOptions == 1 || ProfileManager.CurrentProfile.CorpseOpenOptions == 3) && World.TargetManager.IsTargeting)
+                if (!item.IsDestroyed && item.IsCorpse && item.Distance <= ProfileManager.CurrentProfile.AutoOpenCorpseRange && !AutoOpenedCorpses.Contains(item.Serial))
                 {
-                    return;
-                }
+                    // Check if this is the player's own corpse
+                    bool isOwnCorpse = !string.IsNullOrEmpty(item.Name) &&
+                                       !string.IsNullOrEmpty(Name) &&
+                                       item.Name.Equals($"the remains of {Name}", System.StringComparison.OrdinalIgnoreCase);
 
-                if ((ProfileManager.CurrentProfile.CorpseOpenOptions == 2 || ProfileManager.CurrentProfile.CorpseOpenOptions == 3) && IsHidden)
-                {
-                    return;
-                }
+                    // Open if it's own corpse and AutoOpenOwnCorpse is enabled, or if AutoOpenCorpses is enabled
+                    bool shouldOpen = (isOwnCorpse && ProfileManager.CurrentProfile.AutoOpenOwnCorpse) ||
+                                      ProfileManager.CurrentProfile.AutoOpenCorpses;
 
-                foreach (Item item in World.Items.Values)
-                {
-                    if (!item.IsDestroyed && item.IsCorpse && item.Distance <= ProfileManager.CurrentProfile.AutoOpenCorpseRange && !AutoOpenedCorpses.Contains(item.Serial))
+                    if (shouldOpen)
                     {
+                        // Check targeting and hidden restrictions only for auto open corpses (not own corpse)
+                        if (!isOwnCorpse || !ProfileManager.CurrentProfile.AutoOpenOwnCorpse)
+                        {
+                            if ((ProfileManager.CurrentProfile.CorpseOpenOptions == 1 || ProfileManager.CurrentProfile.CorpseOpenOptions == 3) && World.TargetManager.IsTargeting)
+                            {
+                                continue;
+                            }
+
+                            if ((ProfileManager.CurrentProfile.CorpseOpenOptions == 2 || ProfileManager.CurrentProfile.CorpseOpenOptions == 3) && IsHidden)
+                            {
+                                continue;
+                            }
+                        }
+
                         AutoOpenedCorpses.Add(item.Serial);
                         GameActions.DoubleClickQueued(item.Serial);
                     }

--- a/src/ClassicUO.Client/Game/GameObjects/PlayerMobile.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/PlayerMobile.cs
@@ -386,6 +386,12 @@ namespace ClassicUO.Game.GameObjects
 
         public void TryOpenCorpses()
         {
+            // Early return if both auto-open settings are disabled
+            if (!ProfileManager.CurrentProfile.AutoOpenCorpses && !ProfileManager.CurrentProfile.AutoOpenOwnCorpse)
+            {
+                return;
+            }
+
             foreach (Item item in World.Items.Values)
             {
                 if (!item.IsDestroyed && item.IsCorpse && item.Distance <= ProfileManager.CurrentProfile.AutoOpenCorpseRange && !AutoOpenedCorpses.Contains(item.Serial))

--- a/src/ClassicUO.Client/Game/GameObjects/PlayerMobile.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/PlayerMobile.cs
@@ -392,9 +392,12 @@ namespace ClassicUO.Game.GameObjects
                 return;
             }
 
-            foreach (Item item in World.Items.Values)
+            // Use the optimized corpse collection instead of iterating all items
+            Item[] corpses = World.GetCorpseSnapshot();
+
+            foreach (Item item in corpses)
             {
-                if (!item.IsDestroyed && item.IsCorpse && item.Distance <= ProfileManager.CurrentProfile.AutoOpenCorpseRange && !AutoOpenedCorpses.Contains(item.Serial))
+                if (!item.IsDestroyed && item.Distance <= ProfileManager.CurrentProfile.AutoOpenCorpseRange && !AutoOpenedCorpses.Contains(item.Serial))
                 {
                     // Check if this is the player's own corpse
                     bool isOwnCorpse = !string.IsNullOrEmpty(item.Name) &&

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/General/GeneralWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/General/GeneralWindow.cs
@@ -11,6 +11,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
         private int _objectMoveDelay;
         private bool _highlightObjects;
         private bool _showNames;
+        private bool _autoOpenOwnCorpse;
         private ushort _turnDelay;
         private float _imguiWindowAlpha, _lastImguiWindowAlpha;
         private GeneralWindow() : base("General Tab")
@@ -19,6 +20,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
             _objectMoveDelay = _profile.MoveMultiObjectDelay;
             _highlightObjects = _profile.HighlightGameObjects;
             _showNames = _profile.NameOverheadToggled;
+            _autoOpenOwnCorpse = _profile.AutoOpenOwnCorpse;
             _turnDelay = _profile.TurnDelay;
             _imguiWindowAlpha = _lastImguiWindowAlpha = Client.Settings.Get(SettingsScope.Global, Constants.SqlSettings.IMGUI_ALPHA, 1.0f);
         }
@@ -112,6 +114,12 @@ namespace ClassicUO.Game.UI.ImGuiControls
                 _profile.NameOverheadToggled = _showNames;
             }
             ImGuiComponents.Tooltip("Toggle the display of names above characters and NPCs in the game world.");
+
+            if (ImGui.Checkbox("Auto open own corpse", ref _autoOpenOwnCorpse))
+            {
+                _profile.AutoOpenOwnCorpse = _autoOpenOwnCorpse;
+            }
+            ImGuiComponents.Tooltip("Automatically open your own corpse when you die, even if auto open corpses is disabled.");
 
             ImGui.EndGroup();
 

--- a/src/ClassicUO.Client/Game/World.cs
+++ b/src/ClassicUO.Client/Game/World.cs
@@ -115,6 +115,10 @@ namespace ClassicUO.Game
 
         public Dictionary<uint, Mobile> Mobiles { get; } = new Dictionary<uint, Mobile>();
 
+        // Separate collection for corpses to optimize iteration in TryOpenCorpses
+        private readonly HashSet<Item> _corpses = new HashSet<Item>();
+        private readonly object _corpsesLock = new object();
+
         public Map.Map Map
         {
             get;
@@ -212,6 +216,48 @@ namespace ClassicUO.Game
         public ClientFeatures ClientFeatures { get; } = new ClientFeatures();
 
         public string ServerName { get; set; } = "_";
+
+        /// <summary>
+        /// Adds a corpse to the corpse collection for faster iteration.
+        /// Thread-safe.
+        /// </summary>
+        public void AddCorpse(Item item)
+        {
+            if (item != null && !item.IsDestroyed)
+            {
+                lock (_corpsesLock)
+                {
+                    _corpses.Add(item);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Removes a corpse from the corpse collection.
+        /// Thread-safe.
+        /// </summary>
+        public void RemoveCorpse(Item item)
+        {
+            if (item != null)
+            {
+                lock (_corpsesLock)
+                {
+                    _corpses.Remove(item);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets a snapshot of corpses for iteration.
+        /// Thread-safe.
+        /// </summary>
+        public Item[] GetCorpseSnapshot()
+        {
+            lock (_corpsesLock)
+            {
+                return _corpses.ToArray();
+            }
+        }
 
         public void CreatePlayer(uint serial)
         {
@@ -857,6 +903,10 @@ namespace ClassicUO.Game
             LastObject = 0;
             Items.Clear();
             Mobiles.Clear();
+            lock (_corpsesLock)
+            {
+                _corpses.Clear();
+            }
             Player?.Destroy();
             Player = null;
             Map?.Destroy();


### PR DESCRIPTION
- Added AutoOpenOwnCorpse profile setting (defaults to true)
- Modified TryOpenCorpses() to detect player's own corpse by matching "the remains of [playername]" (case-insensitive)
- Player's own corpse will now auto-open even if AutoOpenCorpses is disabled (if AutoOpenOwnCorpse is enabled)
- Added "Auto open own corpse" checkbox to General Window Options tab
- Own corpse auto-open bypasses targeting and hidden state restrictions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added independent automatic opening control for the player's own corpse, separate from other corpses.
  * New toggle in General settings to enable/disable automatic opening of the player's own corpse with a tooltip.
  * Own corpses can open automatically with relaxed targeting/visibility restrictions when enabled.

* **Improvements**
  * More reliable and efficient corpse tracking/processing for faster, consistent auto-opening behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->