### PR TITLE
Fix #364

### DIFF
--- a/src/ClassicUO.Client/LegionScripting/API.cs
+++ b/src/ClassicUO.Client/LegionScripting/API.cs
@@ -53,6 +53,7 @@ namespace ClassicUO.LegionScripting
         private static readonly ConcurrentDictionary<string, object> sharedVars = new();
         private readonly ConcurrentDictionary<string, object> hotkeyCallbacks = new();
         private readonly ConcurrentDictionary<string, bool> pressedKeys = new();
+        private readonly ConcurrentDictionary<string, string> keyToHotkeyMap = new();
 
         internal void ScheduleCallback(Action action)
         {
@@ -141,6 +142,13 @@ namespace ClassicUO.LegionScripting
         {
             if (disposed) return;
 
+            // It's possible that the key up even will not contain the modifier keys anymore
+            // if the user releases them before releasing the main key, so we need to look up
+            // the original hotkey string that was pressed using the base key.
+            // Main thought: If 'x' is released, then all hotkeys involving mod + 'x' should be released
+            string baseKey = hotkey.Split('+').Last();
+            keyToHotkeyMap[baseKey] = hotkey;
+
             if (pressedKeys.TryAdd(hotkey, true) && hotkeyCallbacks.TryGetValue(hotkey, out object callback))
             {
                 ScheduleCallback(callback);
@@ -151,7 +159,12 @@ namespace ClassicUO.LegionScripting
         {
             if (disposed) return;
 
-            pressedKeys.TryRemove(hotkey, out _);
+            // Get the base key and look up the original hotkey string that was pressed
+            string baseKey = hotkey.Split('+').Last();
+            if (keyToHotkeyMap.TryRemove(baseKey, out string originalHotkey))
+            {
+                pressedKeys.TryRemove(originalHotkey, out _);
+            }
         }
 
         public void Dispose()


### PR DESCRIPTION
## Description
This fixes #364. The root cause is that the Keyboard class is stateless: If a a hotkey like CTRL+D is pressed, it informs all listeners about that. However, if CTRL is released before D is released, it will never inform the listeners that CTRL+D is released again. To fix this in the keyboard class, it would need to keep track of the state of hotkeys without knowing which hotkeys are actually needed by the listeners.

I believe a better API would be adding specific listeners in Keyboard.cs so that the Keyboard class knows which hotkeys are pressed and released, but this would be quite a huge refactoring.

Instead, I changed the LegionScript API class to deal with the current way Keyboard.cs works. It remembers the base key of each hotkey that a script needs. For example, for CTRL+D, it will remember that "D" was pressed for CTRL+D so that when D is released after CTRL, it knows that the release of CTRL+D is pending and will release the debounce lock.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing
Same experiment as described in #364 now functional.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hotkey handling to correctly process key releases when modifier states change during release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->