### PR TITLE
Fix unequip priority so slots are cleared before equipping

### DIFF
--- a/src/ClassicUO.Client/Game/Managers/DressAgentManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/DressAgentManager.cs
@@ -436,7 +436,7 @@ namespace ClassicUO.Game.Managers
                 if (currentlyEquipped == null) continue;
 
                 if(!kr)
-                    ObjectActionQueue.Instance.Enqueue(new MoveRequest(currentlyEquipped, undressBag).ToObjectActionQueueItem(), ActionPriority.MoveItem);
+                    ObjectActionQueue.Instance.Enqueue(new MoveRequest(currentlyEquipped, undressBag).ToObjectActionQueueItem(), ActionPriority.UnequipItem);
                 else
                     toUnequip.Add((Layer)layer);
             }

--- a/src/ClassicUO.Client/Game/Managers/DressAgentManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/DressAgentManager.cs
@@ -408,7 +408,7 @@ namespace ClassicUO.Game.Managers
 
                 Item currentlyEquipped = World.Instance.Player?.FindItemByLayer((Layer)layer);
                 if (currentlyEquipped != null && !config.Contains(currentlyEquipped.Serial))
-                    ObjectActionQueue.Instance.Enqueue(new MoveRequest(currentlyEquipped, undressBag).ToObjectActionQueueItem(), ActionPriority.MoveItem);
+                    ObjectActionQueue.Instance.Enqueue(new MoveRequest(currentlyEquipped, undressBag).ToObjectActionQueueItem(), ActionPriority.UnequipItem);
             }
         }
 
@@ -419,7 +419,7 @@ namespace ClassicUO.Game.Managers
             if (item != null && item.Container == World.Instance.Player?.Serial)
             {
                 uint undressBag = GetUndressBag(config);
-                ObjectActionQueue.Instance.Enqueue(new MoveRequest(item, undressBag).ToObjectActionQueueItem(), ActionPriority.MoveItem);
+                ObjectActionQueue.Instance.Enqueue(new MoveRequest(item, undressBag).ToObjectActionQueueItem(), ActionPriority.UnequipItem);
             }
         }
 

--- a/src/ClassicUO.Client/Game/Managers/ObjectActionQueue.cs
+++ b/src/ClassicUO.Client/Game/Managers/ObjectActionQueue.cs
@@ -26,7 +26,7 @@ public class ObjectActionQueue : ConcurrentPriorityQueue<ObjectActionQueueItem, 
                 continue;
             }
 
-            if (priority >= ActionPriority.MoveItem && Client.Game.UO.GameCursor.ItemHold.Enabled)
+            if (priority >= ActionPriority.UnequipItem && Client.Game.UO.GameCursor.ItemHold.Enabled)
             {
                 Enqueue(item,  priority, sequence); //Return to queue to retry again when not holding an item
                 return;
@@ -96,6 +96,7 @@ public enum ActionPriority
     ManualUseItem, //Higher priority than regular useitem which may occur in scripts
     UseItem,
     OpenCorpse,
+    UnequipItem, //Unequip item to make room for equipping - must run before EquipItem
     EquipItem,
     MoveItem,
     LootItemHigh,   //Auto-loot: High priority items (still lower than manual moves)


### PR DESCRIPTION
Add UnequipItem priority between OpenCorpse and EquipItem so that dress agent unequip operations are guaranteed to execute before equip operations. Previously using MoveItem (lower priority than EquipItem) caused equip to fail when a slot was already occupied.

Also update the item-hold guard in ObjectActionQueue to block from UnequipItem and above, since unequipping is itself a drag operation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unequip prioritization so items are removed before new ones are equipped, resulting in more reliable dress/undress sequences.
  * Queue behavior when handling held items has been refined to reduce retries and smoother item transfers during undressing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->