### PR TITLE
Origaniser cannot select classic paperdoll backpack due to click issue

### DIFF
--- a/src/ClassicUO.Client/Game/Managers/UIManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/UIManager.cs
@@ -228,7 +228,7 @@ namespace ClassicUO.Game.Managers
 
             if (MouseOverControl != null)
             {
-                if (_mouseDownControls[index] != null && MouseOverControl == _mouseDownControls[index] || Client.Game.UO.GameCursor.ItemHold.Enabled)
+                if (_mouseDownControls[index] != null && MouseOverControl.LocalSerial == _mouseDownControls[index]?.LocalSerial || Client.Game.UO.GameCursor.ItemHold.Enabled)
                 {
                     MouseOverControl.InvokeMouseUp(Mouse.Position, button);
                 }

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/Organizer/OrganizerTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/Organizer/OrganizerTabContent.cs
@@ -15,6 +15,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
         private string _addItemGraphicInput = "";
         private string _addItemHueInput = "";
         private bool _showAddItemManual = false;
+        private ulong? _playerBackpackSerial = null;
 
         public OrganizerTabContent()
         {
@@ -27,6 +28,9 @@ namespace ClassicUO.Game.UI.ImGuiControls
                 ImGui.Text("Organizer Agent not loaded");
                 return;
             }
+            
+            if (_playerBackpackSerial is null)
+                _playerBackpackSerial = Client.Game.UO?.World?.Player?.Backpack?.Serial;
 
             // Main layout: left panel for organizer list, right panel for details
             if (ImGui.BeginTable("OrganizerTable", 2, ImGuiTableFlags.Resizable))
@@ -218,13 +222,14 @@ namespace ClassicUO.Game.UI.ImGuiControls
             }
 
             // Display current containers
-            if (_selectedConfig.SourceContSerial != 0)
+            if (_selectedConfig.SourceContSerial != 0 && _selectedConfig.SourceContSerial != _playerBackpackSerial)
             {
                 ImGui.Text($"Source: ({_selectedConfig.SourceContSerial:X})");
             }
             else
             {
-                ImGui.TextColored(new System.Numerics.Vector4(0.0f, 1.0f, 0.0f, 1.0f), "Source: Your backpack");
+                var msg = _playerBackpackSerial is null ? "Source: Your backpack" : $"Source: Your backpack ({_playerBackpackSerial:X8})";
+                ImGui.TextColored(new System.Numerics.Vector4(0.0f, 1.0f, 0.0f, 1.0f), msg);
             }
 
             ImGui.SameLine();


### PR DESCRIPTION
Original problem:
Nothing happens when I click the backpack on my paperdoll when trying to set the source/destination container in the organizer window.

From debugging it seems that the new TargetManager is dependent on GameInputSceneManager which does not fire for clicks outside of the world on left mouse up due to this check:

`
if (!UIManager.IsMouseOverWorld)
{
    return false;
}
`

Though even if this check does not break execution we still have `⁨BaseGameObject lastObj = SelectedObject.Object;⁩` setting `lastObj` to ⁨`null⁩` which is required for the TargetManager's execution.

*__Possible fix:__*
It seems that the paperdol creates new instances of the backpack control which cause the `UIManager` class's click handler's equality check to fail. This was replace with an comparison on `LocalSerial` but the effect of this change is not clear to me.

Will you please review this change as my comfort level is not high?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mouse event handling in UI interactions to use serial-based comparison for more reliable control detection.

* **UI Improvements**
  * Enhanced Organizer display to show "Your backpack" label instead of raw serial numbers for better clarity when setting source containers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->