### PR TITLE
fix: ScriptManagerWindow is hidden and cannot be shown

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Controls/MyraControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/MyraControl.cs
@@ -61,13 +61,7 @@ public class MyraControl : IGui
     #region Event Handlers
     private void UIManagerOnTopMostChanged(object sender, EventArgs e) => _desktop.Opacity = UIManager.TopMostControl == this ? 1f : 0.8f;
 
-    private void OnRootWindowOnClosed(object s, EventArgs a)
-    {
-        if (IsDisposed)
-            return;
-
-        _disposeRequested = true;
-    }
+    private void OnRootWindowOnClosed(object s, EventArgs a) => Dispose();
 
     private void RootWindowOnSizeChanged(object sender = null, EventArgs e = null) => UpdateBoundsToContents(false);
 
@@ -272,6 +266,8 @@ public class MyraControl : IGui
     {
         if (IsDisposed)
             return;
+
+        IsVisible = false;
         _disposeRequested = true;
     }
 

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/ScriptManagerWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/ScriptManagerWindow.cs
@@ -60,6 +60,10 @@ public class ScriptManagerWindow : MyraControl
         {
             if (g is ScriptManagerWindow w)
             {
+                // The OpenLegionScriptingGump/CloseLegionScriptingGump actions consider IsVisible in regard to 'is the window currently open'.
+                // This somewhat conflicts with the Myra approach we currently have, so this is something of a hotfix.
+                w.IsVisible = true;
+
                 w.BringOnTop();
                 return;
             }


### PR DESCRIPTION
## Description
Addresses an issue in which an interaction between OpenLegionScriptingGump and CloseLegionScriptingGump
and `Myra`'s `Dispose` can cause the `ScriptManagerWindow` to be permanently hidden

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing
Manual testing

## Additional Notes

This is *not* a complete fix.
The window does not serialize its state upon dispose meaning subsequent re-opens will use the 'default' positioning.
A full fix would require having the ability to dynamically invoke `Save`.

Closes https://github.com/PlayTazUO/TazUO/issues/447

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced UI control cleanup process to ensure controls are properly hidden and disposed immediately, preventing potential memory leaks and visual glitches
  * Fixed script manager window not displaying when reopening an existing window instance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->