### PR TITLE
fix: Crash on Plugin `UsePrimaryAbility`/`UseSecondaryAbility`

### DIFF
--- a/src/ClassicUO.Client/Game/GameActions.cs
+++ b/src/ClassicUO.Client/Game/GameActions.cs
@@ -1277,10 +1277,10 @@ internal static class GameActions
 
     // ===================================================
     [Obsolete("temporary workaround to not break assistants")]
-    internal static void UsePrimaryAbility() => UsePrimaryAbility(Client.Game.UO.World);
+    public static void UsePrimaryAbility() => UsePrimaryAbility(Client.Game.UO.World);
 
     [Obsolete("temporary workaround to not break assistants")]
-    internal static void UseSecondaryAbility() => UseSecondaryAbility(Client.Game.UO.World);
+    public static void UseSecondaryAbility() => UseSecondaryAbility(Client.Game.UO.World);
     // ===================================================
 
     internal static void QuestArrow(bool rightClick) => Socket.Send_ClickQuestArrow(rightClick);


### PR DESCRIPTION
## Description
Render `UsePrimaryAbility` and `UseSecondaryAbility` methods `public` to allow dynamic usage by plugins (degradation from legacy)

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Additional Notes
[Discord discussion](https://discord.com/channels/1344851225538986064/1344856678767792170/1501327421130149971)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted availability of ability methods through the public API with temporary workaround annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->