### PR TITLE
Add Skills management tab to Legion Assistant

### DIFF
--- a/src/ClassicUO.Client/Game/Data/Skill.cs
+++ b/src/ClassicUO.Client/Game/Data/Skill.cs
@@ -31,11 +31,17 @@ namespace ClassicUO.Game.Data
 
         public ushort BaseFixed { get; internal set; }
 
+        public ushort BaseFixedAtLogin { get; internal set; }
+
+        public bool HasLoginBaseline { get; internal set; }
+
         public ushort CapFixed { get; internal set; }
 
         public float Value => ValueFixed / 10.0f;
 
         public float Base => BaseFixed / 10.0f;
+
+        public float BaseAtLogin => BaseFixedAtLogin / 10.0f;
 
         public float Cap => CapFixed / 10.0f;
 

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/AssistantWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/AssistantWindow.cs
@@ -10,6 +10,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
         private FiltersTabContent _filtersTab;
         private ItemDatabaseTabContent _itemDatabaseTab;
         private MacrosTabContent _macrosTab;
+        private SkillsTabContent _skillsTab;
 
         private AssistantWindow() : base("Legion Assistant")
         {
@@ -21,6 +22,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
             _filtersTab = new FiltersTabContent();
             _itemDatabaseTab = new ItemDatabaseTabContent();
             _macrosTab = new MacrosTabContent();
+            _skillsTab = new SkillsTabContent();
         }
 
         public override void DrawContent()
@@ -64,6 +66,12 @@ namespace ClassicUO.Game.UI.ImGuiControls
                     ImGui.EndTabItem();
                 }
 
+                if (ImGui.BeginTabItem("Skills"))
+                {
+                    _skillsTab.DrawContent();
+                    ImGui.EndTabItem();
+                }
+
                 ImGui.EndTabBar();
             }
         }
@@ -82,6 +90,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
             _filtersTab?.Dispose();
             _itemDatabaseTab?.Dispose();
             _macrosTab?.Dispose();
+            _skillsTab?.Dispose();
             base.Dispose();
         }
     }

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/Skills/SkillsTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/Skills/SkillsTabContent.cs
@@ -50,7 +50,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
             if (!_baselineInitialized || _baselinePlayerSerial != playerSerial)
             {
                 // Don't initialize until the server has sent skill data
-                if (skills.Length == 0 || !skills[0].HasLoginBaseline)
+                if (skills.Length == 0 || skills[0] == null || !skills[0].HasLoginBaseline)
                     return;
 
                 for (int i = 0; i < skills.Length && i < _baselineBase.Length; i++)

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/Skills/SkillsTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/Skills/SkillsTabContent.cs
@@ -49,9 +49,13 @@ namespace ClassicUO.Game.UI.ImGuiControls
 
             if (!_baselineInitialized || _baselinePlayerSerial != playerSerial)
             {
+                // Don't initialize until the server has sent skill data
+                if (skills.Length == 0 || !skills[0].HasLoginBaseline)
+                    return;
+
                 for (int i = 0; i < skills.Length && i < _baselineBase.Length; i++)
                 {
-                    _baselineBase[i] = skills[i].Base;
+                    _baselineBase[i] = skills[i].BaseAtLogin;
                 }
 
                 _baselinePlayerSerial = playerSerial;

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/Skills/SkillsTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/Skills/SkillsTabContent.cs
@@ -1,0 +1,407 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Text;
+using ClassicUO.Game.Data;
+using ClassicUO.Game.Managers;
+using ImGuiNET;
+
+namespace ClassicUO.Game.UI.ImGuiControls
+{
+    public class SkillsTabContent : TabContent
+    {
+        private int _sortColumnIndex = 1;
+        private bool _sortAscending = true;
+
+        private float[] _baselineBase;
+        private bool _baselineInitialized;
+        private uint _baselinePlayerSerial;
+
+        private bool _showGroups;
+
+        private int[] _sortedIndices;
+
+        public SkillsTabContent()
+        {
+            int count = Client.Game.UO.FileManager.Skills.SkillsCount;
+            _baselineBase = new float[count];
+            _sortedIndices = new int[count];
+
+            for (int i = 0; i < count; i++)
+            {
+                _sortedIndices[i] = i;
+            }
+
+            _baselineInitialized = false;
+        }
+
+        public override void DrawContent()
+        {
+            Skill[] skills = World.Instance?.Player?.Skills;
+
+            if (skills == null)
+            {
+                ImGui.Text("Not connected");
+                return;
+            }
+
+            uint playerSerial = World.Instance.Player.Serial;
+
+            if (!_baselineInitialized || _baselinePlayerSerial != playerSerial)
+            {
+                for (int i = 0; i < skills.Length && i < _baselineBase.Length; i++)
+                {
+                    _baselineBase[i] = skills[i].Base;
+                }
+
+                _baselinePlayerSerial = playerSerial;
+                _baselineInitialized = true;
+            }
+
+            DrawToolbar(skills);
+
+            ImGuiTableFlags flags = ImGuiTableFlags.Sortable
+                | ImGuiTableFlags.Borders
+                | ImGuiTableFlags.RowBg
+                | ImGuiTableFlags.ScrollY
+                | ImGuiTableFlags.Resizable;
+
+            float scrollHeight = ImGui.GetContentRegionAvail().Y;
+
+            if (ImGui.BeginTable("SkillsTable", 7, flags, new Vector2(0, scrollHeight)))
+            {
+                ImGui.TableSetupScrollFreeze(0, 1);
+                ImGui.TableSetupColumn("Use", ImGuiTableColumnFlags.WidthFixed | ImGuiTableColumnFlags.NoSort, 30);
+                ImGui.TableSetupColumn("Name", ImGuiTableColumnFlags.WidthStretch | ImGuiTableColumnFlags.DefaultSort);
+                ImGui.TableSetupColumn("Value", ImGuiTableColumnFlags.WidthFixed, 60);
+                ImGui.TableSetupColumn("Base", ImGuiTableColumnFlags.WidthFixed, 60);
+                ImGui.TableSetupColumn("Cap", ImGuiTableColumnFlags.WidthFixed, 60);
+                ImGui.TableSetupColumn("+/-", ImGuiTableColumnFlags.WidthFixed, 60);
+                ImGui.TableSetupColumn("Lock", ImGuiTableColumnFlags.WidthFixed, 50);
+                ImGui.TableHeadersRow();
+
+                ImGuiTableSortSpecsPtr sortSpecs = ImGui.TableGetSortSpecs();
+
+                if (sortSpecs.SpecsDirty)
+                {
+                    if (sortSpecs.SpecsCount > 0)
+                    {
+                        ImGuiTableColumnSortSpecsPtr spec = sortSpecs.Specs;
+                        _sortColumnIndex = spec.ColumnIndex;
+                        _sortAscending = spec.SortDirection == ImGuiSortDirection.Ascending;
+                    }
+
+                    SortSkills(skills);
+                    sortSpecs.SpecsDirty = false;
+                }
+
+                if (_showGroups)
+                {
+                    DrawGroupedRows(skills);
+                }
+                else
+                {
+                    for (int row = 0; row < _sortedIndices.Length; row++)
+                    {
+                        DrawSkillRow(skills, _sortedIndices[row]);
+                    }
+                }
+
+                ImGui.EndTable();
+            }
+        }
+
+        private void DrawSkillRow(Skill[] skills, int idx)
+        {
+            if (idx >= skills.Length)
+                return;
+
+            Skill skill = skills[idx];
+
+            if (skill == null)
+                return;
+
+            ImGui.TableNextRow();
+
+            // Use
+            ImGui.TableNextColumn();
+            if (skill.IsClickable)
+            {
+                if (ImGui.SmallButton("Use##" + idx))
+                {
+                    GameActions.UseSkill(skill.Index);
+                }
+            }
+
+            // Name
+            ImGui.TableNextColumn();
+            ImGui.Text(skill.Name);
+
+            // Value
+            ImGui.TableNextColumn();
+            ImGui.Text(skill.Value.ToString("F1"));
+
+            // Base
+            ImGui.TableNextColumn();
+            ImGui.Text(skill.Base.ToString("F1"));
+
+            // Cap
+            ImGui.TableNextColumn();
+            ImGui.Text(skill.Cap.ToString("F1"));
+
+            // +/-
+            ImGui.TableNextColumn();
+            float delta = idx < _baselineBase.Length ? skill.Base - _baselineBase[idx] : 0f;
+
+            if (delta > 0f)
+            {
+                ImGui.TextColored(ImGuiTheme.Current.Success, $"+{delta:F1}");
+            }
+            else if (delta < 0f)
+            {
+                ImGui.TextColored(ImGuiTheme.Current.Error, $"{delta:F1}");
+            }
+            else
+            {
+                ImGui.Text("0.0");
+            }
+
+            // Lock
+            ImGui.TableNextColumn();
+            string lockText = skill.Lock switch
+            {
+                Lock.Up => "Up",
+                Lock.Down => "Dn",
+                Lock.Locked => "==",
+                _ => "?"
+            };
+
+            Vector4 lockColor = skill.Lock switch
+            {
+                Lock.Up => ImGuiTheme.Current.Success,
+                Lock.Down => ImGuiTheme.Current.Error,
+                _ => ImGuiTheme.Current.Info
+            };
+
+            ImGui.PushStyleColor(ImGuiCol.Button, lockColor);
+            ImGui.PushStyleColor(ImGuiCol.ButtonHovered, lockColor * new Vector4(1.2f, 1.2f, 1.2f, 1.0f));
+            ImGui.PushStyleColor(ImGuiCol.ButtonActive, lockColor * new Vector4(0.8f, 0.8f, 0.8f, 1.0f));
+
+            if (ImGui.SmallButton(lockText + "##lock" + skill.Index))
+            {
+                byte nextLock = (byte)(((byte)skill.Lock + 1) % 3);
+                GameActions.ChangeSkillLockStatus((ushort)skill.Index, nextLock);
+            }
+
+            ImGui.PopStyleColor(3);
+        }
+
+        private void DrawGroupedRows(Skill[] skills)
+        {
+            List<SkillsGroup> groups = World.Instance?.SkillsGroupManager?.Groups;
+
+            if (groups == null)
+                return;
+
+            int skillsCount = skills.Length;
+
+            for (int g = 0; g < groups.Count; g++)
+            {
+                SkillsGroup group = groups[g];
+
+                // Collect valid skill indices for this group
+                List<int> groupIndices = new List<int>(group.Count);
+                float groupBaseTotal = 0f;
+
+                for (int i = 0; i < group.Count; i++)
+                {
+                    byte skillIdx = group.GetSkill(i);
+
+                    if (skillIdx == 0xFF || skillIdx >= skillsCount)
+                        continue;
+
+                    Skill skill = skills[skillIdx];
+
+                    if (skill == null)
+                        continue;
+
+                    groupIndices.Add(skillIdx);
+                    groupBaseTotal += skill.Base;
+                }
+
+                // Sort indices within the group using the current sort settings
+                SortGroupIndices(groupIndices, skills);
+
+                // Render tree node header spanning all columns
+                ImGui.TableNextRow();
+                ImGui.TableNextColumn();
+
+                ImGuiTreeNodeFlags treeFlags = ImGuiTreeNodeFlags.DefaultOpen | ImGuiTreeNodeFlags.SpanAllColumns;
+                bool open = ImGui.TreeNodeEx($"{group.Name} ({groupBaseTotal:F1})##group{g}", treeFlags);
+
+                if (open)
+                {
+                    for (int i = 0; i < groupIndices.Count; i++)
+                    {
+                        DrawSkillRow(skills, groupIndices[i]);
+                    }
+
+                    ImGui.TreePop();
+                }
+            }
+        }
+
+        private void SortGroupIndices(List<int> indices, Skill[] skills)
+        {
+            indices.Sort((a, b) =>
+            {
+                Skill sa = skills[a];
+                Skill sb = skills[b];
+
+                int cmp = _sortColumnIndex switch
+                {
+                    1 => string.Compare(sa.Name, sb.Name, StringComparison.OrdinalIgnoreCase),
+                    2 => sa.Value.CompareTo(sb.Value),
+                    3 => sa.Base.CompareTo(sb.Base),
+                    4 => sa.Cap.CompareTo(sb.Cap),
+                    5 =>
+                        (a < _baselineBase.Length ? sa.Base - _baselineBase[a] : 0f)
+                        .CompareTo(b < _baselineBase.Length ? sb.Base - _baselineBase[b] : 0f),
+                    6 => ((byte)sa.Lock).CompareTo((byte)sb.Lock),
+                    _ => 0
+                };
+
+                return _sortAscending ? cmp : -cmp;
+            });
+        }
+
+        private void DrawToolbar(Skill[] skills)
+        {
+            // Set All buttons
+            if (ImGui.SmallButton("All Up"))
+            {
+                for (int i = 0; i < skills.Length; i++)
+                    GameActions.ChangeSkillLockStatus((ushort)i, (byte)Lock.Up);
+            }
+
+            ImGui.SameLine();
+
+            if (ImGui.SmallButton("All Down"))
+            {
+                for (int i = 0; i < skills.Length; i++)
+                    GameActions.ChangeSkillLockStatus((ushort)i, (byte)Lock.Down);
+            }
+
+            ImGui.SameLine();
+
+            if (ImGui.SmallButton("All Lock"))
+            {
+                for (int i = 0; i < skills.Length; i++)
+                    GameActions.ChangeSkillLockStatus((ushort)i, (byte)Lock.Locked);
+            }
+
+            ImGui.SameLine();
+            ImGui.Text("|");
+            ImGui.SameLine();
+
+            // Reset +/-
+            if (ImGui.SmallButton("Reset +/-"))
+            {
+                for (int i = 0; i < skills.Length && i < _baselineBase.Length; i++)
+                    _baselineBase[i] = skills[i].Base;
+            }
+
+            ImGui.SameLine();
+
+            // Copy All
+            if (ImGui.SmallButton("Copy All"))
+            {
+                var sb = new StringBuilder();
+                sb.AppendLine("Name\tValue\tBase\tCap\t+/-\tLock");
+
+                for (int row = 0; row < _sortedIndices.Length; row++)
+                {
+                    int idx = _sortedIndices[row];
+
+                    if (idx >= skills.Length)
+                        continue;
+
+                    Skill skill = skills[idx];
+
+                    if (skill == null)
+                        continue;
+
+                    float delta = idx < _baselineBase.Length ? skill.Base - _baselineBase[idx] : 0f;
+                    string lockStr = skill.Lock switch
+                    {
+                        Lock.Up => "Up",
+                        Lock.Down => "Down",
+                        Lock.Locked => "Locked",
+                        _ => "?"
+                    };
+
+                    sb.AppendLine($"{skill.Name}\t{skill.Value:F1}\t{skill.Base:F1}\t{skill.Cap:F1}\t{delta:F1}\t{lockStr}");
+                }
+
+                SDL3.SDL.SDL_SetClipboardText(sb.ToString());
+                GameActions.Print("Skills copied to clipboard.", Constants.HUE_SUCCESS);
+            }
+
+            ImGui.SameLine();
+            ImGui.Text("|");
+            ImGui.SameLine();
+
+            // Show Groups checkbox
+            ImGui.Checkbox("Show Groups", ref _showGroups);
+
+            ImGui.SameLine();
+            ImGui.Text("|");
+            ImGui.SameLine();
+
+            // Total
+            float baseSum = 0f;
+            float capSum = 0f;
+
+            for (int i = 0; i < skills.Length; i++)
+            {
+                if (skills[i] != null)
+                {
+                    baseSum += skills[i].Base;
+                    capSum += skills[i].Cap;
+                }
+            }
+
+            ImGui.Text($"Total: {baseSum:F1} / {capSum:F1}");
+        }
+
+        private void SortSkills(Skill[] skills)
+        {
+            Array.Sort(_sortedIndices, (a, b) =>
+            {
+                if (a >= skills.Length || b >= skills.Length)
+                    return 0;
+
+                Skill sa = skills[a];
+                Skill sb = skills[b];
+
+                if (sa == null || sb == null)
+                    return 0;
+
+                int cmp = _sortColumnIndex switch
+                {
+                    1 => string.Compare(sa.Name, sb.Name, StringComparison.OrdinalIgnoreCase), // Name
+                    2 => sa.Value.CompareTo(sb.Value),   // Value
+                    3 => sa.Base.CompareTo(sb.Base),     // Base
+                    4 => sa.Cap.CompareTo(sb.Cap),       // Cap
+                    5 => // +/-
+                        (a < _baselineBase.Length ? sa.Base - _baselineBase[a] : 0f)
+                        .CompareTo(b < _baselineBase.Length ? sb.Base - _baselineBase[b] : 0f),
+                    6 => ((byte)sa.Lock).CompareTo((byte)sb.Lock), // Lock
+                    _ => 0
+                };
+
+                return _sortAscending ? cmp : -cmp;
+            });
+        }
+    }
+}

--- a/src/ClassicUO.Client/Network/PacketHandlers/UpdateSkills.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers/UpdateSkills.cs
@@ -140,6 +140,12 @@ internal static class UpdateSkills
                         skill.CapFixed = cap;
                         skill.Lock = locked;
 
+                        if (!isSingleUpdate && !skill.HasLoginBaseline)
+                        {
+                            skill.BaseFixedAtLogin = baseVal;
+                            skill.HasLoginBaseline = true;
+                        }
+
                         if (isSingleUpdate)
                         {
                             if (lastBase != skill.BaseFixed)


### PR DESCRIPTION
## Description
Adds a new **Skills** tab to the Legion Assistant window for managing character skills. Provides a sortable table with all skill data, lock cycling, group view, bulk actions, and clipboard export.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing
- Opened Legion Assistant window and verified Skills tab appears
- Verified all skills display with correct values, sorting works on all columns
- Tested Use button on activatable skills (e.g. Meditation, Hiding)
- Tested lock cycling buttons (Up → Down → Locked → Up) and confirmed server packets sent
- Tested bulk lock controls (All Up, All Down, All Lock)
- Tested Show Groups checkbox with existing skill group configuration
- Tested Copy All button and verified TSV clipboard content
- Tested Reset +/- button after skill gains
- Verified total skill points display updates correctly

## Screenshots (if applicable)
<img width="630" height="578" alt="image" src="https://github.com/user-attachments/assets/86cd0168-d37b-4d96-adb6-1bbddc08e4ac" />

## Additional Notes
- Uses ASCII text for lock state indicators ("Up", "Dn", "==") since the ImGui font atlas doesn't include Unicode triangle glyphs
- Session delta (+/-) tracking resets automatically when switching characters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Skills tab to the Assistant with a sortable table showing Use, Name, Value, Base, Cap, delta and Lock.
  * Optional grouped view, bulk lock controls, reset baseline, and clipboard export for skills data.
  * Login baselines are recorded so deltas reflect changes from your session-start values; delta and lock states are visually indicated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->