### PR TITLE
fix: Profile setting `GridContainersDefaultToOldStyleView` ignored

### DIFF
--- a/src/ClassicUO.Client/Game/Managers/GridContainerSaveData.cs
+++ b/src/ClassicUO.Client/Game/Managers/GridContainerSaveData.cs
@@ -305,7 +305,12 @@ public class GridContainerEntry
 
     [JsonPropertyName("mny")] public int MinimizedY { get; set; }
 
-    [JsonPropertyName("og")] public bool UseOriginalContainer { get; set; }
+    /// <summary>
+    /// The container's gump style preference.
+    /// <br/>
+    /// When null, the container should be opened in accordance to the <see cref="Profile.GridContainersDefaultToOldStyleView"/> setting
+    /// </summary>
+    [JsonPropertyName("og")] public bool? UseOriginalContainer { get; set; }
 
     [JsonPropertyName("as")] public bool AutoSort { get; set; }
 
@@ -366,7 +371,9 @@ public class GridContainerEntry
         // Store the full height, not the minimized height
         Height = container.IsMinimized ? container.HeightBeforeMinimize : container.Height;
         SetPositionForState(container.X, container.Y, container.IsMinimized);
-        UseOriginalContainer = container.UseOldContainerStyle ?? false;
+        // If the container was given a new explicit preference, use it, otherwise, use whatever we already have stored.
+        // Null is also fine here and indicates a 'default', ergo, go with the profile's `GridContainersDefaultToOldStyleView` settings
+        UseOriginalContainer = container.UseOldContainerStyle ?? container.GridContainerEntry.UseOriginalContainer;
         AutoSort = container.AutoSortContainer;
         VisuallyStackNonStackables = container.StackNonStackableItems;
         SortMode = (int)container.SortMode;

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
@@ -477,7 +477,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             SlotManager = new GridSlotManager(world, LocalSerial, this, scrollArea); //Must come after scroll area
 
-            if (gridContainerEntry.UseOriginalContainer && (UseOldContainerStyle == null || UseOldContainerStyle == true))
+            if (ShouldUseOldContainerStyle())
             {
                 skipSave = true; //Avoid unsaving item slots because they have not be set up yet
                 OpenOldContainer(local);
@@ -497,6 +497,28 @@ namespace ClassicUO.Game.UI.Gumps
                 // to avoid overwriting _heightBeforeMinimize
                 ApplyMinimizedDimensions();
             }
+        }
+
+        /// <summary>
+        ///     Checks whether the container should be opened in the 'old' style.
+        ///     <br />
+        ///     Container style is determined, in order, by:
+        ///     <list type="number">
+        ///         <item>Explicit open request (such as when clicking the `Return to grid container view` button</item>
+        ///         <item>The value of the container's <see cref="GridContainerEntry.UseOriginalContainer" /> (if exists)</item>
+        ///         <item>The global preference in <see cref="Profile.GridContainersDefaultToOldStyleView" /></item>
+        ///     </list>
+        /// </summary>
+        /// <returns></returns>
+        private bool ShouldUseOldContainerStyle()
+        {
+            // If the container has no stored preference and was not opened in a specific mode, use the global default
+            if (gridContainerEntry.UseOriginalContainer == null && UseOldContainerStyle == null)
+                return ProfileManager.CurrentProfile.GridContainersDefaultToOldStyleView;
+
+            // Next, if the open request was made with a specific mode (i.e., useGridStyle != nul), use that,
+            // otherwise, fallback to the stored preference (which, if we got here is *not* null, or we'd fall into the default case above)
+            return UseOldContainerStyle ?? gridContainerEntry.UseOriginalContainer.Value;
         }
 
         public override GumpType GumpType => GumpType.GridContainer;


### PR DESCRIPTION
## Description

Profile setting `GridContainersDefaultToOldStyleView` is ignored, causing new containers to always open in grid mode, if enabled.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing
Manual. Was unable to find existing or determine sane way to test containers.
Might dive into this next.

* Containers should always open using the expected mode when using the 'explicit' overrides (`Open original view` & `Return to grid container view`), regardless of defaults or stored preference

* 'Unknown'  containers (without a stored `grid_containers.json` entry) should open in accordance to `GridContainersDefaultToOldStyleView`

* 'Known' containers should open in the mode the were serialized with, i.e., according to their '`og`' attribute in `grid_containers.json`)

* `null` '`og`' values should be gracefully handled and effectively reset the container's preference to default

* Must not impact the `Enable grid containers` setting

* No change in behavior when switching grid containers off/on; When off, all containers are 'old' and when on, behave as expected.


## Additional Notes

This change addresses the issue by imposing the following 'style' priorities during container open:

* Explicit request for a specific type (such as issued when clicking the `Open original view` button
* Stored preference from the `GridContainerEntry.UseOriginalContainer`
* Default preference from `ProfileManager.CurrentProfile.GridContainersDefaultToOldStyleView`

The reason for the change in `UseOriginalContainer` from `bool` to `bool?` is to avoid forcing a preference during container load.
During load, the container is stored in the GridContainerEntry dictionary which sets  `UseOriginalContainer` which prevented the code from distinguishing between stored preferences and defaults.


#### P.S - I tend to be verbose  in my comments, please let me know if it's too much. Just trying to save a headache for future readers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved grid container styling behavior. Containers now properly default to profile settings when individual preferences aren't specified, ensuring consistent display across the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->