### PR TITLE
Fix cursor alignment when player position is offset

### DIFF
--- a/src/ClassicUO.Client/Game/Scenes/GameSceneDrawingSorting.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameSceneDrawingSorting.cs
@@ -1079,8 +1079,8 @@ namespace ClassicUO.Game.Scenes
 
             int winGameCenterX = winGamePosX + (winGameWidth >> 1);
             int winGameCenterY = winGamePosY + (winGameHeight >> 1) + (_world.Player.Z << 2);
-            winGameCenterX -= (int)_world.Player.Offset.X - ProfileManager.CurrentProfile.PlayerOffset.X;
-            winGameCenterY -= (int)(_world.Player.Offset.Y - _world.Player.Offset.Z - ProfileManager.CurrentProfile.PlayerOffset.Y);
+            winGameCenterX -= (int)_world.Player.Offset.X;
+            winGameCenterY -= (int)(_world.Player.Offset.Y - _world.Player.Offset.Z);
 
             int tileOffX = _world.Player.X - ProfileManager.CurrentProfile.PlayerOffset.X;
             int tileOffY = _world.Player.Y - ProfileManager.CurrentProfile.PlayerOffset.Y;


### PR DESCRIPTION
When PlayerOffset was non-zero, winGameCenterX/Y was incorrectly adjusted by PlayerOffset in raw pixel units, while tileOffX/Y already handled the offset correctly in tile units (22px each). This caused all RealScreenPosition values to shift by N pixels instead of N*22 pixels per unit of PlayerOffset, creating a misalignment between the player's visual position and the center point used for mouse movement direction calculation.

Fixes #193

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved camera viewport centering by refining how the game calculates the view center point relative to the player character. The viewport positioning logic was simplified to provide more accurate camera alignment and consistent behavior when following the player through the game world.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->