### PR TITLE
fix: UIManager.TopMostControl not updated during gump addition/disposal

### DIFF
--- a/src/ClassicUO.Client/Game/Managers/UIManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/UIManager.cs
@@ -441,6 +441,9 @@ namespace ClassicUO.Game.Managers
                 {
                     Gumps.Remove(first);
                     UnregisterGump(g);
+                    // Unset if this was the top gump
+                    if (TopMostControl == g)
+                        TopMostControl = null;
                 }
 
                 first = next;
@@ -468,6 +471,9 @@ namespace ClassicUO.Game.Managers
                 {
                     Gumps.Remove(first);
                     UnregisterGump(g);
+                    // Unset if this was the top gump
+                    if (TopMostControl == g)
+                        TopMostControl = null;
                 }
 
                 first = next;
@@ -495,6 +501,7 @@ namespace ClassicUO.Game.Managers
                 if (front)
                 {
                     Gumps.AddFirst(gump);
+                    TopMostControl = gump; // Set the gump as the top-most so Myra's aware of it
                 }
                 else
                 {
@@ -927,6 +934,11 @@ namespace ClassicUO.Game.Managers
 
             // Reset Ctrl drag state when drag ends
             ResetCtrlDragState();
+        }
+
+        private static void DisposeGump(Gump g)
+        {
+
         }
     }
 }

--- a/src/ClassicUO.Client/Game/Managers/UIManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/UIManager.cs
@@ -935,10 +935,5 @@ namespace ClassicUO.Game.Managers
             // Reset Ctrl drag state when drag ends
             ResetCtrlDragState();
         }
-
-        private static void DisposeGump(Gump g)
-        {
-
-        }
     }
 }


### PR DESCRIPTION
## Description
UIManager.TopMostControl not updated during gump addition/disposal

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing
Local testing

## Additional Notes
Raised by `peaky` in [Discord](https://discord.com/channels/1344851225538986064/1349336655923908658/1479759344798138508)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of top-most window management when opening and closing dialogs to ensure proper tracking and state consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->