### PR TITLE
Add InWarMode virtual property to PyMobile and override in PyPlayer

### DIFF
--- a/src/ClassicUO.Client/LegionScripting/PyClasses/PyMobile.cs
+++ b/src/ClassicUO.Client/LegionScripting/PyClasses/PyMobile.cs
@@ -27,7 +27,12 @@ public class PyMobile : PyEntity
     public int Mana => MainThreadQueue.InvokeOnMainThread(() => GetMobileUnsafe()?.Mana ?? 0);
     public bool IsRenamable => MainThreadQueue.InvokeOnMainThread(() => GetMobileUnsafe()?.IsRenamable ?? false);
     public bool IsHuman => MainThreadQueue.InvokeOnMainThread(() => GetMobileUnsafe()?.IsHuman ?? false);
-    public virtual bool InWarMode => MainThreadQueue.InvokeOnMainThread(() => GetMobileUnsafe()?.InWarMode ?? false);
+
+    public virtual bool InWarMode
+    {
+        get => MainThreadQueue.InvokeOnMainThread(() => GetMobileUnsafe()?.InWarMode ?? false);
+        set { } // Dispose of value - only overrides can set
+    }
 
     /// <summary>
     /// Get the mobile's Backpack item

--- a/src/ClassicUO.Client/LegionScripting/PyClasses/PyMobile.cs
+++ b/src/ClassicUO.Client/LegionScripting/PyClasses/PyMobile.cs
@@ -27,6 +27,7 @@ public class PyMobile : PyEntity
     public int Mana => MainThreadQueue.InvokeOnMainThread(() => GetMobileUnsafe()?.Mana ?? 0);
     public bool IsRenamable => MainThreadQueue.InvokeOnMainThread(() => GetMobileUnsafe()?.IsRenamable ?? false);
     public bool IsHuman => MainThreadQueue.InvokeOnMainThread(() => GetMobileUnsafe()?.IsHuman ?? false);
+    public virtual bool InWarMode => MainThreadQueue.InvokeOnMainThread(() => GetMobileUnsafe()?.InWarMode ?? false);
 
     /// <summary>
     /// Get the mobile's Backpack item

--- a/src/ClassicUO.Client/LegionScripting/PyClasses/PyPlayer.cs
+++ b/src/ClassicUO.Client/LegionScripting/PyClasses/PyPlayer.cs
@@ -91,7 +91,7 @@ public class PyPlayer : PyMobile
     public bool IsHidden =>  MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.IsHidden ?? false);
     public bool IsWalking =>  MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.IsWalking ?? false);
 
-    public bool InWarMode
+    public override bool InWarMode
     {
         get => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.InWarMode ?? false);
         set => MainThreadQueue.InvokeOnMainThread(() =>


### PR DESCRIPTION
- Added virtual InWarMode bool property to PyMobile.cs
- Added override keyword to PyPlayer.cs InWarMode property
- Matches the Mobile/PlayerMobile class hierarchy pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scripts can now access and check war mode status information for mobile entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->