### PR TITLE
[WIP] Grouped Gridhighlight rules

### DIFF
--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -439,6 +439,7 @@ namespace ClassicUO.Configuration
         public List<string> ConfigurableSuperSlayers { get; set; } = new();
         public List<string> ConfigurableSlayers { get; set; } = new();
         public List<string> ConfigurableRarities { get; set; } = new();
+        public Dictionary<string, List<string>> ConfigurableGroupedProperties { get; set; } = new();
 
         #endregion
 

--- a/src/ClassicUO.Client/Configuration/ProfileManager.cs
+++ b/src/ClassicUO.Client/Configuration/ProfileManager.cs
@@ -1,8 +1,10 @@
-﻿// SPDX-License-Identifier: BSD-2-Clause
+// SPDX-License-Identifier: BSD-2-Clause
 
 using System.IO;
+using System.Linq;
 using ClassicUO.Game.UI.Gumps.GridHighLight;
 using ClassicUO.Utility;
+using IronPython.Compiler.Ast;
 using Microsoft.Xna.Framework;
 
 namespace ClassicUO.Configuration
@@ -44,12 +46,23 @@ namespace ClassicUO.Configuration
             CurrentProfile.Username = username;
             CurrentProfile.ServerName = servername;
             CurrentProfile.CharacterName = charactername;
+            bool shouldResave = false;
 
             if (CurrentProfile.GridHighlightSetup.Count == 0)
             {
                 GridHighLightProfile.MigrateGridHighlightToSetup(CurrentProfile);
-                ConfigurationResolver.Save(CurrentProfile, Path.Combine(ProfilePath, "profile.json"), ProfileJsonContext.DefaultToUse.Profile);
+                shouldResave = true;
+               
             }
+            if (CurrentProfile.ConfigurableGroupedProperties.Count == 0)
+            {
+                CurrentProfile.ConfigurableGroupedProperties = GridHighlightRules.GroupedProperties.ToDictionary(
+                        kvp => kvp.Key,
+                        kvp => kvp.Value.ToList());
+                shouldResave = true;
+            }
+            if(shouldResave)
+                ConfigurationResolver.Save(CurrentProfile, Path.Combine(ProfilePath, "profile.json"), ProfileJsonContext.DefaultToUse.Profile);
 
             ValidateFields(CurrentProfile);
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightData.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightData.cs
@@ -142,7 +142,9 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
         private HashSet<string> _cachedNormalizedAllRarities;
         private HashSet<string> _cachedNormalizedAllProperties;
         private HashSet<string> _cachedNormalizedAllNegatives;
-        private Dictionary<string, (int MinValue, bool IsOptional)> _cachedNormalizedRulesProperties;
+        private Dictionary<string, HashSet<string>> _cachedNormalizedAllGroups;
+        private HashSet<string> _cachedNormalizedAllGroupProperties;
+        private Dictionary<string, (int MinValue, bool IsOptional, bool IsGroup)> _cachedNormalizedRulesProperties;
         private static readonly List<ItemPropertiesData> _reusableItemData = new(3);
         private static readonly List<uint> _reusableRequeueItems = new();
         private bool _cacheValid = false;
@@ -345,6 +347,36 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
             RecheckMatchStatus();
         }
 
+        // Returns the sum of all member properties present on the item.
+        // hadMember is true if at least one member property was found (useful when MinValue == -1 meaning "exists").
+        private double ComputeGroupSum(ItemPropertiesData itemData, in HashSet<string> ruleProps, out bool hadMember)
+        {
+            double sum = 0;
+            bool any = false;
+
+            foreach (ItemPropertiesData.SinglePropertyData p in itemData.singlePropertyData)
+            {
+                string n = Normalize(p.Name);
+                string o = Normalize(p.OriginalString);
+
+                for (int i = 0; i < ruleProps.Count; i++)
+                {
+                    string m = Normalize(ruleProps.ElementAt(i));
+
+                    if (n.IndexOf(m, StringComparison.OrdinalIgnoreCase) >= 0 ||
+                        o.IndexOf(m, StringComparison.OrdinalIgnoreCase) >= 0)
+                    {
+                        sum += p.FirstValue;
+                        any = true;
+                        break;
+                    }
+                }
+            }
+
+            hadMember = any;
+            return sum;
+        }
+
         private void EnsureCache()
         {
             if (_cacheValid) return;
@@ -353,9 +385,16 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
             _cachedNormalizedAllRarities = new HashSet<string>(
                 GridHighlightRules.RarityProperties.Select(Normalize), StringComparer.OrdinalIgnoreCase) ?? new();
             _cachedNormalizedAllProperties = new HashSet<string>(
-                GridHighlightRules.Properties.Concat(GridHighlightRules.SlayerProperties).Concat(GridHighlightRules.SuperSlayerProperties).Select(Normalize), StringComparer.OrdinalIgnoreCase) ?? new();
+                GridHighlightRules.Properties.Concat(GridHighlightRules.SlayerProperties).Concat(GridHighlightRules.SuperSlayerProperties).Concat(GridHighlightRules.GroupedProperties.Keys).Select(Normalize), StringComparer.OrdinalIgnoreCase) ?? new();
             _cachedNormalizedAllNegatives = new HashSet<string>(
                 GridHighlightRules.NegativeProperties.Select(Normalize), StringComparer.OrdinalIgnoreCase) ?? new();
+            _cachedNormalizedAllGroups = new Dictionary<string, HashSet<string>>(
+                GridHighlightRules.GroupedProperties.ToDictionary(
+                    kvp => Normalize(kvp.Key),
+                    kvp => new HashSet<string>(kvp.Value.Select(Normalize), StringComparer.OrdinalIgnoreCase)),
+                StringComparer.OrdinalIgnoreCase) ?? new();
+            _cachedNormalizedAllGroupProperties = new HashSet<string>(
+                GridHighlightRules.GroupedProperties.SelectMany(g => g.Value).Select(Normalize), StringComparer.OrdinalIgnoreCase) ?? new();
 
             // Rules
             _cachedNormalizedRulesExcludeNegatives = ExcludeNegatives.Select(Normalize).ToList() ?? new List<string>();
@@ -369,7 +408,8 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
                                   // if duplicates exist, keep the strictest (highest MinValue) and required if any non-optional
                                   int minValue = g.Max(x => x.MinValue);
                                   bool isOptional = g.All(x => x.IsOptional); // any required makes it required
-                                  return (minValue, isOptional);
+                                  bool isGroup = GridHighlightRules.GroupedProperties.Select(k => Normalize(k.Key)).Contains(Normalize(g.First().Name));
+                                  return (minValue, isOptional, isGroup);
                               },
                               StringComparer.OrdinalIgnoreCase) ?? new();
 
@@ -384,7 +424,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
                 return false;
 
             // Rules
-            Dictionary<string, (int MinValue, bool IsOptional)> normalizedRulesProperties = _cachedNormalizedRulesProperties;
+            Dictionary<string, (int MinValue, bool IsOptional, bool IsGroup)> normalizedRulesProperties = _cachedNormalizedRulesProperties;
             List<string> normalizedRulesExcludeNegatives = _cachedNormalizedRulesExcludeNegatives;
             HashSet<string> normalizedRulesRequiredRarities = _cachedNormalizedRulesRequiredRarities;
 
@@ -428,11 +468,33 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
             var matchedProperties = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var matchedRequiredProperties = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-            foreach (KeyValuePair<string, (int MinValue, bool IsOptional)> normalizedRulesProperty in normalizedRulesProperties)
+            foreach (KeyValuePair<string, (int MinValue, bool IsOptional, bool IsGroup)> normalizedRulesProperty in normalizedRulesProperties)
             {
                 string normalizedPropertyName = normalizedRulesProperty.Key;
                 int propertyMinValue = normalizedRulesProperty.Value.MinValue;
                 bool isPropertyOptional = normalizedRulesProperty.Value.IsOptional;
+                bool isPropertyGroup = normalizedRulesProperty.Value.IsGroup;
+
+                if (isPropertyGroup)
+                {
+                    if (!_cachedNormalizedAllGroups.TryGetValue(normalizedPropertyName, out HashSet<string> groupProperties))
+                        continue;
+
+                    bool groupMatched = false;
+                    double groupSum = 0;
+
+                    groupSum = groupProperties.Intersect(normalizedItemProperties.Keys)
+                        .Select(ikey => normalizedItemProperties[ikey])
+                        .Sum(p => p.Value);
+                    groupMatched = groupSum >= propertyMinValue;
+                    if (groupMatched)
+                    {
+                        matchedProperties.Add(normalizedPropertyName);
+                        if (!isPropertyOptional)
+                            matchedRequiredProperties.Add(normalizedPropertyName);
+                        continue;
+                    }
+                }
 
                 if (!normalizedItemProperties.TryGetValue(normalizedPropertyName, out (string Original, double Value) normalizedItemProperty))
                     continue;
@@ -480,7 +542,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
                 );
 
             // Rules
-            Dictionary<string, (int MinValue, bool IsOptional)> normalizedRulesProperties = _cachedNormalizedRulesProperties;
+            Dictionary<string, (int MinValue, bool IsOptional, bool IsGroup)> normalizedRulesProperties = _cachedNormalizedRulesProperties;
             List<string> normalizedRulesExcludeNegatives = _cachedNormalizedRulesExcludeNegatives;
             HashSet<string> normalizedRulesRequiredRarities = _cachedNormalizedRulesRequiredRarities;
 
@@ -541,17 +603,48 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
                 .Where(p => p.Value.IsOptional)
                 .ToList();
 
+            var filteredGroupRules = normalizedRulesProperties
+                .Where(p => _cachedNormalizedAllGroups.ContainsKey(p.Key))
+                .ToList();
+
+            var filteredGroupProperties = filteredGroupRules
+                .SelectMany(g => _cachedNormalizedAllGroups[g.Key])
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
             // Checking if all the itemLines is in a rule (No extra properties allowed)
             foreach (KeyValuePair<string, (string Original, double Value)> filteredItemLine in filteredItemLines)
             {
-                if (!normalizedRulesProperties.TryGetValue(filteredItemLine.Key, out (int MinValue, bool IsOptional) rule))
+
+                if (!filteredGroupProperties.Contains(filteredItemLine.Key)
+                    && !normalizedRulesProperties.Where(r => !r.Value.IsGroup)
+                       .Select(p => p.Key).Contains(filteredItemLine.Key))
                     return false;
-            } 
+            }
 
             // Checking if all the required properties are present
-            foreach (KeyValuePair<string, (int MinValue, bool IsOptional)> filteredNotOptionalRule in filteredNotOptionalRules)
+            foreach (KeyValuePair<string, (int MinValue, bool IsOptional, bool IsGroup)> filteredNotOptionalRule in filteredNotOptionalRules)
             {
                 double minValue = filteredNotOptionalRule.Value.MinValue;
+                bool isPropertyGroup = filteredNotOptionalRule.Value.IsGroup;
+
+                if (isPropertyGroup)
+                {
+                    if (!_cachedNormalizedAllGroups.TryGetValue(filteredNotOptionalRule.Key, out HashSet<string> groupProperties))
+                        continue;
+
+                    bool groupMatched = false;
+                    double groupSum = 0;
+
+                    groupSum = groupProperties.Intersect(normalizedItemLines.Keys)
+                        .Select(ikey => normalizedItemLines[ikey])
+                        .Sum(p => p.Value);
+                    groupMatched = groupSum >= minValue;
+                    if (groupMatched)
+                    {
+                        matchingPropertiesCount++;
+                        continue;
+                    }
+                }
 
                 KeyValuePair<string, (string Original, double Value)> filteredItemLine = filteredItemLines.FirstOrDefault(x => x.Key == filteredNotOptionalRule.Key);
                 if (string.IsNullOrEmpty(filteredItemLine.Key) || (minValue != -1 && filteredItemLine.Value.Value < minValue))
@@ -561,9 +654,30 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
             }
             
             // Adding optional matching rules
-            foreach (KeyValuePair<string, (int MinValue, bool IsOptional)> filteredOptionalRule in filteredOptionalRules)
+            foreach (KeyValuePair<string, (int MinValue, bool IsOptional, bool IsGroup)> filteredOptionalRule in filteredOptionalRules)
             {
                 double minValue = filteredOptionalRule.Value.MinValue;
+
+                bool isPropertyGroup = filteredOptionalRule.Value.IsGroup;
+
+                if (isPropertyGroup)
+                {
+                    if (!_cachedNormalizedAllGroups.TryGetValue(filteredOptionalRule.Key, out HashSet<string> groupProperties))
+                        continue;
+
+                    bool groupMatched = false;
+                    double groupSum = 0;
+
+                    groupSum = groupProperties.Intersect(normalizedItemLines.Keys)
+                        .Select(ikey => normalizedItemLines[ikey])
+                        .Sum(p => p.Value);
+                    groupMatched = groupSum >= minValue;
+                    if (groupMatched)
+                    {
+                        matchingPropertiesCount++;
+                        continue;
+                    }
+                }
 
                 KeyValuePair<string, (string Original, double Value)> filteredItemLine = filteredItemLines.FirstOrDefault(x => x.Key == filteredOptionalRule.Key);
                 if (string.IsNullOrEmpty(filteredItemLine.Key) || (minValue != -1 && filteredItemLine.Value.Value < minValue))

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightProperties.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightProperties.cs
@@ -5,6 +5,7 @@ using ClassicUO.Renderer;
 using Microsoft.Xna.Framework;
 using System.Collections.Generic;
 using ClassicUO.Game.Data;
+using System.Linq;
 
 namespace ClassicUO.Game.UI.Gumps.GridHighLight
 {
@@ -174,7 +175,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
 
             for (int i = 0; i < data.Properties.Count; i++)
             {
-                AddProperty(data.Properties, i, pos.Y, [GridHighlightRules.Properties, GridHighlightRules.SuperSlayerProperties, GridHighlightRules.SlayerProperties]);
+                AddProperty(data.Properties, i, pos.Y, [GridHighlightRules.Properties, GridHighlightRules.SuperSlayerProperties, GridHighlightRules.SlayerProperties, GridHighlightRules.GroupedProperties.Keys.ToHashSet()]);
                 pos.Y += 25;
             }
 
@@ -184,7 +185,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
             {
                 if (e.Button == Input.MouseButtonType.Left)
                 {
-                    data.Properties.Add(new GridHighlightProperty { Name = "", MinValue = -1, IsOptional = false });
+                    data.Properties.Add(new GridHighlightProperty { Name = "", MinValue = -1, IsOptional = false});
                     data.InvalidateCache();
                     Build();
                     GridHighlightData.RecheckMatchStatus(); //Request new opl data and re-check item matches

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightRules.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightRules.cs
@@ -8,6 +8,8 @@ using System.Text.Json;
 
 namespace ClassicUO.Game.UI.Gumps.GridHighLight
 {
+    
+
     public static class GridHighlightRules
     {
         private const string CONFIG_FILE_NAME = "GridHighlightSettings.json";
@@ -39,7 +41,10 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
                 Negatives = ProfileManager.CurrentProfile.ConfigurableNegatives?.ToList(),
                 SuperSlayers = ProfileManager.CurrentProfile.ConfigurableSuperSlayers?.ToList(),
                 Slayers = ProfileManager.CurrentProfile.ConfigurableSlayers?.ToList(),
-                Rarities = ProfileManager.CurrentProfile.ConfigurableRarities?.ToList()
+                Rarities = ProfileManager.CurrentProfile.ConfigurableRarities?.ToList(),
+                GroupedProperties = ProfileManager.CurrentProfile.ConfigurableGroupedProperties?.ToDictionary(
+                    kvp => kvp.Key,
+                    kvp => kvp.Value.ToList())
             };
 
             string path = Path.Combine(CUOEnviroment.ExecutablePath, "Data", CONFIG_FILE_NAME);
@@ -74,6 +79,9 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
                     ProfileManager.CurrentProfile.ConfigurableSuperSlayers = DefaultSuperSlayer.ToList();
                     ProfileManager.CurrentProfile.ConfigurableSlayers = DefaultSlayer.ToList();
                     ProfileManager.CurrentProfile.ConfigurableRarities = DefaultRarity.ToList();
+                    ProfileManager.CurrentProfile.ConfigurableGroupedProperties = DefaultGroupedProperties.ToDictionary(
+                        kvp => kvp.Key,
+                        kvp => kvp.Value.ToList());
                     SaveGridHighlightConfiguration();
                 }
 
@@ -93,6 +101,9 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
                     ProfileManager.CurrentProfile.ConfigurableSuperSlayers = config.SuperSlayers ?? new List<string>();
                     ProfileManager.CurrentProfile.ConfigurableSlayers = config.Slayers ?? new List<string>();
                     ProfileManager.CurrentProfile.ConfigurableRarities = config.Rarities ?? new List<string>();
+                    ProfileManager.CurrentProfile.ConfigurableGroupedProperties = config.GroupedProperties?.ToDictionary(
+                        kvp => kvp.Key,
+                        kvp => kvp.Value.ToList()) ?? new Dictionary<string, List<string>>();
                 }
             }
             catch (Exception ex)
@@ -109,6 +120,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
             public List<string> SuperSlayers { get; set; }
             public List<string> Slayers { get; set; }
             public List<string> Rarities { get; set; }
+            public Dictionary<string, List<string>> GroupedProperties { get; set; }
         }
 
         public static HashSet<string> Properties =>
@@ -247,6 +259,35 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
                 "Major Artifact",
                 "Legendary Artifact"
             };
+
+        public static Dictionary<string, HashSet<string>> GroupedProperties => DefaultGroupedProperties;
+        //GetConfigurableOrDefault(() => ProfileManager.CurrentProfile?.ConfigurableGroupedProperties, DefaultGroupedProperties);
+        private static readonly Dictionary<string, HashSet<string>> DefaultGroupedProperties = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Total Resists"] = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "Physical Resist",
+                "Fire Resist",
+                "Cold Resist",
+                "Poison Resist",
+                "Energy Resist"
+            },
+            ["Total Mana"] = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "Intelligence Bonus",
+                "Mana Increase"
+            },
+            ["Total Hits"] = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "Strength Bonus",
+                "Hit Point Increase"
+            },
+            ["Total Stamina"] = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "Dexterity Bonus",
+                "Stamina Increase"
+            }
+        };
 
         public static string[] FlattenAndDistinctParameters(params HashSet<string>[] propertySets) => propertySets
                 .SelectMany(set => set)


### PR DESCRIPTION
Add support for grouped properties in GridHighLight

Introduced `ConfigurableGroupedProperties` to enable grouping of related properties under a common key, improving organization and functionality. Updated `ProfileManager` to handle initialization and saving of grouped properties. Enhanced `GridHighLightData` with caching, normalization, and matching logic for grouped properties, including optional and required rules.

General improvements include LINQ usage, caching optimizations, and code refactoring for better readability and maintainability.
Add support for grouped properties in GridHighlight

Enhanced the GridHighlight system to support grouped properties:
- Added `ConfigurableGroupedProperties` to `Profile` for grouping.
- Introduced `shouldResave` flag in `ProfileManager` to optimize saving.
- Updated `GridHighLightData` to cache and validate grouped properties.
- Added `ComputeGroupSum` for aggregated property matching logic.
- Modified `GridHighLightProperties` to include grouped properties.
- Introduced `GroupedProperties` in `GridHighlightRules` with defaults.
- Refactored configuration handling to support grouped properties.
- Improved code readability and maintainability with helper methods.

These changes enhance flexibility and functionality, ensuring backward compatibility and better organization of property rules.

What still needs to be done:
 - Update the config gump to support grouped properties.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating and configuring custom property groups within grid highlighting, enabling users to organize related properties under logical categories.
  * Grouped property configurations now persist with user profiles and automatically restore on startup for consistent setups across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->