### PR TITLE
fix: Avoid crashing on clicking an empty dropdown

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Controls/Combobox.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/Combobox.cs
@@ -216,8 +216,18 @@ namespace ClassicUO.Game.UI.Controls
                     labels[i] = label;
                 }
 
-                int totalHeight = Math.Min(maxHeight, labels.Max(o => o.Y + o.Height));
-                int maxWidth = Math.Max(width, labels.Max(o => o.X + o.Width));
+                int totalHeight, maxWidth;
+                if (labels.Length > 0)
+                {
+                    totalHeight = Math.Min(maxHeight, labels.Max(o => o.Y + o.Height));
+                    maxWidth = Math.Max(width, labels.Max(o => o.X + o.Width));
+                }
+                else
+                {
+                    // Render a small empty card so user knows the component is working, if empty
+                    totalHeight = Math.Min(45, maxHeight);
+                    maxWidth = width;
+                }
 
                 var area = new ScrollArea
                 (


### PR DESCRIPTION
## Description
Avoid crashing the app when clicking an empty `ComboBox` (dropdown)

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing
Manual testing, with and without cache


## Additional Notes
Closes https://github.com/PlayTazUO/TazUO/issues/448

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where comboboxes with no items would fail to render properly. The component now correctly handles the empty state and displays a properly-sized empty dropdown card, preventing UI rendering errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->