### PR TITLE
Fix IronPython type mismatch crash when passing serial lists to API

### DIFF
--- a/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
@@ -1067,7 +1067,7 @@ namespace ClassicUO.LegionScripting
                 UseKREquipPacket = kr,
                 Items = serials
                     .Cast<object>()
-                    .Select(o => Utility.TryGetSerial(o, out uint s) ? s : 0u)
+                    .Select(o => Convert.ToUInt32(o))
                     .Where(s => s != 0)
                     .Select(s => (serial: s, item: World.Items.Get(s)))
                     .Where(t => t.item != null)
@@ -2475,7 +2475,7 @@ namespace ClassicUO.LegionScripting
             if (serials == null) return;
             foreach (object o in serials)
             {
-                if (Utility.TryGetSerial(o, out uint serial) && serial != 0)
+                if (Convert.ToUInt32(o) is uint serial && serial != 0)
                     World.OPL.Contains(serial); //Check if it already exists, if not request it
             }
         });

--- a/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
@@ -2472,9 +2472,10 @@ namespace ClassicUO.LegionScripting
         /// <param name="serials">A list of object serials to request OPL data for</param>
         public void RequestOPLData(IEnumerable serials) => OnMain(() =>
         {
+            if (serials == null) return;
             foreach (object o in serials)
             {
-                if (Utility.TryGetSerial(o, out uint serial))
+                if (Utility.TryGetSerial(o, out uint serial) && serial != 0)
                     World.OPL.Contains(serial); //Check if it already exists, if not request it
             }
         });

--- a/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
@@ -2475,7 +2475,7 @@ namespace ClassicUO.LegionScripting
             foreach (object o in serials)
             {
                 if (Utility.TryGetSerial(o, out uint serial))
-                    World.OPL.Contains(Convert.ToUInt32(o)); //Check if it already exists, if not request it
+                    World.OPL.Contains(serial); //Check if it already exists, if not request it
             }
         });
 

--- a/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
@@ -1067,7 +1067,7 @@ namespace ClassicUO.LegionScripting
                 UseKREquipPacket = kr,
                 Items = serials
                     .Cast<object>()
-                    .Select(o => Convert.ToUInt32(o))
+                    .Select(o => Utility.TryGetSerial(o, out uint s) ? s : 0u)
                     .Where(s => s != 0)
                     .Select(s => (serial: s, item: World.Items.Get(s)))
                     .Where(t => t.item != null)
@@ -2473,7 +2473,10 @@ namespace ClassicUO.LegionScripting
         public void RequestOPLData(IEnumerable serials) => OnMain(() =>
         {
             foreach (object o in serials)
-                World.OPL.Contains(Convert.ToUInt32(o)); //Check if it already exists, if not request it
+            {
+                if (Utility.TryGetSerial(o, out uint serial))
+                    World.OPL.Contains(Convert.ToUInt32(o)); //Check if it already exists, if not request it
+            }
         });
 
         /// <summary>

--- a/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
@@ -1058,16 +1058,18 @@ namespace ClassicUO.LegionScripting
         /// </summary>
         /// <param name="serials">The list of serials to dress</param>
         /// <param name="kr">True to use the faster KR packet (not supported everywhere)</param>
-        public void DressItems(IList<int> serials, bool kr = false) => OnMain(() =>
+        public void DressItems(IEnumerable serials, bool kr = false) => OnMain(() =>
         {
-            if (serials == null || serials.Count == 0) return;
+            if (serials == null) return;
 
             var config = new DressConfig
             {
                 UseKREquipPacket = kr,
                 Items = serials
-                    .Where(s => s > 0)
-                    .Select(s => (serial: (uint)s, item: World.Items.Get((uint)s)))
+                    .Cast<object>()
+                    .Select(o => Convert.ToUInt32(o))
+                    .Where(s => s != 0)
+                    .Select(s => (serial: s, item: World.Items.Get(s)))
                     .Where(t => t.item != null)
                     .Select(t => new DressItem
                     {
@@ -2468,10 +2470,10 @@ namespace ClassicUO.LegionScripting
         /// OPL consists of item name and tooltip text(properties).
         /// </summary>
         /// <param name="serials">A list of object serials to request OPL data for</param>
-        public void RequestOPLData(IList<int> serials) => OnMain(() =>
+        public void RequestOPLData(IEnumerable serials) => OnMain(() =>
         {
-            foreach (uint s in serials)
-                World.OPL.Contains(s); //Check if it already exists, if not request it
+            foreach (object o in serials)
+                World.OPL.Contains(Convert.ToUInt32(o)); //Check if it already exists, if not request it
         });
 
         /// <summary>

--- a/src/ClassicUO.Client/LegionScripting/Utility.cs
+++ b/src/ClassicUO.Client/LegionScripting/Utility.cs
@@ -274,23 +274,7 @@ internal static class Utility
         return Color.Black;
     }
 
-    /// <summary>
-    ///     Attempts to convert an arbitrary scripting object to a uint serial.
-    ///     Handles uint, non-negative int, non-negative long, and string representations.
-    ///     Returns false and sets serial to 0 for negative or non-numeric values.
-    /// </summary>
-    /// <param name="o">The value to convert</param>
-    /// <param name="serial">The conversion result</param>
-    /// <returns>True if conversion succeeded, false otherwise</returns>
-    public static bool TryGetSerial(object o, out uint serial)
-    {
-        if (o is uint u) { serial = u; return true; }
-        if (o is int i && i >= 0) { serial = (uint)i; return true; }
-        if (o is long l && l >= 0 && l <= uint.MaxValue) { serial = (uint)l; return true; }
-        if (uint.TryParse(o?.ToString(), out uint parsed)) { serial = parsed; return true; }
-        serial = 0;
-        return false;
-    }
+
 
     /// <summary>
     ///     Converts the given values into an array of <see cref="LegionAPI.Notoriety" />

--- a/src/ClassicUO.Client/LegionScripting/Utility.cs
+++ b/src/ClassicUO.Client/LegionScripting/Utility.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -272,6 +272,24 @@ internal static class Utility
         }
 
         return Color.Black;
+    }
+
+    /// <summary>
+    ///     Attempts to convert an arbitrary scripting object to a uint serial.
+    ///     Handles uint, non-negative int, non-negative long, and string representations.
+    ///     Returns false and sets serial to 0 for negative or non-numeric values.
+    /// </summary>
+    /// <param name="o">The value to convert</param>
+    /// <param name="serial">The conversion result</param>
+    /// <returns>True if conversion succeeded, false otherwise</returns>
+    public static bool TryGetSerial(object o, out uint serial)
+    {
+        if (o is uint u) { serial = u; return true; }
+        if (o is int i && i >= 0) { serial = (uint)i; return true; }
+        if (o is long l && l >= 0 && l <= uint.MaxValue) { serial = (uint)l; return true; }
+        if (uint.TryParse(o?.ToString(), out uint parsed)) { serial = parsed; return true; }
+        serial = 0;
+        return false;
     }
 
     /// <summary>


### PR DESCRIPTION
### Summary
Fixes a crash when Python scripts pass serial lists to `DressItems` and `RequestOPLData`.
### Problem
IronPython wraps list iteration in IEnumeratorOfTWrapper, which throws InvalidCastException if the C# generic type doesn't match the actual CLR type in the list:
- `IList<int>` crashes when passing [item.Serial] (list contains uint)
- `IList<uint>` crashes when passing [0xabc] (list contains int)
### Solution
Both methods now accept non-generic IEnumerable with manual `Convert.ToUInt32()` conversion, following the same pattern used by `ConvertNotorietyOrThrow` in Utility.cs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Scripting API methods now accept more flexible, non-generic input collections for item and data operations.
* **Bug Fixes**
  * More robust conversion and validation of script-provided identifiers: non-numeric or invalid values are skipped and zero values ignored to prevent runtime errors.
* **Style**
  * Removed BOM and applied minor whitespace cleanup in utility sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->