### PR TITLE
Add NameAndProps method to PyItem and PyMobile

### DIFF
--- a/src/ClassicUO.Client/LegionScripting/PyClasses/PyItem.cs
+++ b/src/ClassicUO.Client/LegionScripting/PyClasses/PyItem.cs
@@ -102,4 +102,34 @@ public class PyItem : PyEntity
             return item = GetItemUnsafe();
         });
     }
+
+    /// <summary>
+    /// Gets the item name and properties (tooltip text).
+    /// This returns the name and properties in a single string. You can split it by newline if you want to separate them.
+    /// </summary>
+    /// <param name="wait">True or false to wait for name and props</param>
+    /// <param name="timeout">Timeout in seconds</param>
+    /// <returns>Item name and properties, or empty string if we don't have them.</returns>
+    public string NameAndProps(bool wait = false, int timeout = 10)
+    {
+        if (wait)
+        {
+            System.DateTime expire = System.DateTime.UtcNow.AddSeconds(timeout);
+
+            while (!MainThreadQueue.InvokeOnMainThread(() => Client.Game.UO.World.OPL.Contains(Serial)) && System.DateTime.UtcNow < expire)
+            {
+                System.Threading.Thread.Sleep(100);
+            }
+        }
+
+        return MainThreadQueue.InvokeOnMainThread(() =>
+        {
+            if (Client.Game.UO.World.OPL.TryGetNameAndData(Serial, out string n, out string d))
+            {
+                return n + "\n" + d;
+            }
+
+            return string.Empty;
+        });
+    }
 }

--- a/src/ClassicUO.Client/LegionScripting/PyClasses/PyMobile.cs
+++ b/src/ClassicUO.Client/LegionScripting/PyClasses/PyMobile.cs
@@ -87,4 +87,34 @@ public class PyMobile : PyEntity
 
         return null;
     }
+
+    /// <summary>
+    /// Gets the mobile name and properties (tooltip text).
+    /// This returns the name and properties in a single string. You can split it by newline if you want to separate them.
+    /// </summary>
+    /// <param name="wait">True or false to wait for name and props</param>
+    /// <param name="timeout">Timeout in seconds</param>
+    /// <returns>Mobile name and properties, or empty string if we don't have them.</returns>
+    public string NameAndProps(bool wait = false, int timeout = 10)
+    {
+        if (wait)
+        {
+            System.DateTime expire = System.DateTime.UtcNow.AddSeconds(timeout);
+
+            while (!MainThreadQueue.InvokeOnMainThread(() => Client.Game.UO.World.OPL.Contains(Serial)) && System.DateTime.UtcNow < expire)
+            {
+                System.Threading.Thread.Sleep(100);
+            }
+        }
+
+        return MainThreadQueue.InvokeOnMainThread(() =>
+        {
+            if (Client.Game.UO.World.OPL.TryGetNameAndData(Serial, out string n, out string d))
+            {
+                return n + "\n" + d;
+            }
+
+            return string.Empty;
+        });
+    }
 }


### PR DESCRIPTION
- Added NameAndProps method to PyItem.cs to expose item tooltip data
- Added NameAndProps method to PyMobile.cs to expose mobile tooltip data
- Both methods follow the same pattern as API.ItemNameAndProps
- Supports optional wait parameter with configurable timeout
- Returns item/mobile name and properties as a newline-separated string

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New scripting API methods enable retrieving item and mobile names with their properties in a single call, with optional waiting for data availability up to a configurable timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->