### PR TITLE
fix: Add support for `BACKQUOTE` (```) for MacroWindow hotkey bindings

### DIFF
--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/Agents/MacrosWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/Agents/MacrosWindow.cs
@@ -671,6 +671,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
 
         private static Dictionary<ImGuiKey, SDL.SDL_Keycode> _keyMap = new()
         {
+            { ImGuiKey.GraveAccent, SDL.SDL_Keycode.SDLK_GRAVE },
             { ImGuiKey.F1, SDL.SDL_Keycode.SDLK_F1 },
             { ImGuiKey.F2, SDL.SDL_Keycode.SDLK_F2 },
             { ImGuiKey.F3, SDL.SDL_Keycode.SDLK_F3 },


### PR DESCRIPTION
## Description
Add support for `BACKQUOTE` (```) for MacroWindow hotkey bindings

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing
Tested with Organizer macro

## Additional Notes
Entry was missing from the `_keyMap` dictionary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Grave Accent key in hotkey mappings, enabling users to bind this key as a hotkey in macro configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->