### PR TITLE
fix: Support HTML names in `GridLootGump`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ All notable changes to TazUO will be recorded here.
 * Fixed a crash that occurred when clicking an empty `Combobox` - [P.R 451](https://github.com/PlayTazUO/TazUO/pull/451) ([yuval-po](https://github.com/yuval-po))
 * Dramatically reduced memory footprint and load times for system fonts - [P.R 446](https://github.com/PlayTazUO/TazUO/pull/446) ([yuval-po](https://github.com/yuval-po))
 * Eventine-specific paperdoll layer ordering - [P.R 458](https://github.com/PlayTazUO/TazUO/pull/458) ([yuval-po](https://github.com/yuval-po))
+* Crash when using the Plugin API's UsePrimaryAbility/UseSecondaryAbility methods - [P.R 461](https://github.com/PlayTazUO/TazUO/pull/461) ([yuval-po](https://github.com/yuval-po))
+* HTML control text dispalyed in GridLootGump name label in UO POL based servers - [P.R 462](https://github.com/PlayTazUO/TazUO/pull/462) ([yuval-po](https://github.com/yuval-po) & [bittiez](https://github.com/bittiez))
 
 ## V5.1.0
 

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.1.10</AssemblyVersion>
-    <FileVersion>5.1.10</FileVersion>
+    <AssemblyVersion>5.1.11</AssemblyVersion>
+    <FileVersion>5.1.11</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridLootGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridLootGump.cs
@@ -135,7 +135,8 @@ namespace ClassicUO.Game.UI.Gumps
                     true,
                     0x0481,
                     align: TEXT_ALIGN_TYPE.TS_CENTER,
-                    maxwidth: 300
+                    maxwidth: 300,
+                    ishtml: true
                 )
                 {
                     Width = 300,


### PR DESCRIPTION
## Description
Fix rendering of HTML names in `GridLootGump` label

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing
Manual test via a supporting POL server

## Screenshots (if applicable)
Before:
<img width="643" height="509" alt="image" src="https://github.com/user-attachments/assets/7ec625c5-44bf-4451-b2e1-463cc1a3cde0" />
After:
<img width="336" height="345" alt="image" src="https://github.com/user-attachments/assets/f67783cc-7480-47dc-8d1f-f951bb8eb132" />


## Additional Notes
Seems to affect UO POL servers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed corpse name label to properly render HTML-formatted text in the loot interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->