### PR TITLE
Fix bulletin board showing 11 messages per page instead of 9

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/BulletinBoardGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/BulletinBoardGump.cs
@@ -74,7 +74,7 @@ namespace ClassicUO.Game.UI.Gumps
                 127,
                 159,
                 241,
-                195,
+                BulletinBoardObject.ITEM_HEIGHT * 9,
                 false
             );
 
@@ -478,12 +478,14 @@ namespace ClassicUO.Game.UI.Gumps
 
     public class BulletinBoardObject : Control
     {
+        public const int ITEM_HEIGHT = 18;
+
         public BulletinBoardObject(uint serial, string text)
         {
             LocalSerial = serial; //board
             CanMove = true;
             Width = 230;
-            Height = 18;
+            Height = ITEM_HEIGHT;
 
             Add(new GumpPic(0, 0, 0x1523, 0));
 


### PR DESCRIPTION
Port of ClassicUO PR #1871. The scroll area height is now calculated as BulletinBoardObject.ITEM_HEIGHT * 9 (162px) instead of the hardcoded 195px, matching the official client's 9-messages-per-page behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to bulletin board interface code organization and dimension handling for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->