### PR TITLE
fix: Add `Hit Magic Arrow` to `DefaultProperties` in GridHighLightRules.cs

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightRules.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightRules.cs
@@ -136,6 +136,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
                 "Hit Lightning",
                 "Hit Lower Attack",
                 "Hit Lower Defense",
+                "Hit Magic Arrow",
                 "Hit Mana Drain",
                 "Hit Mana Leech",
                 "Hit Point Increase",


### PR DESCRIPTION
## Description
Add `Hit Magic Arrow` to `DefaultProperties` in GridHighLightRules.cs

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Hit Magic Arrow" as a configurable property in grid highlighting settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->