### PR TITLE
add DressItems method to scripting API

### DIFF
--- a/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -1047,6 +1047,30 @@ namespace ClassicUO.LegionScripting
         {
             return DressAgentManager.Instance?.CurrentPlayerConfigs?.Select((cfg) => cfg.Name)?.ToList() ?? [];
         });
+
+        /// <summary>
+        /// Dress items by serial
+        /// example:
+        /// ```py
+        /// serials = [0xabc, 0xdef]
+        /// API.DressItems(serials, kr=True)
+        /// ```
+        /// </summary>
+        /// <param name="serials">The list of serials to dress</param>
+        /// <param name="kr">Whether to use the faster KR packet</param>
+        public void DressItems(IList<int> serials, bool kr = true)
+        {
+            // create temporary dress agent entry
+            var temp = new DressConfig {
+                UseKREquipPacket = kr,
+                Items = serials.Select(i => new DressItem { Serial = (uint)i }).ToList()
+            };
+
+            if (temp != null)
+            {
+                DressAgentManager.Instance.DressFromConfig(temp);
+            }
+        }
 
         /// <summary>
         /// Runs an organizer agent to move items between containers.

--- a/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
@@ -1057,20 +1057,27 @@ namespace ClassicUO.LegionScripting
         /// ```
         /// </summary>
         /// <param name="serials">The list of serials to dress</param>
-        /// <param name="kr">Whether to use the faster KR packet</param>
-        public void DressItems(IList<int> serials, bool kr = true)
+        /// <param name="kr">True to use the faster KR packet (not supported everywhere)</param>
+        public void DressItems(IList<int> serials, bool kr = true) => OnMain(() =>
         {
-            // create temporary dress agent entry
-            var temp = new DressConfig {
+            if (serials == null || serials.Count == 0) return;
+
+            var config = new DressConfig
+            {
                 UseKREquipPacket = kr,
-                Items = serials.Select(i => new DressItem { Serial = (uint)i }).ToList()
+                Items = serials
+                    .Where(s => s > 0)
+                    .Select(s => (serial: (uint)s, item: World.Items.Get((uint)s)))
+                    .Where(t => t.item != null)
+                    .Select(t => new DressItem
+                    {
+                        Serial = t.serial,
+                        Layer = t.item.ItemData.Layer,
+                    }).ToList()
             };
 
-            if (temp != null)
-            {
-                DressAgentManager.Instance.DressFromConfig(temp);
-            }
-        }
+            DressAgentManager.Instance.DressFromConfig(config);
+        });
 
         /// <summary>
         /// Runs an organizer agent to move items between containers.

--- a/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
@@ -2461,7 +2461,7 @@ namespace ClassicUO.LegionScripting
         /// OPL consists of item name and tooltip text(properties).
         /// </summary>
         /// <param name="serials">A list of object serials to request OPL data for</param>
-        public void RequestOPLData(IList<uint> serials) => OnMain(() =>
+        public void RequestOPLData(IList<int> serials) => OnMain(() =>
         {
             foreach (uint s in serials)
                 World.OPL.Contains(s); //Check if it already exists, if not request it

--- a/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
@@ -1058,7 +1058,7 @@ namespace ClassicUO.LegionScripting
         /// </summary>
         /// <param name="serials">The list of serials to dress</param>
         /// <param name="kr">True to use the faster KR packet (not supported everywhere)</param>
-        public void DressItems(IList<int> serials, bool kr = true) => OnMain(() =>
+        public void DressItems(IList<int> serials, bool kr = false) => OnMain(() =>
         {
             if (serials == null || serials.Count == 0) return;
 

--- a/src/ClassicUO.Client/LegionScripting/docs/API.py
+++ b/src/ClassicUO.Client/LegionScripting/docs/API.py
@@ -1522,6 +1522,18 @@ def GetAvailableDressOutfits() -> "list[str]":
     """
     pass
 
+def DressItems(serials: "list[int]", kr: "bool" = True) -> None:
+    """
+     Dress items by serial
+     example:
+     ```py
+     serials = [0xabc, 0xdef]
+     API.DressItems(serials, kr=True)
+     ```
+    
+    """
+    pass
+
 def Organizer(name: "str", source: "int" = 0, destination: "int" = 0) -> None:
     """
      Runs an organizer agent to move items between containers.

--- a/src/ClassicUO.Client/LegionScripting/docs/LegionAPI.md
+++ b/src/ClassicUO.Client/LegionScripting/docs/LegionAPI.md
@@ -2035,7 +2035,7 @@ You can now type `-updateapi` in game to download the latest API.py file.
 
 | Name | Type | Optional | Description |
 | --- | --- | --- | --- |
-| `serials` | `IList<uint>` | ❌ No | A list of object serials to request OPL data for |
+| `serials` | `IList<int>` | ❌ No | A list of object serials to request OPL data for |
 
 **Return Type:** `void` *(Does not return anything)*
 

--- a/src/ClassicUO.Client/LegionScripting/docs/LegionAPI.md
+++ b/src/ClassicUO.Client/LegionScripting/docs/LegionAPI.md
@@ -845,7 +845,7 @@ You can now type `-updateapi` in game to download the latest API.py file.
 | Name | Type | Optional | Description |
 | --- | --- | --- | --- |
 | `serials` | `IList<int>` | ❌ No | The list of serials to dress |
-| `kr` | `bool` | ✅ Yes | Whether to use the faster KR packet |
+| `kr` | `bool` | ✅ Yes | True to use the faster KR packet (not supported everywhere) |
 
 **Return Type:** `void` *(Does not return anything)*
 

--- a/src/ClassicUO.Client/LegionScripting/docs/LegionAPI.md
+++ b/src/ClassicUO.Client/LegionScripting/docs/LegionAPI.md
@@ -21,7 +21,7 @@ You can now type `-updateapi` in game to download the latest API.py file.
 
 [Additional notes](../notes/)  
 
-*This was generated on `3/15/26`.*
+*This was generated on `3/17/26`.*
 
 ## Properties
 ### `Events`

--- a/src/ClassicUO.Client/LegionScripting/docs/LegionAPI.md
+++ b/src/ClassicUO.Client/LegionScripting/docs/LegionAPI.md
@@ -21,7 +21,7 @@ You can now type `-updateapi` in game to download the latest API.py file.
 
 [Additional notes](../notes/)  
 
-*This was generated on `3/12/26`.*
+*This was generated on `3/15/26`.*
 
 ## Properties
 ### `Events`
@@ -827,6 +827,27 @@ You can now type `-updateapi` in game to download the latest API.py file.
 
 
 **Return Type:** `IList<string>`
+
+---
+
+### DressItems
+`(serials, kr)`
+ Dress items by serial
+ example:
+ ```py
+ serials = [0xabc, 0xdef]
+ API.DressItems(serials, kr=True)
+ ```
+
+
+**Parameters:**
+
+| Name | Type | Optional | Description |
+| --- | --- | --- | --- |
+| `serials` | `IList<int>` | ❌ No | The list of serials to dress |
+| `kr` | `bool` | ✅ Yes | Whether to use the faster KR packet |
+
+**Return Type:** `void` *(Does not return anything)*
 
 ---
 


### PR DESCRIPTION
### Summary
Add `DressItems` method to the scripting API to allow dressing items directly by serial number without requiring a saved dress outfit.
### Changes
- Add `API.DressItems(serials, kr=True)` method to LegionScripting API
- Allows dressing items by their serial numbers programmatically
### Example Usage
```py
# Dress specific items by serial
API.DressItems([0x12345678, 0x87654321], kr=True)
```
### Motivation
Currently, dressing items via script requires creating a dress outfit config first. This adds the ability to dress items directly by serial, which is more flexible for scripting use cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DressItems to the Legion scripting API to equip items by serials, with an optional KR compatibility flag.

* **Documentation**
  * Added API docs and usage examples for DressItems.
  * Updated documentation to reflect RequestOPLData's serials parameter now using signed integer lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->