### PR TITLE
Fix ThreadInterruptedException crash when script errors during stop

### DIFF
--- a/src/ClassicUO.Client/Game/Managers/MainThreadQueue.cs
+++ b/src/ClassicUO.Client/Game/Managers/MainThreadQueue.cs
@@ -104,6 +104,10 @@ public static class MainThreadQueue
         {
             return default;
         }
+        catch (ThreadInterruptedException)
+        {
+            return default;
+        }
 
         return result;
 

--- a/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
@@ -521,7 +521,7 @@ namespace ClassicUO.LegionScripting
                 }
 
                 if (errorLocations.Count > 0)
-                    MainThreadQueue.InvokeOnMainThread(() => new ScriptErrorWindow(new ScriptErrorDetails(e.Message, errorLocations, script)));
+                    MainThreadQueue.EnqueueAction(() => { new ScriptErrorWindow(new ScriptErrorDetails(e.Message, errorLocations, script)); });
                 else
                     GameActions.Print(_world, formattedEx, Constants.HUE_ERROR);
             }

--- a/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
@@ -425,20 +425,16 @@ namespace ClassicUO.LegionScripting
 
             try
             {
-                try
-                {
-                    ScriptSource source = script.PythonEngine.CreateScriptSourceFromString(script.FileContentsJoined, script.FullPath, SourceCodeKind.File);
-                    source?.Execute(script.PythonScope);
-                }
-                catch (ThreadInterruptedException) { }
-                catch (ThreadAbortException) { }
-                catch (OperationCanceledException) { }
-                catch (Exception e)
-                {
-                    ShowScriptError(script, e);
-                }
+                ScriptSource source = script.PythonEngine.CreateScriptSourceFromString(script.FileContentsJoined, script.FullPath, SourceCodeKind.File);
+                source?.Execute(script.PythonScope);
             }
             catch (ThreadInterruptedException) { }
+            catch (ThreadAbortException) { }
+            catch (OperationCanceledException) { }
+            catch (Exception e)
+            {
+                ShowScriptError(script, e);
+            }
 
             MainThreadQueue.EnqueueAction(() => { StopScript(script); });
         }
@@ -447,40 +443,36 @@ namespace ClassicUO.LegionScripting
         {
             try
             {
-                try
-                {
-                    script.SetupCSharpScript();
-                    script.SetupCSharpGlobals();
+                script.SetupCSharpScript();
+                script.SetupCSharpGlobals();
 
-                    // Execute with cancellation support
-                    Task<ScriptState<object>> task = script.CSharpCompiledScript.RunAsync(
-                        new ScriptGlobals { GlobalApiInstance = script.ScopedApi },
-                        script.ScopedApi.CancellationToken.Token
-                    );
+                // Execute with cancellation support
+                Task<ScriptState<object>> task = script.CSharpCompiledScript.RunAsync(
+                    new ScriptGlobals { GlobalApiInstance = script.ScopedApi },
+                    script.ScopedApi.CancellationToken.Token
+                );
 
-                    // Block thread until the script completes or is canceled
-                    task.Wait(script.ScopedApi.CancellationToken.Token);
-                }
-                catch (CompilationErrorException e)
-                {
-                    ShowCSharpCompilationError(script, e);
-                }
-                catch (AggregateException ae) when (ae.InnerException is OperationCanceledException or ThreadInterruptedException or ThreadAbortException)
-                {
-                    // Script was canceled via the stop button
-                }
-                catch (OperationCanceledException)
-                {
-                    // Script was canceled
-                }
-                catch (ThreadInterruptedException) { }
-                catch (ThreadAbortException) { }
-                catch (Exception e)
-                {
-                    ShowCSharpRuntimeError(script, e);
-                }
+                // Block thread until the script completes or is canceled
+                task.Wait(script.ScopedApi.CancellationToken.Token);
+            }
+            catch (CompilationErrorException e)
+            {
+                ShowCSharpCompilationError(script, e);
+            }
+            catch (AggregateException ae) when (ae.InnerException is OperationCanceledException or ThreadInterruptedException or ThreadAbortException)
+            {
+                // Script was canceled via the stop button
+            }
+            catch (OperationCanceledException)
+            {
+                // Script was canceled
             }
             catch (ThreadInterruptedException) { }
+            catch (ThreadAbortException) { }
+            catch (Exception e)
+            {
+                ShowCSharpRuntimeError(script, e);
+            }
 
             MainThreadQueue.EnqueueAction(() => { StopScript(script); });
         }

--- a/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
@@ -425,17 +425,20 @@ namespace ClassicUO.LegionScripting
 
             try
             {
-                ScriptSource source = script.PythonEngine.CreateScriptSourceFromString(script.FileContentsJoined, script.FullPath, SourceCodeKind.File);
-                source?.Execute(script.PythonScope);
+                try
+                {
+                    ScriptSource source = script.PythonEngine.CreateScriptSourceFromString(script.FileContentsJoined, script.FullPath, SourceCodeKind.File);
+                    source?.Execute(script.PythonScope);
+                }
+                catch (ThreadInterruptedException) { }
+                catch (ThreadAbortException) { }
+                catch (OperationCanceledException) { }
+                catch (Exception e)
+                {
+                    ShowScriptError(script, e);
+                }
             }
             catch (ThreadInterruptedException) { }
-            catch (ThreadAbortException) { }
-            catch (OperationCanceledException) { }
-            catch (Exception e)
-            {
-                try { ShowScriptError(script, e); }
-                catch (ThreadInterruptedException) { }
-            }
 
             MainThreadQueue.EnqueueAction(() => { StopScript(script); });
         }
@@ -444,37 +447,40 @@ namespace ClassicUO.LegionScripting
         {
             try
             {
-                script.SetupCSharpScript();
-                script.SetupCSharpGlobals();
+                try
+                {
+                    script.SetupCSharpScript();
+                    script.SetupCSharpGlobals();
 
-                // Execute with cancellation support
-                Task<ScriptState<object>> task = script.CSharpCompiledScript.RunAsync(
-                    new ScriptGlobals { GlobalApiInstance = script.ScopedApi },
-                    script.ScopedApi.CancellationToken.Token
-                );
+                    // Execute with cancellation support
+                    Task<ScriptState<object>> task = script.CSharpCompiledScript.RunAsync(
+                        new ScriptGlobals { GlobalApiInstance = script.ScopedApi },
+                        script.ScopedApi.CancellationToken.Token
+                    );
 
-                // Block thread until the script completes or is canceled
-                task.Wait(script.ScopedApi.CancellationToken.Token);
-            }
-            catch (CompilationErrorException e)
-            {
-                ShowCSharpCompilationError(script, e);
-            }
-            catch (AggregateException ae) when (ae.InnerException is OperationCanceledException or ThreadInterruptedException or ThreadAbortException)
-            {
-                // Script was canceled via the stop button
-            }
-            catch (OperationCanceledException)
-            {
-                // Script was canceled
+                    // Block thread until the script completes or is canceled
+                    task.Wait(script.ScopedApi.CancellationToken.Token);
+                }
+                catch (CompilationErrorException e)
+                {
+                    ShowCSharpCompilationError(script, e);
+                }
+                catch (AggregateException ae) when (ae.InnerException is OperationCanceledException or ThreadInterruptedException or ThreadAbortException)
+                {
+                    // Script was canceled via the stop button
+                }
+                catch (OperationCanceledException)
+                {
+                    // Script was canceled
+                }
+                catch (ThreadInterruptedException) { }
+                catch (ThreadAbortException) { }
+                catch (Exception e)
+                {
+                    ShowCSharpRuntimeError(script, e);
+                }
             }
             catch (ThreadInterruptedException) { }
-            catch (ThreadAbortException) { }
-            catch (Exception e)
-            {
-                try { ShowCSharpRuntimeError(script, e); }
-                catch (ThreadInterruptedException) { }
-            }
 
             MainThreadQueue.EnqueueAction(() => { StopScript(script); });
         }

--- a/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
@@ -404,9 +404,9 @@ namespace ClassicUO.LegionScripting
 
                 // Route to correct executor based on script type
                 if (script.Type == ScriptFile.ScriptType.CSharp)
-                    script.ScriptThread = new Thread(() => ExecuteCSharpScript(script)) { Name = $"Legion: {script.FileName}" };
+                    script.ScriptThread = new Thread(() => { try { ExecuteCSharpScript(script); } catch (ThreadInterruptedException) { } }) { Name = $"Legion: {script.FileName}" };
                 else
-                    script.ScriptThread = new Thread(() => ExecutePythonScript(script)) { Name = $"Legion: {script.FileName}" };
+                    script.ScriptThread = new Thread(() => { try { ExecutePythonScript(script); } catch (ThreadInterruptedException) { } }) { Name = $"Legion: {script.FileName}" };
 
                 if(!PyThreads.TryAdd(script.ScriptThread.ManagedThreadId, script))
                     PyThreads[script.ScriptThread.ManagedThreadId] = script;

--- a/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
@@ -404,9 +404,9 @@ namespace ClassicUO.LegionScripting
 
                 // Route to correct executor based on script type
                 if (script.Type == ScriptFile.ScriptType.CSharp)
-                    script.ScriptThread = new Thread(() => { try { ExecuteCSharpScript(script); } catch (ThreadInterruptedException) { } }) { Name = $"Legion: {script.FileName}" };
+                    script.ScriptThread = new Thread(() => ExecuteCSharpScript(script)) { Name = $"Legion: {script.FileName}" };
                 else
-                    script.ScriptThread = new Thread(() => { try { ExecutePythonScript(script); } catch (ThreadInterruptedException) { } }) { Name = $"Legion: {script.FileName}" };
+                    script.ScriptThread = new Thread(() => ExecutePythonScript(script)) { Name = $"Legion: {script.FileName}" };
 
                 if(!PyThreads.TryAdd(script.ScriptThread.ManagedThreadId, script))
                     PyThreads[script.ScriptThread.ManagedThreadId] = script;

--- a/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
@@ -433,7 +433,8 @@ namespace ClassicUO.LegionScripting
             catch (OperationCanceledException) { }
             catch (Exception e)
             {
-                ShowScriptError(script, e);
+                try { ShowScriptError(script, e); }
+                catch (ThreadInterruptedException) { }
             }
 
             MainThreadQueue.EnqueueAction(() => { StopScript(script); });
@@ -471,7 +472,8 @@ namespace ClassicUO.LegionScripting
             catch (ThreadAbortException) { }
             catch (Exception e)
             {
-                ShowCSharpRuntimeError(script, e);
+                try { ShowCSharpRuntimeError(script, e); }
+                catch (ThreadInterruptedException) { }
             }
 
             MainThreadQueue.EnqueueAction(() => { StopScript(script); });


### PR DESCRIPTION
When a Python script threw an exception while being stopped, ShowScriptError would call InvokeOnMainThread<T> which blocks via Monitor.Wait. If StopScript ran concurrently and called Thread.Interrupt(), this interrupted the waiting thread causing an unhandled ThreadInterruptedException to surface in the log.

Two fixes:
- ShowScriptError now uses EnqueueAction (non-blocking fire-and-forget) to show the error window, since the return value of ScriptErrorWindow is unused
- InvokeOnMainThread<T> now also catches ThreadInterruptedException as a defensive guard against future similar race conditions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of thread interruptions to ensure stable operation
  * Enhanced script error reporting mechanism to prevent UI freezing during error detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->