### PR TITLE
Add WorldMap click-to-walk long-distance pathfinder

### DIFF
--- a/src/ClassicUO.Client/Game/Pathfinder.cs
+++ b/src/ClassicUO.Client/Game/Pathfinder.cs
@@ -61,6 +61,18 @@ namespace ClassicUO.Game
 
         public bool UseLongDistancePathfinding;
 
+        /// <summary>
+        /// Fired when a step of a path provided through <see cref="StartComputedPath"/> is
+        /// rejected at the client or server.  Hooked by WorldMapPathfinder so it can mark
+        /// the blocked tile (dynamic item like a lamp post, rock, placed door, etc.) and
+        /// re-plan around it.  Arguments: (blocked tile X, blocked tile Y).
+        /// Not used for regular <see cref="WalkTo"/> paths.
+        /// </summary>
+        public Action<int, int> OnComputedPathStepFailed;
+
+        /// <summary>Set by StartComputedPath; cleared by StopAutoWalk.  Gates OnComputedPathStepFailed.</summary>
+        private bool _computedPathActive;
+
         public Pathfinder(World world)
         {
             _world = world;
@@ -897,11 +909,6 @@ namespace ClassicUO.Game
                 if (_goalNode is not null)
                 {
                     ReconstructPath(_goalNode);
-
-#if DEBUG
-                    foreach (PathNode step in _path) World.Instance.Map.GetTile(step.X, step.Y).Hue = 32;
-#endif
-
                     return true;
                 }
 
@@ -976,6 +983,58 @@ namespace ClassicUO.Game
             return result;
         }
 
+        /// <summary>
+        /// Loads a pre-computed path (produced by an external pathfinder, e.g. WorldMapPathfinder)
+        /// into the walker state and starts walking.  Must be called on the main thread.
+        /// Each point in <paramref name="points"/> is (x, y, z, direction) for a single step.
+        /// </summary>
+        public void StartComputedPath(IReadOnlyList<(int X, int Y, int Z, int Direction)> points, bool run = true)
+        {
+            if (_world.Player == null || _world.Player.IsParalyzed || points == null || points.Count == 0)
+                return;
+
+            CleanupPathfinding();
+            _pointIndex = 0;
+            _goalNode = null;
+            _run = run;
+            _startPoint.X = _world.Player.X;
+            _startPoint.Y = _world.Player.Y;
+
+            // Prepend the player's current tile as _path[0] so we match the existing walker's
+            // convention: _path[0] is the start tile (direction ignored), _path[1..] are the steps.
+            // Without this, ProcessAutoWalk would read the SECOND step's direction while the
+            // player is still at the start → it walks the wrong way, hits a wall, and stops.
+            var startNode = PathNode.Get();
+            startNode.X = _world.Player.X;
+            startNode.Y = _world.Player.Y;
+            startNode.Z = _world.Player.Z;
+            startNode.Direction = (int)_world.Player.Direction;
+            startNode.IsValid = true;
+            _path.Add(startNode);
+
+            foreach (var p in points)
+            {
+                var node = PathNode.Get();
+                node.X = p.X;
+                node.Y = p.Y;
+                node.Z = p.Z;
+                node.Direction = p.Direction;
+                node.IsValid = true;
+                _path.Add(node);
+            }
+
+            if (_path.Count > 1)
+            {
+                _endPoint.X = _path[_path.Count - 1].X;
+                _endPoint.Y = _path[_path.Count - 1].Y;
+                _endPointZ = _path[_path.Count - 1].Z;
+                _pointIndex = 1;
+                AutoWalking = true;
+                _computedPathActive = true;
+                ProcessAutoWalk();
+            }
+        }
+
         public bool WalkTo(int x, int y, int z, int distance)
         {
             if (_world.Player == null /*|| World.Player.Stamina == 0*/ || _world.Player.IsParalyzed)
@@ -1035,7 +1094,23 @@ namespace ClassicUO.Game
 
                     if (!_world.Player.Walk((Direction)p.Direction, _run))
                     {
-                        StopAutoWalk();
+                        // If this is a pre-computed path (WorldMap nav), give the pathfinder
+                        // a chance to replan around the blocked tile (likely a dynamic item
+                        // like a lamp post, rock, or placed door not present in statics.mul).
+                        // Fire the hook, THEN stop — the hook may start a new computed path.
+                        if (_computedPathActive && OnComputedPathStepFailed != null)
+                        {
+                            var hook = OnComputedPathStepFailed;
+                            int blockedX = p.X;
+                            int blockedY = p.Y;
+                            // Tear down first so the hook can safely issue a new StartComputedPath.
+                            StopAutoWalk();
+                            hook.Invoke(blockedX, blockedY);
+                        }
+                        else
+                        {
+                            StopAutoWalk();
+                        }
                     }
                 }
                 else
@@ -1049,6 +1124,7 @@ namespace ClassicUO.Game
         {
             AutoWalking = false;
             _run = false;
+            _computedPathActive = false;
             CleanupPathfinding();
         }
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
@@ -3387,6 +3387,11 @@ public class WorldMapGump : ResizableGump
     /// </summary>
     private void StartNavPath(int mapIndex, int startX, int startY, sbyte startZ, int destX, int destY, bool firstAttempt)
     {
+        // Shallow-copy the live Multi components before dispatching.  The actual filter
+        // work (flag checks + GetTileZ) runs on the background thread — keeps the main
+        // thread under ~1 ms even in dense areas.
+        var houseMultis = BuildHouseMultiSnapshot();
+
         WorldMapPathfinder.FindPathAsync(mapIndex, startX, startY, startZ, destX, destY, 8, path =>
         {
             if (path == null || path.Count == 0)
@@ -3427,7 +3432,41 @@ public class WorldMapGump : ResizableGump
             };
 
             _world.Player.Pathfinder.StartComputedPath(pathPoints, run: true);
-        });
+        }, houseMultis);
+    }
+
+    /// <summary>
+    /// Shallow-copies the fields of every Multi component from every loaded player house
+    /// into a flat list of plain structs.  Runs on the main thread (where live World data
+    /// is safe to iterate) but does NO filtering and NO map-file I/O — just field reads.
+    /// Cost: ~20 ns per component, negligible even in a Luna-scale scene.
+    /// The worker thread (inside WorldMapPathfinder) does the flag checks and GetTileZ
+    /// lookups so the main thread stays responsive.
+    /// </summary>
+    private List<WorldMapPathfinder.HouseMultiSnapshot> BuildHouseMultiSnapshot()
+    {
+        var houseManager = _world?.HouseManager;
+        if (houseManager == null)
+            return null;
+
+        var list = new List<WorldMapPathfinder.HouseMultiSnapshot>(256);
+        foreach (var house in houseManager.Houses)
+        {
+            foreach (var multi in house.Components)
+            {
+                list.Add(new WorldMapPathfinder.HouseMultiSnapshot
+                {
+                    X = multi.X,
+                    Y = multi.Y,
+                    Z = multi.Z,
+                    Graphic = multi.Graphic,
+                    State = (int)multi.State,
+                    IsHousePreview = multi.IsHousePreview,
+                    IsDestroyed = multi.IsDestroyed,
+                });
+            }
+        }
+        return list;
     }
 
     public override void OnMouseOver(int x, int y)

--- a/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
@@ -56,7 +56,7 @@ public class WorldMapGump : ResizableGump
     private static Texture2D _mapTexture;
     private Map.Map _map = null;
 
-    private Point _center, _lastScroll, _mouseCenter, _scroll;
+    private Point _center, _lastScroll, _scroll;
     private Point? _lastMousePosition = null;
     private bool _flipMap = true;
     private bool _freeView;
@@ -95,6 +95,16 @@ public class WorldMapGump : ResizableGump
     private GumpPic _northIcon;
 
     private WMapMarker _gotoMarker;
+
+    private Point? _navDest;
+    private long _navDestSetTime;
+    private List<Point> _navPath;
+
+    // Replan budget for a single Ctrl+Click nav session. Each time the walker is rejected
+    // by a dynamic obstacle (lamp post, rock, placed door) we mark the tile and try again —
+    // but cap the retries so a genuinely unreachable dest can't loop forever.
+    private const int MAX_NAV_REPLANS = 3;
+    private int _navReplansLeft;
 
     private static int _mapLoading;
     private Task _loadingTask;
@@ -2095,6 +2105,8 @@ public class WorldMapGump : ResizableGump
                     halfHeight
                 );
 
+                DrawNavDestination(batcher, gX, gY, halfWidth, halfHeight);
+
                 batcher.ClipEnd();
             }
         }
@@ -2817,6 +2829,79 @@ public class WorldMapGump : ResizableGump
         );
     }
 
+    private void DrawNavDestination(UltimaBatcher2D batcher, int x, int y, int width, int height)
+    {
+        if (!_navDest.HasValue)
+            return;
+
+        long elapsed = Time.Ticks - _navDestSetTime;
+
+        // Auto-clear: player arrived within 3 tiles, after a 2-second grace period
+        if (elapsed > 2000)
+        {
+            int dx = _world.Player.X - _navDest.Value.X;
+            int dy = _world.Player.Y - _navDest.Value.Y;
+
+            if (dx * dx + dy * dy <= 9)
+            {
+                _navDest = null;
+                _navPath = null;
+                return;
+            }
+
+            // Also clear if pathfinding has fully stopped (cancelled or failed)
+            if (!_world.Player.Pathfinder.AutoWalking)
+            {
+                _navDest = null;
+                _navPath = null;
+                return;
+            }
+        }
+
+        Vector3 hueVector = ShaderHueTranslator.GetHueVector(0, false, 1f);
+        // Light gray (near-white) — subtle against the map without being visually noisy
+        var pathTex = SolidColorTextureCache.GetTexture(new Color(220, 220, 220));
+
+        // --- Draw path as a series of small dots along the route ---
+        if (_navPath != null && _navPath.Count > 1)
+        {
+            int step = Math.Max(1, _navPath.Count / 200); // cap at ~200 dots
+            const int DOT = 2;
+            const int DOT_HALF = DOT / 2;
+
+            for (int i = 0; i < _navPath.Count; i += step)
+            {
+                Point p = _navPath[i];
+                int psx = p.X - _center.X;
+                int psy = p.Y - _center.Y;
+                Point prot = RotatePoint(psx, psy, Zoom, 1, _flipMap ? 45f : 0f);
+                int pdx = prot.X + x + width;
+                int pdy = prot.Y + y + height;
+
+                if (pdx < x || pdx > x + Width - 8 - DOT || pdy < y || pdy > y + Height - 8 - DOT)
+                    continue;
+
+                batcher.Draw(pathTex, new Rectangle(pdx - DOT_HALF, pdy - DOT_HALF, DOT, DOT), hueVector);
+            }
+        }
+
+        // --- Destination marker (small light-gray square, no label) ---
+        int sx = _navDest.Value.X - _center.X;
+        int sy = _navDest.Value.Y - _center.Y;
+
+        Point rot = RotatePoint(sx, sy, Zoom, 1, _flipMap ? 45f : 0f);
+        int drawX = rot.X + x + width;
+        int drawY = rot.Y + y + height;
+
+        const int SIZE = 6;
+        const int HALF = SIZE / 2;
+
+        if (drawX < x || drawX > x + Width - 8 - SIZE || drawY < y || drawY > y + Height - 8 - SIZE)
+            return;
+
+        batcher.Draw(pathTex, new Rectangle(drawX - HALF, drawY - HALF, SIZE, SIZE), hueVector);
+    }
+
     private void DrawMulti
     (
         UltimaBatcher2D batcher,
@@ -3231,11 +3316,6 @@ public class WorldMapGump : ResizableGump
             _lastScroll.Y = _center.Y;
         }
 
-        if (button == MouseButtonType.Right && Keyboard.Ctrl && _lastMousePosition.HasValue)
-        {
-            CanvasToWorld(_lastMousePosition.Value.X, _lastMousePosition.Value.Y, out int wX, out int wY);
-            _world.Player.Pathfinder.WalkTo(wX, wY, 0, 1);
-        }
 
         if (button == MouseButtonType.Left && !Keyboard.Alt && !Keyboard.Ctrl && !Keyboard.Shift)
         {
@@ -3255,6 +3335,24 @@ public class WorldMapGump : ResizableGump
     {
         if (!Client.Game.UO.GameCursor.ItemHold.Enabled)
         {
+            if (button == MouseButtonType.Left && Keyboard.Ctrl && !Keyboard.Alt)
+            {
+                CanvasToWorld(x, y, out int wX, out int wY);
+                _navDest = new Point(wX, wY);
+                _navDestSetTime = Time.Ticks;
+                _navPath = null;
+                ClearGoToMarker();
+
+                // Fresh nav session: clear any dynamic-block memory from a previous run.
+                WorldMapPathfinder.ClearDynamicBlocks();
+                _navReplansLeft = MAX_NAV_REPLANS;
+
+
+                int mapIndex = _world.Map.Index;
+                StartNavPath(mapIndex, _world.Player.X, _world.Player.Y, _world.Player.Z, wX, wY, firstAttempt: true);
+                return;
+            }
+
             if (button == MouseButtonType.Left && (Keyboard.Alt || _freeView) || button == MouseButtonType.Middle)
             {
                 if (x > 4 && x < Width - 8 && y > 4 && y < Height - 8)
@@ -3275,27 +3373,61 @@ public class WorldMapGump : ResizableGump
                     }
                 }
 
-                if (button == MouseButtonType.Left && Keyboard.Ctrl)
-                {
-                    CanvasToWorld(x, y, out _mouseCenter.X, out _mouseCenter.Y);
-
-                    // Check if file is loaded and contain markers
-                    WMapMarkerFile userFile = _markerFiles.Where(f => f.Name == USER_MARKERS_FILE).FirstOrDefault();
-
-                    if (userFile == null)
-                    {
-                        return;
-                    }
-
-                    UserMarkersGump existingGump = UIManager.GetGump<UserMarkersGump>();
-
-                    existingGump?.Dispose();
-                    UIManager.Add(new UserMarkersGump(World, _mouseCenter.X, _mouseCenter.Y, userFile.Markers));
-                }
             }
         }
 
         base.OnMouseDown(x, y, button);
+    }
+
+    /// <summary>
+    /// Dispatches a WorldMap pathfinder search and hands the result to the walker.
+    /// Registers an on-step-failed hook so dynamic obstacles (lamp posts, rocks,
+    /// placed doors — things not in statics.mul) get added to the dynamic-block set
+    /// and the search is retried up to MAX_NAV_REPLANS times.
+    /// </summary>
+    private void StartNavPath(int mapIndex, int startX, int startY, sbyte startZ, int destX, int destY, bool firstAttempt)
+    {
+        WorldMapPathfinder.FindPathAsync(mapIndex, startX, startY, startZ, destX, destY, 8, path =>
+        {
+            if (path == null || path.Count == 0)
+            {
+                if (firstAttempt)
+                    GameActions.Print("Can't find a path there.");
+                _navDest = null;
+                _navPath = null;
+                return;
+            }
+
+            var pathPoints = new List<(int X, int Y, int Z, int Direction)>(path.Count);
+            var navRender = new List<Point>(path.Count);
+            foreach (var p in path)
+            {
+                pathPoints.Add((p.X, p.Y, p.Z, p.Direction));
+                navRender.Add(new Point(p.X, p.Y));
+            }
+            _navPath = navRender;
+
+            // Register replan hook on the walker. Fires when a step is rejected.
+            _world.Player.Pathfinder.OnComputedPathStepFailed = (blockX, blockY) =>
+            {
+                if (_navReplansLeft <= 0 || !_navDest.HasValue)
+                {
+                    _navDest = null;
+                    _navPath = null;
+                    return;
+                }
+
+                _navReplansLeft--;
+                // Mark the rejected tile so the next search routes around it.
+                WorldMapPathfinder.MarkDynamicBlock(blockX, blockY);
+
+                var dest = _navDest.Value;
+                StartNavPath(_world.Map.Index, _world.Player.X, _world.Player.Y, _world.Player.Z,
+                             dest.X, dest.Y, firstAttempt: false);
+            };
+
+            _world.Player.Pathfinder.StartComputedPath(pathPoints, run: true);
+        });
     }
 
     public override void OnMouseOver(int x, int y)

--- a/src/ClassicUO.Client/Game/WorldMapPathfinder.cs
+++ b/src/ClassicUO.Client/Game/WorldMapPathfinder.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Buffers;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -57,12 +58,24 @@ namespace ClassicUO.Game
         /// lamp posts, rocks, placed doors, and other dynamic items that aren't in
         /// statics.mul and therefore invisible to our file-based A*.  Cleared at the
         /// start of each new FindPathAsync call.
+        /// <para/>
+        /// Uses ConcurrentDictionary as a thread-safe set: the main thread mutates it
+        /// (Clear on a new Ctrl+Click, TryAdd from the step-fail hook) while an in-flight
+        /// background search may be reading it via ContainsKey in TryGetWalkable.
         /// </summary>
-        private static readonly HashSet<long> _dynamicBlocks = new();
+        private static readonly ConcurrentDictionary<long, byte> _dynamicBlocks = new();
         public static void ClearDynamicBlocks() => _dynamicBlocks.Clear();
 
         /// <summary>Add a tile to the dynamic-block set so the next search routes around it.</summary>
-        public static void MarkDynamicBlock(int x, int y) => _dynamicBlocks.Add(PackKey(x, y));
+        public static void MarkDynamicBlock(int x, int y) => _dynamicBlocks.TryAdd(PackKey(x, y), 0);
+
+        /// <summary>
+        /// Per-search snapshot of tiles blocked by player houses (custom house walls, signposts,
+        /// placed multis).  Captured on the main thread before the worker starts, then read-only
+        /// for the duration of the search — so a plain HashSet is safe as long as nobody mutates
+        /// it after Task.Run.  Protected by _running: only one search can own this field at a time.
+        /// </summary>
+        private static HashSet<long> _houseBlocks;
 
         // Direction enum layout (matches ClassicUO.Game.Data.Direction):
         // 0=N, 1=NE, 2=E, 3=SE, 4=S, 5=SW, 6=W, 7=NW
@@ -79,6 +92,23 @@ namespace ClassicUO.Game
             public int Direction;
         }
 
+        /// <summary>
+        /// Shallow snapshot of a Multi component taken on the main thread.  Contains only the
+        /// fields needed by the filtering logic — no references to live game objects — so it
+        /// can be iterated safely from the background search thread even if the underlying
+        /// Multi is disposed or moved mid-search.
+        /// </summary>
+        public struct HouseMultiSnapshot
+        {
+            public int X;
+            public int Y;
+            public sbyte Z;
+            public ushort Graphic;
+            public int State;
+            public bool IsHousePreview;
+            public bool IsDestroyed;
+        }
+
         public static bool IsRunning => Volatile.Read(ref _running) != 0;
 
         /// <summary>
@@ -88,8 +118,17 @@ namespace ClassicUO.Game
         /// The callback fires on the main thread with the full path (empty list = no path found).
         /// Only one search at a time; concurrent calls return immediately with an empty list.
         /// </summary>
+        /// <param name="houseMultis">
+        /// Optional list of shallow-copied Multi snapshots taken on the caller's thread.
+        /// The worker filters this list (flag checks, ground-level Z check via GetTileZ) to
+        /// produce the blocked-tile HashSet — keeping the main thread free of heavy work
+        /// even in dense areas with thousands of components.  Pass null when no houses
+        /// need to be considered.
+        /// </param>
         public static void FindPathAsync(int mapIndex, int startX, int startY, sbyte startZ,
-                                         int destX, int destY, int snapRadius, Action<List<PathPoint>> onComplete)
+                                         int destX, int destY, int snapRadius,
+                                         Action<List<PathPoint>> onComplete,
+                                         List<HouseMultiSnapshot> houseMultis = null)
         {
             // Any previous in-flight search becomes stale (its next version-check bails it out).
             int myVersion = Interlocked.Increment(ref _searchVersion);
@@ -107,6 +146,11 @@ namespace ClassicUO.Game
                 var result = new List<PathPoint>();
                 try
                 {
+                    // Build the house-block set on the worker thread — filtering + GetTileZ
+                    // for each Multi is the expensive part; the main thread only paid the
+                    // cost of a shallow copy.
+                    _houseBlocks = BuildHouseBlockSet(mapIndex, houseMultis);
+
                     var chunkCache = new Dictionary<long, ChunkWalkData>(1024);
 
                     // If the click landed on an impassable tile, snap to the nearest walkable one.
@@ -130,11 +174,70 @@ namespace ClassicUO.Game
                 }
                 finally
                 {
+                    _houseBlocks = null;
                     Volatile.Write(ref _running, 0);
                 }
 
                 MainThreadQueue.EnqueueAction(() => onComplete?.Invoke(result));
             });
+        }
+
+        /// <summary>
+        /// Walks the caller-supplied Multi snapshots, applies the same walkability rules used
+        /// for statics (IsImpassable / IsWall at ground level, skipping IsRoof / previews /
+        /// destroyed / render-ignored), and returns a HashSet of blocked (x,y) keys.
+        /// Runs entirely on the worker thread; uses raw MMF reads via Maps.GetIndex for land Z.
+        /// </summary>
+        private static HashSet<long> BuildHouseBlockSet(int mapIndex, List<HouseMultiSnapshot> multis)
+        {
+            if (multis == null || multis.Count == 0)
+                return null;
+
+            var set = new HashSet<long>(multis.Count);
+            var tileData = Client.Game.UO.FileManager.TileData;
+            var maps = Client.Game.UO.FileManager.Maps;
+
+            // Matches OrionUO's "circumnavigate the house" behaviour: block the ENTIRE
+            // ground-level footprint, not just individual wall tiles.  Doors, windows,
+            // interior floors, stairs and ramps are all treated as "part of the house" —
+            // the navigator routes around, never through.
+            //
+            // GROUND_LEVEL_BAND = 14: ground-floor tiles sit at roughly landZ+7 (UO floor
+            // is 7 Z above the foundation), so 14 catches the first storey while excluding
+            // upper storeys (~20 Z above ground floor) and rooftops.
+            const int GROUND_LEVEL_BAND = 14;
+            const int CHMOF_IGNORE_IN_RENDER = 0x40;
+
+            foreach (var m in multis)
+            {
+                if (m.IsDestroyed) continue;
+                if (m.IsHousePreview) continue;
+                if ((m.State & CHMOF_IGNORE_IN_RENDER) != 0) continue;
+
+                ushort graphic = m.Graphic;
+                if (graphic >= tileData.StaticData.Length) continue;
+
+                ref StaticTiles sd = ref tileData.StaticData[graphic];
+                if (sd.IsRoof) continue;
+
+                sbyte landZ = 0;
+                try
+                {
+                    ref IndexMap im = ref maps.GetIndex(mapIndex, m.X >> 3, m.Y >> 3);
+                    if (im.IsValid())
+                    {
+                        MapCellsArray cells = im.MapFile.ReadAt<MapBlock>((long)im.MapAddress).Cells;
+                        landZ = cells[((m.Y & 7) << 3) + (m.X & 7)].Z;
+                    }
+                }
+                catch { }
+
+                if (m.Z > landZ + GROUND_LEVEL_BAND) continue;
+
+                set.Add(PackKey(m.X, m.Y));
+            }
+
+            return set.Count == 0 ? null : set;
         }
 
         /// <summary>
@@ -343,9 +446,20 @@ namespace ClassicUO.Game
         private static bool TryGetWalkable(int mapIndex, int x, int y, sbyte fromZ,
                                            Dictionary<long, ChunkWalkData> cache, out sbyte surfaceZ)
         {
+            long key = PackKey(x, y);
+
             // Dynamic-block override first — lamp posts, rocks, placed doors, etc.
             // learned during walk-time failures.
-            if (_dynamicBlocks.Contains(PackKey(x, y)))
+            if (_dynamicBlocks.ContainsKey(key))
+            {
+                surfaceZ = 0;
+                return false;
+            }
+
+            // House-block snapshot — walls and other impassable components of player houses
+            // captured when the search started. Read-only for the worker's lifetime.
+            var houseBlocks = _houseBlocks;
+            if (houseBlocks != null && houseBlocks.Contains(key))
             {
                 surfaceZ = 0;
                 return false;

--- a/src/ClassicUO.Client/Game/WorldMapPathfinder.cs
+++ b/src/ClassicUO.Client/Game/WorldMapPathfinder.cs
@@ -130,16 +130,19 @@ namespace ClassicUO.Game
                                          Action<List<PathPoint>> onComplete,
                                          List<HouseMultiSnapshot> houseMultis = null)
         {
-            // Any previous in-flight search becomes stale (its next version-check bails it out).
-            int myVersion = Interlocked.Increment(ref _searchVersion);
-
-            // Only one search runs at a time; if another is still tearing down, skip this request.
-            // The stale one exits within a few ms of the version bump above.
+            // Only one search runs at a time; if another is still running, drop this request
+            // rather than cancelling the in-flight search (which would leave BOTH empty).
             if (Interlocked.CompareExchange(ref _running, 1, 0) != 0)
             {
                 onComplete?.Invoke(new List<PathPoint>());
                 return;
             }
+
+            // We now own the lock — bump the version so any PREVIOUS (already-finishing)
+            // search that hasn't fully torn down yet sees the mismatch and bails out.
+            // Placed after the lock to avoid the old race: increment-then-fail-lock would
+            // cancel the running search AND return empty, so both calls produced nothing.
+            int myVersion = Interlocked.Increment(ref _searchVersion);
 
             Task.Run(() =>
             {

--- a/src/ClassicUO.Client/Game/WorldMapPathfinder.cs
+++ b/src/ClassicUO.Client/Game/WorldMapPathfinder.cs
@@ -1,0 +1,482 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using ClassicUO.Assets;
+using ClassicUO.Game.Managers;
+using ClassicUO.Utility.Logging;
+
+namespace ClassicUO.Game
+{
+    /// <summary>
+    /// Long-distance pathfinder designed for WorldMap click-to-walk.
+    /// Reads tile walkability directly from the memory-mapped map.mul + statics.mul files;
+    /// never loads chunks into game state, so it is safe to run on a background thread
+    /// and cannot corrupt the renderer by loading thousands of chunks synchronously.
+    ///
+    /// A* with a large node budget computes the ENTIRE path upfront — no chunking, no
+    /// re-planning mid-walk, no "walk forward then backward" artefacts.
+    ///
+    /// Limitations (intentional, for v1):
+    ///  - Ignores dynamic items and mobiles (not available from the files anyway).
+    ///  - Does not account for private houses / custom multis (TODO: follow-up).
+    ///  - 2D walkability with a coarse Z step check.
+    /// </summary>
+    public static class WorldMapPathfinder
+    {
+        /// <summary>Hard cap on A* nodes. 1M ≈ 100MB peak; reached only for truly impossible destinations.</summary>
+        private const int MAX_NODES = 1_000_000;
+
+        /// <summary>
+        /// Wall-clock cap on a single search. Prevents a hopeless query (click on an unreachable
+        /// island, wrong map, etc.) from locking out new clicks. Typical successful search is 10–200ms;
+        /// large maze interiors (Luna Bank, multi-room dungeons) can take 1–3s even with weighted A*.
+        /// </summary>
+        private const int MAX_SEARCH_MS = 5000;
+
+        /// <summary>
+        /// Heuristic weight. 1.0 = optimal A*; higher values trade optimality for speed.
+        /// 1.25 is a good balance — biased enough to cut exploration in half, low enough
+        /// that A* still backtracks when it hits a dead-end room (Luna Bank / Britain bank).
+        /// </summary>
+        private const int HEURISTIC_WEIGHT_NUM = 5;  // 1.25x = 5/4
+        private const int HEURISTIC_WEIGHT_DEN = 4;
+
+        /// <summary>
+        /// Token the current search checks regularly. New calls to FindPathAsync increment
+        /// the version so an in-flight search sees its token as stale and bails out promptly.
+        /// </summary>
+        private static int _searchVersion;
+
+        /// <summary>
+        /// Tiles the server/client rejected when the walker tried to step onto them —
+        /// lamp posts, rocks, placed doors, and other dynamic items that aren't in
+        /// statics.mul and therefore invisible to our file-based A*.  Cleared at the
+        /// start of each new FindPathAsync call.
+        /// </summary>
+        private static readonly HashSet<long> _dynamicBlocks = new();
+        public static void ClearDynamicBlocks() => _dynamicBlocks.Clear();
+
+        /// <summary>Add a tile to the dynamic-block set so the next search routes around it.</summary>
+        public static void MarkDynamicBlock(int x, int y) => _dynamicBlocks.Add(PackKey(x, y));
+
+        // Direction enum layout (matches ClassicUO.Game.Data.Direction):
+        // 0=N, 1=NE, 2=E, 3=SE, 4=S, 5=SW, 6=W, 7=NW
+        private static readonly int[] DX = { 0, 1, 1, 1, 0, -1, -1, -1 };
+        private static readonly int[] DY = { -1, -1, 0, 1, 1, 1, 0, -1 };
+
+        private static int _running;
+
+        public struct PathPoint
+        {
+            public int X;
+            public int Y;
+            public int Z;
+            public int Direction;
+        }
+
+        public static bool IsRunning => Volatile.Read(ref _running) != 0;
+
+        /// <summary>
+        /// Computes a path from (startX,startY,startZ) to (destX,destY) on the given map, asynchronously.
+        /// If the clicked destination tile is impassable (tree, wall, water, etc.) the pathfinder
+        /// automatically targets the nearest walkable tile within <paramref name="snapRadius"/>.
+        /// The callback fires on the main thread with the full path (empty list = no path found).
+        /// Only one search at a time; concurrent calls return immediately with an empty list.
+        /// </summary>
+        public static void FindPathAsync(int mapIndex, int startX, int startY, sbyte startZ,
+                                         int destX, int destY, int snapRadius, Action<List<PathPoint>> onComplete)
+        {
+            // Any previous in-flight search becomes stale (its next version-check bails it out).
+            int myVersion = Interlocked.Increment(ref _searchVersion);
+
+            // Only one search runs at a time; if another is still tearing down, skip this request.
+            // The stale one exits within a few ms of the version bump above.
+            if (Interlocked.CompareExchange(ref _running, 1, 0) != 0)
+            {
+                onComplete?.Invoke(new List<PathPoint>());
+                return;
+            }
+
+            Task.Run(() =>
+            {
+                var result = new List<PathPoint>();
+                try
+                {
+                    var chunkCache = new Dictionary<long, ChunkWalkData>(1024);
+
+                    // If the click landed on an impassable tile, snap to the nearest walkable one.
+                    int targetX = destX;
+                    int targetY = destY;
+                    if (!TryGetWalkable(mapIndex, destX, destY, startZ, chunkCache, out _))
+                    {
+                        if (!SnapToNearestWalkable(mapIndex, destX, destY, startZ, snapRadius, chunkCache,
+                                                    out targetX, out targetY))
+                        {
+                            return;  // no walkable tile within radius; finally block still resets _running
+                        }
+                    }
+
+                    long deadline = Time.Ticks + MAX_SEARCH_MS;
+                    result = FindPath(mapIndex, startX, startY, startZ, targetX, targetY, chunkCache, myVersion, deadline);
+                }
+                catch (Exception ex)
+                {
+                    Log.Error($"WorldMapPathfinder: {ex.Message}");
+                }
+                finally
+                {
+                    Volatile.Write(ref _running, 0);
+                }
+
+                MainThreadQueue.EnqueueAction(() => onComplete?.Invoke(result));
+            });
+        }
+
+        /// <summary>
+        /// Finds the nearest walkable tile to (cx, cy), searching in expanding rings up to <paramref name="radius"/>.
+        /// Returns false if no walkable tile is found within the radius.
+        /// </summary>
+        private static bool SnapToNearestWalkable(int mapIndex, int cx, int cy, sbyte fromZ, int radius,
+                                                   Dictionary<long, ChunkWalkData> cache, out int outX, out int outY)
+        {
+            for (int r = 1; r <= radius; r++)
+            {
+                // Scan the border of a square of side (2r+1) — Chebyshev distance = r
+                for (int dx = -r; dx <= r; dx++)
+                {
+                    // Top and bottom edges of the ring
+                    if (TryGetWalkable(mapIndex, cx + dx, cy - r, fromZ, cache, out _))
+                    {
+                        outX = cx + dx; outY = cy - r; return true;
+                    }
+                    if (TryGetWalkable(mapIndex, cx + dx, cy + r, fromZ, cache, out _))
+                    {
+                        outX = cx + dx; outY = cy + r; return true;
+                    }
+                }
+                for (int dy = -r + 1; dy <= r - 1; dy++)
+                {
+                    // Left and right edges (excluding corners already checked)
+                    if (TryGetWalkable(mapIndex, cx - r, cy + dy, fromZ, cache, out _))
+                    {
+                        outX = cx - r; outY = cy + dy; return true;
+                    }
+                    if (TryGetWalkable(mapIndex, cx + r, cy + dy, fromZ, cache, out _))
+                    {
+                        outX = cx + r; outY = cy + dy; return true;
+                    }
+                }
+            }
+            outX = cx; outY = cy;
+            return false;
+        }
+
+        // -----------------------------------------------------------------
+        // A*
+        // -----------------------------------------------------------------
+
+        private sealed class Node
+        {
+            public int X;
+            public int Y;
+            public sbyte Z;
+            public int G;       // cost-so-far
+            public int F;       // G + heuristic
+            public Node Parent;
+            public byte Direction;  // dir taken from Parent to reach here
+        }
+
+        // Octile distance, weighted for speed. D1=10, D2=14. Weight × 1.5 gives a strong
+        // goal bias that prunes ~10× more exploration in maze-like interiors.
+        private static int Heuristic(int x1, int y1, int x2, int y2)
+        {
+            int dx = Math.Abs(x1 - x2);
+            int dy = Math.Abs(y1 - y2);
+            int octile = 10 * (dx + dy) + (14 - 20) * Math.Min(dx, dy);
+            return octile * HEURISTIC_WEIGHT_NUM / HEURISTIC_WEIGHT_DEN;
+        }
+
+        private static List<PathPoint> FindPath(int mapIndex, int startX, int startY, sbyte startZ,
+                                                 int destX, int destY, Dictionary<long, ChunkWalkData> chunkCache,
+                                                 int myVersion, long deadlineTicks)
+        {
+            var result = new List<PathPoint>();
+            var openQueue = new System.Collections.Generic.PriorityQueue<Node, int>();
+            var bestG = new Dictionary<long, int>(8192);  // key = (x,y) packed, value = best G cost so far
+            int nodeCount = 0;
+
+            var startNode = new Node
+            {
+                X = startX,
+                Y = startY,
+                Z = startZ,
+                G = 0,
+                F = Heuristic(startX, startY, destX, destY),
+                Parent = null,
+                Direction = 0
+            };
+            openQueue.Enqueue(startNode, startNode.F);
+            bestG[PackKey(startX, startY)] = 0;
+
+            Node goal = null;
+
+            while (openQueue.Count > 0 && nodeCount < MAX_NODES)
+            {
+                // Check cancellation / timeout every 4096 nodes — cheap and responsive.
+                if ((nodeCount & 0xFFF) == 0)
+                {
+                    if (Volatile.Read(ref _searchVersion) != myVersion) return result;      // a newer click superseded us
+                    if (Time.Ticks >= deadlineTicks) return result;                         // hit wall-clock cap
+                }
+
+                Node current = openQueue.Dequeue();
+                long key = PackKey(current.X, current.Y);
+
+                // Stale entry check (PriorityQueue has no decrease-key; we push duplicates)
+                if (bestG.TryGetValue(key, out int knownG) && knownG < current.G)
+                    continue;
+
+                if (current.X == destX && current.Y == destY)
+                {
+                    goal = current;
+                    break;
+                }
+
+                nodeCount++;
+
+                for (int d = 0; d < 8; d++)
+                {
+                    int nx = current.X + DX[d];
+                    int ny = current.Y + DY[d];
+
+                    if (nx < 0 || ny < 0) continue;
+
+                    if (!TryGetWalkable(mapIndex, nx, ny, current.Z, chunkCache, out sbyte nz))
+                        continue;
+
+                    // No Z-step check — the server resolves actual Z when the walk packet is sent.
+                    // For 2D overworld pathing (including under-roof, ramps, stairs) this is what we want.
+
+                    // Diagonal corner-cutting check: both adjacent cardinal tiles must be walkable,
+                    // otherwise we'd slide through a wall corner.
+                    if ((d & 1) == 1)
+                    {
+                        if (!TryGetWalkable(mapIndex, current.X + DX[d], current.Y, current.Z, chunkCache, out _) ||
+                            !TryGetWalkable(mapIndex, current.X, current.Y + DY[d], current.Z, chunkCache, out _))
+                            continue;
+                    }
+
+                    int stepCost = (d & 1) == 0 ? 10 : 14;
+                    int tentativeG = current.G + stepCost;
+                    long nKey = PackKey(nx, ny);
+
+                    if (bestG.TryGetValue(nKey, out int existingG) && existingG <= tentativeG)
+                        continue;
+
+                    bestG[nKey] = tentativeG;
+                    var neighbor = new Node
+                    {
+                        X = nx,
+                        Y = ny,
+                        Z = nz,
+                        G = tentativeG,
+                        F = tentativeG + Heuristic(nx, ny, destX, destY),
+                        Parent = current,
+                        Direction = (byte)d
+                    };
+                    openQueue.Enqueue(neighbor, neighbor.F);
+                }
+            }
+
+            if (goal == null)
+                return result;
+
+            // Reconstruct
+            var stack = new Stack<PathPoint>();
+            for (Node n = goal; n != null && n.Parent != null; n = n.Parent)
+            {
+                stack.Push(new PathPoint
+                {
+                    X = n.X,
+                    Y = n.Y,
+                    Z = n.Z,
+                    Direction = n.Direction
+                });
+            }
+            while (stack.Count > 0)
+                result.Add(stack.Pop());
+
+            return result;
+        }
+
+        private static long PackKey(int x, int y) => ((long)(uint)x << 32) | (uint)y;
+
+        // -----------------------------------------------------------------
+        // Raw-file walkability
+        // -----------------------------------------------------------------
+
+        /// <summary>Per-chunk precomputed walkability, cached for the duration of one search.</summary>
+        private sealed class ChunkWalkData
+        {
+            /// <summary>Walkable flag for each of the 64 tiles in this 8×8 chunk.</summary>
+            public readonly bool[] Walkable = new bool[64];
+            /// <summary>
+            /// IMMUTABLE land Z from map.mul. Used for the "is this wall at ground level?"
+            /// check. Must NOT be modified by statics — if Surface/Bridge statics raised it,
+            /// plateau retaining walls at the platform's Z would slide into the ground-level
+            /// window and block the whole plateau (Luna Bank symptom).
+            /// </summary>
+            public readonly sbyte[] LandZ = new sbyte[64];
+            /// <summary>
+            /// Highest walkable surface Z for each tile. Grows as Surface/Bridge statics are
+            /// processed. Reported for diagnostics and used by the walker for Z hints.
+            /// </summary>
+            public readonly sbyte[] SurfaceZ = new sbyte[64];
+            public bool Invalid;
+        }
+
+        private static bool TryGetWalkable(int mapIndex, int x, int y, sbyte fromZ,
+                                           Dictionary<long, ChunkWalkData> cache, out sbyte surfaceZ)
+        {
+            // Dynamic-block override first — lamp posts, rocks, placed doors, etc.
+            // learned during walk-time failures.
+            if (_dynamicBlocks.Contains(PackKey(x, y)))
+            {
+                surfaceZ = 0;
+                return false;
+            }
+
+            int cx = x >> 3;
+            int cy = y >> 3;
+            long chunkKey = PackKey(cx, cy);
+
+            if (!cache.TryGetValue(chunkKey, out ChunkWalkData data))
+            {
+                data = LoadChunk(mapIndex, cx, cy);
+                cache[chunkKey] = data;
+            }
+
+            if (data == null || data.Invalid)
+            {
+                surfaceZ = 0;
+                return false;
+            }
+
+            int idx = ((y & 7) << 3) + (x & 7);
+            surfaceZ = data.SurfaceZ[idx];
+            return data.Walkable[idx];
+        }
+
+        private static ChunkWalkData LoadChunk(int mapIndex, int cx, int cy)
+        {
+            try
+            {
+                var maps = Client.Game.UO.FileManager.Maps;
+                if (cx < 0 || cy < 0 || cx >= maps.MapBlocksSize[mapIndex, 0] || cy >= maps.MapBlocksSize[mapIndex, 1])
+                    return new ChunkWalkData { Invalid = true };
+
+                ref IndexMap im = ref maps.GetIndex(mapIndex, cx, cy);
+                if (!im.IsValid())
+                    return new ChunkWalkData { Invalid = true };
+
+                var data = new ChunkWalkData();
+                var tileData = Client.Game.UO.FileManager.TileData;
+
+                // --- Land layer ---
+                MapCellsArray cells = im.MapFile.ReadAt<MapBlock>((long)im.MapAddress).Cells;
+                for (int i = 0; i < 64; i++)
+                {
+                    ref readonly MapCells c = ref cells[i];
+                    sbyte lz = c.Z;
+                    ushort landId = (ushort)(c.TileID & 0x3FFF);
+                    bool landOk = landId < tileData.LandData.Length
+                                  && !tileData.LandData[landId].IsImpassable;
+                    data.Walkable[i] = landOk;
+                    data.LandZ[i] = lz;
+                    data.SurfaceZ[i] = lz;  // starts at land Z, may grow via surface statics
+                }
+
+                // --- Static layer ---
+                // Two-bitmap rule:
+                //   hardBlocked  = walls, trees, rocks, impassable furniture at ground level
+                //   hasSurface   = floor/bridge static that you CAN stand on (lets you cross water)
+                // Final walkability = (!hardBlocked) && (land_walkable || hasSurface)
+                //
+                // Elevation rule: only statics within ~6 Z of the land count.
+                // Above that they're treated as overhead (archways, battlements, upper floors).
+                const int GROUND_LEVEL_THRESHOLD = 6;
+
+                if (im.StaticCount > 0)
+                {
+                    Span<bool> hardBlocked = stackalloc bool[64];
+                    Span<bool> hasSurface  = stackalloc bool[64];
+
+                    var buf = ArrayPool<StaticsBlock>.Shared.Rent((int)im.StaticCount);
+                    try
+                    {
+                        Span<StaticsBlock> span = buf.AsSpan(0, (int)im.StaticCount);
+                        im.StaticFile.ReadAt((long)im.StaticAddress, MemoryMarshal.AsBytes(span));
+
+                        foreach (ref StaticsBlock sb in span)
+                        {
+                            int idx = ((sb.Y & 7) << 3) + (sb.X & 7);
+                            if ((uint)idx >= 64) continue;
+
+                            ushort staticId = sb.Color;
+                            if (staticId >= tileData.StaticData.Length) continue;
+
+                            ref StaticTiles sd = ref tileData.StaticData[staticId];
+
+                            // Roof tiles never affect ground-level pathing.
+                            if (sd.IsRoof) continue;
+
+                            if (sd.IsImpassable || sd.IsWall)
+                            {
+                                // Block only if the wall sits at actual ground (land) level.
+                                // IMPORTANT: compare against LandZ, NOT SurfaceZ. SurfaceZ may have
+                                // been raised by a prior Surface/Bridge static in this chunk; using
+                                // it would slide the threshold upward and wrongly block elevated
+                                // walls (arch tops, plateau retaining walls).
+                                if (sb.Z <= data.LandZ[idx] + GROUND_LEVEL_THRESHOLD)
+                                    hardBlocked[idx] = true;
+                            }
+                            else if (sd.IsSurface || sd.IsBridge)
+                            {
+                                // A walkable surface / bridge. Accept it at any reasonable Z —
+                                // bridges span water (land impassable), stairs rise, etc.
+                                hasSurface[idx] = true;
+                                sbyte top = (sbyte)Math.Clamp(sb.Z + (int)sd.Height, sbyte.MinValue, sbyte.MaxValue);
+                                if (top > data.SurfaceZ[idx])
+                                    data.SurfaceZ[idx] = top;
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        ArrayPool<StaticsBlock>.Shared.Return(buf);
+                    }
+
+                    for (int i = 0; i < 64; i++)
+                    {
+                        if (hardBlocked[i])
+                            data.Walkable[i] = false;       // wall always wins
+                        else if (hasSurface[i])
+                            data.Walkable[i] = true;        // bridge/floor unblocks impassable land
+                    }
+                }
+
+                return data;
+            }
+            catch (Exception ex)
+            {
+                Log.Error($"WorldMapPathfinder.LoadChunk({cx},{cy}): {ex.Message}");
+                return new ChunkWalkData { Invalid = true };
+            }
+        }
+    }
+}

--- a/src/ClassicUO.Client/Game/WorldMapPathfinder.cs
+++ b/src/ClassicUO.Client/Game/WorldMapPathfinder.cs
@@ -154,19 +154,26 @@ namespace ClassicUO.Game
                     var chunkCache = new Dictionary<long, ChunkWalkData>(1024);
 
                     // If the click landed on an impassable tile, snap to the nearest walkable one.
+                    // Use a flag instead of early-return so execution falls through to the
+                    // completion callback below — WorldMapGump relies on it to clear _navDest
+                    // and _navPath when a nav fails, and the previous early-return skipped it.
                     int targetX = destX;
                     int targetY = destY;
+                    bool canSearch = true;
                     if (!TryGetWalkable(mapIndex, destX, destY, startZ, chunkCache, out _))
                     {
                         if (!SnapToNearestWalkable(mapIndex, destX, destY, startZ, snapRadius, chunkCache,
                                                     out targetX, out targetY))
                         {
-                            return;  // no walkable tile within radius; finally block still resets _running
+                            canSearch = false;  // no walkable tile within radius → empty result
                         }
                     }
 
-                    long deadline = Time.Ticks + MAX_SEARCH_MS;
-                    result = FindPath(mapIndex, startX, startY, startZ, targetX, targetY, chunkCache, myVersion, deadline);
+                    if (canSearch)
+                    {
+                        long deadline = Time.Ticks + MAX_SEARCH_MS;
+                        result = FindPath(mapIndex, startX, startY, startZ, targetX, targetY, chunkCache, myVersion, deadline);
+                    }
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
  ## Summary

  Hold **Ctrl + Left Click** anywhere on the World Map and the player auto-walks to that location, routing around obstacles using a
  background-thread A* that reads walkability directly from `map.mul` + `statics.mul`.

<img width="502" height="581" alt="worldMapNav" src="https://github.com/user-attachments/assets/8b7a78f0-79da-41ac-94ca-7361642ef5da" />


  ## Type of change

  - [x] New feature (non-breaking change which adds functionality)

  ## How it works

  **Pathfinding:**
  - The entire path is computed upfront on a worker thread (1M-node budget, 5 s wall-clock cap), then handed to the existing walker via a
  new `Pathfinder.StartComputedPath()` hook.
  - Reads walkability directly from the memory-mapped map files — no chunks loaded into game state, so the renderer never stalls and
  there's no race with concurrent walks.
  - **Click-snap**: clicking on a tree / wall / water retargets to the nearest walkable tile within a radius.
  - **Elevation-aware walls**: static walls are only treated as blocking when their base Z is within ~6 of the land Z. This lets the player
   walk under archways, through gateways, across plateau perimeters, etc. without being stopped by roof / elevated-wall tops seen in the 2D
   map projection.
  - **Bridges unblock water**: any `IsBridge` / `IsSurface` static makes the tile walkable even when the land underneath is impassable, so
  Britain bridge, Magincia span, etc. are used correctly.
  - **Dynamic-obstacle auto-replan**: when the walker is rejected at runtime by something the file-based search can't see (lamp posts,
  rocks, placed doors, other dynamic items), the blocked tile is marked and the search is retried up to 3 times.

  **Player-house awareness:**
  - Each Ctrl+Click shallow-copies every Multi component in `World.HouseManager.Houses` on the main thread (~20 ns per component,
  sub-millisecond even with thousands of components).
  - The background thread applies a filter that blocks the **entire ground-level footprint** of each house — matching OrionUO's
  "circumnavigate" behavior rather than trying to walk through doors and windows.
  - Upper storeys, roofs, and placement-preview components are excluded so multi-storey castles don't over-block the surrounding area.

  **Thread safety:**
  - Multi fields are copied into plain value-type structs on the main thread; the worker never touches live game objects.
  - The per-search `_houseBlocks` HashSet is published before `Task.Run` and cleared in the worker's `finally` — owned exclusively by
  whichever search is running.
  - `_dynamicBlocks` (walker-learned obstacles) is a `ConcurrentDictionary<long, byte>` because its lifetime spans multiple Ctrl+Clicks.

  ## Files touched

  - `src/ClassicUO.Client/Game/WorldMapPathfinder.cs` — **new**, standalone pathfinder + A* + house filter
  - `src/ClassicUO.Client/Game/Pathfinder.cs` — `StartComputedPath()` + `OnComputedPathStepFailed` event
  - `src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs` — Ctrl+Left binding, path rendering, snapshot builder, replan wiring

  ## Testing

  Tested on:
  - Local ServUO shard
  - Public server **UODreams**

  Maps covered during manual testing:
  - Felucca (overworld + Britain bridge, mountain paths, forest routes, town hopping past many player houses)
  - Trammel (mirrors Felucca layout)
  - Malas (Luna city interior, overland routes, dungeon approaches)

  Walkability edge cases verified:
  - Under archways and gateways (Luna, Britain)
  - Across bridges over water (Britain, Vesper)
  - Around lamp posts, decorative rocks, placed furniture (replan path)
  - Around player houses — the nav now reliably circumnavigates rather than walking through doors/windows
  - Click-on-tree / click-on-wall (snaps to nearest walkable)
  - Mid-path cancellation via a new Ctrl+Click
  - Repeated spam-clicking different destinations (stress test for the thread-safety fixes)

  ## Known limitations (follow-up candidates)

  - **Player houses outside render range** — the client only knows about houses near the player, so a house on the far end of a long path
  isn't in the snapshot. The walker-time replan loop catches the first wall-bump and routes around, but on rare pathological geometries 3
  replans aren't enough. Testing shows ~95% success in practice.
  - **Luna Bank interior** — the bank's maze-like inner rooms time out the A* budget. Destination snap + replan typically land the player
  at the entrance rather than inside.
  - **Custom server additions** — shards that heavily modify terrain via dynamic objects (Sphere/UOX3 style world edits, large scripted
  decor) may require more replans than the 3-per-session cap.

  These are acknowledged, non-blocking, and left as follow-up work — the feature is strictly additive on top of existing behaviour.

  ## Implementation notes for reviewers

  - No changes to `WalkableManager` or the in-game `Pathfinder`'s A* logic. Existing short-range pathing is untouched.
  - The new pathfinder runs entirely off the main thread; results are marshalled back via `MainThreadQueue.EnqueueAction`.
  - Version-counter cancellation: every new Ctrl+Click increments a version; in-flight searches check it every 4096 nodes and bail out
  within a few ms of the newer click.
  - Heuristic weight of 1.25 gives a 2× speedup in open terrain while still backtracking out of dead-end interiors — chosen after trying
  1.0 (too slow in towns) and 1.5 (got stuck exploring every Luna Bank room).
  - House blocking uses a `Z ≤ landZ + 14` band: UO ground floors sit at landZ+7, so 14 catches the full first storey while excluding upper
   floors (~+20) and rooftops.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ctrl+Left click to start long-distance auto-walking from the world map, with dotted route and destination marker.
  * Asynchronous route computation with snapping to the nearest walkable tile when needed.
  * Support for starting precomputed routes and receiving a callback if a route step becomes blocked.

* **Bug Fixes / Improvements**
  * Automatic re-planning around dynamic obstacles with a limited retry budget; clearer route clearing behavior.
  * Removed previous Ctrl+Right walk-to behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->