### PR TITLE
perf: `PixelPicker` cache optimization

### DIFF
--- a/src/ClassicUO.Client/Game/GameObjects/RenderedText.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/RenderedText.cs
@@ -40,7 +40,7 @@ namespace ClassicUO.Game
             }
         );
 
-        private static PixelPicker _picker = new PixelPicker();
+        private static PixelPicker _picker = new PixelPicker(true);
         private byte _font;
 
         private MultilinesFontInfo _info;

--- a/src/ClassicUO.Client/Game/GameObjects/RenderedText.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/RenderedText.cs
@@ -40,7 +40,7 @@ namespace ClassicUO.Game
             }
         );
 
-        private static PixelPicker _picker = new PixelPicker(true);
+        private static PixelPicker _picker = new(false);
         private byte _font;
 
         private MultilinesFontInfo _info;

--- a/src/ClassicUO.Renderer/Animations/Animation.cs
+++ b/src/ClassicUO.Renderer/Animations/Animation.cs
@@ -10,7 +10,7 @@ namespace ClassicUO.Renderer.Animations
         const int MAX_ANIMATIONS_DATA_INDEX_COUNT = 8192;
 
         private readonly TextureAtlas _atlas;
-        private readonly PixelPicker _picker = new PixelPicker();
+        private readonly PixelPicker _picker = new PixelPicker(false);
         private readonly AnimationsLoader _animationLoader;
         private IndexAnimation[] _dataIndex = new IndexAnimation[MAX_ANIMATIONS_DATA_INDEX_COUNT];
         private readonly object _dataIndexLock = new object();

--- a/src/ClassicUO.Renderer/Arts/Art.cs
+++ b/src/ClassicUO.Renderer/Arts/Art.cs
@@ -12,7 +12,7 @@ namespace ClassicUO.Renderer.Arts
     {
         private readonly SpriteInfo[] _spriteInfos;
         private readonly TextureAtlas _atlas;
-        private readonly PixelPicker _picker = new PixelPicker();
+        private readonly PixelPicker _picker = new PixelPicker(true);
         private readonly Rectangle[] _realArtBounds;
         private readonly ArtLoader _artLoader;
         private readonly HuesLoader _huesLoader;

--- a/src/ClassicUO.Renderer/Gumps/Gump.cs
+++ b/src/ClassicUO.Renderer/Gumps/Gump.cs
@@ -7,7 +7,7 @@ namespace ClassicUO.Renderer.Gumps
     {
         private readonly TextureAtlas _atlas;
         private readonly SpriteInfo[] _spriteInfos;
-        private readonly PixelPicker _picker = new PixelPicker();
+        private readonly PixelPicker _picker = new PixelPicker(true);
         private readonly GumpsLoader _gumpsLoader;
 
         public GumpsLoader GetGumpsLoader => _gumpsLoader;

--- a/src/ClassicUO.Renderer/Texmaps/Texmap.cs
+++ b/src/ClassicUO.Renderer/Texmaps/Texmap.cs
@@ -7,7 +7,7 @@ namespace ClassicUO.Renderer.Texmaps
     {
         private readonly TextureAtlas _atlas;
         private readonly SpriteInfo[] _spriteInfos;
-        private readonly PixelPicker _picker = new PixelPicker();
+        private readonly PixelPicker _picker = new PixelPicker(true);
         private readonly TexmapsLoader _texmapsLoader;
 
         public Texmap(TexmapsLoader texmapsLoader, GraphicsDevice device)

--- a/src/ClassicUO.Utility/Collections/FastUlongLookupTable.cs
+++ b/src/ClassicUO.Utility/Collections/FastUlongLookupTable.cs
@@ -4,31 +4,81 @@ using System.Runtime.CompilerServices;
 
 namespace ClassicUO.Utility.Collections;
 
+/// <summary>
+///     A fast lookup table that accepts ulong keys.
+///     Instances of this class pre-allocate memory, depending on bias configuration.
+///     <br />
+///     <para>
+///         For a typical nullable int value-type, a short biased allocation is ~124KiB and a long biased one is
+///         ~94KiB
+///     </para>
+/// </summary>
+/// <remarks>
+///     <para>
+///         While <see cref="Dictionary{TKey,TValue}" /> is highly capable and usually delivers <em>O(1)</em>
+///         time-complexity,
+///         it makes use of some reflection
+///         to broaden compatibility and does not make assumptions on the underlying data.
+///     </para>
+///     <para>
+///         This data structure is explicitly tailored to the graphics sub-system and makes a few assumptions that allow it
+///         to maintain a <em>O(1)</em> complexity whilst still omitting the abovementioned overheads.
+///     </para>
+///     <para>
+///         To eke out the most performance possible, this class does not attempt to provide proper dictionary semantics,
+///         instead opting for an opaque Get/Set
+///         and delegating key management for the caller.
+///     </para>
+/// </remarks>
+/// <typeparam name="T">The data type to be indexed</typeparam>
 public class FastUlongLookupTable<T>
 {
-    // All, or close to all keys in the short-biased flows are expected to land in a 15 bit range or so.
-    // By trading a tiny bit of performance for the outliers, we can significantly reduce allocation size.
-    // Since this map is mostly used for nullable integer (expected to be 8-byte), this is a difference of 256KiB per-instance (5) so a total of 1.25MiB saved.
+    // All, or close to all keys in the short-biased flows are expected to land in a 14 bit range or so.
+    // By trading a tiny bit of lookup performance for the outliers, we can significantly reduce allocation size.
     private const ushort SHORT_BIAS_FAST_LOOKUP_CAPACITY = 16384;
     private const ushort LONG_BIAS_FAST_LOOKUP_CAPACITY = 16;
 
+    // When the bias is for short keys (key <= SHORT_BIAS_FAST_LOOKUP_CAPACITY)
     private const ushort SHORT_BIAS_DICT_INIT_CAPACITY = 16;
     private const ushort LONG_BIAS_DICT_INIT_CAPACITY = 4096;
 
     private readonly bool _shortBiased;
-    private ushort _fastLookupCount;
+
+    /// <summary>
+    ///     A pre-allocated O(1) lookup array
+    /// </summary>
     private readonly T[] _fastLookup;
+
+    /// <summary>
+    ///     A pre-allocated dictionary to fall back to if a key exceeds the fast lookup table
+    /// </summary>
     private readonly Dictionary<ulong, T> _slowDict;
 
-    private ulong maxFastKey, maxDictKey ;
-    private ulong minFastKey = ulong.MaxValue, minDictKey = ulong.MaxValue;
-
+    /// <summary>
+    ///     Determines whether a given key can be indexed by the fast lookup table
+    /// </summary>
+    /// <param name="key"></param>
+    /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool IsFastFlowSized(ulong key) =>
         key < (_shortBiased ? SHORT_BIAS_FAST_LOOKUP_CAPACITY : LONG_BIAS_FAST_LOOKUP_CAPACITY);
 
-    public int Count => _fastLookupCount + _slowDict.Count;
 
+    /// <summary>
+    ///     Constructs a new, pre-allocated lookup table
+    /// </summary>
+    /// <param name="shortBiased">
+    ///     Determines whether the lookup table will be biased for <see cref="ushort" /> or <see cref="ulong" /> keys.
+    ///     <br />
+    ///     Bias significantly affects performance - short bias implies most keys are expected to be smaller than
+    ///     <em>16384</em>
+    ///     and can be directly accessed via an array index.
+    ///     <para>
+    ///         Setting <paramref name="shortBiased" /> to <em>false</em> means most operations will be done against the
+    ///         internal <see cref="Dictionary{TKey,TValue}" />
+    ///         which is slower
+    ///     </para>
+    /// </param>
     public FastUlongLookupTable(bool shortBiased)
     {
         _shortBiased = shortBiased;
@@ -45,6 +95,11 @@ public class FastUlongLookupTable<T>
         }
     }
 
+    /// <summary>
+    ///     Gets the value indexed by the key/>
+    /// </summary>
+    /// <param name="key">The key to get the value of</param>
+    /// <returns>The requested value or default <see cref="T" />, if one does not exist</returns>
     public T Get(ulong key)
     {
         if (IsFastFlowSized(key))
@@ -54,38 +109,34 @@ public class FastUlongLookupTable<T>
         return value;
     }
 
+    /// <summary>
+    ///     Sets the value for a given key, overwriting any previously existing value
+    /// </summary>
+    /// <param name="key">The key to store the value under</param>
+    /// <param name="value">The value to store</param>
     public void Set(ulong key, T value)
     {
         if (IsFastFlowSized(key))
-        {
             _fastLookup[(int)key] = value;
-            ++_fastLookupCount;
-            if (key < minFastKey)
-                minFastKey = key;
-            if (key > maxFastKey)
-                maxFastKey = key;
-        }
         else
-        {
             _slowDict[key] = value;
-            if (key < minDictKey)
-                minDictKey = key;
-            if (key > maxDictKey)
-                maxDictKey = key;
-        }
     }
 
+    /// <summary>
+    ///     Removes the given key from the lookup table
+    /// </summary>
+    /// <param name="key"></param>
     public void Remove(ulong key)
     {
         if (IsFastFlowSized(key))
-        {
             _fastLookup[(int)key] = default;
-            --_fastLookupCount;
-        }
         else
             _slowDict.Remove(key);
     }
 
+    /// <summary>
+    ///     Clears the lookup table
+    /// </summary>
     public void Clear()
     {
         Array.Clear(_fastLookup);

--- a/src/ClassicUO.Utility/Collections/FastUlongLookupTable.cs
+++ b/src/ClassicUO.Utility/Collections/FastUlongLookupTable.cs
@@ -96,7 +96,7 @@ public class FastUlongLookupTable<T>
     }
 
     /// <summary>
-    ///     Gets the value indexed by the key/>
+    ///     Gets the value indexed by the key
     /// </summary>
     /// <param name="key">The key to get the value of</param>
     /// <returns>The requested value or default <see cref="T" />, if one does not exist</returns>

--- a/src/ClassicUO.Utility/Collections/FastUlongLookupTable.cs
+++ b/src/ClassicUO.Utility/Collections/FastUlongLookupTable.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace ClassicUO.Utility.Collections;
+
+public class FastUlongLookupTable<T>
+{
+    // All, or close to all keys in the short-biased flows are expected to land in a 15 bit range or so.
+    // By trading a tiny bit of performance for the outliers, we can significantly reduce allocation size.
+    // Since this map is mostly used for nullable integer (expected to be 8-byte), this is a difference of 256KiB per-instance (5) so a total of 1.25MiB saved.
+    private const ushort SHORT_BIAS_FAST_LOOKUP_CAPACITY = 16384;
+    private const ushort LONG_BIAS_FAST_LOOKUP_CAPACITY = 16;
+
+    private const ushort SHORT_BIAS_DICT_INIT_CAPACITY = 16;
+    private const ushort LONG_BIAS_DICT_INIT_CAPACITY = 4096;
+
+    private readonly bool _shortBiased;
+    private ushort _fastLookupCount;
+    private readonly T[] _fastLookup;
+    private readonly Dictionary<ulong, T> _slowDict;
+
+    private ulong maxFastKey, maxDictKey ;
+    private ulong minFastKey = ulong.MaxValue, minDictKey = ulong.MaxValue;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool IsFastFlowSized(ulong key) =>
+        key < (_shortBiased ? SHORT_BIAS_FAST_LOOKUP_CAPACITY : LONG_BIAS_FAST_LOOKUP_CAPACITY);
+
+    public int Count => _fastLookupCount + _slowDict.Count;
+
+    public FastUlongLookupTable(bool shortBiased)
+    {
+        _shortBiased = shortBiased;
+
+        if (shortBiased)
+        {
+            _fastLookup = new T[SHORT_BIAS_FAST_LOOKUP_CAPACITY];
+            _slowDict = new Dictionary<ulong, T>(SHORT_BIAS_DICT_INIT_CAPACITY);
+        }
+        else
+        {
+            _fastLookup = new T[LONG_BIAS_FAST_LOOKUP_CAPACITY];
+            _slowDict = new Dictionary<ulong, T>(LONG_BIAS_DICT_INIT_CAPACITY);
+        }
+    }
+
+    public T Get(ulong key)
+    {
+        if (IsFastFlowSized(key))
+            return _fastLookup[(int)key];
+
+        _slowDict.TryGetValue(key, out T value);
+        return value;
+    }
+
+    public void Set(ulong key, T value)
+    {
+        if (IsFastFlowSized(key))
+        {
+            _fastLookup[(int)key] = value;
+            ++_fastLookupCount;
+            if (key < minFastKey)
+                minFastKey = key;
+            if (key > maxFastKey)
+                maxFastKey = key;
+        }
+        else
+        {
+            _slowDict[key] = value;
+            if (key < minDictKey)
+                minDictKey = key;
+            if (key > maxDictKey)
+                maxDictKey = key;
+        }
+    }
+
+    public void Remove(ulong key)
+    {
+        if (IsFastFlowSized(key))
+        {
+            _fastLookup[(int)key] = default;
+            --_fastLookupCount;
+        }
+        else
+            _slowDict.Remove(key);
+    }
+
+    public void Clear()
+    {
+        Array.Clear(_fastLookup);
+        _slowDict.Clear();
+    }
+}


### PR DESCRIPTION
## Description
Changed `PixelPicker`'s underlying cache mechanism to eke out a bit more performance

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing
* Profiler/backtraces
* Manual source and IL inspection
* Comparative testing against existing code

## Screenshots (Left side is before, right side after changes)

### Note:
Still figuring out proper testing procedures. Multiple traces were captured in the same busy location and for the same timeframes and compared.

<img width="2425" height="794" alt="image" src="https://github.com/user-attachments/assets/a3f044b8-4159-47f2-bf78-f4b38fefaa74" />

<img width="2102" height="341" alt="image" src="https://github.com/user-attachments/assets/0224a216-bf2e-4b04-9706-dd8ec675ab4c" />


## Additional Notes

* On my test machine, this change results in an apparent 1-2% uplift in FPS, measured by the in-game tool
  as well as stabler frametime pacing though the last bit is somewhat subjective and not accurately measured.
  Will consider using `PresentMon` for larger changes.

* Reduces main thread draw time by about 1%

* As per usual, this is *not* LLM code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated pixel-picking initialization across rendering components to use configurable modes.
  * Added a high-performance ulong-keyed lookup structure for texture data.
  * Standardized public API parameter naming for consistency and clearer usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->