### PR TITLE
Add Take Item button the Item Detail Window in item database interface

### DIFF
--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/General/ItemDetailWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/General/ItemDetailWindow.cs
@@ -228,8 +228,8 @@ namespace ClassicUO.Game.UI.ImGuiControls
                 if (ImGui.Button("Take Item"))
                 {
                     MoveItemToBackpack(_itemInfo);
-                    SetTooltip("Move the item to your backpack");
                 }
+                SetTooltip("Move the item to your backpack");
             }
             else
             {

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/General/ItemDetailWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/General/ItemDetailWindow.cs
@@ -15,11 +15,13 @@ namespace ClassicUO.Game.UI.ImGuiControls
         public static HashSet<ItemInfo> OpenedWindows = new();
 
         private readonly ItemInfo _itemInfo;
+        private readonly uint? _backpackSerial;
 
         public ItemDetailWindow(ItemInfo itemInfo) : base($"Item Details - {itemInfo.Name}")
         {
-            _itemInfo = itemInfo ?? throw new ArgumentNullException(nameof(itemInfo));
-            WindowFlags = ImGuiWindowFlags.AlwaysAutoResize;
+            _itemInfo       = itemInfo ?? throw new ArgumentNullException(nameof(itemInfo));
+            _backpackSerial = Client.Game.UO?.World?.Player?.Backpack?.Serial;
+            WindowFlags     = ImGuiWindowFlags.AlwaysAutoResize;
             OpenedWindows.Add(itemInfo);
         }
 
@@ -219,11 +221,9 @@ namespace ClassicUO.Game.UI.ImGuiControls
                 ImGui.PopStyleColor(3);
             }
 
-            var player = Client.Game.UO?.World?.Player;
-            Item item = Client.Game.UO?.World?.Items?.Get(_itemInfo.Serial);
-            Item container = item != null ? Client.Game.UO?.World?.Items?.Get(item.Container) : null;
+            Item container = worldItem != null ? Client.Game.UO?.World?.Items?.Get(worldItem.Container) : null;
             //NOTE: There seems to be an error in container.Opened when the grid container preview closes this check returns false even though the container is open in game
-            if (worldItem != null && ((container != null && player?.Backpack != null && container.Opened && player.Backpack.Serial != container.Serial) || worldItem.OnGround))
+            if (worldItem != null && ((container != null && _backpackSerial != null && container.Opened && _backpackSerial != container.Serial) || worldItem.OnGround))
             {
                 if (ImGui.Button("Take Item"))
                 {

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/General/ItemDetailWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/General/ItemDetailWindow.cs
@@ -238,7 +238,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
                 ImGui.PushStyleColor(ImGuiCol.ButtonActive, new Vector4(0.5f, 0.5f, 0.5f, 1.0f));
 
                 ImGui.Button("Take Item");
-                SetTooltip("This item is not currently visible in the game world, the container is not open or its already in your backpack.");
+                SetTooltip("This item is not currently visible in the game world, the container is not open or the item is already in your backpack.");
 
                 ImGui.PopStyleColor(3);
             }

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/General/ItemDetailWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/General/ItemDetailWindow.cs
@@ -219,11 +219,11 @@ namespace ClassicUO.Game.UI.ImGuiControls
                 ImGui.PopStyleColor(3);
             }
 
-            var player = GetPlayer();
+            var player = Client.Game.UO?.World?.Player;
             Item item = Client.Game.UO?.World?.Items?.Get(_itemInfo.Serial);
             Item container = item != null ? Client.Game.UO?.World?.Items?.Get(item.Container) : null;
             //NOTE: There seems to be an error in container.Opened when the grid container preview closes this check returns false even though the container is open in game
-            if (worldItem != null && ((container != null && container.Opened && player?.Backpack?.Serial != container.Serial) || worldItem.OnGround))
+            if (worldItem != null && ((container != null && player?.Backpack != null && container.Opened && player.Backpack.Serial != container.Serial) || worldItem.OnGround))
             {
                 if (ImGui.Button("Take Item"))
                 {
@@ -264,12 +264,24 @@ namespace ClassicUO.Game.UI.ImGuiControls
             try
             {
                 World world = Client.Game.UO?.World;
-                var player = GetPlayer(world);
+                var player = world?.Player;
 
                 Item item = world?.Items?.Get(itemInfo.Serial);
                 if (item == null)
                 {
                     Utility.Logging.Log.Warn("Cannot move item: Item not found in world");
+                    return;
+                }
+                
+                if (player == null)
+                {
+                    Utility.Logging.Log.Warn("Cannot move item: Player not available");
+                    return;
+                }
+                
+                if (player.Backpack == null)
+                {
+                    Utility.Logging.Log.Warn("Cannot move item: Player backpack not available");
                     return;
                 }
 
@@ -282,7 +294,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
                 
                 if(backpack.Serial == item.Container)
                 {
-                    Utility.Logging.Log.Info("Item is already in backpack");
+                    Utility.Logging.Log.Info("Cannot move item: Item is already in backpack");
                     return;
                 }
 
@@ -485,20 +497,6 @@ namespace ClassicUO.Game.UI.ImGuiControls
             {
                 Utility.Logging.Log.Error($"Failed to search for container 0x{containerSerial:X8}: {ex.Message}");
             }
-        }
-        
-        private PlayerMobile GetPlayer(World world = null)
-        {
-            world ??= Client.Game.UO?.World;
-            if (world == null)
-                Utility.Logging.Log.Warn("Cannot get player: World not available");
-                
-            
-            var player = world?.Player;
-            if (player == null)
-                Utility.Logging.Log.Warn("Cannot get player: Player not available");
-            
-            return player;
         }
 
         public override void Dispose()


### PR DESCRIPTION
Add a button the Item Detail window in the Item Database to attempt to move the item to the player backpack if the container is open or the item is on the ground

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Take Item" button in the item detail window to move visible items to your backpack; enabled only when applicable and shows a disabled style with an explanatory tooltip otherwise.

* **Bug Fixes / Improvements**
  * Move attempts now validate common issues (item presence, player/backpack state) and provide clear success/failure messages and warnings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->