### PR TITLE
Add auto-loot priority tiers (High/Normal/Low)

### DIFF
--- a/src/ClassicUO.Client/Game/Managers/ObjectActionQueue.cs
+++ b/src/ClassicUO.Client/Game/Managers/ObjectActionQueue.cs
@@ -26,7 +26,7 @@ public class ObjectActionQueue : ConcurrentPriorityQueue<ObjectActionQueueItem, 
                 continue;
             }
 
-            if (priority == ActionPriority.MoveItem && Client.Game.UO.GameCursor.ItemHold.Enabled)
+            if (priority >= ActionPriority.MoveItem && Client.Game.UO.GameCursor.ItemHold.Enabled)
             {
                 Enqueue(item,  priority, sequence); //Return to queue to retry again when not holding an item
                 return;
@@ -98,5 +98,7 @@ public enum ActionPriority
     OpenCorpse,
     EquipItem,
     MoveItem,
-    LootItem, //Same as Moveitem, but lower priority in case user tries to manually move an item, it will happen before auto loot continues
+    LootItemHigh,   //Auto-loot: High priority items (still lower than manual moves)
+    LootItemMedium, //Auto-loot: Normal priority items
+    LootItem,       //Auto-loot: Low priority items - lowest overall priority
 }

--- a/src/ClassicUO.Client/Game/UI/ImGuiControls/Agents/AutoLootTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/ImGuiControls/Agents/AutoLootTabContent.cs
@@ -25,6 +25,7 @@ namespace ClassicUO.Game.UI.ImGuiControls
         private Dictionary<string, string> entryRegexInputs = new Dictionary<string, string>();
         private Dictionary<string, string> entryDestinationInputs = new Dictionary<string, string>();
         private bool showCharacterImportPopup = false;
+        private static readonly string[] PriorityLabels = { "Low", "Normal", "High" };
 
         public AutoLootTabContent()
         {
@@ -212,12 +213,13 @@ namespace ClassicUO.Game.UI.ImGuiControls
             }
             else
             // Table headers
-            if (ImGui.BeginTable("AutoLootTable", 6, ImGuiTableFlags.Borders | ImGuiTableFlags.RowBg | ImGuiTableFlags.ScrollY, new Vector2(0, ImGuiTheme.Dimensions.STANDARD_TABLE_SCROLL_HEIGHT)))
+            if (ImGui.BeginTable("AutoLootTable", 7, ImGuiTableFlags.Borders | ImGuiTableFlags.RowBg | ImGuiTableFlags.ScrollY, new Vector2(0, ImGuiTheme.Dimensions.STANDARD_TABLE_SCROLL_HEIGHT)))
             {
                 ImGui.TableSetupColumn(string.Empty, ImGuiTableColumnFlags.WidthFixed, 52);
                 ImGui.TableSetupColumn("Graphic", ImGuiTableColumnFlags.WidthFixed, ImGuiTheme.Dimensions.STANDARD_INPUT_WIDTH);
                 ImGui.TableSetupColumn("Hue", ImGuiTableColumnFlags.WidthFixed, ImGuiTheme.Dimensions.STANDARD_INPUT_WIDTH);
                 ImGui.TableSetupColumn("Regex", ImGuiTableColumnFlags.WidthFixed, 60);
+                ImGui.TableSetupColumn("Priority", ImGuiTableColumnFlags.WidthFixed, 80);
                 ImGui.TableSetupColumn("Destination", ImGuiTableColumnFlags.WidthFixed, 150);
                 ImGui.TableSetupColumn("Actions", ImGuiTableColumnFlags.WidthFixed, 60);
                 ImGui.TableHeadersRow();
@@ -298,6 +300,14 @@ namespace ClassicUO.Game.UI.ImGuiControls
                             ImGui.CloseCurrentPopup();
 
                         ImGui.EndPopup();
+                    }
+
+                    ImGui.TableNextColumn();
+                    int priorityIndex = (int)entry.Priority;
+                    ImGui.SetNextItemWidth(70);
+                    if (ImGui.Combo($"##Priority{i}", ref priorityIndex, PriorityLabels, PriorityLabels.Length))
+                    {
+                        entry.Priority = (AutoLootManager.AutoLootPriority)priorityIndex;
                     }
 
                     ImGui.TableNextColumn();


### PR DESCRIPTION
## Summary
- Adds priority levels (High / Normal / Low) to auto-loot entries so high-value items are grabbed before low-value ones
- Uses ObjectActionQueue's existing ActionPriority system with two new priority levels (LootItemHigh / LootItemMedium)
- Adds a Priority dropdown column to the auto-loot configuration UI
- Existing configs default to Normal priority (backward compatible)

## Files Changed
- **AutoLootManager.cs** — `AutoLootPriority` enum, `Priority` property on config entries, priority-aware enqueue
- **ObjectActionQueue.cs** — `LootItemHigh` and `LootItemMedium` action priority levels
- **AutoLootTabContent.cs** — Priority dropdown column in the UI

## Test plan
- [ ] Verify existing auto-loot behavior unchanged with default (Normal) priority
- [ ] Set entries to High priority and confirm they are looted before Normal entries
- [ ] Set entries to Low priority and confirm they are looted after Normal entries
- [ ] Import a config from clipboard — verify priority defaults to Normal
- [ ] Import from another character — verify priority defaults to Normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added priority level settings for auto-loot entries. Users can now assign Low, Normal, or High priority to each auto-loot item, providing greater control over the sequence in which items are automatically looted during gameplay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->