### PR TITLE
Slider updates, and add filter tabs

### DIFF
--- a/src/ClassicUO.Client/Game/UI/MyraWindows/AssistantWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/AssistantWindow.cs
@@ -2,6 +2,7 @@ using ClassicUO.Game.UI.Controls;
 using ClassicUO.Game.UI.MyraWindows.Widgets;
 using ClassicUO.Game.UI.MyraWindows.Widgets.Assistant;
 using ClassicUO.Game.UI.MyraWindows.Widgets.Assistant.Agents;
+using ClassicUO.Game.UI.MyraWindows.Widgets.Assistant.Filters;
 
 namespace ClassicUO.Game.UI.MyraWindows;
 
@@ -18,6 +19,7 @@ public class AssistantWindow : MyraControl
         var tabs = new MyraTabControl();
         tabs.AddTab("General", GeneralTab.Build);
         tabs.AddTab("Agents", AgentTab.Build);
+        tabs.AddTab("Filters", FiltersTab.Build);
         tabs.SelectFirst();
         SetRootContent(tabs);
     }

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Filters/FiltersTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Filters/FiltersTab.cs
@@ -1,0 +1,17 @@
+using Myra.Graphics2D.UI;
+
+namespace ClassicUO.Game.UI.MyraWindows.Widgets.Assistant.Filters;
+
+public static class FiltersTab
+{
+    public static Widget Build()
+    {
+        var tabs = new MyraTabControl();
+        tabs.AddTab("Graphics", GraphicReplacementTabContent.Build);
+        tabs.AddTab("Journal Filter", JournalFilterTabContent.Build);
+        tabs.AddTab("Sound Filter", SoundFilterTabContent.Build);
+        tabs.AddTab("Season Filter", SeasonFilterTabContent.Build);
+        tabs.SelectFirst();
+        return tabs;
+    }
+}

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Filters/GraphicReplacementTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Filters/GraphicReplacementTabContent.cs
@@ -1,0 +1,291 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using ClassicUO.Game.GameObjects;
+using ClassicUO.Game.Managers;
+using ClassicUO.Utility;
+using Myra.Graphics2D.UI;
+using TextBox = Myra.Graphics2D.UI.TextBox;
+
+namespace ClassicUO.Game.UI.MyraWindows.Widgets.Assistant.Filters;
+
+public static class GraphicReplacementTabContent
+{
+    private static readonly string[] TypeNames = { "Mobile", "Land", "Static" };
+    private static readonly byte[] TypeValues = { 1, 2, 3 };
+
+    private static string GetTypeName(byte t) => t switch { 1 => "Mobile", 2 => "Land", _ => "Static" };
+
+    public static Widget Build()
+    {
+        var root = new VerticalStackPanel { Spacing = 6 };
+
+        root.Widgets.Add(new MyraLabel(
+            "Replace graphics with other graphics. Mobile = animations, Land = terrain tiles, Static = items/statics.",
+            MyraLabel.Style.P));
+
+        var filtersPanel = new VerticalStackPanel { Spacing = 2 };
+
+        void BuildFilterList()
+        {
+            filtersPanel.Widgets.Clear();
+            Dictionary<(ushort, byte), GraphicChangeFilter> filters = GraphicsReplacement.GraphicFilters;
+
+            if (filters.Count == 0)
+            {
+                filtersPanel.Widgets.Add(new MyraLabel("No replacements configured.", MyraLabel.Style.P));
+                return;
+            }
+
+            var grid = new MyraGrid();
+            grid.AddColumn(new Proportion(ProportionType.Auto));  // Original
+            grid.AddColumn(new Proportion(ProportionType.Auto));  // Type
+            grid.AddColumn(new Proportion(ProportionType.Auto));  // Replacement
+            grid.AddColumn(new Proportion(ProportionType.Auto));  // Preview
+            grid.AddColumn(new Proportion(ProportionType.Auto));  // New Hue
+            grid.AddColumn(new Proportion(ProportionType.Auto));  // Del
+            MyraStyle.ApplyStandardGridStyling(grid);
+
+            grid.AddWidget(new MyraLabel("Original", MyraLabel.Style.H3), 0, 0);
+            grid.AddWidget(new MyraLabel("Type", MyraLabel.Style.H3), 0, 1);
+            grid.AddWidget(new MyraLabel("Replacement", MyraLabel.Style.H3), 0, 2);
+            grid.AddWidget(new MyraLabel("Preview", MyraLabel.Style.H3), 0, 3);
+            grid.AddWidget(new MyraLabel("New Hue", MyraLabel.Style.H3), 0, 4);
+            grid.AddWidget(new MyraLabel("Del", MyraLabel.Style.H3), 0, 5);
+
+            var filterList = filters.Values.ToList();
+            int dataRow = 1;
+            for (int i = filterList.Count - 1; i >= 0; i--)
+            {
+                GraphicChangeFilter filter = filterList[i];
+
+                // Original — show as label (changing original = key change, use delete+re-add)
+                grid.AddWidget(new MyraLabel($"0x{filter.OriginalGraphic:X4}", MyraLabel.Style.P), dataRow, 0);
+
+                // Type — cycle button using wrapper panel (key change requires rebuild)
+                var typeWrapper = new HorizontalStackPanel();
+                void BuildTypeBtn()
+                {
+                    typeWrapper.Widgets.Clear();
+                    typeWrapper.Widgets.Add(new MyraButton(GetTypeName(filter.OriginalType), () =>
+                    {
+                        int idx = System.Array.IndexOf(TypeValues, filter.OriginalType);
+                        byte newType = TypeValues[(idx + 1) % TypeValues.Length];
+                        GraphicsReplacement.DeleteFilter(filter.OriginalGraphic, filter.OriginalType);
+                        GraphicsReplacement.NewFilter(
+                            filter.OriginalGraphic, newType,
+                            filter.ReplacementGraphic, newType,
+                            filter.NewHue);
+                        BuildFilterList();
+                    }) { Tooltip = "Click to cycle: Mobile / Land / Static" });
+                }
+                BuildTypeBtn();
+                grid.AddWidget(typeWrapper, dataRow, 1);
+
+                // Preview wrapper — rebuilt in-place when replacement changes
+                var previewWrapper = new HorizontalStackPanel { Spacing = 2 };
+                void BuildPreview()
+                {
+                    previewWrapper.Widgets.Clear();
+                    if (filter.OriginalType == 3)
+                    {
+                        previewWrapper.Widgets.Add(new MyraArtTexture(filter.OriginalGraphic));
+                        previewWrapper.Widgets.Add(new MyraLabel("→", MyraLabel.Style.P));
+                        previewWrapper.Widgets.Add(new MyraArtTexture(filter.ReplacementGraphic));
+                    }
+                    else
+                    {
+                        previewWrapper.Widgets.Add(new MyraLabel(
+                            $"0x{filter.OriginalGraphic:X4} → 0x{filter.ReplacementGraphic:X4}", MyraLabel.Style.P));
+                    }
+                }
+                BuildPreview();
+                grid.AddWidget(previewWrapper, dataRow, 3);
+
+                // Replacement Graphic — inline edit, immediate commit + preview update
+                var replacementBox = new TextBox { Text = $"0x{filter.ReplacementGraphic:X4}", Width = 90 };
+                replacementBox.TextChangedByUser += (_, _) =>
+                {
+                    string txt = replacementBox.Text ?? "";
+                    if (StringHelper.TryParseInt(txt, out int newReplacement) && newReplacement is >= 0 and <= ushort.MaxValue)
+                    {
+                        filter.ReplacementGraphic = (ushort)newReplacement;
+                        filter.ReplacementType = filter.OriginalType;
+                        BuildPreview();
+                    }
+                };
+                grid.AddWidget(replacementBox, dataRow, 2);
+
+                // Hue — inline edit, immediate commit
+                var hueBox = new TextBox
+                {
+                    Text = filter.NewHue == ushort.MaxValue ? "-1" : filter.NewHue.ToString(),
+                    Width = 60,
+                    Tooltip = "-1 will not change the hue"
+                };
+                hueBox.TextChangedByUser += (_, _) =>
+                {
+                    string txt = hueBox.Text ?? "";
+                    if (txt == "-1")
+                        filter.NewHue = ushort.MaxValue;
+                    else if (ushort.TryParse(txt, out ushort newHue))
+                        filter.NewHue = newHue;
+                };
+                grid.AddWidget(hueBox, dataRow, 4);
+
+                // Delete
+                ushort capturedOrigGraphic = filter.OriginalGraphic;
+                byte capturedOrigType = filter.OriginalType;
+                grid.AddWidget(MyraStyle.ApplyButtonDangerStyle(new MyraButton("X", () =>
+                {
+                    GraphicsReplacement.DeleteFilter(capturedOrigGraphic, capturedOrigType);
+                    BuildFilterList();
+                }) { Tooltip = "Delete this replacement" }), dataRow, 5);
+
+                dataRow++;
+            }
+
+            filtersPanel.Widgets.Add(grid);
+        }
+
+        // Add entry panel
+        var addEntryPanel = new VerticalStackPanel { Visible = false, Spacing = 4 };
+        var newOriginalBox = new TextBox { HintText = "Original graphic (e.g. 0x0EED)", Width = 170 };
+        var newReplacementBox = new TextBox { HintText = "Replacement graphic", Width = 170 };
+        var newHueBox = new TextBox { HintText = "Hue (-1 = unchanged)", Width = 120 };
+        int[] newTypeIndex = { 2 }; // Default: Static
+
+        var newTypeWrapper = new HorizontalStackPanel();
+        var validationLabel = new MyraLabel("", MyraLabel.Style.P) { Visible = false };
+
+        void BuildNewTypeBtn()
+        {
+            newTypeWrapper.Widgets.Clear();
+            newTypeWrapper.Widgets.Add(new MyraButton(TypeNames[newTypeIndex[0]], () =>
+            {
+                newTypeIndex[0] = (newTypeIndex[0] + 1) % TypeNames.Length;
+                BuildNewTypeBtn();
+            }) { Tooltip = "Click to cycle: Mobile / Land / Static" });
+        }
+        BuildNewTypeBtn();
+
+        var addConfirmRow = new HorizontalStackPanel { Spacing = 4 };
+        addConfirmRow.Widgets.Add(new MyraButton("Add", () =>
+        {
+            string origText = newOriginalBox.Text ?? "";
+            string replText = newReplacementBox.Text ?? "";
+
+            if (!StringHelper.TryParseInt(origText, out int origGraphic) ||
+                !StringHelper.TryParseInt(replText, out int replGraphic))
+                return;
+
+            ushort hue = ushort.MaxValue;
+            string hueText = newHueBox.Text ?? "";
+            if (!string.IsNullOrEmpty(hueText) && hueText != "-1")
+            {
+                if (!ushort.TryParse(hueText, out hue))
+                {
+                    validationLabel.Text = $"Invalid hue: '{hueText}'. Must be 0-65535 or -1";
+                    validationLabel.Visible = true;
+                    return;
+                }
+            }
+
+            validationLabel.Visible = false;
+            byte type = TypeValues[newTypeIndex[0]];
+            GraphicsReplacement.NewFilter((ushort)origGraphic, type, (ushort)replGraphic, type, hue);
+
+            newOriginalBox.Text = "";
+            newReplacementBox.Text = "";
+            newHueBox.Text = "";
+            newTypeIndex[0] = 2;
+            BuildNewTypeBtn();
+            addEntryPanel.Visible = false;
+            BuildFilterList();
+        }));
+        addConfirmRow.Widgets.Add(new MyraButton("Cancel", () =>
+        {
+            addEntryPanel.Visible = false;
+            newOriginalBox.Text = "";
+            newReplacementBox.Text = "";
+            newHueBox.Text = "";
+            validationLabel.Visible = false;
+        }));
+
+        var addFieldsRow1 = new HorizontalStackPanel { Spacing = 4 };
+        addFieldsRow1.Widgets.Add(new MyraLabel("Original:", MyraLabel.Style.P));
+        addFieldsRow1.Widgets.Add(newOriginalBox);
+        addFieldsRow1.Widgets.Add(new MyraLabel("Replacement:", MyraLabel.Style.P));
+        addFieldsRow1.Widgets.Add(newReplacementBox);
+
+        var addFieldsRow2 = new HorizontalStackPanel { Spacing = 4 };
+        addFieldsRow2.Widgets.Add(new MyraLabel("Type:", MyraLabel.Style.P));
+        addFieldsRow2.Widgets.Add(newTypeWrapper);
+        addFieldsRow2.Widgets.Add(new MyraLabel("New Hue:", MyraLabel.Style.P));
+        addFieldsRow2.Widgets.Add(newHueBox);
+
+        addEntryPanel.Widgets.Add(new MyraLabel("New Entry:", MyraLabel.Style.H3));
+        addEntryPanel.Widgets.Add(addFieldsRow1);
+        addEntryPanel.Widgets.Add(addFieldsRow2);
+        addEntryPanel.Widgets.Add(validationLabel);
+        addEntryPanel.Widgets.Add(addConfirmRow);
+
+        var actionRow = new HorizontalStackPanel { Spacing = 4 };
+        actionRow.Widgets.Add(new MyraButton("Add Entry", () => addEntryPanel.Visible = !addEntryPanel.Visible));
+        actionRow.Widgets.Add(new MyraButton("Target Entity", () =>
+        {
+            if (World.Instance == null) return;
+            World.Instance.TargetManager.SetTargeting(targeted =>
+            {
+                if (targeted == null) return;
+                ushort graphic = 0;
+                ushort hue = 0;
+                byte entityType = 3;
+
+                if (targeted is Mobile mob) { graphic = mob.Graphic; hue = mob.Hue; entityType = 1; }
+                else if (targeted is Land land) { graphic = land.Graphic; hue = land.Hue; entityType = 2; }
+                else if (targeted is Entity entity) { graphic = entity.Graphic; hue = entity.Hue; }
+                else if (targeted is Static stat) { graphic = stat.Graphic; hue = stat.Hue; }
+                else if (targeted is GameObject obj) { graphic = obj.Graphic; hue = obj.Hue; }
+                else return;
+
+                GraphicsReplacement.NewFilter(graphic, entityType, graphic, entityType, hue);
+                BuildFilterList();
+            });
+        }) { Tooltip = "Target an entity to add it to the replacement list" });
+        actionRow.Widgets.Add(new MyraButton("Import", () =>
+        {
+            string? json = Clipboard.GetClipboardText();
+            if (json.NotNullNotEmpty() && GraphicsReplacement.ImportFromJson(json))
+            {
+                BuildFilterList();
+                return;
+            }
+            GameActions.Print("Your clipboard does not have a valid export copied.", Constants.HUE_ERROR);
+        }) { Tooltip = "Import from your clipboard, must have a valid export copied." });
+        actionRow.Widgets.Add(new MyraButton("Export", () =>
+        {
+            GraphicsReplacement.GetJsonExport()?.CopyToClipboard();
+            GameActions.Print("Exported graphic filters to your clipboard!", Constants.HUE_SUCCESS);
+        }) { Tooltip = "Export your filters to your clipboard." });
+        actionRow.Widgets.Add(new MyraButton("Apply to All Entities", () =>
+        {
+            World? world = World.Instance;
+            if (world == null) return;
+            int count = 0;
+            foreach (Mobile mobile in world.Mobiles.Values.ToList())
+                if (!mobile.IsDestroyed && mobile.OriginalGraphic != 0) { mobile.Graphic = mobile.OriginalGraphic; count++; }
+            foreach (Item item in world.Items.Values.ToList())
+                if (!item.IsDestroyed && item.OriginalGraphic != 0) { item.Graphic = item.OriginalGraphic; count++; }
+            GameActions.Print($"Refreshed {count} entities with graphic replacements");
+        }) { Tooltip = "Reapply graphic replacements to all entities currently in the world" });
+
+        root.Widgets.Add(actionRow);
+        root.Widgets.Add(addEntryPanel);
+        root.Widgets.Add(new MyraLabel("Current Graphic Replacements:", MyraLabel.Style.H3));
+        BuildFilterList();
+        root.Widgets.Add(new ScrollViewer { Height = 300, Content = filtersPanel });
+
+        return root;
+    }
+}

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Filters/JournalFilterTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Filters/JournalFilterTabContent.cs
@@ -1,0 +1,133 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using ClassicUO.Game.Managers;
+using ClassicUO.Utility;
+using Myra.Graphics2D.UI;
+using TextBox = Myra.Graphics2D.UI.TextBox;
+
+namespace ClassicUO.Game.UI.MyraWindows.Widgets.Assistant.Filters;
+
+public static class JournalFilterTabContent
+{
+    public static Widget Build()
+    {
+        var root = new VerticalStackPanel { Spacing = 6 };
+
+        root.Widgets.Add(new MyraLabel(
+            "Journal Filter hides specific messages from the journal. Messages that match exactly will be filtered out.",
+            MyraLabel.Style.P));
+
+        var addFilterPanel = new VerticalStackPanel { Visible = false, Spacing = 4 };
+        var newFilterBox = new TextBox { HintText = "Filter text (exact match)", Width = 300 };
+
+        var filtersPanel = new VerticalStackPanel { Spacing = 2 };
+
+        void BuildFilterList()
+        {
+            filtersPanel.Widgets.Clear();
+            List<string> filters = JournalFilterManager.Instance.Filters.ToList();
+
+            if (filters.Count == 0)
+            {
+                filtersPanel.Widgets.Add(new MyraLabel("No filters configured.", MyraLabel.Style.P));
+                return;
+            }
+
+            var grid = new MyraGrid();
+            grid.AddColumn(new Proportion(ProportionType.Fill));
+            grid.AddColumn(new Proportion(ProportionType.Auto));
+            MyraStyle.ApplyStandardGridStyling(grid);
+
+            grid.AddWidget(new MyraLabel("Filter Text", MyraLabel.Style.H3), 0, 0);
+            grid.AddWidget(new MyraLabel("Del", MyraLabel.Style.H3), 0, 1);
+
+            int dataRow = 1;
+            for (int i = filters.Count - 1; i >= 0; i--)
+            {
+                string filter = filters[i];
+
+                // Track current value so we can remove-old/add-new on every edit
+                string[] current = { filter };
+                var filterBox = new TextBox { Text = filter };
+                filterBox.TextChangedByUser += (_, _) =>
+                {
+                    string newVal = filterBox.Text ?? "";
+                    if (!string.IsNullOrWhiteSpace(newVal) && newVal != current[0])
+                    {
+                        JournalFilterManager.Instance.RemoveFilter(current[0]);
+                        JournalFilterManager.Instance.AddFilter(newVal);
+                        JournalFilterManager.Instance.Save(false);
+                        current[0] = newVal;
+                    }
+                };
+                grid.AddWidget(filterBox, dataRow, 0);
+
+                grid.AddWidget(MyraStyle.ApplyButtonDangerStyle(new MyraButton("X", () =>
+                {
+                    JournalFilterManager.Instance.RemoveFilter(current[0]);
+                    JournalFilterManager.Instance.Save(false);
+                    BuildFilterList();
+                }) { Tooltip = "Delete this filter" }), dataRow, 1);
+
+                dataRow++;
+            }
+
+            filtersPanel.Widgets.Add(grid);
+        }
+
+        var addConfirmRow = new HorizontalStackPanel { Spacing = 4 };
+        addConfirmRow.Widgets.Add(new MyraButton("Add", () =>
+        {
+            string text = newFilterBox.Text ?? "";
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                JournalFilterManager.Instance.AddFilter(text);
+                JournalFilterManager.Instance.Save(false);
+                newFilterBox.Text = "";
+                addFilterPanel.Visible = false;
+                BuildFilterList();
+            }
+        }));
+        addConfirmRow.Widgets.Add(new MyraButton("Cancel", () =>
+        {
+            addFilterPanel.Visible = false;
+            newFilterBox.Text = "";
+        }));
+
+        var addFieldRow = new HorizontalStackPanel { Spacing = 4 };
+        addFieldRow.Widgets.Add(new MyraLabel("Filter Text:", MyraLabel.Style.P)
+            { Tooltip = "Must match the journal entry exactly. Partial matches not supported." });
+        addFieldRow.Widgets.Add(newFilterBox);
+
+        addFilterPanel.Widgets.Add(new MyraLabel("Add New Filter:", MyraLabel.Style.H3));
+        addFilterPanel.Widgets.Add(addFieldRow);
+        addFilterPanel.Widgets.Add(addConfirmRow);
+
+        var actionRow = new HorizontalStackPanel { Spacing = 4 };
+        actionRow.Widgets.Add(new MyraButton("Add Filter Entry", () => addFilterPanel.Visible = !addFilterPanel.Visible));
+        actionRow.Widgets.Add(new MyraButton("Import", () =>
+        {
+            string? json = Clipboard.GetClipboardText();
+            if (json.NotNullNotEmpty() && JournalFilterManager.Instance.ImportFromJson(json))
+            {
+                BuildFilterList();
+                return;
+            }
+            GameActions.Print("Your clipboard does not have a valid export copied.", Constants.HUE_ERROR);
+        }) { Tooltip = "Import from your clipboard, must have a valid export copied." });
+        actionRow.Widgets.Add(new MyraButton("Export", () =>
+        {
+            JournalFilterManager.Instance.GetJsonExport()?.CopyToClipboard();
+            GameActions.Print("Exported journal filters to your clipboard!", Constants.HUE_SUCCESS);
+        }) { Tooltip = "Export your filters to your clipboard." });
+
+        root.Widgets.Add(actionRow);
+        root.Widgets.Add(addFilterPanel);
+        root.Widgets.Add(new MyraLabel("Current Journal Filters:", MyraLabel.Style.H3));
+        BuildFilterList();
+        root.Widgets.Add(new ScrollViewer { Height = 250, Content = filtersPanel });
+
+        return root;
+    }
+}

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Filters/SeasonFilterTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Filters/SeasonFilterTabContent.cs
@@ -35,8 +35,14 @@ public static class SeasonFilterTabContent
             "Override seasons sent by the server. For example, if the server sends Winter, you can display Fall instead.",
             MyraLabel.Style.P));
 
-        root.Widgets.Add(new MyraButton("Clear All Filters", () => SeasonFilter.Instance.Clear())
-            { Tooltip = "Remove all season filters and display seasons as sent by the server" });
+        // Collect BuildCycleBtn delegates so Clear can refresh all wrappers
+        var rebuildActions = new System.Collections.Generic.List<System.Action>();
+
+        root.Widgets.Add(new MyraButton("Clear All Filters", () =>
+        {
+            SeasonFilter.Instance.Clear();
+            foreach (System.Action rebuild in rebuildActions) rebuild();
+        }) { Tooltip = "Remove all season filters and display seasons as sent by the server" });
 
         root.Widgets.Add(new MyraLabel("Season Filters:", MyraLabel.Style.H3));
 
@@ -55,8 +61,6 @@ public static class SeasonFilterTabContent
 
             grid.AddWidget(new MyraLabel(incomingName, MyraLabel.Style.P), i + 1, 0);
 
-            // Use a wrapper panel so we can swap the button on click
-            int capturedRow = i;
             var cycleWrapper = new HorizontalStackPanel();
 
             void BuildCycleBtn()
@@ -89,6 +93,7 @@ public static class SeasonFilterTabContent
                 }) { Tooltip = $"Click to cycle season override for {incomingName}" });
             }
 
+            rebuildActions.Add(BuildCycleBtn);
             BuildCycleBtn();
             grid.AddWidget(cycleWrapper, i + 1, 1);
         }

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Filters/SeasonFilterTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Filters/SeasonFilterTabContent.cs
@@ -1,0 +1,103 @@
+#nullable enable
+using ClassicUO.Game.Managers;
+using Myra.Graphics2D.UI;
+
+namespace ClassicUO.Game.UI.MyraWindows.Widgets.Assistant.Filters;
+
+public static class SeasonFilterTabContent
+{
+    private static readonly string[] SeasonNames = { "Spring", "Summer", "Fall", "Winter", "Desolation" };
+    private static readonly Season[] AllSeasons =
+    {
+        Season.Spring,
+        Season.Summer,
+        Season.Fall,
+        Season.Winter,
+        Season.Desolation
+    };
+
+    // Display options: "None" followed by each season
+    private static readonly string[] DisplayOptions;
+
+    static SeasonFilterTabContent()
+    {
+        DisplayOptions = new string[AllSeasons.Length + 1];
+        DisplayOptions[0] = "None";
+        for (int j = 0; j < SeasonNames.Length; j++)
+            DisplayOptions[j + 1] = SeasonNames[j];
+    }
+
+    public static Widget Build()
+    {
+        var root = new VerticalStackPanel { Spacing = 6 };
+
+        root.Widgets.Add(new MyraLabel(
+            "Override seasons sent by the server. For example, if the server sends Winter, you can display Fall instead.",
+            MyraLabel.Style.P));
+
+        root.Widgets.Add(new MyraButton("Clear All Filters", () => SeasonFilter.Instance.Clear())
+            { Tooltip = "Remove all season filters and display seasons as sent by the server" });
+
+        root.Widgets.Add(new MyraLabel("Season Filters:", MyraLabel.Style.H3));
+
+        var grid = new MyraGrid();
+        grid.AddColumn(new Proportion(ProportionType.Auto));
+        grid.AddColumn(new Proportion(ProportionType.Auto));
+        MyraStyle.ApplyStandardGridStyling(grid);
+
+        grid.AddWidget(new MyraLabel("When Server Sends", MyraLabel.Style.H3), 0, 0);
+        grid.AddWidget(new MyraLabel("Show As", MyraLabel.Style.H3), 0, 1);
+
+        for (int i = 0; i < AllSeasons.Length; i++)
+        {
+            Season incoming = AllSeasons[i];
+            string incomingName = SeasonNames[i];
+
+            grid.AddWidget(new MyraLabel(incomingName, MyraLabel.Style.P), i + 1, 0);
+
+            // Use a wrapper panel so we can swap the button on click
+            int capturedRow = i;
+            var cycleWrapper = new HorizontalStackPanel();
+
+            void BuildCycleBtn()
+            {
+                cycleWrapper.Widgets.Clear();
+
+                string currentLabel = "None";
+                int currentIdx = 0;
+                if (SeasonFilter.Instance.Filters.TryGetValue(incoming, out Season replacement))
+                {
+                    for (int k = 0; k < AllSeasons.Length; k++)
+                    {
+                        if (AllSeasons[k] == replacement)
+                        {
+                            currentIdx = k + 1;
+                            currentLabel = SeasonNames[k];
+                            break;
+                        }
+                    }
+                }
+
+                cycleWrapper.Widgets.Add(new MyraButton(currentLabel, () =>
+                {
+                    int nextIdx = (currentIdx + 1) % DisplayOptions.Length;
+                    if (nextIdx == 0)
+                        SeasonFilter.Instance.RemoveFilter(incoming);
+                    else
+                        SeasonFilter.Instance.SetFilter(incoming, AllSeasons[nextIdx - 1]);
+                    BuildCycleBtn();
+                }) { Tooltip = $"Click to cycle season override for {incomingName}" });
+            }
+
+            BuildCycleBtn();
+            grid.AddWidget(cycleWrapper, i + 1, 1);
+        }
+
+        root.Widgets.Add(grid);
+        root.Widgets.Add(new MyraLabel(
+            "Click the button to cycle through options. 'None' disables the filter.",
+            MyraLabel.Style.P));
+
+        return root;
+    }
+}

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Filters/SoundFilterTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Filters/SoundFilterTabContent.cs
@@ -1,0 +1,230 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using ClassicUO.Game.Managers;
+using ClassicUO.Utility;
+using Myra.Graphics2D.UI;
+using TextBox = Myra.Graphics2D.UI.TextBox;
+
+namespace ClassicUO.Game.UI.MyraWindows.Widgets.Assistant.Filters;
+
+public static class SoundFilterTabContent
+{
+    public static Widget Build()
+    {
+        var root = new VerticalStackPanel { Spacing = 6 };
+
+        root.Widgets.Add(new MyraLabel(
+            "Sound Filter allows you to mute specific in-game sounds by their ID.",
+            MyraLabel.Style.P));
+
+        var lastSoundPanel = new VerticalStackPanel { Spacing = 2 };
+        var filtersPanel = new VerticalStackPanel { Spacing = 2 };
+
+        void BuildFilterList()
+        {
+            filtersPanel.Widgets.Clear();
+            List<int> filterList = SoundFilterManager.Instance.FilteredSounds.OrderBy(x => x).ToList();
+
+            if (filterList.Count == 0)
+            {
+                filtersPanel.Widgets.Add(new MyraLabel("No sounds filtered.", MyraLabel.Style.P));
+                return;
+            }
+
+            filtersPanel.Widgets.Add(new MyraLabel($"Total: {filterList.Count} sound(s) filtered", MyraLabel.Style.P));
+
+            filtersPanel.Widgets.Add(MyraStyle.ApplyButtonDangerStyle(new MyraButton("Clear All Filters", () =>
+            {
+                SoundFilterManager.Instance.Clear();
+                BuildFilterList();
+            })));
+
+            var grid = new MyraGrid();
+            grid.AddColumn(new Proportion(ProportionType.Auto));
+            grid.AddColumn(new Proportion(ProportionType.Auto));
+            grid.AddColumn(new Proportion(ProportionType.Auto));
+            MyraStyle.ApplyStandardGridStyling(grid);
+
+            grid.AddWidget(new MyraLabel("Sound ID", MyraLabel.Style.H3), 0, 0);
+            grid.AddWidget(new MyraLabel("Actions", MyraLabel.Style.H3), 0, 1);
+            grid.AddWidget(new MyraLabel("Del", MyraLabel.Style.H3), 0, 2);
+
+            int dataRow = 1;
+            for (int i = filterList.Count - 1; i >= 0; i--)
+            {
+                int soundId = filterList[i];
+
+                // Track current ID so we can remove-old/add-new on edit without rebuilding
+                int[] current = { soundId };
+                var soundBox = new TextBox { Text = soundId.ToString(), Width = 80 };
+                soundBox.TextChangedByUser += (_, _) =>
+                {
+                    if (int.TryParse(soundBox.Text, out int newId))
+                    {
+                        newId = Math.Clamp(newId, 0, 65535);
+                        if (newId != current[0])
+                        {
+                            SoundFilterManager.Instance.RemoveFilter(current[0]);
+                            SoundFilterManager.Instance.AddFilter(newId);
+                            current[0] = newId;
+                        }
+                    }
+                };
+                grid.AddWidget(soundBox, dataRow, 0);
+
+                int capturedId = soundId;
+                var actionsPanel = new HorizontalStackPanel { Spacing = 2 };
+                actionsPanel.Widgets.Add(new MyraButton("Play", () =>
+                    Client.Game.Audio.PlaySound(current[0], true))
+                { Tooltip = "Test play this sound (bypasses filter)" });
+                grid.AddWidget(actionsPanel, dataRow, 1);
+
+                grid.AddWidget(MyraStyle.ApplyButtonDangerStyle(new MyraButton("X", () =>
+                {
+                    SoundFilterManager.Instance.RemoveFilter(current[0]);
+                    BuildFilterList();
+                }) { Tooltip = "Delete this filter" }), dataRow, 2);
+
+                dataRow++;
+            }
+
+            filtersPanel.Widgets.Add(grid);
+        }
+
+        void BuildLastSoundSection()
+        {
+            lastSoundPanel.Widgets.Clear();
+            lastSoundPanel.Widgets.Add(new MyraLabel("Last Sound Played:", MyraLabel.Style.H3));
+
+            int lastSoundId = Client.Game.Audio.LastPlayedSoundId;
+            if (lastSoundId >= 0)
+            {
+                var row = new HorizontalStackPanel { Spacing = 4 };
+                row.Widgets.Add(new MyraLabel($"Sound ID: {lastSoundId}", MyraLabel.Style.P));
+                row.Widgets.Add(new MyraButton("Add Filter", () =>
+                {
+                    SoundFilterManager.Instance.AddFilter(lastSoundId);
+                    BuildFilterList();
+                }) { Tooltip = "Add this sound to the filter list" });
+                row.Widgets.Add(new MyraButton("Play Again", () =>
+                    Client.Game.Audio.PlaySound(lastSoundId, true))
+                { Tooltip = "Play this sound again" });
+                row.Widgets.Add(new MyraButton("Refresh", () => BuildLastSoundSection())
+                    { Tooltip = "Refresh last played sound display" });
+                lastSoundPanel.Widgets.Add(row);
+                lastSoundPanel.Widgets.Add(new MyraLabel(
+                    "Tip: Play a sound in-game to see its ID above, then click Add Filter.",
+                    MyraLabel.Style.P));
+            }
+            else
+            {
+                var row = new HorizontalStackPanel { Spacing = 4 };
+                row.Widgets.Add(new MyraLabel("No sound played yet.", MyraLabel.Style.P));
+                row.Widgets.Add(new MyraButton("Refresh", () => BuildLastSoundSection())
+                    { Tooltip = "Refresh last played sound display" });
+                lastSoundPanel.Widgets.Add(row);
+            }
+        }
+
+        var addFilterPanel = new VerticalStackPanel { Visible = false, Spacing = 4 };
+        var newSoundBox = new TextBox { HintText = "Sound ID (0-65535)", Width = 120 };
+
+        var addConfirmRow = new HorizontalStackPanel { Spacing = 4 };
+        addConfirmRow.Widgets.Add(new MyraButton("Add", () =>
+        {
+            if (int.TryParse(newSoundBox.Text, out int soundId))
+            {
+                soundId = Math.Clamp(soundId, 0, 65535);
+                SoundFilterManager.Instance.AddFilter(soundId);
+                newSoundBox.Text = "";
+                addFilterPanel.Visible = false;
+                BuildFilterList();
+            }
+        }));
+        addConfirmRow.Widgets.Add(new MyraButton("Test Play", () =>
+        {
+            if (int.TryParse(newSoundBox.Text, out int soundId))
+                Client.Game.Audio.PlaySound(Math.Clamp(soundId, 0, 65535), true);
+        }) { Tooltip = "Test play this sound ID" });
+        addConfirmRow.Widgets.Add(new MyraButton("Cancel", () =>
+        {
+            addFilterPanel.Visible = false;
+            newSoundBox.Text = "";
+        }));
+
+        var addFieldRow = new HorizontalStackPanel { Spacing = 4 };
+        addFieldRow.Widgets.Add(new MyraLabel("Sound ID:", MyraLabel.Style.P)
+            { Tooltip = "Enter the numeric ID of the sound to filter (0-65535)" });
+        addFieldRow.Widgets.Add(newSoundBox);
+
+        addFilterPanel.Widgets.Add(new MyraLabel("Add Sound Filter:", MyraLabel.Style.H3));
+        addFilterPanel.Widgets.Add(addFieldRow);
+        addFilterPanel.Widgets.Add(addConfirmRow);
+
+        var actionRow = new HorizontalStackPanel { Spacing = 4 };
+        actionRow.Widgets.Add(new MyraButton("Add Filter Entry", () => addFilterPanel.Visible = !addFilterPanel.Visible));
+        actionRow.Widgets.Add(new MyraButton("Import", () =>
+        {
+            try
+            {
+                string? json = Clipboard.GetClipboardText();
+                if (string.IsNullOrWhiteSpace(json))
+                {
+                    GameActions.Print("Clipboard is empty", Constants.HUE_ERROR);
+                    return;
+                }
+
+                HashSet<int>? importedFilters = JsonSerializer.Deserialize(json, HashSetIntContext.Default.HashSetInt32);
+                if (importedFilters == null)
+                {
+                    GameActions.Print("Failed to parse clipboard data", Constants.HUE_ERROR);
+                    return;
+                }
+
+                int added = 0;
+                foreach (int id in importedFilters)
+                {
+                    if (SoundFilterManager.Instance.FilteredSounds.Add(Math.Clamp(id, 0, 65535)))
+                        added++;
+                }
+                SoundFilterManager.Instance.Save();
+                BuildFilterList();
+                GameActions.Print($"Added {added} sound filter(s) from clipboard", Constants.HUE_SUCCESS);
+            }
+            catch (Exception ex)
+            {
+                GameActions.Print($"Import failed: {ex.Message}", Constants.HUE_ERROR);
+            }
+        }) { Tooltip = "Import filtered sounds from clipboard JSON (adds to current filters)" });
+        actionRow.Widgets.Add(new MyraButton("Export", () =>
+        {
+            try
+            {
+                string json = JsonSerializer.Serialize(
+                    SoundFilterManager.Instance.FilteredSounds,
+                    HashSetIntContext.Default.HashSetInt32);
+                json.CopyToClipboard();
+                GameActions.Print(
+                    $"Exported {SoundFilterManager.Instance.FilteredSounds.Count} sound filter(s) to clipboard",
+                    Constants.HUE_SUCCESS);
+            }
+            catch (Exception ex)
+            {
+                GameActions.Print($"Export failed: {ex.Message}", Constants.HUE_ERROR);
+            }
+        }) { Tooltip = "Export all filtered sounds as JSON to clipboard" });
+
+        BuildLastSoundSection();
+        root.Widgets.Add(lastSoundPanel);
+        root.Widgets.Add(actionRow);
+        root.Widgets.Add(addFilterPanel);
+        root.Widgets.Add(new MyraLabel("Filtered Sounds:", MyraLabel.Style.H3));
+        BuildFilterList();
+        root.Widgets.Add(new ScrollViewer { Height = 250, Content = filtersPanel });
+
+        return root;
+    }
+}

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/GeneralTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/GeneralTabContent.cs
@@ -63,10 +63,11 @@ public static class GeneralTabContent
 
         row++;
 
+
         grid.AddWidget(MyraHSlider.SliderWithLabel(lang.GameScale, out MyraHSlider gsSlider, v =>
         {
-            gameScale = Math.Clamp(v, Constants.MIN_GAME_SCALE, Constants.MAX_GAME_SCALE);
-        }, Constants.MIN_GAME_SCALE, Constants.MAX_GAME_SCALE, Client.Game.RenderScale), row, Col.LeftColumn.ToInt());
+            gameScale = Math.Clamp(v / 100, Constants.MIN_GAME_SCALE, Constants.MAX_GAME_SCALE);
+        }, Constants.MIN_GAME_SCALE * 100, Constants.MAX_GAME_SCALE * 100, Client.Game.RenderScale * 100), row, Col.LeftColumn.ToInt());
         gsSlider.Tooltip = lang.GameScaleTooltip;
 
         row++;

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/MyraHSlider.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/MyraHSlider.cs
@@ -11,6 +11,12 @@ public class MyraHSlider : Grid
     private OverlayLabel _valueLabel = new();
     private HorizontalSlider _slider = new();
 
+    public bool RoundValues { get; set; } = true;
+    /// <summary>
+    /// This is only used when RoundValues is true
+    /// </summary>
+    public int DecimalPlaces { get; set; } = 0;
+
     public float Minimum
     {
         get => _slider.Minimum;
@@ -28,8 +34,9 @@ public class MyraHSlider : Grid
         get => _slider.Value;
         set
         {
-            _slider.Value = value;
-            _valueLabel.Text = FormatValue(value);
+            var val = ValidateValues(value);
+            _slider.Value = val;
+            _valueLabel.Text = FormatValue(val);
         }
     }
 
@@ -44,6 +51,15 @@ public class MyraHSlider : Grid
         Build();
     }
 
+    private float ValidateValues(float value)
+    {
+        if (!RoundValues) return value;
+
+        value = Math.Clamp(value, Minimum, Maximum);
+        value = (float)Math.Round(value, DecimalPlaces);
+        return value;
+    }
+
     private void Build()
     {
         ColumnsProportions.Add(new Proportion(ProportionType.Auto));
@@ -55,6 +71,10 @@ public class MyraHSlider : Grid
         _valueLabel.Font = TrueTypeLoader.Instance.GetFont(TrueTypeLoader.EMBEDDED_FONT, 12);
 
         _slider.ValueChangedByUser += (_, _) => _valueLabel.Text = FormatValue(_slider.Value);
+        _slider.ValueChanged += (sender, args) =>
+        {
+            Value = ValidateValues(args.NewValue); //This may get called twice: Value updated -> Event fired -> Value changes -> Event fired -> Value changes but the value is the same this time so this event isn't called again
+        };
 
         Widgets.Add(_slider);
         SetRow(_slider, 0);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Filters tab to the Assistant with Graphics Replacement, Journal, Sound, and Season filter panels.
  * Graphics Replacement supports per-entry preview, in-place edits, target-entity capture, import/export, and batch apply.
  * Journal and Sound filters offer add/remove, inline edit, and clipboard import/export with feedback.
  * Season filters provide per-season override cycling and clear-all.
  * GameScale slider now uses percentage input.
  * Slider control supports rounding and decimal precision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->