### PR TITLE
feat: Added a way to clear the `Go-To` marker on the world map

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/LocationGoGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/LocationGoGump.cs
@@ -19,17 +19,28 @@ public partial class LocationGoGump : Gump
     [GeneratedRegex(@"^(?<X>\d+)\s*[,:\s]\s*(?<Y>\d+)$")]
     private static partial Regex PointCoordsRegex();
 
+    private const int VALID_POINT_HUE = 0x40;
+    private const int INVALID_POINT_HUE = 0x33;
+
     private readonly World _world;
     private readonly Action<int, int> _goTo;
+    private readonly Action _onClear;
 
     private readonly StbTextBox _textBox;
-    private readonly string _message = ResGumps.EnterLocation;
-    private Point _location = Sextant.InvalidPoint;
+    private Point _location;
 
-    public LocationGoGump(World world, Action<int, int> goTo) : base(world, 0, 0)
+    public LocationGoGump(
+        World world,
+        Action<int, int> goTo,
+        Action onClear,
+        Point? prefilledLocation = null
+    ) : base(world, 0, 0)
     {
         _world = world;
         _goTo = goTo;
+        _onClear = onClear;
+        _location  = prefilledLocation ?? Sextant.InvalidPoint;
+
         CanMove = true;
         CanCloseWithRightClick = true;
         CanCloseWithEsc = true;
@@ -56,7 +67,7 @@ public partial class LocationGoGump : Gump
 
         Label l = Add
         (
-            new Label(_message, true, 0xFFFF, Width - 90, 0xFF)
+            new Label(ResGumps.EnterLocation, true, 0xFFFF, Width - 90, 0xFF)
             {
                 X = 12,
                 Y = 12
@@ -64,7 +75,6 @@ public partial class LocationGoGump : Gump
         );
 
         int ww = Width - 94;
-
 
         Add
         (
@@ -77,6 +87,7 @@ public partial class LocationGoGump : Gump
             }
         );
 
+        // Coordinates input box
         _textBox = Add
         (
             new StbTextBox(0xFF, -1, ww, true, FontStyle.BlackBorder, align: TEXT_ALIGN_TYPE.TS_LEFT)
@@ -85,11 +96,18 @@ public partial class LocationGoGump : Gump
                 Y = 20 + l.Height + 7,
                 Width = ww,
                 Height = 25,
+                Text = prefilledLocation.HasValue ? $"{prefilledLocation.Value.X}, {prefilledLocation.Value.Y}" : "",
             }
         );
 
-        _textBox.TextChanged += OnTextChange;
+        if (prefilledLocation.HasValue)
+        {
+            // Updating here instead of initializer to avoid unintended changes if default hue ever changes
+            _textBox.Hue = VALID_POINT_HUE;
+        }
 
+        _textBox.TextChanged += OnTextChange;
+        _textBox.SetKeyboardFocus();
 
         // OK
         Button b = Add
@@ -104,7 +122,7 @@ public partial class LocationGoGump : Gump
 
         Add
         (
-            new Label("Examples:\n 1639, 1532\n 100o25'S,40o04'E\n 9 14'N 91 37'W", true, 0xFFFF, Width - 90, 0xFF)
+            new Label(ResGumps.GoToExampleLabel, true, 0xFFFF, Width - 90, 0xFF)
             {
                 X = _textBox.X - 6,
                 Y = _textBox.Y + 28,
@@ -157,34 +175,35 @@ public partial class LocationGoGump : Gump
         if (string.IsNullOrWhiteSpace(text))
             return;
 
-        _textBox.Hue = (ushort)(Sextant.Parse(_world.Map, text, out _location) || ParsePoint(text, out _location) ? 0x40 : 0x33);
+        _textBox.Hue = (ushort)(Sextant.Parse(_world.Map, text, out _location) || ParsePoint(text, out _location) ? VALID_POINT_HUE : INVALID_POINT_HUE);
     }
 
     public override void OnButtonClick(int id)
     {
-        switch (id)
-        {
-            case 0:
-            {
-                if (Go())
-                    Dispose();
-
-                break;
-            }
-        }
+        if (id == 0)
+            Submit();
     }
 
     public override void OnKeyboardReturn(int id, string text)
     {
-        switch (id)
-        {
-            case 0:
-            {
-                if (Go())
-                    Dispose();
+        if (id == 0)
+            Submit();
+    }
 
-                break;
-            }
+    private void Submit()
+    {
+        bool shouldDispose;
+
+        // Default to the 'Go To' branch if no On-Clear callback was given. This retains standard behavior.
+        if (_onClear != null && string.IsNullOrWhiteSpace(_textBox.Text))
+        {
+            _onClear();
+            shouldDispose = true;
         }
+        else
+            shouldDispose = Go();
+
+        if (shouldDispose)
+            Dispose();
     }
 }

--- a/src/ClassicUO.Client/Game/UI/Gumps/LocationGoGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/LocationGoGump.cs
@@ -39,7 +39,7 @@ public partial class LocationGoGump : Gump
         _world = world;
         _goTo = goTo;
         _onClear = onClear;
-        _location  = prefilledLocation ?? Sextant.InvalidPoint;
+        _location = prefilledLocation ?? Sextant.InvalidPoint;
 
         CanMove = true;
         CanCloseWithRightClick = true;

--- a/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
@@ -311,7 +311,15 @@ public class WorldMapGump : ResizableGump
         _options["goto_location"] = new ContextMenuItemEntry
         (
             ResGumps.GotoLocation,
-            () => UIManager.Add(new LocationGoGump(World, (x, y) => GoToMarker(x, y, true)))
+            () => UIManager.Add(new LocationGoGump(
+                    World,
+                    (x, y) => GoToMarker(x, y, true),
+                    ClearGoToMarker,
+                    _gotoMarker != null // Pass in the current marker location, if any
+                        ? new Point(_gotoMarker.X, _gotoMarker.Y)
+                        : null
+                )
+            )
         );
 
         _options["top_most"] = new ContextMenuItemEntry(ResGumps.TopMost, () => { TopMost = !TopMost; }, true, _isTopMost);
@@ -417,6 +425,8 @@ public class WorldMapGump : ResizableGump
         _center.X = x;
         _center.Y = y;
     }
+
+    public void ClearGoToMarker() => _gotoMarker = null;
 
     private void BuildContextMenuForZones(ContextMenuControl parent)
     {

--- a/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
@@ -426,6 +426,9 @@ public class WorldMapGump : ResizableGump
         _center.Y = y;
     }
 
+    /// <summary>
+    /// Clears the current <em>Go-To</em> marker, if it was set
+    /// </summary>
     public void ClearGoToMarker() => _gotoMarker = null;
 
     private void BuildContextMenuForZones(ContextMenuControl parent)

--- a/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
+++ b/src/ClassicUO.Client/Resources/ResGumps.Designer.cs
@@ -4568,5 +4568,14 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("YourCurrentChannel", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///     Looks up a localized string similar to Examples:\n 1639, 1532\n 100o25'S,40o04'E\n 9 14'N 91 37'W
+        /// </summary>
+        public static string GoToExampleLabel {
+            get {
+                return ResourceManager.GetString("GoToExampleLabel", resourceCulture);
+            }
+        }
     }
 }

--- a/src/ClassicUO.Client/Resources/ResGumps.resx
+++ b/src/ClassicUO.Client/Resources/ResGumps.resx
@@ -1624,4 +1624,10 @@ Client version: '{0}'</value>
   <data name="OverheadPartyMessages" xml:space="preserve">
     <value>Show party messages overhead</value>
   </data>
+  <data name="GoToExampleLabel" xml:space="preserve">
+    <value>Examples:
+ 1639, 1532
+ 100o25'S,40o04'E
+ 9 14'N 91 37'W</value>
+  </data>
 </root>


### PR DESCRIPTION
## Description

Added a way to clear the `Go-To` marker on the world map by submitting a blank location in the `Go-To` gump.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing
Manual testing. Verified that:

* Clean-slate behavior unaffected
* Input is prefilled with existing marker coordinates when available
* Prefilled coordinates are highlighted green (i.e., are considered valid)
* Input validation is not affected (Additional note below)
* Clearing the input and confirming results in the marker being removed from the world map
* Localized strings are properly displayed as they were when they were hard-coded

## Additional Notes

* Change is not immediately obvious in terms of UX/UI. Might submit an additional PR to the Website repository to update documentation.

* Added automatic keyboard focus to the gump's input box. Was previously missing.

* [Discord discussion](https://discord.com/channels/1344851225538986064/1344856678767792170/1462934544650080422)

* Existing input validations (both `Point` and `Sextant`) do not properly verify whether the given coordinates are within the map.
This behavior remains unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a coordinate input box to the location UI.
  * Supports pre-filling the location field from an existing map marker.
  * Visual feedback for valid/invalid coordinates via color cues.
  * New option to clear the active map marker.
  * Updated example/help text shown in the location UI.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->