### PR TITLE
feat: GetPartyMemberSerials API

### DIFF
--- a/src/ClassicUO.Client/LegionScripting/API.cs
+++ b/src/ClassicUO.Client/LegionScripting/API.cs
@@ -3410,6 +3410,29 @@ namespace ClassicUO.LegionScripting
 
         #endregion
 
+        #region Party
+
+        /// <summary>
+        /// Gets a list of serials for all current party members, excluding yourself.
+        ///
+        ///
+        /// Note that members may not always have an associated Mobile.
+        /// </summary>
+        /// <returns>A list of party member serials</returns>
+        public PythonList GetPartyMemberSerials() => MainThreadQueue.InvokeOnMainThread(() =>
+        {
+            PythonList members = [];
+            foreach (PartyMember member in World?.Party?.Members ?? [])
+            {
+                if (member != null && member.Serial != 0 && member.Serial != World?.Player?.Serial)
+                    members.Add(member.Serial);
+            }
+
+            return members;
+        });
+
+        #endregion
+
         #region Gumps
         /// <summary>
         /// Use API.Gumps.CreateGump instead


### PR DESCRIPTION
## Description
feat: Added a `GetPartyMemberSerials` API to obtain party member serials from the `PartyManager`

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing
Manual testing. Injected fake entities via code and tested with a real player on a live shard.

## Additional Notes

* [Discord discussion](https://discord.com/channels/1344851225538986064/1349336655923908658/1463264663209775325)

* Intentionally elected to return serials-only.
  While serials are always available, the mobiles themselves may not be which could result in un-intuitive behavior.
  Delegating mobile querying to consumers seems like the most explicit and fool proof way to go.

* The player's own mobile is excluded from the results


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new scripting API method to retrieve a list of party member identifiers, enabling scripts to access information about other members in your active party.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->