### PR TITLE
Add ally auto-bandage option based on notoriety flag

### DIFF
--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -145,6 +145,7 @@ namespace ClassicUO.Configuration
         public int BandageAgentHPPercentage { get; set; } = 80;
         public bool BandageAgentCheckInvul { get; set; } = true;
         public bool BandageAgentBandageFriends { get; set; } = false;
+        public bool BandageAgentBandageAllies { get; set; } = false;
         public bool BandageAgentUseDexFormula { get; set; } = false;
         public bool BandageAgentDisableSelfHeal { get; set; } = false;
 

--- a/src/ClassicUO.Client/Game/Managers/BandageManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/BandageManager.cs
@@ -35,6 +35,7 @@ namespace ClassicUO.Game.Managers
 
         private bool IsEnabled => ProfileManager.CurrentProfile?.EnableBandageAgent ?? false;
         private bool FriendBandagingEnabled => ProfileManager.CurrentProfile?.BandageAgentBandageFriends ?? false;
+        private bool AllyBandagingEnabled => ProfileManager.CurrentProfile?.BandageAgentBandageAllies ?? false;
         private int HealDelayMs => ProfileManager.CurrentProfile?.BandageAgentDelay ?? 3000;
         private bool CheckForBuff => ProfileManager.CurrentProfile?.BandageAgentCheckForBuff ?? false;
         private ushort BandageGraphic => ProfileManager.CurrentProfile?.BandageAgentGraphic ?? 0x0E21;
@@ -185,7 +186,8 @@ namespace ClassicUO.Game.Managers
 
             bool isPlayer = mobile == player;
             bool isFriend = !isPlayer && FriendBandagingEnabled && FriendsListManager.Instance.IsFriend(mobile);
-            if (!isPlayer && !isFriend)
+            bool isAlly = !isPlayer && AllyBandagingEnabled && mobile.NotorietyFlag == NotorietyFlag.Ally;
+            if (!isPlayer && !isFriend && !isAlly)
                 return false;
 
             if (isPlayer && DisableSelfHeal)
@@ -207,18 +209,19 @@ namespace ClassicUO.Game.Managers
             if (mobile.IsDead)
                 return false;
 
-            // Check if this is the player or a friend
+            // Check if this is the player or a friend/ally
             bool isPlayer = mobile == player;
             bool isFriend = !isPlayer && FriendBandagingEnabled && FriendsListManager.Instance.IsFriend(mobile.Serial);
-            if (!isPlayer && !isFriend)
+            bool isAlly = !isPlayer && AllyBandagingEnabled && mobile.NotorietyFlag == NotorietyFlag.Ally;
+            if (!isPlayer && !isFriend && !isAlly)
                 return false;
 
             // Check if self-healing is disabled
             if (isPlayer && DisableSelfHeal)
                 return false;
 
-            // Check distance for friends (within 3 tiles)
-            if (isFriend && mobile.Distance > 3)
+            // Check distance for friends/allies (within 3 tiles)
+            if ((isFriend || isAlly) && mobile.Distance > 3)
                 return false;
 
             // Guard against divide-by-zero and invul

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/BandageAgentTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/BandageAgentTabContent.cs
@@ -30,6 +30,11 @@ public static class BandageAgentTabContent
             profile.BandageAgentBandageFriends,
             b => profile.BandageAgentBandageFriends = b,
             "Bandage friends"));
+        enableRow.Widgets.Add(MyraCheckButton.CreateWithCallback(
+            profile.BandageAgentBandageAllies,
+            b => profile.BandageAgentBandageAllies = b,
+            "Bandage allies",
+            "Bandage nearby guild/alliance members (notoriety: ally)"));
         root.Widgets.Add(enableRow);
 
         enableRow.Widgets.Add(MyraCheckButton.CreateWithCallback(


### PR DESCRIPTION
Adds a new 'Bandage allies' option to the bandage agent that automatically heals nearby mobiles with NotorietyFlag.Ally (guild/alliance members as designated by the server). The option is available as a checkbox in the Bandage Agent settings alongside the existing 'Bandage friends' option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bandage Agent can now bandage nearby guild and alliance members in addition to friends
  * Added a configuration toggle in Bandage Agent settings to enable ally bandaging
  * Allies are now treated as valid healing targets within the same proximity range as friends

<!-- end of auto-generated comment: release notes by coderabbit.ai -->