### PR TITLE
Improve script recorder: current menu replies and Script Manager refresh

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/MenuGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/MenuGump.cs
@@ -1,8 +1,9 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
 using System.Linq;
-using ClassicUO.Game.UI.Controls;
 using ClassicUO.Assets;
+using ClassicUO.Game.UI.Controls;
+using ClassicUO.LegionScripting;
 using ClassicUO.Network;
 using ClassicUO.Renderer;
 using ClassicUO.Utility.Logging;
@@ -122,6 +123,8 @@ namespace ClassicUO.Game.UI.Gumps
                     graphic,
                     hue
                 );
+                ScriptRecorder.Instance.RecordMenuResponse(LocalSerial, (ushort)ServerSerial, index, graphic, hue);
+                ScriptingInfoGump.AddOrUpdateInfo("Last Menu Response", $"{name} ({index})");
                 Dispose();
                 e.Result = true;
             };
@@ -318,6 +321,8 @@ namespace ClassicUO.Game.UI.Gumps
                                 (ushort)ServerSerial,
                                 index
                             );
+                            ScriptRecorder.Instance.RecordGrayMenuResponse(LocalSerial, (ushort)ServerSerial, index);
+                            ScriptingInfoGump.AddOrUpdateInfo("Last Menu Response", $"{radioButton.Text} ({index})");
 
                             Dispose();
                             break;

--- a/src/ClassicUO.Client/LegionScripting/API.cs
+++ b/src/ClassicUO.Client/LegionScripting/API.cs
@@ -575,6 +575,45 @@ namespace ClassicUO.LegionScripting
         );
 
         /// <summary>
+        /// Send a response to the currently open menu (uses the latest MenuGump).
+        /// Useful when menu IDs change every time (e.g., Tracking skill).
+        /// Returns true if a menu was found and a response was sent.
+        /// </summary>
+        public bool MenuResponseCurrent(int index, ushort itemGraphic = 0, ushort itemHue = 0) => MainThreadQueue.InvokeOnMainThread<bool>
+        (() =>
+            {
+                MenuGump menu = UIManager.Gumps.OfType<MenuGump>()
+                    .LastOrDefault(g => !g.IsDisposed && g.IsVisible);
+
+                if (menu == null)
+                    return false;
+
+                AsyncNetClient.Socket.Send_MenuResponse(menu.LocalSerial, (ushort)menu.ServerSerial, index, itemGraphic, itemHue);
+                menu.Dispose();
+                return true;
+            }
+        );
+
+        /// <summary>
+        /// Send a response to the currently open gray menu (text list menu).
+        /// Returns true if a gray menu was found and a response was sent.
+        /// </summary>
+        public bool GrayMenuResponseCurrent(ushort index) => MainThreadQueue.InvokeOnMainThread<bool>
+        (() =>
+            {
+                GrayMenuGump menu = UIManager.Gumps.OfType<GrayMenuGump>()
+                    .LastOrDefault(g => !g.IsDisposed && g.IsVisible);
+
+                if (menu == null)
+                    return false;
+
+                AsyncNetClient.Socket.Send_GrayMenuResponse(menu.LocalSerial, (ushort)menu.ServerSerial, index);
+                menu.Dispose();
+                return true;
+            }
+        );
+
+        /// <summary>
         /// Attempt to equip an item. Layer is automatically detected.
         /// Example:
         /// ```py

--- a/src/ClassicUO.Client/LegionScripting/ScriptRecorder.cs
+++ b/src/ClassicUO.Client/LegionScripting/ScriptRecorder.cs
@@ -207,6 +207,36 @@ namespace ClassicUO.LegionScripting
                 { "index", index }
             });
 
+        public void RecordMenuResponse(uint serial, ushort menuId, int index, ushort itemGraphic, ushort itemHue)
+        {
+            var parameters = new Dictionary<string, object>
+            {
+                { "serial", serial },
+                { "menuid", menuId },
+                { "index", index }
+            };
+
+            if (itemGraphic != 0)
+                parameters["itemgraphic"] = itemGraphic;
+
+            if (itemHue != 0)
+                parameters["itemhue"] = itemHue;
+
+            RecordAction("menuresponse", parameters);
+        }
+
+        public void RecordGrayMenuResponse(uint serial, ushort menuId, ushort index)
+        {
+            var parameters = new Dictionary<string, object>
+            {
+                { "serial", serial },
+                { "menuid", menuId },
+                { "index", index }
+            };
+
+            RecordAction("graymenuresponse", parameters);
+        }
+
         public void RecordUseSkill(string skillName) => RecordAction("useskill", new Dictionary<string, object> { { "skill", skillName } });
 
         public void RecordEquipItem(uint serial, Layer layer) => RecordAction("equipitem", new Dictionary<string, object>
@@ -390,6 +420,41 @@ namespace ClassicUO.LegionScripting
                         if (action.Parameters.TryGetValue("serial", out object contextSerial) &&
                             action.Parameters.TryGetValue("index", out object contextIndex))
                             script.AppendLine($"API.ContextMenu(0x{contextSerial:X8}, {contextIndex})");
+                        break;
+
+                    case "menuresponse":
+                        if (action.Parameters.TryGetValue("serial", out object menuSerial) &&
+                            action.Parameters.TryGetValue("menuid", out object menuId) &&
+                            action.Parameters.TryGetValue("index", out object menuIndex))
+                        {
+                            int indexValue = Convert.ToInt32(menuIndex);
+
+                            string menuCall = $"API.MenuResponseCurrent({indexValue}";
+
+                            bool hasGraphic = action.Parameters.TryGetValue("itemgraphic", out object menuGraphic);
+                            bool hasHue = action.Parameters.TryGetValue("itemhue", out object menuHue);
+
+                            if (hasGraphic || hasHue)
+                            {
+                                ushort graphicValue = hasGraphic ? Convert.ToUInt16(menuGraphic) : (ushort)0;
+                                ushort hueValue = hasHue ? Convert.ToUInt16(menuHue) : (ushort)0;
+                                menuCall += $", 0x{graphicValue:X4}, 0x{hueValue:X4}";
+                            }
+
+                            menuCall += ")";
+                            script.AppendLine(menuCall);
+                        }
+                        break;
+
+                    case "graymenuresponse":
+                        if (action.Parameters.TryGetValue("serial", out object graySerial) &&
+                            action.Parameters.TryGetValue("menuid", out object grayMenuId) &&
+                            action.Parameters.TryGetValue("index", out object grayIndex))
+                        {
+                            ushort indexValue = Convert.ToUInt16(grayIndex);
+
+                            script.AppendLine($"API.GrayMenuResponseCurrent({indexValue})");
+                        }
                         break;
 
                     case "useskill":

--- a/src/ClassicUO.Client/LegionScripting/ScriptRecordingGump.cs
+++ b/src/ClassicUO.Client/LegionScripting/ScriptRecordingGump.cs
@@ -533,11 +533,7 @@ namespace ClassicUO.LegionScripting
                 System.IO.File.WriteAllText(filePath, script);
                 GameActions.Print($"Script saved as {fileName}");
 
-                Task.Run(async () =>
-                {
-                    await Task.Delay(300);
-                    MainThreadQueue.EnqueueAction(() => ScriptManagerWindow.Instance?.Refresh());
-                });
+                MainThreadQueue.EnqueueAction(() => ScriptManagerWindow.Instance?.Refresh());
             }
             catch (Exception ex)
             {

--- a/src/ClassicUO.Client/LegionScripting/ScriptRecordingGump.cs
+++ b/src/ClassicUO.Client/LegionScripting/ScriptRecordingGump.cs
@@ -435,6 +435,12 @@ namespace ClassicUO.LegionScripting
                     object contextSerial = action.Parameters.ContainsKey("serial") ? action.Parameters["serial"] : "?";
                     object contextIndex = action.Parameters.ContainsKey("index") ? action.Parameters["index"] : "?";
                     return $"Context Menu 0x{contextSerial:X8} [{contextIndex}]";
+                case "menuresponse":
+                    object menuIndex = action.Parameters.ContainsKey("index") ? action.Parameters["index"] : "?";
+                    return $"Menu Response [{menuIndex}]";
+                case "graymenuresponse":
+                    object grayMenuIndex = action.Parameters.ContainsKey("index") ? action.Parameters["index"] : "?";
+                    return $"Gray Menu Response [{grayMenuIndex}]";
                 case "useskill":
                     object skillName = action.Parameters.ContainsKey("skill") ? action.Parameters["skill"] : "?";
                     return $"Use Skill \"{skillName}\"";

--- a/src/ClassicUO.Client/LegionScripting/ScriptRecordingGump.cs
+++ b/src/ClassicUO.Client/LegionScripting/ScriptRecordingGump.cs
@@ -3,9 +3,12 @@ using System.Collections.Generic;
 using ClassicUO.Assets;
 using ClassicUO.Game;
 using ClassicUO.Game.Data;
+using ClassicUO.Game.Managers;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Game.UI.Gumps;
+using ClassicUO.Game.UI.ImGuiControls;
 using ClassicUO.Input;
+using System.Threading.Tasks;
 
 namespace ClassicUO.LegionScripting
 {
@@ -517,12 +520,24 @@ namespace ClassicUO.LegionScripting
         {
             try
             {
+                if (ScriptRecorder.Instance.IsRecording)
+                {
+                    ScriptRecorder.Instance.StopRecording();
+                    UpdateUI();
+                }
+
                 string script = ScriptRecorder.Instance.GenerateScript(_recordPausesCheckbox.IsChecked);
                 string fileName = $"recorded_script_{DateTime.Now:yyyyMMdd_HHmmss}.py";
                 string filePath = System.IO.Path.Combine(LegionScripting.ScriptPath, fileName);
 
                 System.IO.File.WriteAllText(filePath, script);
                 GameActions.Print($"Script saved as {fileName}");
+
+                Task.Run(async () =>
+                {
+                    await Task.Delay(300);
+                    MainThreadQueue.EnqueueAction(() => ScriptManagerWindow.Instance?.Refresh());
+                });
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Description
- Add “current menu” helpers and script generation to use them, so menu responses work even when menu IDs change; remove legacy menu-response APIs and update docs.
- Add auto-stop-and-save flow: clicking “Save Script” stops recording if active, writes the script, then refreshes Script Manager after a short delay so the new file appears.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Documentation update

## Testing
- Manually recorded a menu selection, saved while recording, and confirmed: recording stops, file is created, and Script Manager shows it after the delay; replay uses MenuResponseCurrent/GrayMenuResponseCurrent successfully.

## Screenshots (if applicable)
<img width="1029" height="777" alt="image" src="https://github.com/user-attachments/assets/c5f97f1d-61ee-411f-aff0-5596e1b1991a" />


## Additional Notes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Menu interactions are now recorded during scripting sessions, capturing both normal and gray menu responses (including selected item or radio text and index).
  * Added ability to programmatically respond to the currently open menu or gray menu.
  * Script recording displays menu response actions in a readable format.
  * Script saving now stops active recording and refreshes the scripting UI automatically.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->