### PR TITLE
Restore read settings from command line arguments in  Main.cs

### DIFF
--- a/src/ClassicUO.Client/Main.cs
+++ b/src/ClassicUO.Client/Main.cs
@@ -94,6 +94,8 @@ namespace ClassicUO
                 }
             };
 
+            ReadSettingsFromArgs(args);
+
             if (CUOEnviroment.IsHighDPI)
             {
                 Environment.SetEnvironmentVariable("FNA_GRAPHICS_ENABLE_HIGHDPI", "1");


### PR DESCRIPTION
Added ReadSettingsFromArgs(args) back in at line 97 to restore command line argument read. This was preventing using login, server, password, and a few other settings from the profile json file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line argument processing timing during application startup to ensure settings overrides take effect earlier in the initialization sequence.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->