### PR TITLE
Updated `LastTargetPos` signature and `CHANGELOG.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,12 +39,13 @@ All notable changes to TazUO will be recorded here.
 * Added a *Skill Management* tab to the *Legion Assistant* - [P.R 359](https://github.com/PlayTazUO/TazUO/pull/359) ([crameep](https://github.com/crameep))
 * Organizer tab now shows graphic when hovering over the graphic art - ([bittiez](https://github.com/bittiez))
 * Added Mobile outline option - Highlighting mobiles by notoriety - ([bittiez](https://github.com/bittiez))
-* Added TazUO chat(Top menu -> More -> TazUO Chat) - ([bittiez](https://github.com/bittiez))
+* Added TazUO chat (Top menu -> More -> TazUO Chat) - ([bittiez](https://github.com/bittiez))
 * ItemDatabase search now defaults to not only "this character" - ([bittiez](https://github.com/bittiez))
 
 
 ### Fixes
 
+* Fixed empty ability name on active ability when calling `CurrentAbilityNames` - [P.R 373](https://github.com/PlayTazUO/TazUO/pull/373) ([yuval-po](https://github.com/yuval-po))
 * Fixed automatic corpse opening when too far away - [P.R 371](https://github.com/PlayTazUO/TazUO/pull/371) ([yuval-po](https://github.com/yuval-po))
 * Fixed a reliability issue with `API.OnHotKey` - [P.R 365](https://github.com/PlayTazUO/TazUO/pull/365) ([fpw](https://github.com/fpw))
 * Fixed healthbar collector occasionally becoming unresponsive to targeting/clicks - ([bittiez](https://github.com/bittiez))
@@ -58,7 +59,7 @@ All notable changes to TazUO will be recorded here.
 * Updated PSL browser UI and backend - ([bittiez](https://github.com/bittiez))
 * Move automatic py doc gen to tool usage - ([bittiez](https://github.com/bittiez))
 * Added ibm-plex font to embedded fonts - ([bittiez](https://github.com/bittiez))
-* Clean up a bunch of compile-time warnings - ([bittiez](https://github.com/bittiez))
+* Cleaned up a bunch of compile-time warnings - ([bittiez](https://github.com/bittiez))
 
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,22 +7,18 @@ All notable changes to TazUO will be recorded here.
 
 ## Breaking Changes
 
-As part of the *C#* scripting integration, the following changes were made, with the intent
-to standardize the API better state the purposes of different classes.
 
-* Python API classes (`Py___` were renamed to `Api___` or `ApiUi___` depending on their intended purposes
+* Python API classes (`Py___`) renamed to `Api___` or `ApiUi___`
 
-* All `IronPython` types/classes were removed from LegionAPI and replaced with standard C# constructs.
-  * PythonList -> IList<T>
-  * PythonTuple -> ApiPoint3D
+* All `IronPython` types/classes in `LegionAPI` were replaced with standard C# constructs
 
-* Return type for `LegionAPI.LastTargetPos` changed from `Vector3Int` to `ApiPoint3D`
+* Return type for `API.LastTargetPos` changed from `Vector3Int` to `ApiPoint3D`
 
-* `API.Events` signatures changes
+* `API.Events` signature changes
 
-* `PyOnItemCreated` renamed to `OnItemCreated` and its signature changed from `EventArgs<uint>` to `EventArgs<ApiItem>`
+* `PyOnItemCreated` renamed to `OnItemCreated` and now sends an `ApiItem` as an argument
 
-* Signature for `OnItemUpdated` changed from effectivley void to `EventArgs<ApiItem>`
+* `OnItemUpdated` event now sends an `ApiItem` as an argument
 
 * `PyOnBuffAdded` renamed to `OnBuffAdded`
 
@@ -31,72 +27,47 @@ to standardize the API better state the purposes of different classes.
 * `Buff` renamed to `ApiBuff` (Affects `OnBuffAdded` & `OnBuffRemoved`)
 
 
-### Features
+## Features
 
-* [P.R 369](https://github.com/PlayTazUO/TazUO/pull/369) - Added support for *C#* scripting (detected via a `.cs` file extension check)
-* [P.R 369](https://github.com/PlayTazUO/TazUO/pull/369) - Added an `Open Location` context menu to the `ScriptManagerWindow`
-* [P.R 366](https://github.com/PlayTazUO/TazUO/pull/366) - Added built-in IRC (`Internet Relay Chat`) support and channel
-* [P.R 363](https://github.com/PlayTazUO/TazUO/pull/363) - Added Auto-Loot priotrity tiers (High/Normal/Low)
-* [P.R 362](https://github.com/PlayTazUO/TazUO/pull/362) - Added *Sound* APIs to for `Legion Scripting`
-* [P.R 359](https://github.com/PlayTazUO/TazUO/pull/359) - Added a *Skill Management* tab to the *Legion Assistant*
+* Added support for *C#* scripting - [P.R 369](https://github.com/PlayTazUO/TazUO/pull/369) ([bittiez](https://github.com/bittiez) & [yuval-po](https://github.com/yuval-po))
+* Added an `Open Location` to the script manager window- [P.R 369](https://github.com/PlayTazUO/TazUO/pull/369) ([yuval-po](https://github.com/yuval-po))
+* Added built-in IRC support and channel - [P.R 366](https://github.com/PlayTazUO/TazUO/pull/366) ([bittiez](https://github.com/bittiez))
+* Added Auto-Loot priotrity tiers (High/Normal/Low) - [P.R 363](https://github.com/PlayTazUO/TazUO/pull/363) ([crameep](https://github.com/crameep))
+* Added `ToggleAutoLoot` macro to quickly enable/disable autolooting - ([bittiez](https://github.com/bittiez))
+
+### API
+
+* Added *Sound* APIs to for `Legion Scripting` - [P.R 362](https://github.com/PlayTazUO/TazUO/pull/362) ([fpw](https://github.com/fpw))
+* Added `API.PickUpToCursor`, `API.DropFromCursor` and `API.GetHeldItem` - ([bittiez](https://github.com/bittiez))
+* Added `IsHidden`, `IsGargoyle`, `IsMounted`, `IsDrivingBoat`, and `IsRunning` to `ApiMobile` - ([bittiez](https://github.com/bittiez))
+* Added `API.ScriptName` and `API.ScriptPath` - ([bittiez](https://github.com/bittiez))
+* Added missing API documentation types - [P.R 369](https://github.com/PlayTazUO/TazUO/pull/369), [P.R 370](https://github.com/PlayTazUO/TazUO/pull/370), [P.R 371](https://github.com/PlayTazUO/TazUO/pull/371) ([yuval-po](https://github.com/yuval-po))
+
+### Assistant
+
+* Added a *Skill Management* tab to the *Legion Assistant* - [P.R 359](https://github.com/PlayTazUO/TazUO/pull/359) ([crameep](https://github.com/crameep))
+* Organizer tab now shows graphic when hovering over the graphic art - ([bittiez](https://github.com/bittiez))
+* Added Mobile outline option - Highlighting mobiles by notoriety - ([bittiez](https://github.com/bittiez))
+* Added TazUO chat(Top menu -> More -> TazUO Chat) - ([bittiez](https://github.com/bittiez))
+* ItemDatabase search now defaults to not only "this character" - ([bittiez](https://github.com/bittiez))
+
 
 ### Fixes
-* [P.R 371](https://github.com/PlayTazUO/TazUO/pull/371) - Fixed an issue in which automatic corpse opening would continue to try opening corpses
-  after the player had moved away.
-* [P.R 365](https://github.com/PlayTazUO/TazUO/pull/365) - Fixed a reliability issues with `LegionAPI.OnHotKey`
 
-* Added missing API documentation types:
-  * `EventSinkApiDeclaration`
-  * `ApiPoint3D`
-  * `ApiSoundEntry`
-  * `ApiJournalEntry`
-  * `ApiEntity`
-  * `ApiStatic`
-  * `ApiItemData`
-  * `ApiUiMenuItem`
-  * `ApiMulti`
-  * `ApiBuff`
-  * `PersistentVar`
-  * `LegionApiConfig`
-  * `ApiUiTiledGumpPic`
-
+* Fixed automatic corpse opening when too far away - [P.R 371](https://github.com/PlayTazUO/TazUO/pull/371) ([yuval-po](https://github.com/yuval-po))
+* Fixed a reliability issue with `API.OnHotKey` - [P.R 365](https://github.com/PlayTazUO/TazUO/pull/365) ([fpw](https://github.com/fpw))
+* Fixed healthbar collector occasionally becoming unresponsive to targeting/clicks - ([bittiez](https://github.com/bittiez))
+* Fixed a rare crash when removing messages from system chat - ([bittiez](https://github.com/bittiez))
 
 ### Misc
-* `ApiUiNineSliceGump` (previously `PyNineSliceGump`) now uses a `75ms` `OnResize` debounce 
+
+* A `CHANGELOG.md` was added to the repository - ([bittiez](https://github.com/bittiez))
+* `ApiUiNineSliceGump` `OnResize` de-bouncer - [P.R 369](https://github.com/PlayTazUO/TazUO/pull/369) ([yuval-po](https://github.com/yuval-po))
+* Removed *Discord* integration - ([bittiez](https://github.com/bittiez))
+* Updated PSL browser UI and backend - ([bittiez](https://github.com/bittiez))
+* Move automatic py doc gen to tool usage - ([bittiez](https://github.com/bittiez))
+* Added ibm-plex font to embedded fonts - ([bittiez](https://github.com/bittiez))
+* Clean up a bunch of compile-time warnings - ([bittiez](https://github.com/bittiez))
 
 
 ---
-
-## In Development
-`Dev channel / branch`
-
-### Misc
-- This changelog
-- Added auto-loot priority tiers (High/Normal/Low) - Coryigon
-- Removed integrated Discord features
-- Added ToggleAutoLoot macro to quickly enable/disable autolooting
-
-### Legion
-- Added sound API endpoints to LegionScripts - fpw
-- Added `API.ScriptName` and `API.ScriptPath`
-- Updated PSL browser UI and backend
-- Added `.IsHidden` to PyMobile in API
-- Added `API.PickUpToCursor`, `API.DropFromCursor` and `API.GetHeldItem`
-- Added `IsGargoyle`, `IsMounted`, `IsDrivingBoat`, and `IsRunning` to PyMobile
-
-### Assistant
-- Added skills tab to Legion Assistant - Coryigon
-- Organizer tab now shows graphic when hovering over the graphic art
-- Added Mobile outline option - Highlighting mobiles by notoriety
-- Added TazUO chat(Top menu -> More -> TazUO Chat)
-- ItemDatabase search now defaults to not only "this character"
-
-### Other
-- Move automatic py doc gen to tool usage
-- Added ibm-plex font to embedded fonts
-- Clean up a bunch of compile-time warnings
-
-### Bugs
-- Fixed healthbar collector occasionally becoming unresponsive to targeting/clicks
-- Fix rare crash when removing messages from system chat
-- Various other bugs fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,72 @@
 # Changelog
 All notable changes to TazUO will be recorded here.
 
+---
+
+## v4.18.0
+
+## Breaking Changes
+
+As part of the *C#* scripting integration, the following changes were made, with the intent
+to standardize the API better state the purposes of different classes.
+
+* Python API classes (`Py___` were renamed to `Api___` or `ApiUi___` depending on their intended purposes
+
+* All `IronPython` types/classes were removed from LegionAPI and replaced with standard C# constructs.
+  * PythonList -> IList<T>
+  * PythonTuple -> ApiPoint3D
+
+* Return type for `LegionAPI.LastTargetPos` changed from `Vector3Int` to `ApiPoint3D`
+
+* `API.Events` signatures changes
+
+* `PyOnItemCreated` renamed to `OnItemCreated` and its signature changed from `EventArgs<uint>` to `EventArgs<ApiItem>`
+
+* Signature for `OnItemUpdated` changed from effectivley void to `EventArgs<ApiItem>`
+
+* `PyOnBuffAdded` renamed to `OnBuffAdded`
+
+* `PyOnBuffRemoved` renamed to `OnBuffRemoved`
+
+* `Buff` renamed to `ApiBuff` (Affects `OnBuffAdded` & `OnBuffRemoved`)
+
+
+### Features
+
+* [P.R 369](https://github.com/PlayTazUO/TazUO/pull/369) - Added support for *C#* scripting (detected via a `.cs` file extension check)
+* [P.R 369](https://github.com/PlayTazUO/TazUO/pull/369) - Added an `Open Location` context menu to the `ScriptManagerWindow`
+* [P.R 366](https://github.com/PlayTazUO/TazUO/pull/366) - Added built-in IRC (`Internet Relay Chat`) support and channel
+* [P.R 363](https://github.com/PlayTazUO/TazUO/pull/363) - Added Auto-Loot priotrity tiers (High/Normal/Low)
+* [P.R 362](https://github.com/PlayTazUO/TazUO/pull/362) - Added *Sound* APIs to for `Legion Scripting`
+* [P.R 359](https://github.com/PlayTazUO/TazUO/pull/359) - Added a *Skill Management* tab to the *Legion Assistant*
+
+### Fixes
+* [P.R 371](https://github.com/PlayTazUO/TazUO/pull/371) - Fixed an issue in which automatic corpse opening would continue to try opening corpses
+  after the player had moved away.
+* [P.R 365](https://github.com/PlayTazUO/TazUO/pull/365) - Fixed a reliability issues with `LegionAPI.OnHotKey`
+
+* Added missing API documentation types:
+  * `EventSinkApiDeclaration`
+  * `ApiPoint3D`
+  * `ApiSoundEntry`
+  * `ApiJournalEntry`
+  * `ApiEntity`
+  * `ApiStatic`
+  * `ApiItemData`
+  * `ApiUiMenuItem`
+  * `ApiMulti`
+  * `ApiBuff`
+  * `PersistentVar`
+  * `LegionApiConfig`
+  * `ApiUiTiledGumpPic`
+
+
+### Misc
+* `ApiUiNineSliceGump` (previously `PyNineSliceGump`) now uses a `75ms` `OnResize` debounce 
+
+
+---
+
 ## In Development
 `Dev channel / branch`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ All notable changes to TazUO will be recorded here.
 * Added support for *C#* scripting - [P.R 369](https://github.com/PlayTazUO/TazUO/pull/369) ([bittiez](https://github.com/bittiez) & [yuval-po](https://github.com/yuval-po))
 * Added an `Open Location` to the script manager window- [P.R 369](https://github.com/PlayTazUO/TazUO/pull/369) ([yuval-po](https://github.com/yuval-po))
 * Added built-in IRC support and channel - [P.R 366](https://github.com/PlayTazUO/TazUO/pull/366) ([bittiez](https://github.com/bittiez))
-* Added Auto-Loot priotrity tiers (High/Normal/Low) - [P.R 363](https://github.com/PlayTazUO/TazUO/pull/363) ([crameep](https://github.com/crameep))
+* Added Auto-Loot priority tiers (High/Normal/Low) - [P.R 363](https://github.com/PlayTazUO/TazUO/pull/363) ([crameep](https://github.com/crameep))
 * Added `ToggleAutoLoot` macro to quickly enable/disable autolooting - ([bittiez](https://github.com/bittiez))
 
 ### API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,27 +3,18 @@ All notable changes to TazUO will be recorded here.
 
 ---
 
-## v4.18.0
+## Currently in `dev channel`
 
 ## Breaking Changes
 
-
 * Python API classes (`Py___`) renamed to `Api___` or `ApiUi___`
-
 * All `IronPython` types/classes in `LegionAPI` were replaced with standard C# constructs
-
 * Return type for `API.LastTargetPos` changed from `Vector3Int` to `ApiPoint3D`
-
 * `API.Events` signature changes
-
 * `PyOnItemCreated` renamed to `OnItemCreated` and now sends an `ApiItem` as an argument
-
 * `OnItemUpdated` event now sends an `ApiItem` as an argument
-
 * `PyOnBuffAdded` renamed to `OnBuffAdded`
-
 * `PyOnBuffRemoved` renamed to `OnBuffRemoved`
-
 * `Buff` renamed to `ApiBuff` (Affects `OnBuffAdded` & `OnBuffRemoved`)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to TazUO will be recorded here.
 
 ## Currently in `dev channel`
 
-## Breaking Changes
+### Breaking Changes
 
 * Python API classes (`Py___`) renamed to `Api___` or `ApiUi___`
 * All `IronPython` types/classes in `LegionAPI` were replaced with standard C# constructs
@@ -18,7 +18,7 @@ All notable changes to TazUO will be recorded here.
 * `Buff` renamed to `ApiBuff` (Affects `OnBuffAdded` & `OnBuffRemoved`)
 
 
-## Features
+### Features
 
 * Added support for *C#* scripting - [P.R 369](https://github.com/PlayTazUO/TazUO/pull/369) ([bittiez](https://github.com/bittiez) & [yuval-po](https://github.com/yuval-po))
 * Added an `Open Location` to the script manager window- [P.R 369](https://github.com/PlayTazUO/TazUO/pull/369) ([yuval-po](https://github.com/yuval-po))

--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiPoint3D.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiPoint3D.cs
@@ -5,7 +5,9 @@ namespace ClassicUO.LegionScripting.ApiClasses;
 /// </summary>
 public class ApiPoint3D
 {
-    public int X { get; set; }
-    public int Y { get; set; }
-    public int Z { get; set; }
+    public int X { get; init; }
+    public int Y { get; init; }
+    public int Z { get; init; }
+
+    public override string ToString() => $"({X}, {Y}, {Z})";
 }

--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiPoint3D.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiPoint3D.cs
@@ -5,9 +5,9 @@ namespace ClassicUO.LegionScripting.ApiClasses;
 /// </summary>
 public class ApiPoint3D
 {
-    public int X { get; init; }
-    public int Y { get; init; }
-    public int Z { get; init; }
+    public int X { get; set; }
+    public int Y { get; set; }
+    public int Z { get; set; }
 
     public override string ToString() => $"({X}, {Y}, {Z})";
 }

--- a/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
@@ -288,7 +288,11 @@ namespace ClassicUO.LegionScripting
         /// <summary>
         /// The last target's position
         /// </summary>
-        public Vector3Int LastTargetPos => MainThreadQueue.InvokeOnMainThread(() => World.TargetManager.LastTargetInfo.Position);
+        public ApiPoint3D LastTargetPos => MainThreadQueue.InvokeOnMainThread(() =>
+        {
+            Vector3Int pos = World.TargetManager.LastTargetInfo.Position;
+            return new ApiPoint3D { X = pos.X, Y = pos.Y, Z = pos.Z };
+        });
 
         /// <summary>
         /// The graphic of the last targeting object

--- a/src/ClassicUO.Client/LegionScripting/docs/API.py
+++ b/src/ClassicUO.Client/LegionScripting/docs/API.py
@@ -276,6 +276,9 @@ class ApiPoint3D:
     Y: int = None
     Z: int = None
 
+    def ToString(self) -> "str":
+        pass
+
 class ApiSoundEntry:
     ""
     ID: int = None
@@ -1087,7 +1090,7 @@ Player: ApiPlayer = None
 Bank: int = None
 Random = None
 LastTargetSerial: int = None
-LastTargetPos = None
+LastTargetPos: ApiPoint3D = None
 LastTargetGraphic: int = None
 Found: int = None
 Profile: ApiUserProfile = None

--- a/src/ClassicUO.Client/LegionScripting/docs/ApiPoint3D.md
+++ b/src/ClassicUO.Client/LegionScripting/docs/ApiPoint3D.md
@@ -27,4 +27,9 @@ description:  Represents a point in a three-dimensional space
 *No enums found.*
 
 ## Methods
-*No methods found.*
+### ToString
+
+**Return Type:** `string`
+
+---
+

--- a/src/ClassicUO.Client/LegionScripting/docs/LegionAPI.md
+++ b/src/ClassicUO.Client/LegionScripting/docs/LegionAPI.md
@@ -21,7 +21,7 @@ You can now type `-updateapi` in game to download the latest API.py file.
 
 [Additional notes](../notes/)  
 
-*This was generated on `2/20/26`.*
+*This was generated on `2/21/26`.*
 
 ## Properties
 ### `Events`
@@ -93,7 +93,7 @@ You can now type `-updateapi` in game to download the latest API.py file.
 
 ### `LastTargetPos`
 
-**Type:** `Vector3Int`
+**Type:** `ApiPoint3D`
 
  The last target's position
 


### PR DESCRIPTION
## Description
Updated `LastTargetPos` to return `ApiPoint3D` instead of `Vector3Int` (same 'read' API) and added 4.18 to `CHANGELOG.md`

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Documentation update


## Additional Notes
* [Discord discussion](https://discord.com/channels/1344851225538986064/1344855384459972638/1474518532568911924)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote changelog into dev-channel sections and updated API docs, including the last-target property type.
* **Breaking Changes**
  * Multiple public API types and event signatures were renamed and standardized; last-target now exposes a coordinate object type.
* **Improvements**
  * Coordinate objects now include a human-readable string representation for display/debug.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->