### PR TITLE
fix: Empty ability names when querying active abilities

### DIFF
--- a/src/ClassicUO.Client/Game/Data/Ability.cs
+++ b/src/ClassicUO.Client/Game/Data/Ability.cs
@@ -325,4 +325,41 @@ namespace ClassicUO.Game.Data
             { 0x4071, new (0x4071, Ability.ArmorIgnore, Ability.ParalyzingBlow) },
         };
     }
+
+    /// <summary>
+    /// Extension methods for <see cref="Ability"/> values.
+    /// </summary>
+    public static class AbilityExtensions
+    {
+        /// <summary>
+        ///     A bit flag that marks an ability as active
+        /// </summary>
+        public const byte ABILITY_ACTIVE_FLAG = 0x80;
+
+        /// <summary>
+        ///     A bit mask that negates the ability activation flag
+        /// </summary>
+        public const byte ABILITY_DEACTIVATE_MASK = 0x7F;
+
+        extension(Ability ability)
+        {
+            /// <summary>
+            ///     Checks whether the ability is active
+            /// </summary>
+            /// <returns>True if the ability is active, false otherwise</returns>
+            public bool IsActive() => ability != Ability.None && ((int)ability & ABILITY_ACTIVE_FLAG) != 0;
+
+            /// <summary>
+            ///     Gets the ability's 'clean' value, that is, without the activation flag
+            /// </summary>
+            /// <returns>The ability without the activation flags</returns>
+            public Ability CleanValue() => (Ability)((int)ability & ABILITY_DEACTIVATE_MASK);
+
+            /// <summary>
+            ///     Gets the ability's display name
+            /// </summary>
+            /// <returns>The ability's display name</returns>
+            public string GetName() => Enum.GetName(ability.CleanValue());
+        }
+    }
 }

--- a/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
@@ -2806,7 +2806,13 @@ namespace ClassicUO.LegionScripting
         /// The full list of known abilities can be obtained via the `KnownAbilityNames` API
         /// </summary>
         /// <returns>The returned array will be [PrimaryAbility, SecondaryAbility] or an empty array if no ability is available</returns>
-        public string[] CurrentAbilityNames() => World.Player != null?[Enum.GetName(World.Player.PrimaryAbility), Enum.GetName(World.Player.SecondaryAbility)] : [];
+        public string[] CurrentAbilityNames()
+        {
+            if (World?.Player == null)
+                return [];
+
+            return [World.Player.PrimaryAbility.GetName(), World.Player.SecondaryAbility.GetName()];
+        }
 
         /// <summary>
         /// Gets an array of all known ability names


### PR DESCRIPTION
## Description
Fixes an issue in which `CurrentAbilityNames` returns empty/null names for active abilities

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Additional Notes
Raised by fspy on [Discord](https://discord.com/channels/1344851225538986064/1349336655923908658/1475260185462313242)

Also added extension methods to `Ability` for better ergonomics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized ability handling with improved robustness and enhanced null-safety checks for more reliable ability name retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->