### PR TITLE
Add python API endpoint to get items in the current menu gump

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/MenuGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/MenuGump.cs
@@ -14,11 +14,21 @@ namespace ClassicUO.Game.UI.Gumps
     public class MenuGump : Gump
     {
         private readonly ContainerHorizontal _container;
-        private bool _isDown,
-            _isLeft;
+        private bool _isDown, _isLeft;
         private readonly HSliderBar _slider;
         public override bool ShouldBeSaved => false;
         public override GumpType GumpType => GumpType.MenuGump;
+
+        public MenuGumpItemViewMetadata[] MenuItemsMetadata => _container.Children
+            .OfType<ItemView>()
+            .Select(iv => new MenuGumpItemViewMetadata
+            {
+                Graphic = iv.Graphic,
+                Hue     = iv.Hue,
+                Index   = iv.Index,
+                Name    = iv.Name
+            })
+            .ToArray();
 
         public MenuGump(World world, uint serial, uint serv, string name) : base(world, serial, serv)
         {
@@ -108,7 +118,7 @@ namespace ClassicUO.Game.UI.Gumps
 
         public void AddItem(ushort graphic, ushort hue, string name, int x, int y, int index)
         {
-            var view = new ItemView(graphic, hue)
+            var view = new ItemView(graphic, hue, index, name)
             {
                 X = x,
                 Y = y
@@ -149,8 +159,15 @@ namespace ClassicUO.Game.UI.Gumps
             private readonly ushort _graphic;
             private readonly ushort _hue;
             private readonly bool _isPartial;
+            private readonly int _index;
+            private readonly string _name;
+            
+            internal int Index => _index;
+            internal string Name => _name;
+            internal ushort Graphic => _graphic;
+            internal ushort Hue => _hue;
 
-            public ItemView(ushort graphic, ushort hue)
+            public ItemView(ushort graphic, ushort hue, int index, string name)
             {
                 AcceptMouseInput = true;
                 WantUpdateSize = true;
@@ -159,9 +176,11 @@ namespace ClassicUO.Game.UI.Gumps
 
                 ref readonly SpriteInfo artInfo = ref Client.Game.UO.Arts.GetArt(_graphic);
 
-                Width = artInfo.UV.Width;
-                Height = artInfo.UV.Height;
-                _hue = hue;
+                Width      = artInfo.UV.Width;
+                Height     = artInfo.UV.Height;
+                _hue       = hue;
+                _index     = index;
+                _name      = name;
                 _isPartial = Client.Game.UO.FileManager.TileData.StaticData[graphic].IsPartialHue;
             }
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/MenuGumpItemViewMetadata.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/MenuGumpItemViewMetadata.cs
@@ -1,0 +1,9 @@
+namespace ClassicUO.Game.UI.Gumps;
+
+public record MenuGumpItemViewMetadata
+{
+    public required int Index { get; init; }
+    public required string Name { get; init; }
+    public required ushort Graphic { get; init; }
+    public required ushort Hue { get; init; }
+}

--- a/src/ClassicUO.Client/LegionScripting/API.cs
+++ b/src/ClassicUO.Client/LegionScripting/API.cs
@@ -593,6 +593,26 @@ namespace ClassicUO.LegionScripting
                 return true;
             }
         );
+        
+        /// <summary>
+        /// Retrieve the current open menu's (uses the latest MenuGump) menu item descriptions.
+        /// Useful when menu IDs change every time (e.g., Tracking skill).
+        /// </summary>
+        public PythonList MenuItemsCurrent() => MainThreadQueue.InvokeOnMainThread<PythonList>
+        (() =>
+            {
+                MenuGump menu = UIManager.Gumps
+                    .OfType<MenuGump>()
+                    .LastOrDefault(g => !g.IsDisposed && g.IsVisible);
+
+                if (menu is null)
+                    return [];
+
+                PythonList items = [];
+                items.AddRange(menu.MenuItemsMetadata.Select(mim => new PyMenuItem(mim.Index, mim.Name, mim.Graphic, mim.Hue)));
+                return items;
+            }
+        );
 
         /// <summary>
         /// Send a response to the currently open gray menu (text list menu).

--- a/src/ClassicUO.Client/LegionScripting/API.cs
+++ b/src/ClassicUO.Client/LegionScripting/API.cs
@@ -598,6 +598,7 @@ namespace ClassicUO.LegionScripting
         /// Retrieve the current open menu's (uses the latest MenuGump) menu item descriptions.
         /// Useful when menu IDs change every time (e.g., Tracking skill).
         /// </summary>
+        /// <returns>List of <see cref="PyMenuItem"/> containing Index, Name, Graphic and Hue values for each menu item</returns>
         public PythonList MenuItemsCurrent() => MainThreadQueue.InvokeOnMainThread<PythonList>
         (() =>
             {

--- a/src/ClassicUO.Client/LegionScripting/PyClasses/PyMenuItem.cs
+++ b/src/ClassicUO.Client/LegionScripting/PyClasses/PyMenuItem.cs
@@ -1,0 +1,39 @@
+namespace ClassicUO.LegionScripting.PyClasses;
+
+/// <summary>
+/// Represents a Python-accessible item in a menu.
+/// </summary>
+public class PyMenuItem
+{
+    public int Index { get;}
+    public string Name { get; }
+    public ushort Graphic { get; }
+    public ushort Hue { get; }
+    
+    internal PyMenuItem(int index, string name, ushort graphic, ushort hue)
+    {
+        Index   = index;
+        Name    = name;
+        Graphic = graphic;
+        Hue     = hue;
+    }
+    
+    /// <summary>
+    /// Returns a readable string representation of the menu item.
+    /// Used when printing or converting the object to a string in Python scripts.
+    /// </summary>
+    public override string ToString() => $"<{__class__} Index={Index:X8} Graphic=0x{Graphic:X4} Hue=0x{Hue:X4} Name=\"{Name}\">";
+    
+    /// <summary>
+    /// The Python-visible class name of this object.
+    /// Accessible in Python as <c>obj.__class__</c>.
+    /// </summary>
+    public virtual string __class__ => nameof(PyMenuItem);
+
+    /// <summary>
+    /// Returns a detailed string representation of the object.
+    /// This string is used by Python’s built-in <c>repr()</c> function.
+    /// </summary>
+    /// <returns>A string suitable for debugging and inspection in Python.</returns>
+    public virtual string __repr__() => ToString();
+}

--- a/src/ClassicUO.Client/LegionScripting/PyClasses/PyMenuItem.cs
+++ b/src/ClassicUO.Client/LegionScripting/PyClasses/PyMenuItem.cs
@@ -22,7 +22,7 @@ public class PyMenuItem
     /// Returns a readable string representation of the menu item.
     /// Used when printing or converting the object to a string in Python scripts.
     /// </summary>
-    public override string ToString() => $"<{__class__} Index={Index:X8} Graphic=0x{Graphic:X4} Hue=0x{Hue:X4} Name=\"{Name}\">";
+    public override string ToString() => $"<{__class__} Index={Index:D} Graphic=0x{Graphic:X4} Hue=0x{Hue:X4} Name=\"{Name}\">";
     
     /// <summary>
     /// The Python-visible class name of this object.


### PR DESCRIPTION
Add API.MenuItemsCurrent() to retrieve the menu items contained in the active Menu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Menu items now expose extended metadata (index, name, graphic, hue) in the UI.
  * Scripting API can retrieve the current menu's item list for inspection.
  * Scripting-facing menu item objects provide readable string representations for easier debugging and display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->