### PR TITLE
fix: Add a corpse validity check prior to opening via `QueueOpenCorpse`

### DIFF
--- a/src/ClassicUO.Client/Game/GameActions.cs
+++ b/src/ClassicUO.Client/Game/GameActions.cs
@@ -583,7 +583,23 @@ internal static class GameActions
         Socket.Send_AttackRequest(serial);
     }
 
-    internal static void QueueOpenCorpse(uint serial) => ObjectActionQueue.Instance.Enqueue(ObjectActionQueueItem.DoubleClick(serial), ActionPriority.OpenCorpse);
+    internal static void QueueOpenCorpse(uint serial) =>
+        ObjectActionQueue.Instance.Enqueue(
+            new ObjectActionQueueItem(() =>
+            {
+                if (serial == 0)
+                    return;
+
+                Item item = World.Instance?.Items?.Get(serial);
+                if (item != null &&
+                    !item.IsDestroyed &&
+                    item.IsCorpse &&
+                    item.Distance <= ProfileManager.CurrentProfile.AutoOpenCorpseRange
+                   )
+                    ObjectActionQueueItem.DoubleClick(serial).Action(); // Using the 'Action' here to remain DRY.
+            }),
+            ActionPriority.OpenCorpse
+        );
 
     internal static void DoubleClickQueued(uint serial) => ObjectActionQueue.Instance.Enqueue(ObjectActionQueueItem.DoubleClick(serial), ActionPriority.UseItem);
 


### PR DESCRIPTION
## Description

Fixes a set of cases where automatic corpse openers (via `QueueOpenCorpse`) did not check corpse validity prior to opening via.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Additional Notes
[Discord discussion](https://discord.com/channels/1344851225538986064/1345866311716311080/1474504812782424150)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of corpse opening by adding validation checks to prevent attempting to open invalid or out-of-range corpses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->