### PR TITLE
fix: Autolooter does not re-try corpses unless an Item/OPL trigger is fired

### DIFF
--- a/src/ClassicUO.Client/Game/Managers/AutoLootManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/AutoLootManager.cs
@@ -223,17 +223,38 @@ namespace ClassicUO.Game.Managers
             Instance = null;
         }
 
+        /// <summary>
+        /// Invoked whenever the player changes position.
+        ///
+        /// The other looter entry points are item update events but those are not enough;
+        /// If the player opens a corpse and walks away a few steps, there wouldn't be any new events firing.
+        ///
+        /// This handler effectively allows re-triggering as soon as the corpses are back in range.
+        ///
+        /// Note that this venue kicks in only when distance is less than 3.
+        /// </summary>
+        /// <param name="sender">The source event sink</param>
+        /// <param name="e">The position change event arguments</param>
         private void OnPositionChanged(object sender, PositionChangedArgs e)
         {
             if (!_loaded) return;
 
-            if(ProfileManager.CurrentProfile.EnableScavenger)
-                foreach (Item item in _world.Items.Values)
-                {
-                    if (item == null || !item.OnGround || item.IsCorpse || item.IsLocked) continue;
-                    if (item.Distance >= 3) continue;
+            if (!ProfileManager.CurrentProfile.EnableScavenger && !IsEnabled)
+                return;
+
+            foreach (Item item in _world.Items.Values)
+            {
+                if (item == null || !item.OnGround || item.Distance >= 3)
+                    continue;
+
+                // The scavenger only picks up not-locked/not-corpse objects;
+                // The looter only picks corpses, but both ultimately use the same code paths
+                if (
+                    (ProfileManager.CurrentProfile.EnableScavenger && !item.IsLocked && !item.IsCorpse)
+                    || (IsEnabled && item.IsCorpse)
+                )
                     CheckAndLoot(item);
-                }
+            }
         }
 
         private void OnOpenContainer(object sender, uint e)

--- a/src/ClassicUO.Client/Game/Managers/AutoLootManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/AutoLootManager.cs
@@ -239,22 +239,14 @@ namespace ClassicUO.Game.Managers
         {
             if (!_loaded) return;
 
-            if (!ProfileManager.CurrentProfile.EnableScavenger && !IsEnabled)
-                return;
+            if (ProfileManager.CurrentProfile.EnableScavenger)
+                foreach (Item item in _world.Items.Values)
+                    if (item != null && item.OnGround && !item.IsLocked && !item.IsCorpse && item.Distance < 3)
+                        CheckAndLoot(item);
 
-            foreach (Item item in _world.Items.Values)
-            {
-                if (item == null || !item.OnGround || item.Distance >= 3)
-                    continue;
-
-                // The scavenger only picks up not-locked/not-corpse objects;
-                // The looter only picks corpses, but both ultimately use the same code paths
-                if (
-                    (ProfileManager.CurrentProfile.EnableScavenger && !item.IsLocked && !item.IsCorpse)
-                    || (IsEnabled && item.IsCorpse)
-                )
-                    CheckAndLoot(item);
-            }
+            if (IsEnabled)
+                foreach (Item corpse in _world.GetCorpseSnapshot())
+                    CheckCorpse(corpse);
         }
 
         private void OnOpenContainer(object sender, uint e)


### PR DESCRIPTION
## Description
Autolooter does not trigger on position updates. More info below

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing
Long session on T-Weald, Harrower, etc.

## Additional Notes

Autolooter is wired to Item/OPL events but not movement.

Consider the case where a player starts looting a corpse but moves away a few tiles before finishing.
The corpse is still in range so Item/OPL triggers are not guaranteed.
However, moving back into loot range should, in fact, trigger a continuation of the looting procedure, so long as eligible items remain on the corpse


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-loot now re-checks corpses when you move, allowing re-looting if a corpse comes back into range.

* **Bug Fixes**
  * Improved coordination between auto-loot and scavenger modes for reliable behavior when both are active.
  * Better item detection and filtering to correctly handle corpses, locked items, and ground items.
  * More responsive handling of position changes for auto-looting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->