### PR TITLE
Fix map chunk loading artifacts with async loading

### DIFF
--- a/src/ClassicUO.Client/Game/Map/Chunk.cs
+++ b/src/ClassicUO.Client/Game/Map/Chunk.cs
@@ -34,7 +34,7 @@ namespace ClassicUO.Game.Map
 
         public GameObject[,] Tiles { get; } = new GameObject[8, 8];
         public bool IsDestroyed;
-        public bool IsLoading;
+        public volatile bool IsLoading;
         public long LastAccessTime;
         public LinkedListNode<int> Node;
 
@@ -45,7 +45,7 @@ namespace ClassicUO.Game.Map
 
         public static Chunk Create(World world, int x, int y, bool isAsync = false)
         {
-            var c = new Chunk(world); // _pool.GetOne();
+            Chunk c = new Chunk(world); // _pool.GetOne();
             c.LastAccessTime = Time.Ticks + Constants.CLEAR_TEXTURES_DELAY;
             c.X = x;
             c.Y = y;
@@ -60,173 +60,177 @@ namespace ClassicUO.Game.Map
             IsLoading = true;
             IsDestroyed = false;
 
-            Map map = _world.Map;
-
-            ref IndexMap im = ref GetIndex(index);
-
-            if (!im.IsValid())
+            try
             {
-                IsLoading = false;
-                return;
-            }
+                Map map = _world.Map;
 
-            im.MapFile.Seek((long)im.MapAddress, System.IO.SeekOrigin.Begin);
-            MapBlock block = im.MapFile.Read<MapBlock>();
+                ref IndexMap im = ref GetIndex(index);
 
-            MapCellsArray cells = block.Cells;
-            int bx = X << 3;
-            int by = Y << 3;
-
-            uint[] bufferBlock = new uint[64];
-            sbyte[] bufferBlockZ = new sbyte[64];
-            HuesLoader huesLoader = Client.Game.UO.FileManager.Hues;
-
-            for (int y = 0; y < 8; ++y)
-            {
-                int pos = y << 3;
-                ushort tileY = (ushort)(by + y);
-
-                for (int x = 0; x < 8; ++x, ++pos)
+                if (!im.IsValid())
                 {
-                    ushort tileID = (ushort)(cells[pos].TileID & 0x3FFF);
-
-                    sbyte z = cells[pos].Z;
-
-                    var land = Land.Create(_world, tileID);
-
-                    ushort tileX = (ushort)(bx + x);
-
-                    land.ApplyStretch(map, tileX, tileY, z);
-                    land.X = tileX;
-                    land.Y = tileY;
-                    land.Z = z;
-                    land.UpdateScreenPosition();
-
-                    if (TileMarkerManager.Instance.IsTileMarked(land.X, land.Y, map.Index, out ushort hue))
-                        land.Hue = hue;
-
-                    AddGameObject(land, x, y);
-
-                    if (updateWorldMap)
-                    {
-                        ushort color = (ushort)(0x8000 | huesLoader.GetRadarColorData(tileID & 0x3FFF));
-
-                        int blockIndex = y * 8 + x;
-                        bufferBlock[blockIndex] = HuesHelper.Color16To32(color) | 0xFF_00_00_00;
-                        bufferBlockZ[blockIndex] = z;
-                    }
-                }
-            }
-
-            //If Ultima Live is on, the statics of the first map block explored could be saved to StaticAdress 0, because the static file could be empty, so we can't check StaticAdress != 0
-            if (im.StaticAddress >= 0 && im.StaticCount > 0)
-            {
-                StaticsBlock[] staticsBlockBuffer = ArrayPool<StaticsBlock>.Shared.Rent((int)im.StaticCount);
-                Span<StaticsBlock> staticsSpan = staticsBlockBuffer.AsSpan(0, (int)im.StaticCount);
-                im.StaticFile.Seek((long)im.StaticAddress, System.IO.SeekOrigin.Begin);
-                im.StaticFile.Read(MemoryMarshal.AsBytes(staticsSpan));
-
-                foreach (ref StaticsBlock sb in staticsSpan)
-                {
-                    if (sb.Color != 0 && sb.Color != 0xFFFF)
-                    {
-                        int pos = (sb.Y << 3) + sb.X;
-
-                        if (pos >= 64)
-                        {
-                            continue;
-                        }
-
-                        var staticObject = Static.Create(_world, sb.Color, sb.Hue, pos);
-                        staticObject.X = (ushort)(bx + sb.X);
-                        staticObject.Y = (ushort)(by + sb.Y);
-                        staticObject.Z = sb.Z;
-                        staticObject.UpdateScreenPosition();
-
-                        if (TileMarkerManager.Instance.IsTileMarked(staticObject.X, staticObject.Y, map.Index, out ushort hue))
-                            staticObject.Hue = hue;
-
-                        AddGameObject(staticObject, sb.X, sb.Y);
-
-                        if (updateWorldMap)
-                        {
-                            int blockIndex = (sb.Y << 3) + sb.X;
-                            if (GameObject.CanBeDrawn(_world, sb.Color) && sb.Z >= bufferBlockZ[blockIndex])
-                            {
-                                ushort color = (ushort)(0x8000 | (sb.Hue != 0 ? huesLoader.GetColor16(16384, sb.Hue) : huesLoader.GetRadarColorData(sb.Color + 0x4000)));
-
-                                bufferBlock[blockIndex] = HuesHelper.Color16To32(color) | 0xFF_00_00_00;
-                                bufferBlockZ[blockIndex] = sb.Z;
-                            }
-                        }
-                    }
+                    return;
                 }
 
-                ArrayPool<StaticsBlock>.Shared.Return(staticsBlockBuffer);
-            }
+                im.MapFile.Seek((long)im.MapAddress, System.IO.SeekOrigin.Begin);
+                MapBlock block = im.MapFile.Read<MapBlock>();
 
-            if (updateWorldMap)
-            {
-                const float MAG_0 = 80f / 100f;
-                const float MAG_1 = 100f / 80f;
+                MapCellsArray cells = block.Cells;
+                int bx = X << 3;
+                int by = Y << 3;
+
+                uint[] bufferBlock = new uint[64];
+                sbyte[] bufferBlockZ = new sbyte[64];
+                HuesLoader huesLoader = Client.Game.UO.FileManager.Hues;
 
                 for (int y = 0; y < 8; ++y)
                 {
-                    for (int x = 0; x < 8; ++x)
+                    int pos = y << 3;
+                    ushort tileY = (ushort)(by + y);
+
+                    for (int x = 0; x < 8; ++x, ++pos)
                     {
-                        int blockCurrent = y * 8 + x;
-                        int blockNext = (y + 1) * 8 + x;
+                        ushort tileID = (ushort)(cells[pos].TileID & 0x3FFF);
 
-                        //Reached last line, nothing to compare with
-                        if (y == 7)
+                        sbyte z = cells[pos].Z;
+
+                        Land land = Land.Create(_world, tileID);
+
+                        ushort tileX = (ushort)(bx + x);
+
+                        land.ApplyStretch(map, tileX, tileY, z);
+                        land.X = tileX;
+                        land.Y = tileY;
+                        land.Z = z;
+                        land.UpdateScreenPosition();
+
+                        if (TileMarkerManager.Instance.IsTileMarked(land.X, land.Y, map.Index, out ushort hue))
+                            land.Hue = hue;
+
+                        AddGameObject(land, x, y);
+
+                        if (updateWorldMap)
                         {
-                            break;
-                        }
+                            ushort color = (ushort)(0x8000 | huesLoader.GetRadarColorData(tileID & 0x3FFF));
 
-                        sbyte z0 = bufferBlockZ[++blockCurrent];
-                        sbyte z1 = bufferBlockZ[blockNext];
-
-                        if (z0 == z1)
-                        {
-                            continue;
-                        }
-
-                        ref uint cc = ref bufferBlock[blockCurrent];
-
-                        if (cc == 0)
-                        {
-                            continue;
-                        }
-
-                        byte r = (byte)(cc & 0xFF);
-                        byte g = (byte)((cc >> 8) & 0xFF);
-                        byte b = (byte)((cc >> 16) & 0xFF);
-                        byte a = (byte)((cc >> 24) & 0xFF);
-
-                        if (r != 0 || g != 0 || b != 0)
-                        {
-                            if (z0 < z1)
-                            {
-                                r = (byte)Math.Min(0xFF, r * MAG_0);
-                                g = (byte)Math.Min(0xFF, g * MAG_0);
-                                b = (byte)Math.Min(0xFF, b * MAG_0);
-                            }
-                            else
-                            {
-                                r = (byte)Math.Min(0xFF, r * MAG_1);
-                                g = (byte)Math.Min(0xFF, g * MAG_1);
-                                b = (byte)Math.Min(0xFF, b * MAG_1);
-                            }
-
-                            cc = (uint)(r | (g << 8) | (b << 16) | (a << 24));
+                            int blockIndex = y * 8 + x;
+                            bufferBlock[blockIndex] = HuesHelper.Color16To32(color) | 0xFF_00_00_00;
+                            bufferBlockZ[blockIndex] = z;
                         }
                     }
                 }
 
-                UIManager.GetGump<WorldMapGump>()?.UpdateWorldMapChunk(X, Y, bufferBlock);
-            }
+                //If Ultima Live is on, the statics of the first map block explored could be saved to StaticAdress 0, because the static file could be empty, so we can't check StaticAdress != 0
+                if (im.StaticAddress >= 0 && im.StaticCount > 0)
+                {
+                    StaticsBlock[] staticsBlockBuffer = ArrayPool<StaticsBlock>.Shared.Rent((int)im.StaticCount);
+                    Span<StaticsBlock> staticsSpan = staticsBlockBuffer.AsSpan(0, (int)im.StaticCount);
+                    im.StaticFile.Seek((long)im.StaticAddress, System.IO.SeekOrigin.Begin);
+                    im.StaticFile.Read(MemoryMarshal.AsBytes(staticsSpan));
 
-            IsLoading = false;
+                    foreach (ref StaticsBlock sb in staticsSpan)
+                    {
+                        if (sb.Color != 0 && sb.Color != 0xFFFF)
+                        {
+                            int pos = (sb.Y << 3) + sb.X;
+
+                            if (pos >= 64)
+                            {
+                                continue;
+                            }
+
+                            Static staticObject = Static.Create(_world, sb.Color, sb.Hue, pos);
+                            staticObject.X = (ushort)(bx + sb.X);
+                            staticObject.Y = (ushort)(by + sb.Y);
+                            staticObject.Z = sb.Z;
+                            staticObject.UpdateScreenPosition();
+
+                            if (TileMarkerManager.Instance.IsTileMarked(staticObject.X, staticObject.Y, map.Index, out ushort hue))
+                                staticObject.Hue = hue;
+
+                            AddGameObject(staticObject, sb.X, sb.Y);
+
+                            if (updateWorldMap)
+                            {
+                                int blockIndex = (sb.Y << 3) + sb.X;
+                                if (GameObject.CanBeDrawn(_world, sb.Color) && sb.Z >= bufferBlockZ[blockIndex])
+                                {
+                                    ushort color = (ushort)(0x8000 | (sb.Hue != 0 ? huesLoader.GetColor16(16384, sb.Hue) : huesLoader.GetRadarColorData(sb.Color + 0x4000)));
+
+                                    bufferBlock[blockIndex] = HuesHelper.Color16To32(color) | 0xFF_00_00_00;
+                                    bufferBlockZ[blockIndex] = sb.Z;
+                                }
+                            }
+                        }
+                    }
+
+                    ArrayPool<StaticsBlock>.Shared.Return(staticsBlockBuffer);
+                }
+
+                if (updateWorldMap)
+                {
+                    const float MAG_0 = 80f / 100f;
+                    const float MAG_1 = 100f / 80f;
+
+                    for (int y = 0; y < 8; ++y)
+                    {
+                        for (int x = 0; x < 8; ++x)
+                        {
+                            int blockCurrent = y * 8 + x;
+                            int blockNext = (y + 1) * 8 + x;
+
+                            //Reached last line, nothing to compare with
+                            if (y == 7)
+                            {
+                                break;
+                            }
+
+                            sbyte z0 = bufferBlockZ[++blockCurrent];
+                            sbyte z1 = bufferBlockZ[blockNext];
+
+                            if (z0 == z1)
+                            {
+                                continue;
+                            }
+
+                            ref uint cc = ref bufferBlock[blockCurrent];
+
+                            if (cc == 0)
+                            {
+                                continue;
+                            }
+
+                            byte r = (byte)(cc & 0xFF);
+                            byte g = (byte)((cc >> 8) & 0xFF);
+                            byte b = (byte)((cc >> 16) & 0xFF);
+                            byte a = (byte)((cc >> 24) & 0xFF);
+
+                            if (r != 0 || g != 0 || b != 0)
+                            {
+                                if (z0 < z1)
+                                {
+                                    r = (byte)Math.Min(0xFF, r * MAG_0);
+                                    g = (byte)Math.Min(0xFF, g * MAG_0);
+                                    b = (byte)Math.Min(0xFF, b * MAG_0);
+                                }
+                                else
+                                {
+                                    r = (byte)Math.Min(0xFF, r * MAG_1);
+                                    g = (byte)Math.Min(0xFF, g * MAG_1);
+                                    b = (byte)Math.Min(0xFF, b * MAG_1);
+                                }
+
+                                cc = (uint)(r | (g << 8) | (b << 16) | (a << 24));
+                            }
+                        }
+                    }
+
+                    UIManager.GetGump<WorldMapGump>()?.UpdateWorldMapChunk(X, Y, bufferBlock);
+                }
+            }
+            finally
+            {
+                IsLoading = false;
+            }
         }
 
 

--- a/src/ClassicUO.Client/Game/Map/Chunk.cs
+++ b/src/ClassicUO.Client/Game/Map/Chunk.cs
@@ -34,6 +34,7 @@ namespace ClassicUO.Game.Map
 
         public GameObject[,] Tiles { get; } = new GameObject[8, 8];
         public bool IsDestroyed;
+        public bool IsLoading;
         public long LastAccessTime;
         public LinkedListNode<int> Node;
 
@@ -42,12 +43,13 @@ namespace ClassicUO.Game.Map
         public int Y;
 
 
-        public static Chunk Create(World world, int x, int y)
+        public static Chunk Create(World world, int x, int y, bool isAsync = false)
         {
             var c = new Chunk(world); // _pool.GetOne();
             c.LastAccessTime = Time.Ticks + Constants.CLEAR_TEXTURES_DELAY;
             c.X = x;
             c.Y = y;
+            c.IsLoading = isAsync;
 
             return c;
         }
@@ -55,6 +57,7 @@ namespace ClassicUO.Game.Map
 
         public unsafe void Load(int index, bool updateWorldMap = false)
         {
+            IsLoading = true;
             IsDestroyed = false;
 
             Map map = _world.Map;
@@ -63,6 +66,7 @@ namespace ClassicUO.Game.Map
 
             if (!im.IsValid())
             {
+                IsLoading = false;
                 return;
             }
 
@@ -221,6 +225,8 @@ namespace ClassicUO.Game.Map
 
                 UIManager.GetGump<WorldMapGump>()?.UpdateWorldMapChunk(X, Y, bufferBlock);
             }
+
+            IsLoading = false;
         }
 
 

--- a/src/ClassicUO.Client/Game/Map/Map.cs
+++ b/src/ClassicUO.Client/Game/Map/Map.cs
@@ -124,7 +124,7 @@ namespace ClassicUO.Game.Map
 
             ref Chunk chunk = ref _terrainChunks[block];
 
-            if (chunk is { IsDestroyed: false })
+            if (chunk is { IsDestroyed: false, IsLoading: false })
             {
                 chunk.LastAccessTime = Time.Ticks;
                 return chunk;
@@ -152,7 +152,7 @@ namespace ClassicUO.Game.Map
                     if (chunk == null)
                     {
                         LinkedListNode<int> node = _usedIndices.AddLast(block);
-                        chunk = Chunk.Create(_world, chunkX, chunkY);
+                        chunk = Chunk.Create(_world, chunkX, chunkY, isAsync: true);
                         chunk.Load(Index);
                         chunk.Node = node;
                         chunk.LastAccessTime = Time.Ticks;
@@ -168,6 +168,7 @@ namespace ClassicUO.Game.Map
                         LinkedListNode<int> node = _usedIndices.AddLast(block);
                         chunk.X = chunkX;
                         chunk.Y = chunkY;
+                        chunk.IsLoading = true;
                         chunk.Load(Index);
                         chunk.Node = node;
                         chunk.LastAccessTime = Time.Ticks;


### PR DESCRIPTION
Fixed race condition where chunks were being rendered while still loading in background threads, causing visual artifacts (missing tiles or stretched terrain effects).

Root cause:
- PreloadChunk2() returned chunks as soon as IsDestroyed=false
- But IsDestroyed was set at the START of Load(), not the end
- Renderer accessed partially-loaded chunks with incomplete Tiles arrays
- Background thread modified linked lists while renderer iterated them

Solution:
- Added IsLoading flag to Chunk class
- Set IsLoading=true when async loading starts, false when complete
- PreloadChunk2() now only returns chunks with IsLoading=false
- Ensures chunks are fully loaded before renderer can access them

Files modified:
- src/ClassicUO.Client/Game/Map/Chunk.cs: Added IsLoading property
- src/ClassicUO.Client/Game/Map/Map.cs: Check IsLoading in PreloadChunk2()

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved chunk loading state management to make map loading more robust during asynchronous operations and when reusing chunks.
  * Chunk creation now explicitly supports asynchronous creation to better coordinate background loads.

* **Bug Fixes**
  * Ensured loading state is consistently set and cleared to prevent stale or stuck chunk loads and reduce map visual glitches during async load/reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->