### PR TITLE
fix: Suppress FNA scissor rect/viewport warnings

### DIFF
--- a/src/ClassicUO.Client/GameController.cs
+++ b/src/ClassicUO.Client/GameController.cs
@@ -55,6 +55,11 @@ namespace ClassicUO
         private static Vector3 bgHueShader = new(0, 0, 0.3f);
         private bool drawScene;
 
+        static GameController()
+        {
+            RegisterFnaLoggerListeners();
+        }
+
         public GameController(IPluginHost pluginHost)
         {
             GraphicManager = new GraphicsDeviceManager(this);
@@ -1238,6 +1243,34 @@ namespace ClassicUO
                     GameActions.Print(UO.World, message, 0x44, MessageType.System);
                 }
             }
+        }
+
+        private static void FnaLogInfo(string message)=> Log.Info(message);
+
+        private static void FnaLogWarn(string message)
+        {
+            {
+                // This message spams the console and is generally unhelpful.
+                if (message == null || message.StartsWith("Scissor rect and viewport"))
+                    return;
+
+                Log.Warn(message);
+            }
+        }
+
+        private static void FnaLogError(string message) => Log.Error(message);
+
+
+        private static void RegisterFnaLoggerListeners()
+        {
+#if DEBUG
+            FNALoggerEXT.LogInfo += FnaLogInfo;
+#else
+            // Suppress in release. Done here to make it clear to the compiler it can inline/omit the call
+            FNALoggerEXT.LogInfo += (s) => {};
+#endif
+            FNALoggerEXT.LogWarn += FnaLogWarn;
+            FNALoggerEXT.LogError += FnaLogError;
         }
     }
 }

--- a/src/ClassicUO.Client/GameController.cs
+++ b/src/ClassicUO.Client/GameController.cs
@@ -55,10 +55,12 @@ namespace ClassicUO
         private static Vector3 bgHueShader = new(0, 0, 0.3f);
         private bool drawScene;
 
+#if DEBUG
         static GameController()
         {
             RegisterFnaLoggerListeners();
         }
+#endif
 
         public GameController(IPluginHost pluginHost)
         {
@@ -1263,12 +1265,7 @@ namespace ClassicUO
 
         private static void RegisterFnaLoggerListeners()
         {
-#if DEBUG
             FNALoggerEXT.LogInfo += FnaLogInfo;
-#else
-            // Suppress in release. Done here to make it clear to the compiler it can inline/omit the call
-            FNALoggerEXT.LogInfo += (s) => {};
-#endif
             FNALoggerEXT.LogWarn += FnaLogWarn;
             FNALoggerEXT.LogError += FnaLogError;
         }


### PR DESCRIPTION
## Description
Suppress FNA scissor rect/viewport warnings in console **in DEBUG mode**

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing
Local

## Additional Notes
**DEBUG only**

* Suppresses the `Scissor rect and viewport appear not to overlap` message from `FNA`
* Registers FNA logger methods to emit proper logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Filtered out noisy warning messages (e.g., repetitive viewport/scissor warnings) for cleaner debug output.

* **Refactor**
  * Improved internal logging so runtime logs from underlying systems are forwarded and handled conditionally in debug builds, with new internal helpers and listener wiring for more reliable diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->