### PR TITLE
feat: Auto-Unequip for Potions

### DIFF
--- a/src/ClassicUO.Client/Game/GameActions.cs
+++ b/src/ClassicUO.Client/Game/GameActions.cs
@@ -631,8 +631,9 @@ internal static class GameActions
                 ObjectActionQueue.Instance.Enqueue(ObjectActionQueueItem.DoubleClick(serial), ActionPriority.ManualUseItem);
             else
             {
-                // This should be generalized to a form of blocking interceptor
-                if (!AutoUnequipActionManager.Instance.TryInterceptDoubleClick(serial, Socket.Send_DoubleClick))
+                bool intercepted = AutoUnequipActionManager.Instance?.TryInterceptDoubleClick(serial, Socket.Send_DoubleClick) ?? false;
+
+                if (!intercepted)
                     // Run the actual send only if the interceptor yielded control back, otherwise, the auto manager would have handled the 'send' part
                     Socket.Send_DoubleClick(serial);
             }

--- a/src/ClassicUO.Client/Game/GameActions.cs
+++ b/src/ClassicUO.Client/Game/GameActions.cs
@@ -598,8 +598,11 @@ internal static class GameActions
 
     internal static void DoubleClick(World world, uint serial, bool ignoreWarMode = false, bool ignoreQueue = false)
     {
+        bool isItem = SerialHelper.IsItem(serial);
+        bool isMobile = SerialHelper.IsMobile(serial);
+
         // Record action for script recording (only for items)
-        if (SerialHelper.IsItem(serial))
+        if (isItem)
             ScriptRecorder.Instance.RecordUseItem(serial);
 
         ScriptingInfoGump.AddOrUpdateInfo("Last Object", $"0x{serial:X}");
@@ -607,14 +610,14 @@ internal static class GameActions
         if (obj != null)
             ScriptingInfoGump.AddOrUpdateInfo("Last Object Graphic", $"0x{obj.Graphic:X}");
 
-        if (serial != world.Player && SerialHelper.IsMobile(serial) && world.Player.InWarMode && !ignoreWarMode)
+        if (serial != world.Player && isMobile && world.Player.InWarMode && !ignoreWarMode)
         {
             RequestMobileStatus(world, serial);
             Attack(world, serial);
         }
         else
         {
-            if (SerialHelper.IsItem(serial))
+            if (isItem)
             {
                 Gump g = UIManager.GetGump<GridContainer>(serial);
                 if (g != null)
@@ -627,10 +630,15 @@ internal static class GameActions
             if (ProfileManager.CurrentProfile.QueueManualItemUses && !ignoreQueue)
                 ObjectActionQueue.Instance.Enqueue(ObjectActionQueueItem.DoubleClick(serial), ActionPriority.ManualUseItem);
             else
-                Socket.Send_DoubleClick(serial);
+            {
+                // This should be generalized to a form of blocking interceptor
+                if (!AutoUnequipActionManager.Instance.TryInterceptDoubleClick(serial, Socket.Send_DoubleClick))
+                    // Run the actual send only if the interceptor yielded control back, otherwise, the auto manager would have handled the 'send' part
+                    Socket.Send_DoubleClick(serial);
+            }
         }
 
-        if (SerialHelper.IsItem(serial) || (SerialHelper.IsMobile(serial) && (world.Mobiles.Get(serial)?.IsHuman ?? false)))
+        if (isItem || (isMobile && (world.Mobiles.Get(serial)?.IsHuman ?? false)))
         {
             world.LastObject = serial;
         }

--- a/src/ClassicUO.Client/Game/Managers/AutoUnequipActionManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/AutoUnequipActionManager.cs
@@ -315,13 +315,14 @@ public sealed partial class AutoUnequipActionManager : IDisposable
     private ObjectActionQueueItem CreateUnequipQueueItem(uint serial, Layer layer) =>
         new(() =>
         {
-            Item item = _world?.Items?.Get(serial);
+            if (!IsPlayerBackpackAvailable)
+                return;
+
+            Item item = _world.Items?.Get(serial);
             if (item == null || item.Container != _world.Player.Serial || item.Layer != layer)
                 return;
 
-            Item bp = _world.Player?.Backpack;
-            if (bp != null)
-                new MoveRequest(serial, bp.Serial, item.Amount).Execute();
+            new MoveRequest(serial, _world.Player.Backpack.Serial, item.Amount).Execute();
         });
 
     /// <summary>

--- a/src/ClassicUO.Client/Game/Managers/AutoUnequipActionManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/AutoUnequipActionManager.cs
@@ -83,6 +83,7 @@ public sealed partial class AutoUnequipActionManager : IDisposable
             _flushChannel.Writer.Complete();
             // Synchronously wait for the reader to terminate. This should be measured in several milliseconds
             Task.WaitAll(_flushChannel.Reader.Completion);
+            _cTokenSource.Dispose();
             Instance = null;
             _disposed = true;
         }

--- a/src/ClassicUO.Client/Game/Managers/AutoUnequipActionManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/AutoUnequipActionManager.cs
@@ -178,7 +178,7 @@ public sealed partial class AutoUnequipActionManager : IDisposable
     /// <summary>
     ///     The task channel's consumer, responsible for actually performing any disarming/rearming
     /// </summary>
-    private async ValueTask ActionConsumer()
+    private async Task ActionConsumer()
     {
         try
         {

--- a/src/ClassicUO.Client/Game/Managers/AutoUnequipActionManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/AutoUnequipActionManager.cs
@@ -122,10 +122,13 @@ public sealed partial class AutoUnequipActionManager : IDisposable
         {
             while (!_cTokenSource.IsCancellationRequested && await _flushChannel.Reader.WaitToReadAsync())
             {
+                // A micro-delay to let producers settle, in case of a series of actions
+                await Task.Delay(50);
                 var tasks = new List<Action>();
                 while (_flushChannel.Reader.TryRead(out Action task))
                     tasks.Add(task);
                 ExecuteBatchedTasks(tasks);
+                await Task.Delay(250); // A short delay to avoid spammy edge cases
             }
         }
         catch (TaskCanceledException)

--- a/src/ClassicUO.Client/Game/Managers/MainThreadQueue.cs
+++ b/src/ClassicUO.Client/Game/Managers/MainThreadQueue.cs
@@ -92,21 +92,20 @@ public static class MainThreadQueue
     /// This will wait for the returned result.
     /// </summary>
     /// <param name="func"></param>
-    /// <param name="cancellationToken">An optional cancellation token to interrupt result wait</param>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
-    public static T InvokeOnMainThread<T>(Func<T> func, CancellationToken? cancellationToken = null)
+    public static T InvokeOnMainThread<T>(Func<T> func)
     {
         if (_isMainThread) return func();
 
         // The MT is so slow there's no real point in spinning; Just wastes CPU.
-        var resultEvent = new ManualResetEventSlim(false, 0);
+        var resultEvent = new ManualResetEvent(false);
         T result = default;
 
         _queuedActions.Enqueue(Action);
 
         // Wait for the main thread to complete the operation
-        resultEvent.Wait(cancellationToken ?? CancellationToken.None);
+        resultEvent.WaitOne();
 
         return result;
 

--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -388,7 +388,7 @@ namespace ClassicUO.Game.Scenes
             JournalFilterManager.Instance.Save();
 
             SpellBarManager.Unload();
-            _autoUnequipActionManager?.Clear();
+            _autoUnequipActionManager?.Dispose();
             ObjectActionQueue.Instance.Clear();
 
             GraphicsReplacement.Save();

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/General/GeneralTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/General/GeneralTabContent.cs
@@ -278,7 +278,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
             }
             ImGuiComponents.Tooltip("Automatically open your own corpse when you die, even if auto open corpses is disabled.");
 
-            if (ImGui.Checkbox("Auto unequip for spells", ref _autoUnequipForActions))
+            if (ImGui.Checkbox("Auto unequip for spells & potions", ref _autoUnequipForActions))
             {
                 _profile.AutoUnequipForActions = _autoUnequipForActions;
             }

--- a/src/ClassicUO.Client/Resources/ResErrorMessages.Designer.cs
+++ b/src/ClassicUO.Client/Resources/ResErrorMessages.Designer.cs
@@ -10,8 +10,8 @@
 
 namespace ClassicUO.Resources {
     using System;
-    
-    
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -23,15 +23,15 @@ namespace ClassicUO.Resources {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class ResErrorMessages {
-        
+
         private static global::System.Resources.ResourceManager resourceMan;
-        
+
         private static global::System.Globalization.CultureInfo resourceCulture;
-        
+
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal ResErrorMessages() {
         }
-        
+
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
@@ -45,7 +45,7 @@ namespace ClassicUO.Resources {
                 return resourceMan;
             }
         }
-        
+
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
@@ -59,7 +59,7 @@ namespace ClassicUO.Resources {
                 resourceCulture = value;
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Another character from this account is currently online in this world.  You must either log in as that character or wait for it to time out..
         /// </summary>
@@ -68,7 +68,13 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("AnotherCharacterOnline", resourceCulture);
             }
         }
-        
+
+        public static string AutoUnequipFailedStopped {
+            get {
+                return ResourceManager.GetString("AutoUnequipFailedStopped", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to This character already exists.
         ///Playing....
@@ -78,7 +84,7 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("CharacterAlreadyExists", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to This character does not exist anymore.  You will have to recreate it..
         /// </summary>
@@ -87,7 +93,7 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("CharacterDoesNotExist", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to That character is not old enough to delete. The character must be 7 days old before it can be deleted..
         /// </summary>
@@ -96,7 +102,7 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("CharacterIsNotOldEnough", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to That character is currently queued for backup and cannot be deleted..
         /// </summary>
@@ -105,7 +111,7 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("CharacterIsQueuedForBackup", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to That character password is invalid..
         /// </summary>
@@ -114,7 +120,7 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("CharacterPasswordInvalid", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Character transfer in progress..
         /// </summary>
@@ -123,7 +129,7 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("CharacterTransferInProgress", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The client could not attach to the game server. It must have been taken down, please wait a few minutes and try again..
         /// </summary>
@@ -132,7 +138,7 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("ClientCouldNotAttachToServer", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; is not a valid UO directory.
         /// </summary>
@@ -141,7 +147,7 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("ClientPathIsNotAValidUODirectory", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Communication problem..
         /// </summary>
@@ -150,7 +156,7 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("CommunicationProblem", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Could not attach to game server..
         /// </summary>
@@ -159,7 +165,7 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("CouldNotAttachServer", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Couldn&apos;t carry out your request..
         /// </summary>
@@ -168,7 +174,7 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("CouldntCarryOutYourRequest", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Couldn&apos;t connect to Ultima Online.  Please try again in a few moments..
         /// </summary>
@@ -177,7 +183,7 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("CouldntConnectToUO", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to An error has occurred in the synchronization between the login servers and this world.  Please close your client and try again..
         /// </summary>
@@ -186,7 +192,7 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("ErrorInSynchronization", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to General IGR authentication failure..
         /// </summary>
@@ -195,7 +201,7 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("GeneralIGRAuthenticationFailure", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to You have been idle for too long.  If you do not do anything in the next minute, you will be logged out..
         /// </summary>
@@ -204,7 +210,7 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("IdleTooLong", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Incorrect name/password..
         /// </summary>
@@ -213,7 +219,7 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("IncorrectNamePassword", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Incorrect password.
         /// </summary>
@@ -222,7 +228,7 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("IncorrectPassword", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Invalid name.
         /// </summary>
@@ -231,7 +237,7 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("NameIsInvalid", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Someone is already using this account..
         /// </summary>
@@ -240,7 +246,7 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("SomeoneIsAlreadyUsingThisAccount", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to That character does not exist..
         /// </summary>
@@ -249,7 +255,7 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("ThatCharacterDoesNotExist", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to That character is being played right now..
         /// </summary>
@@ -258,7 +264,7 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("ThatCharacterIsBeingPlayed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to That is out of sight..
         /// </summary>
@@ -267,7 +273,7 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("ThatIsOutOfSight", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to That is too far away..
         /// </summary>
@@ -276,7 +282,7 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("ThatIsTooFarAway", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to That item does not belong to you.  You&apos;ll have to steal it..
         /// </summary>
@@ -285,7 +291,7 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("ThatItemDoesNotBelongToYou", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The IGR concurrency limit has been met..
         /// </summary>
@@ -294,7 +300,7 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("TheIGRConcurrencyLimitHasBeenMet", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The IGR time limit has been met..
         /// </summary>
@@ -303,7 +309,7 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("TheIGRTimeLimitHasBeenMet", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to You are already holding an item..
         /// </summary>
@@ -312,7 +318,7 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("YouAreAlreadyHoldingAnItem", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to You can not pick that up..
         /// </summary>
@@ -321,7 +327,7 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("YouCanNotPickThatUp", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Your account credentials are invalid..
         /// </summary>
@@ -330,7 +336,7 @@ namespace ClassicUO.Resources {
                 return ResourceManager.GetString("YourAccountCredentialsAreInvalid", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Your account has been blocked..
         /// </summary>

--- a/src/ClassicUO.Client/Resources/ResErrorMessages.resx
+++ b/src/ClassicUO.Client/Resources/ResErrorMessages.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -210,5 +210,8 @@ Playing...</value>
   </data>
   <data name="NameIsInvalid" xml:space="preserve">
     <value>Invalid name</value>
+  </data>
+  <data name="AutoUnequipFailedStopped" xml:space="preserve">
+    <value>The Auto-Unequip agent has encountered an error and was stopped</value>
   </data>
 </root>


### PR DESCRIPTION
## Description
Fixed a misbehavior in existing `AutoUnequipActionManager` and introduced auto-unequip  for potions

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Documentation update

## Testing
Manual testing using a variety of spells and potion, with and without the manager enabled


## Additional Notes
This is a complete re-write of the `AutoUnequipActionManager`.

* Added an intercept for `Double Click`.  
  This allows automatic disarming/rearming when using drinkable potions (Strength, Agility, Heal, Cure, Nightsight, Refresh). This behavior is bound to the same toggle as the `Auto unequip for spells` assistant setting
* Fixed an erratic behavior in which the `AutoUnequipActionManager` could disarm again after re-arming
* Added `Spell-Channeling` as a consideration when casting spells, potentially avoiding unnecessary disarms
* Added micro-batching - actions within a certain time-frame will be batched to the same disarm cycle
* Rendered most of the manager asynchronous while simplifying the code itself.
* Added full documentation

**Notes**

* Actual behavior may vary depending on the player's configured object delay.
  Excessively short delays may cause the actions to fail.
  This is a limitation and is outside the scope of this change.

* Neither existing nor new behavior cover complex cases involving targeted spells.
  Those may be interrupted during the re-arm cycle.
  This is a limitation and can be addressed separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-unequip now also covers potions (UI label updated).

* **Improvements**
  * More robust interception to prevent unintended double-clicks and spell casts.
  * Reduced redundant item/mobile checks for smoother responsiveness.
  * Auto-unequip subsystem now cleans up reliably when leaving a scene.
  * Main-thread invoke APIs support optional cancellation for waiting operations.

* **Bug Fixes**
  * Added user-facing error text for auto-unequip failure and account-blocked cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->