### PR TITLE
fix: Grid Containers `Sort by Name` does not ignore stacksize

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
@@ -2054,11 +2054,16 @@ namespace ClassicUO.Game.UI.Gumps
 
             private static string GetItemName(Item item)
             {
-                if (World.Instance != null && World.Instance.OPL.TryGetNameAndData(item.Serial, out string name, out string data))
-                {
-                    return !string.IsNullOrEmpty(name) ? name : item.ItemData.Name;
-                }
-                return !string.IsNullOrEmpty(item.Name) ? item.Name : item.ItemData.Name;
+                if (World.Instance?.OPL?.TryGetNameAndData(item.Serial, out string name, out string data) != true)
+                    return !string.IsNullOrEmpty(item.Name) ? item.Name : item.ItemData.Name;
+
+                if (string.IsNullOrEmpty(name))
+                    return item.ItemData.Name;
+
+                string itemAmountStr = item.Amount.ToString();
+                return name.StartsWith(itemAmountStr)
+                    ? name[itemAmountStr.Length..]
+                    : name;
             }
 
             private void SetupGridItemControls()

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
@@ -2057,12 +2057,13 @@ namespace ClassicUO.Game.UI.Gumps
                 if (World.Instance?.OPL?.TryGetNameAndData(item.Serial, out string name, out string data) != true)
                     return !string.IsNullOrEmpty(item.Name) ? item.Name : item.ItemData.Name;
 
+                // OPL has a cached name for the item
                 if (string.IsNullOrEmpty(name))
                     return item.ItemData.Name;
 
                 string itemAmountStr = item.Amount.ToString();
                 return name.StartsWith(itemAmountStr)
-                    ? name[itemAmountStr.Length..]
+                    ? name[(itemAmountStr.Length + 1)..] // The +1 is for the whitespace between the Amount and Name
                     : name;
             }
 


### PR DESCRIPTION
## Description

Grid Containers `Sort by Name` does not ignore stacksize, causing mis-sorts like `1 Ruby` before `2 Arrow`

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update


## Additional Notes
Note the condition itself has been reversed to reduce nesting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved item name display in grid containers by properly handling cached name data and removing quantity information from displayed names.
  * Enhanced item property data retrieval with better fallback handling when data is unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->