### PR TITLE
Fix spell icon dragging from spellbooks

### DIFF
--- a/src/ClassicUO.Client/Game/Managers/UIManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/UIManager.cs
@@ -686,7 +686,7 @@ namespace ClassicUO.Game.Managers
                 Point delta = Mouse.LDragOffset;
 
                 bool doDrag = (ProfileManager.CurrentProfile == null || Math.Abs(delta.X) >= ProfileManager.CurrentProfile.MinGumpMoveDistance || Math.Abs(delta.Y) >= ProfileManager.CurrentProfile.MinGumpMoveDistance) || attemptAlwaysSuccessful;
-                if (doDrag && !_isDraggingControl)
+                if (doDrag && (!_isDraggingControl || attemptAlwaysSuccessful))
                 {
                     DraggingControl = dragTarget;
                     _dragOrigin = Mouse.LClickPosition;


### PR DESCRIPTION
When dragging a spell icon out of a spellbook, the minimum drag distance check was causing the spellbook itself to be dragged instead of creating and dragging the spell icon.

The issue was in UIManager.AttemptDragControl():
- When minimum drag distance was met, the spellbook became DraggingControl
- The spellbook's OnDragBegin created a UseSpellButtonGump and called AttemptDragControl(gump, true) to start dragging it
- But the check `if (doDrag && !_isDraggingControl)` prevented updating DraggingControl because _isDraggingControl was already true
- Result: spellbook continued being dragged instead of the spell icon

Fix: Allow switching DraggingControl when attemptAlwaysSuccessful=true by changing the condition to `(!_isDraggingControl || attemptAlwaysSuccessful)`

This allows the drag to be "handed off" from the spellbook to the newly created spell icon when pulling spells out of the book.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced drag and drop responsiveness by improving drag operation initialization logic under specific conditions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->