### PR TITLE
Improved Python interop for `ApiPoint3D`

### DIFF
--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiPlayer.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiPlayer.cs
@@ -16,6 +16,18 @@ public class ApiPlayer : ApiMobile
     public override ushort Y => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.Y ?? 0);
     public override sbyte Z => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.Z ?? 0);
 
+    /// <summary>
+    /// Retrieves the player's current position in the game world.
+    /// This API is most useful in combination with the Legion API's `GetPath`.
+    /// </summary>
+    public ApiPoint3D Position => MainThreadQueue.InvokeOnMainThread(() =>
+        {
+            PlayerMobile p = GetPlayerUnsafe();
+            return new ApiPoint3D { X = p?.X ?? 0, Y = p?.Y ?? 0, Z = p?.Z ?? 0 };
+        }
+    );
+
+
     // Primary Stats
     public ushort Strength => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.Strength ?? 0);
     public ushort Dexterity => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.Dexterity ?? 0);

--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiPoint3D.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiPoint3D.cs
@@ -3,11 +3,20 @@ namespace ClassicUO.LegionScripting.ApiClasses;
 /// <summary>
 /// Represents a point in a three-dimensional space
 /// </summary>
-public class ApiPoint3D
+public record struct ApiPoint3D
 {
     public int X { get; set; }
     public int Y { get; set; }
     public int Z { get; set; }
 
     public override string ToString() => $"({X}, {Y}, {Z})";
+
+    // Note - this section may be moved to a dedicated abstract class at a later point
+
+    #region Python Emulation
+
+    public string __str__() => ToString();
+    public string __repr__() => ToString();
+
+    #endregion
 }


### PR DESCRIPTION
## Description
Improved Python interop for `ApiPoint3D`

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing
Local testing.
The following script was used:

```py
import API

targ_path = API.GetPath(API.Player.X, API.Player.Y)
API.SysMsg(f"Target: X={targ_path[1].X}, Y={targ_path[1].Y}")


while True:
	pos = API.Player.Position
	API.SysMsg(f"Current: {pos}")
	if pos in targ_path:
		API.SysMsg("True")
	else:
		API.SysMsg("False")
	API.Pause(1)
```

## Additional Notes

Raised by `peaky` on https://discord.com/channels/1344851225538986064/1349336655923908658/1479769729408176250

* Converted `ApiPoint3D` into a `record struct` for by-value comparisons
* Added Python `__str__` and `__repr__` for `ApiPoint3D`
* Added `Position` API for `ApiPlayer` to allow for easy interop with the problematic `GetPath` API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Position property to the player API, enabling Legion scripts to retrieve the player's current world coordinates for navigation and path-finding.

* **Refactor**
  * Enhanced ApiPoint3D structure to use optimized value-type semantics for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->