### PR TITLE
Fix static items not drawn at Z = 127

### DIFF
--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: BSD-2-Clause
+// SPDX-License-Identifier: BSD-2-Clause
 
 
 using ClassicUO.Assets;
@@ -794,7 +794,7 @@ namespace ClassicUO.Game.Scenes
                         if (firstObj?.IsDestroyed != false)
                             continue;
 
-                        AddTileToRenderList(firstObj, useHandles, 150, maxCotZ, ref playerPos);
+                        AddTileToRenderList(firstObj, useHandles, 200, maxCotZ, ref playerPos);
                     }
                 }
             }

--- a/src/ClassicUO.Client/Game/Scenes/GameSceneDrawingSorting.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameSceneDrawingSorting.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: BSD-2-Clause
+// SPDX-License-Identifier: BSD-2-Clause
 
 using System;
 using System.Runtime.CompilerServices;
@@ -361,7 +361,7 @@ namespace ClassicUO.Game.Scenes
             {
                 if (Vector2.Distance(new Vector2(obj.RealScreenPosition.X, obj.RealScreenPosition.Y), playerPos) < ProfileManager.CurrentProfile.CircleOfTransparencyRadius)
                 {
-                    if (obj.Z >= _maxZ)
+                    if (obj.Z > _maxZ)
                     {
                         obj.AlphaHue = 0;
                         //CalculateAlpha(ref obj.AlphaHue, 0);
@@ -393,7 +393,7 @@ namespace ClassicUO.Game.Scenes
                     }
                 }
             }
-            if (obj.Z >= _maxZ)
+            if (obj.Z > _maxZ)
             {
                 bool changed;
 


### PR DESCRIPTION
Fix static items not drawn if Z + tiledata Height > 150 (at 127 Z the max item height was 23, there are more than 500 items in latest tiledata with height > 23. Now the cap will be 73, the max item height currently is 60)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering and visibility behavior for objects at various distances in gameplay.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->