### PR TITLE
fix: Font memory usage

### DIFF
--- a/src/ClassicUO.Assets/SystemFontProvider.cs
+++ b/src/ClassicUO.Assets/SystemFontProvider.cs
@@ -42,6 +42,17 @@ public static class SystemFontProvider
         select @group.Value;
 
     /// <summary>
+    ///     Retrieves the font faces for the given font family name if it exists
+    /// </summary>
+    /// <param name="name">The name of the font family to retrieve</param>
+    /// <returns>
+    ///     A <see cref="FontsByFamily" /> object containing the font family's name and font faces
+    ///     or <c>null</c> if the family does not exist or could not be processed
+    /// </returns>
+    public static FontsByFamily? GetSystemFontFamilyByName(string name) =>
+        SystemFonts.TryGet(name, out FontFamily family) ? GetSystemFontsByFamily(family) : null;
+
+    /// <summary>
     ///     Retrieves the font faces and the corresponding family name for a given font family.
     /// </summary>
     /// <param name="family">The font family from which font data will be retrieved.</param>

--- a/src/ClassicUO.Assets/TrueTypeLoader.cs
+++ b/src/ClassicUO.Assets/TrueTypeLoader.cs
@@ -390,7 +390,7 @@ public class TrueTypeLoader
             if (TryGetSystemFont(name, size, out SpriteFontBase sysFont))
                 return sysFont;
 
-            // This is to repeated disk hits if a font is botched or otherwise unusable.
+            // This is to prevent repeated disk hits if a font is botched or otherwise unusable.
             // We can also note in cache that this font family is problematic, but if we've gotten here,
             // it means the initial cache population run concluded that this font is valid.
             Log.Warn($"Could not load system font '{name}'. Family will be ignored");
@@ -407,7 +407,16 @@ public class TrueTypeLoader
 
     public SpriteFontBase GetFont(string name) => GetFont(name, 12);
 
-    public string[] Fonts => _fonts.Keys.Concat(_availableSystemFontFamilyNames).ToArray();
+    public string[] Fonts
+    {
+        get
+        {
+            // Construct a deduplicated list of font names.
+            // This is used only for the options gump so performance is less of a concern here.
+            var fontNames = new List<string>(_fonts.Keys.Where(name => !_availableSystemFontFamilyNames.Contains(name)));
+            return fontNames.Concat(_availableSystemFontFamilyNames).ToArray();
+        }
+    }
 }
 
 /// <summary>

--- a/src/ClassicUO.Assets/TrueTypeLoader.cs
+++ b/src/ClassicUO.Assets/TrueTypeLoader.cs
@@ -81,6 +81,8 @@ public class TrueTypeLoader
 {
     public const string EMBEDDED_FONT = EmbeddedFontNames.ROBOTO;
 
+    private const uint MAX_NUMBER_OF_SYS_FONT_FAMILIES = 1000;
+
     private readonly Dictionary<string, FontSystem> _fonts = new();
     /// <summary>
     /// Contains the names of all available system fonts.
@@ -104,7 +106,6 @@ public class TrueTypeLoader
     {
         LoadUserFonts();
         LoadEmbeddedFonts();
-        PopulateAvailableSystemFontFamilyNames();
         BuildSysFontsCache();
     }
 
@@ -128,12 +129,6 @@ public class TrueTypeLoader
     }
 
     /// <summary>
-    ///     Populates an in-memory cache of available font family names
-    /// </summary>
-    private void PopulateAvailableSystemFontFamilyNames() => _availableSystemFontFamilyNames =
-        [..SystemFontProvider.GetSystemFonts().Select(f => f.FamilyName)];
-
-    /// <summary>
     ///     Greedily attempts to load all available system fonts to determine which ones can be processed
     ///     by FontStashSharp and marks them accordingly in a cache file
     /// </summary>
@@ -150,44 +145,32 @@ public class TrueTypeLoader
     {
         int totalLoaded = 0;
         int familyCount = 0;
-        bool needsCacheUpdate = false;
+
         var cacheDefinition = new FontPersistentDefinition();
-        FontCacheData cachedData = null;
+        FontCacheData cachedData = GetFontCacheData(cacheDefinition);
+
+        if (cachedData.IsCacheFresh)
+        {
+            Log.Debug("Font cache is fresh, skipping rebuild");
+            _availableSystemFontFamilyNames = [..cachedData.Families];
+            return;
+        }
 
         var stopwatch = Stopwatch.StartNew();
-
         try
         {
-            // The result of .Get can't actually be null but doesn't hurt to be defensive.
-            cachedData = CacheManager.Instance.Get(cacheDefinition) ?? new FontCacheData();
-            cachedData.DoNotLoadFamilies ??= [];
-
-            if (cachedData.IsCacheFresh)
-            {
-                Log.Debug("Font cache is fresh, skipping rebuild");
-                return;
-            }
-
             Log.Debug("Rebuilding system fonts cache...");
             foreach (FontsByFamily fontFamily in SystemFontProvider.GetSystemFonts())
             {
-                if (cachedData.DoNotLoadFamilies.Contains(fontFamily.FamilyName))
-                {
-                    Log.Debug($"Font family {fontFamily.FamilyName} is excluded from loading");
-                    continue;
-                }
-
-                (int loadedInFamily, _) = CreateFontSystemForFamily(fontFamily);
-
-                if (loadedInFamily <= 0)
-                {
-                    Log.Warn($"Font family {fontFamily.FamilyName} is empty or unavailable. It will be ignored.");
-                    cachedData.DoNotLoadFamilies.Add(fontFamily.FamilyName);
-                    needsCacheUpdate = true;
-                }
-
-                totalLoaded += loadedInFamily;
+                totalLoaded += DryLoadSysFontFamily(cachedData, fontFamily);
                 ++familyCount;
+
+                // A quick check to keep the cache small and load times manageable
+                if (familyCount > MAX_NUMBER_OF_SYS_FONT_FAMILIES)
+                {
+                    Log.Warn($"Exceeded maximum number of allowed system font families ({MAX_NUMBER_OF_SYS_FONT_FAMILIES}). Will not load any more system fonts.");
+                    break;
+                }
             }
         }
         catch (Exception e)
@@ -195,19 +178,75 @@ public class TrueTypeLoader
             Log.Error($"Failed to load system fonts - {e.Message}");
         }
 
-        // Update the cache if content change or timestamp has never been updated
-        if (needsCacheUpdate || cachedData is { LastUpdated: null })
-        {
-            cachedData.LastUpdated = DateTime.UtcNow;
-            if (CacheManager.Instance.Set(cacheDefinition, cachedData))
-                Log.Debug("System fonts cache updated");
-            else
-                Log.WarnDebug("Failed to update system font cache");
-        }
+        _availableSystemFontFamilyNames = [..cachedData.Families];
+        UpdateFontCache(cacheDefinition, cachedData);
 
         stopwatch.Stop();
-        Log.Debug(
-            $"System fonts cache build concluded. Processed total of {totalLoaded} fonts over {familyCount} families in {stopwatch.ElapsedMilliseconds}ms");
+        Log.Debug($"Cache build concluded. Processed a total of {totalLoaded} fonts over {familyCount} families in {stopwatch.ElapsedMilliseconds}ms");
+    }
+
+    /// <summary>
+    /// Gets the font cache data object
+    /// </summary>
+    /// <param name="definition">The cache definition to use</param>
+    /// <returns>A fully usable <see cref="FontCacheData"/> object with all properties initialized</returns>
+    private static FontCacheData GetFontCacheData(FontPersistentDefinition definition)
+    {
+        // The result of .Get can't actually be null but doesn't hurt to be defensive.
+        // The arrays should also be initialized to empty, but just in case.
+        FontCacheData data = CacheManager.Instance.Get(definition) ?? new FontCacheData();
+        data.Families ??= [];
+        data.DoNotLoadFamilies ??= [];
+        return data;
+    }
+
+    /// <summary>
+    /// Updates the font cache file with the given values.
+    /// Cache update timestamp is automatically updated
+    /// </summary>
+    /// <param name="cacheDefinition">The cache definition to use</param>
+    /// <param name="cacheData">The data to store</param>
+    private static void UpdateFontCache(FontPersistentDefinition cacheDefinition, FontCacheData cacheData)
+    {
+        cacheData.LastUpdated = DateTime.UtcNow;
+        if (CacheManager.Instance.Set(cacheDefinition, cacheData))
+            Log.Debug("System fonts cache updated");
+        else
+            Log.WarnDebug("Failed to update system font cache");
+    }
+
+    /// <summary>
+    ///     Attempts to load a font family (if it is not excluded) to ensure it is valid.
+    ///     Updates the cache with the results (either a valid or invalid family name) and returns the number of fonts loaded
+    /// </summary>
+    /// <remarks>
+    ///     This method does not attempt to retain loaded fonts, it simply updates the cache and discards the font system afterward.
+    /// </remarks>
+    /// <param name="cachedData">The cache to update</param>
+    /// <param name="fontFamily">The font family to load</param>
+    /// <returns>The number of fonts loaded</returns>
+    private int DryLoadSysFontFamily(FontCacheData cachedData, FontsByFamily fontFamily)
+    {
+        if (cachedData.DoNotLoadFamilies.Contains(fontFamily.FamilyName))
+        {
+            Log.Debug($"Font family '{fontFamily.FamilyName}' is already excluded from loading");
+            return 0;
+        }
+
+        (int loadedInFamily, FontSystem system) = CreateFontSystemForFamily(fontFamily);
+
+        // We just want to verify everything can be loaded, not actually keep the data.
+        system?.Dispose();
+
+        if (loadedInFamily > 0)
+            cachedData.Families.Add(fontFamily.FamilyName);
+        else
+        {
+            Log.Warn($"Font family '{fontFamily.FamilyName}' is empty or unavailable. It will be ignored.");
+            cachedData.DoNotLoadFamilies.Add(fontFamily.FamilyName);
+        }
+
+        return loadedInFamily;
     }
 
     /// <summary>
@@ -304,9 +343,16 @@ public class TrueTypeLoader
         }
     }
 
-    private bool TryGetSystemFont(string name, float size, out SpriteFontBase font)
+    /// <summary>
+    /// Attempts to get, from disk, a system font by family name
+    /// </summary>
+    /// <param name="familyName">The font family to obtain</param>
+    /// <param name="size">The requested font face size</param>
+    /// <param name="font">The loaded font, if successful, otherwise <c>null</c></param>
+    /// <returns>True if the font was successfully loaded, otherwise false</returns>
+    private bool TryGetSystemFont(string familyName, float size, out SpriteFontBase font)
     {
-        FontsByFamily? fontFamily = SystemFontProvider.GetSystemFontFamilyByName(name);
+        FontsByFamily? fontFamily = SystemFontProvider.GetSystemFontFamilyByName(familyName);
         if (fontFamily == null)
         {
             font = null;
@@ -318,6 +364,20 @@ public class TrueTypeLoader
         return font != null;
     }
 
+    /// <summary>
+    ///     Returns a font, specified by name
+    /// </summary>
+    /// <param name="name">The name of the font to load. For system fonts, this is usually the family name</param>
+    /// <param name="size">The size of the font face to return</param>
+    /// <returns>
+    ///     In order of priority:
+    ///     <list type="number">
+    ///         <item> The requested font</item>
+    ///         <item> The primary TUO embedded font (Roboto)</item>
+    ///         <item> The first available loaded font</item>
+    ///         <item> null (catastrophic failure)</item>
+    ///     </list>
+    /// </returns>
     public SpriteFontBase GetFont(string name, float size)
     {
         // Try standard fonts first
@@ -326,8 +386,16 @@ public class TrueTypeLoader
 
         // If the font isn't present in the loaded ones but is available on the system, try to load it
         if (_availableSystemFontFamilyNames.Contains(name))
+        {
             if (TryGetSystemFont(name, size, out SpriteFontBase sysFont))
                 return sysFont;
+
+            // This is to repeated disk hits if a font is botched or otherwise unusable.
+            // We can also note in cache that this font family is problematic, but if we've gotten here,
+            // it means the initial cache population run concluded that this font is valid.
+            Log.Warn($"Could not load system font '{name}'. Family will be ignored");
+            _availableSystemFontFamilyNames.Remove(name);
+        }
 
         // Use the default embedded font as a fallback
         if (_fonts.TryGetValue(EmbeddedFontNames.ROBOTO, out FontSystem embeddedFont))
@@ -342,10 +410,14 @@ public class TrueTypeLoader
     public string[] Fonts => _fonts.Keys.Concat(_availableSystemFontFamilyNames).ToArray();
 }
 
+/// <summary>
+/// Cached data representing available font families and their status
+/// </summary>
 internal class FontCacheData
 {
     public DateTime? LastUpdated { get; set; }
-    public List<string> DoNotLoadFamilies { get; set; } = [];
+    public HashSet<string> DoNotLoadFamilies { get; set; } = [];
+    public HashSet<string> Families { get; set; } = [];
 
     [JsonIgnore]
     // We can re-build the cache every 30 days for good measure

--- a/src/ClassicUO.Assets/TrueTypeLoader.cs
+++ b/src/ClassicUO.Assets/TrueTypeLoader.cs
@@ -82,6 +82,10 @@ public class TrueTypeLoader
     public const string EMBEDDED_FONT = EmbeddedFontNames.ROBOTO;
 
     private readonly Dictionary<string, FontSystem> _fonts = new();
+    /// <summary>
+    /// Contains the names of all available system fonts.
+    /// This can be used to render a font list without loading the fonts into memory
+    /// </summary>
     private HashSet<string> _availableSystemFontFamilyNames = [];
 
     private TrueTypeLoader()
@@ -105,7 +109,7 @@ public class TrueTypeLoader
     }
 
     /// <summary>
-    /// Loads user-provided fonts present in the 'Fonts' directory
+    ///     Loads user-provided fonts present in the 'Fonts' directory
     /// </summary>
     private void LoadUserFonts()
     {
@@ -124,7 +128,7 @@ public class TrueTypeLoader
     }
 
     /// <summary>
-    /// Populates an in-memory cache of available font family names
+    ///     Populates an in-memory cache of available font family names
     /// </summary>
     private void PopulateAvailableSystemFontFamilyNames() => _availableSystemFontFamilyNames =
         [..SystemFontProvider.GetSystemFonts().Select(f => f.FamilyName)];
@@ -154,6 +158,7 @@ public class TrueTypeLoader
 
         try
         {
+            // The result of .Get can't actually be null but doesn't hurt to be defensive.
             cachedData = CacheManager.Instance.Get(cacheDefinition) ?? new FontCacheData();
             cachedData.DoNotLoadFamilies ??= [];
 
@@ -201,9 +206,18 @@ public class TrueTypeLoader
         }
 
         stopwatch.Stop();
-        Log.Debug($"System fonts cache build concluded. Processed total of {totalLoaded} fonts over {familyCount} families in {stopwatch.ElapsedMilliseconds}ms");
+        Log.Debug(
+            $"System fonts cache build concluded. Processed total of {totalLoaded} fonts over {familyCount} families in {stopwatch.ElapsedMilliseconds}ms");
     }
 
+    /// <summary>
+    ///     Creates a FontSystem object for a given FontsByFamily object
+    /// </summary>
+    /// <param name="family">The family to create a <see cref="FontSystem" /> of</param>
+    /// <returns>
+    ///     A tuple containing the number of fonts loaded and the created <see cref="FontSystem" />
+    ///     object, or (0, null) if the family is empty or could not be loaded
+    /// </returns>
     private (int LoadedCount, FontSystem FontSys) CreateFontSystemForFamily(FontsByFamily family)
     {
         if (family.FontFaces.Length <= 0)
@@ -228,6 +242,14 @@ public class TrueTypeLoader
         return (numLoadedInSystem, numLoadedInSystem > 0 ? fontSystem : null);
     }
 
+    /// <summary>
+    ///     Loads a font family and returns a FontSystem object if successful
+    /// </summary>
+    /// <param name="family">The family to load</param>
+    /// <returns>
+    ///     A <see cref="FontSystem" /> object created for the family or <c>null</c> of the family is empty or could not
+    ///     be loaded
+    /// </returns>
     private FontSystem LoadAndGetFontByFamily(FontsByFamily family)
     {
         (int loadedInFamily, FontSystem fontSystem) = CreateFontSystemForFamily(family);
@@ -243,7 +265,9 @@ public class TrueTypeLoader
         return loadedInFamily > 0 ? fontSystem : null;
     }
 
-
+    /// <summary>
+    ///     Loads the fonts embedded into the TUO binary
+    /// </summary>
     private void LoadEmbeddedFonts()
     {
         var settings = new FontSystemSettings();
@@ -320,7 +344,7 @@ public class TrueTypeLoader
 
 internal class FontCacheData
 {
-    public DateTime? LastUpdated { get; set; } = null;
+    public DateTime? LastUpdated { get; set; }
     public List<string> DoNotLoadFamilies { get; set; } = [];
 
     [JsonIgnore]

--- a/src/ClassicUO.Assets/TrueTypeLoader.cs
+++ b/src/ClassicUO.Assets/TrueTypeLoader.cs
@@ -37,6 +37,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.Json.Serialization;
 using ClassicUO.IO.Persistency;
 using ClassicUO.Utility.Logging;
 using FontStashSharp;
@@ -61,7 +62,7 @@ public static class EmbeddedFontNames
     public const string UO_UNICODE = "uo-unicode-1";
 
     /// <summary>
-    /// The names of all embedded fonts
+    ///     The names of all embedded fonts
     /// </summary>
     public static FrozenSet<string> Names { get; }
 
@@ -74,7 +75,6 @@ public static class EmbeddedFontNames
             .Select(fi => (string)fi.GetRawConstantValue())
             .ToFrozenSet();
     }
-
 }
 
 public class TrueTypeLoader
@@ -82,6 +82,7 @@ public class TrueTypeLoader
     public const string EMBEDDED_FONT = EmbeddedFontNames.ROBOTO;
 
     private readonly Dictionary<string, FontSystem> _fonts = new();
+    private HashSet<string> _availableSystemFontFamilyNames = [];
 
     private TrueTypeLoader()
     {
@@ -97,6 +98,17 @@ public class TrueTypeLoader
 
     public void Load()
     {
+        LoadUserFonts();
+        LoadEmbeddedFonts();
+        PopulateAvailableSystemFontFamilyNames();
+        BuildSysFontsCache();
+    }
+
+    /// <summary>
+    /// Loads user-provided fonts present in the 'Fonts' directory
+    /// </summary>
+    private void LoadUserFonts()
+    {
         string fontPath = Path.Combine(AppContext.BaseDirectory, "Fonts");
 
         if (!Directory.Exists(fontPath))
@@ -109,18 +121,28 @@ public class TrueTypeLoader
 
             _fonts[Path.GetFileNameWithoutExtension(ttf)] = fontSystem;
         }
-
-        LoadEmbeddedFonts();
-        LoadSystemFonts();
     }
 
     /// <summary>
-    /// Loads fonts available on the local system
+    /// Populates an in-memory cache of available font family names
+    /// </summary>
+    private void PopulateAvailableSystemFontFamilyNames() => _availableSystemFontFamilyNames =
+        [..SystemFontProvider.GetSystemFonts().Select(f => f.FamilyName)];
+
+    /// <summary>
+    ///     Greedily attempts to load all available system fonts to determine which ones can be processed
+    ///     by FontStashSharp and marks them accordingly in a cache file
     /// </summary>
     /// <remarks>
-    /// The underlying implementation currently resolves only <em>TTF, TTC</em>, and <em>OTF</em> files
+    ///     This is a sort-of prefetch routine; Some fonts may have valid extensions and be perfectly fine but may not be
+    ///     properly loaded by <em>FontStashSharp</em>.
+    ///     To allow for a consistent experience when displaying available fonts in the UI, we need to figure out, in advance,
+    ///     which ones are usable and which aren't.
+    ///     This method does so and stores a 'blacklist' of font families that cannot be loaded.'
+    ///     It does *not* attempt to actually keep the fonts loaded in memory.
+    ///     The underlying implementation currently resolves only <em>TTF, TTC</em>, and <em>OTF</em> files
     /// </remarks>
-    private void LoadSystemFonts()
+    private void BuildSysFontsCache()
     {
         int totalLoaded = 0;
         int familyCount = 0;
@@ -132,22 +154,35 @@ public class TrueTypeLoader
 
         try
         {
-            cachedData = CacheManager.Instance.Get(cacheDefinition);
+            cachedData = CacheManager.Instance.Get(cacheDefinition) ?? new FontCacheData();
+            cachedData.DoNotLoadFamilies ??= [];
+
+            if (cachedData.IsCacheFresh)
+            {
+                Log.Debug("Font cache is fresh, skipping rebuild");
+                return;
+            }
+
+            Log.Debug("Rebuilding system fonts cache...");
             foreach (FontsByFamily fontFamily in SystemFontProvider.GetSystemFonts())
             {
-                if (cachedData?.DoNotLoadFamilies?.Contains(fontFamily.FamilyName) == true)
+                if (cachedData.DoNotLoadFamilies.Contains(fontFamily.FamilyName))
                 {
                     Log.Debug($"Font family {fontFamily.FamilyName} is excluded from loading");
                     continue;
                 }
 
-                int loadedInFamily = LoadFontFamily(cachedData, fontFamily);
+                (int loadedInFamily, _) = CreateFontSystemForFamily(fontFamily);
+
+                if (loadedInFamily <= 0)
+                {
+                    Log.Warn($"Font family {fontFamily.FamilyName} is empty or unavailable. It will be ignored.");
+                    cachedData.DoNotLoadFamilies.Add(fontFamily.FamilyName);
+                    needsCacheUpdate = true;
+                }
+
                 totalLoaded += loadedInFamily;
                 ++familyCount;
-
-                // If nothing was loaded for the family, we'll need to update the cache to ignore it in the future.
-                if (loadedInFamily <= 0)
-                    needsCacheUpdate = true;
             }
         }
         catch (Exception e)
@@ -155,35 +190,31 @@ public class TrueTypeLoader
             Log.Error($"Failed to load system fonts - {e.Message}");
         }
 
-        if (needsCacheUpdate && cachedData != null)
+        // Update the cache if content change or timestamp has never been updated
+        if (needsCacheUpdate || cachedData is { LastUpdated: null })
         {
-            if (!CacheManager.Instance.Set(cacheDefinition, cachedData))
-                Log.WarnDebug($"Failed to update system font cache");
+            cachedData.LastUpdated = DateTime.UtcNow;
+            if (CacheManager.Instance.Set(cacheDefinition, cachedData))
+                Log.Debug("System fonts cache updated");
+            else
+                Log.WarnDebug("Failed to update system font cache");
         }
 
         stopwatch.Stop();
-        Log.Debug($"Loaded a total of {totalLoaded} system fonts over {familyCount} families in {stopwatch.ElapsedMilliseconds}ms");
+        Log.Debug($"System fonts cache build concluded. Processed total of {totalLoaded} fonts over {familyCount} families in {stopwatch.ElapsedMilliseconds}ms");
     }
 
-    private int LoadFontFamily(FontCacheData cacheData, FontsByFamily family)
+    private (int LoadedCount, FontSystem FontSys) CreateFontSystemForFamily(FontsByFamily family)
     {
-        if (_fonts.ContainsKey(family.FamilyName))
-        {
-            Log.WarnDebug($"System font family {family.FamilyName} appears more than once");
-            return 0;
-        }
-
         if (family.FontFaces.Length <= 0)
         {
             Log.Warn($"Could not find any available fonts for family '{family.FamilyName}'");
-            cacheData.DoNotLoadFamilies.Add(family.FamilyName);
-            return 0;
+            return (0, null);
         }
 
         int numLoadedInSystem = 0;
         var fontSystem = new FontSystem(_fontSysSettings);
         foreach (byte[] font in family.FontFaces)
-        {
             try
             {
                 fontSystem.AddFont(font);
@@ -193,21 +224,25 @@ public class TrueTypeLoader
             {
                 Log.Warn($"Failed to load a font binary from family {family.FamilyName} - {e.Message}");
             }
-        }
 
-        if (numLoadedInSystem > 0)
+        return (numLoadedInSystem, numLoadedInSystem > 0 ? fontSystem : null);
+    }
+
+    private FontSystem LoadAndGetFontByFamily(FontsByFamily family)
+    {
+        (int loadedInFamily, FontSystem fontSystem) = CreateFontSystemForFamily(family);
+
+        if (loadedInFamily > 0)
         {
             _fonts[family.FamilyName] = fontSystem;
-            Log.Debug($"Loaded {numLoadedInSystem} fonts for family '{family.FamilyName}'");
+            Log.Debug($"Loaded {loadedInFamily} fonts for family '{family.FamilyName}'");
         }
         else
-        {
-            cacheData.DoNotLoadFamilies.Add(family.FamilyName);
             Log.Warn($"Could not load any fonts for family '{family.FamilyName}'. The entire family will be ignored");
-        }
 
-        return numLoadedInSystem;
+        return loadedInFamily > 0 ? fontSystem : null;
     }
+
 
     private void LoadEmbeddedFonts()
     {
@@ -245,10 +280,30 @@ public class TrueTypeLoader
         }
     }
 
+    private bool TryGetSystemFont(string name, float size, out SpriteFontBase font)
+    {
+        FontsByFamily? fontFamily = SystemFontProvider.GetSystemFontFamilyByName(name);
+        if (fontFamily == null)
+        {
+            font = null;
+            return false;
+        }
+
+        FontSystem fontSystem = LoadAndGetFontByFamily(fontFamily.Value);
+        font = fontSystem?.GetFont(size);
+        return font != null;
+    }
+
     public SpriteFontBase GetFont(string name, float size)
     {
+        // Try standard fonts first
         if (_fonts.TryGetValue(name, out FontSystem font))
             return font.GetFont(size);
+
+        // If the font isn't present in the loaded ones but is available on the system, try to load it
+        if (_availableSystemFontFamilyNames.Contains(name))
+            if (TryGetSystemFont(name, size, out SpriteFontBase sysFont))
+                return sysFont;
 
         // Use the default embedded font as a fallback
         if (_fonts.TryGetValue(EmbeddedFontNames.ROBOTO, out FontSystem embeddedFont))
@@ -260,12 +315,17 @@ public class TrueTypeLoader
 
     public SpriteFontBase GetFont(string name) => GetFont(name, 12);
 
-    public string[] Fonts => _fonts.Keys.ToArray();
+    public string[] Fonts => _fonts.Keys.Concat(_availableSystemFontFamilyNames).ToArray();
 }
 
 internal class FontCacheData
 {
+    public DateTime? LastUpdated { get; set; } = null;
     public List<string> DoNotLoadFamilies { get; set; } = [];
+
+    [JsonIgnore]
+    // We can re-build the cache every 30 days for good measure
+    public bool IsCacheFresh => LastUpdated != null && DateTime.UtcNow - LastUpdated.Value < TimeSpan.FromDays(30);
 }
 
 internal class FontPersistentDefinition : PersistentItemDefinition<CacheType, FontCacheData>


### PR DESCRIPTION
## Description
Shift system font loading to be done lazily to improve memory footprint

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing
Manual testing, with and without cache


## Additional Notes
Change https://github.com/PlayTazUO/TazUO/pull/444 added greedy automatic loading for system fonts.
For some systems, this caused significant unnecessary memory bloat.

This fix addresses that by building a cache of 'known bad fonts' that allows the UI to correctly render all valid/working fonts
without actually loading them.
Fonts will then be loaded on a need-only basis

Closes https://github.com/PlayTazUO/TazUO/issues/445

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to look up and select system font families by name; UI font list now includes known system families.

* **Refactor**
  * Font loading reorganized into staged steps (user, embedded, system) with on-demand system-font loading.
  * Introduced a system-font cache with freshness checks, a limit on processed families, and blacklist handling to avoid repeated failed loads—improves startup performance and reduces disk work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->