### PR TITLE
fix: `API.ConfigNextGump` crashes client

### DIFF
--- a/src/ClassicUO.Client/Network/OutgoingPackets.cs
+++ b/src/ClassicUO.Client/Network/OutgoingPackets.cs
@@ -1272,6 +1272,13 @@ namespace ClassicUO.Network
         {
             const byte ID = 0xB1;
 
+            // Switches are "what radios and checkboxes are checked?"
+            switches ??= [];
+
+            // Entries are responses for text inputs, from the user,
+            // i.e., a user input some arbitrary string into a gump
+            entries ??= [];
+
             int length = AsyncNetClient.PacketsTable.GetPacketLength(ID);
 
             var writer = new StackDataWriter(length < 0 ? 64 : length);


### PR DESCRIPTION
## Description
When `API.ConfigNextGump` is called with AutoRespond active, the next gump open will crash client  due to a null dereference when serializing `switches` and `entries` for packet `0xB1` (`GumpResponse`) 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing
Manual, cursory testing


## Additional Notes

**Note:**  API does not appear to currently handle gumps with switches or inputs. Those are ignored.
This is an existing limitation.


Yields stack-traces similar to:

```text
System.NullReferenceException: Arg_NullReferenceException
   at ClassicUO.Network.NetClientExt.Send_GumpResponse(AsyncNetClient socket, World world, UInt32 local, UInt32 server, Int32 button, UInt32[] switches, Tuple`2[] entries) in /home/runner/work/TazUO/TazUO/src/ClassicUO.Client/Network/OutgoingPackets.cs:line 1288
   at ClassicUO.Game.GameActions.ReplyGump(World world, UInt32 local, UInt32 server, Int32 button, UInt32[] switches, Tuple`2[] entries) in /home/runner/work/TazUO/TazUO/src/ClassicUO.Client/Game/GameActions.cs:line 916
   at ClassicUO.Game.Managers.NextGumpConfig.Apply(Gump gump) in /home/runner/work/TazUO/TazUO/src/ClassicUO.Client/Game/Managers/NextGumpConfig.cs:line 31
   at ClassicUO.Network.PacketHandlers.CreateGump(World world, UInt32 sender, UInt32 gumpID, Int32 x, Int32 y, String layout, String[] lines) in /home/runner/work/TazUO/TazUO/src/ClassicUO.Client/Network/PacketHandlers.cs:line 7514
   at ClassicUO.Network.PacketHandlers.OpenCompressedGump(World world, StackDataReader& p) in /home/runner/work/TazUO/TazUO/src/ClassicUO.Client/Network/PacketHandlers.cs:line 5703
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced null-safety handling for dialog interactions, preventing potential crashes when processing responses with missing or empty values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->