### PR TITLE
Fix ArgumentOutOfRangeException in CleanUpDisposedChildren

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Controls/Control.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/Control.cs
@@ -482,16 +482,13 @@ namespace ClassicUO.Game.UI.Controls
     {
         bool childRemoved = false;
         for (int i = Children.Count - 1; i >= 0; i--)
-            if (i < Children.Count)
+        {
+            if (i < Children.Count && Children[i]?.IsDisposed == true)
             {
-                IGui c = Children[i];
-
-                if (c?.IsDisposed == true)
-                {
-                    Children.Remove(c);
-                    childRemoved = true;
-                }
+                Children.RemoveAt(i);
+                childRemoved = true;
             }
+        }
 
         if (childRemoved)
             OnChildRemoved();


### PR DESCRIPTION
Replace Children.Remove(c) with Children.RemoveAt(i) to avoid the internal IndexOf+RemoveAt two-step in List.Remove, which could use a stale index if the list changed between the two calls.