### PR TITLE
Add CloseLastServerGump to python API

### DIFF
--- a/src/ClassicUO.Client/LegionScripting/API.cs
+++ b/src/ClassicUO.Client/LegionScripting/API.cs
@@ -633,6 +633,24 @@ namespace ClassicUO.LegionScripting
                 return true;
             }
         );
+        
+        /// <summary>
+        /// Close the current (last opened) gump created by the server.
+        /// Returns true if a server gump was found and closed.
+        /// </summary>
+        public bool CloseLastServerGump() => MainThreadQueue.InvokeOnMainThread<bool>
+        (() =>
+            {
+                var gump = UIManager.Gumps
+                    .LastOrDefault(g => g is not null && !g.IsDisposed && g.IsVisible && g.IsFromServer);
+
+                if (gump is null)
+                    return false;
+
+                DisposeGump(gump);
+                return true;
+            }
+        );
 
         /// <summary>
         /// Attempt to equip an item. Layer is automatically detected.


### PR DESCRIPTION
Close the current (last opened) gump created by the server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API method to close the last server-created window. Returns true if a window was successfully closed, false if no server windows were available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->