### PR TITLE
fix: Cast Timer Progress Bar is never shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to TazUO will be recorded here.
 * Eventine-specific paperdoll layer ordering - [P.R 458](https://github.com/PlayTazUO/TazUO/pull/458) ([yuval-po](https://github.com/yuval-po))
 * Crash when using the Plugin API's UsePrimaryAbility/UseSecondaryAbility methods - [P.R 461](https://github.com/PlayTazUO/TazUO/pull/461) ([yuval-po](https://github.com/yuval-po))
 * HTML control text dispalyed in GridLootGump name label in UO POL based servers - [P.R 462](https://github.com/PlayTazUO/TazUO/pull/462) ([yuval-po](https://github.com/yuval-po) & [bittiez](https://github.com/bittiez))
+* Spell progress indicator never shows - [P.R 464](https://github.com/PlayTazUO/TazUO/pull/464) ([yuval-po](https://github.com/yuval-po))
 
 ## V5.1.0
 

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.1.11</AssemblyVersion>
-    <FileVersion>5.1.11</FileVersion>
+    <AssemblyVersion>5.1.12</AssemblyVersion>
+    <FileVersion>5.1.12</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -669,14 +669,20 @@ namespace ClassicUO.Configuration
 
         public List<string> AutoOpenXmlGumps { get; set => SetProperty(ref field, value); } = new List<string>();
 
-        public int ControllerMouseSensitivity
+        /// <summary>
+        /// The sensitivity of the controller mouse input.
+        /// </summary>
+        /// <remarks>
+        /// The typo here is a bit problematic as it's also serialized, meaning if we change it here, we essentially invalidate the user's configuration.
+        /// </remarks>
+        public int ControllerMouseSensativity
         {
-            get => Input.Mouse.ControllerSensativity;
+            get => Input.Mouse.ControllerSensitivity;
             set
             {
-                if (Input.Mouse.ControllerSensativity != value)
+                if (Input.Mouse.ControllerSensitivity != value)
                 {
-                    Input.Mouse.ControllerSensativity = value;
+                    Input.Mouse.ControllerSensitivity = value;
                     OnPropertyChanged();
                 }
             }

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -17,6 +17,8 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using System.Xml;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using ClassicUO.Game.UI;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Game.UI.Gumps.GridHighLight;
@@ -51,306 +53,333 @@ namespace ClassicUO.Configuration
 
 
 
-    public sealed partial class Profile
+    public sealed partial class Profile : INotifyPropertyChanged
     {
-        [JsonIgnore] public string Username { get; set; }
-        [JsonIgnore] public string ServerName { get; set; }
-        [JsonIgnore] public string CharacterName { get; set; }
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <summary>
+        /// Raises the <see cref="PropertyChanged"/> event with the specified property name
+        /// </summary>
+        /// <param name="propertyName">The property that was updated. Passed by the compiler.</param>
+        private void OnPropertyChanged([CallerMemberName] string propertyName = null) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
+        /// <summary>
+        /// Updates the given property with the given value if it is different from the current one.
+        /// Raises the <see cref="PropertyChanged" /> event, if a change has occurred
+        /// </summary>
+        /// <param name="storage">The field to update</param>
+        /// <param name="value">The value to set</param>
+        /// <param name="propertyName">The name of the property being updated</param>
+        /// <typeparam name="T">The type of property being updated</typeparam>
+        /// <returns><c>true</c> if a change has occurred, <c>false</c> otherwise</returns>
+        private bool SetProperty<T>(ref T storage, T value, [CallerMemberName] string propertyName = null)
+        {
+            if (EqualityComparer<T>.Default.Equals(storage, value))
+                return false;
+
+            storage = value;
+            OnPropertyChanged(propertyName);
+            return true;
+        }
+
+        [JsonIgnore] public string Username { get; set => SetProperty(ref field, value); }
+        [JsonIgnore] public string ServerName { get; set => SetProperty(ref field, value); }
+        [JsonIgnore] public string CharacterName { get; set => SetProperty(ref field, value); }
 
         // voice recognition
-        public bool VoiceRecognitionEnabled { get; set; } = false;
-        public string VoiceModelPath { get; set; } = string.Empty;
+        public bool VoiceRecognitionEnabled { get; set => SetProperty(ref field, value); } = false;
+        public string VoiceModelPath { get; set => SetProperty(ref field, value); } = string.Empty;
 
         // sounds
-        public bool EnableSound { get; set; } = true;
-        public int SoundVolume { get; set; } = 50;
-        public bool EnableMusic { get; set; } = true;
-        public int MusicVolume { get; set; } = 50;
-        public bool EnableFootstepsSound { get; set; } = true;
-        public bool EnableCombatMusic { get; set; } = true;
-        public bool ReproduceSoundsInBackground { get; set; }
+        public bool EnableSound { get; set => SetProperty(ref field, value); } = true;
+        public int SoundVolume { get; set => SetProperty(ref field, value); } = 50;
+        public bool EnableMusic { get; set => SetProperty(ref field, value); } = true;
+        public int MusicVolume { get; set => SetProperty(ref field, value); } = 50;
+        public bool EnableFootstepsSound { get; set => SetProperty(ref field, value); } = true;
+        public bool EnableCombatMusic { get; set => SetProperty(ref field, value); } = true;
+        public bool ReproduceSoundsInBackground { get; set => SetProperty(ref field, value); }
 
         // fonts and speech
-        public byte ChatFont { get; set; } = 1;
-        public int SpeechDelay { get; set; } = 100;
-        public bool ScaleSpeechDelay { get; set; } = true;
-        public bool SaveJournalToFile { get; set; } = false;
-        public bool ForceUnicodeJournal { get; set; }
-        public bool IgnoreAllianceMessages { get; set; }
-        public bool IgnoreGuildMessages { get; set; }
+        public byte ChatFont { get; set => SetProperty(ref field, value); } = 1;
+        public int SpeechDelay { get; set => SetProperty(ref field, value); } = 100;
+        public bool ScaleSpeechDelay { get; set => SetProperty(ref field, value); } = true;
+        public bool SaveJournalToFile { get; set => SetProperty(ref field, value); } = false;
+        public bool ForceUnicodeJournal { get; set => SetProperty(ref field, value); }
+        public bool IgnoreAllianceMessages { get; set => SetProperty(ref field, value); }
+        public bool IgnoreGuildMessages { get; set => SetProperty(ref field, value); }
 
         // hues
-        public ushort SpeechHue { get; set; } = 0x02B2;
-        public ushort WhisperHue { get; set; } = 0x0033;
-        public ushort EmoteHue { get; set; } = 0x0021;
-        public ushort YellHue { get; set; } = 0x0021;
-        public ushort PartyMessageHue { get; set; } = 0x0044;
-        public ushort GuildMessageHue { get; set; } = 0x0044;
-        public ushort AllyMessageHue { get; set; } = 0x0057;
-        public ushort ChatMessageHue { get; set; } = 0x0256;
-        public ushort InnocentHue { get; set; } = 0x005A;
-        public ushort PartyAuraHue { get; set; } = 0x0044;
-        public ushort FriendHue { get; set; } = 0x0044;
-        public ushort CriminalHue { get; set; } = 0x03B2;
-        public ushort CanAttackHue { get; set; } = 0x03B2;
-        public ushort EnemyHue { get; set; } = 0x0031;
-        public ushort MurdererHue { get; set; } = 0x0023;
-        public ushort BeneficHue { get; set; } = 0x0059;
-        public ushort HarmfulHue { get; set; } = 0x0020;
-        public ushort NeutralHue { get; set; } = 0x03B1;
-        public bool EnabledSpellHue { get; set; }
-        public bool EnabledSpellFormat { get; set; } = true;
-        public string SpellDisplayFormat { get; set; } = "{power} [{spell}]";
-        public ushort PoisonHue { get; set; } = 0x0044;
-        public ushort ParalyzedHue { get; set; } = 0x014C;
-        public ushort InvulnerableHue { get; set; } = 0x0030;
-        public ushort AltJournalBackgroundHue { get; set; } = 0x0000;
-        public ushort AltGridContainerBackgroundHue { get; set; } = 0x0000;
-        public bool OverridePartyAndGuildHue { get; set; } = false;
+        public ushort SpeechHue { get; set => SetProperty(ref field, value); } = 0x02B2;
+        public ushort WhisperHue { get; set => SetProperty(ref field, value); } = 0x0033;
+        public ushort EmoteHue { get; set => SetProperty(ref field, value); } = 0x0021;
+        public ushort YellHue { get; set => SetProperty(ref field, value); } = 0x0021;
+        public ushort PartyMessageHue { get; set => SetProperty(ref field, value); } = 0x0044;
+        public ushort GuildMessageHue { get; set => SetProperty(ref field, value); } = 0x0044;
+        public ushort AllyMessageHue { get; set => SetProperty(ref field, value); } = 0x0057;
+        public ushort ChatMessageHue { get; set => SetProperty(ref field, value); } = 0x0256;
+        public ushort InnocentHue { get; set => SetProperty(ref field, value); } = 0x005A;
+        public ushort PartyAuraHue { get; set => SetProperty(ref field, value); } = 0x0044;
+        public ushort FriendHue { get; set => SetProperty(ref field, value); } = 0x0044;
+        public ushort CriminalHue { get; set => SetProperty(ref field, value); } = 0x03B2;
+        public ushort CanAttackHue { get; set => SetProperty(ref field, value); } = 0x03B2;
+        public ushort EnemyHue { get; set => SetProperty(ref field, value); } = 0x0031;
+        public ushort MurdererHue { get; set => SetProperty(ref field, value); } = 0x0023;
+        public ushort BeneficHue { get; set => SetProperty(ref field, value); } = 0x0059;
+        public ushort HarmfulHue { get; set => SetProperty(ref field, value); } = 0x0020;
+        public ushort NeutralHue { get; set => SetProperty(ref field, value); } = 0x03B1;
+        public bool EnabledSpellHue { get; set => SetProperty(ref field, value); }
+        public bool EnabledSpellFormat { get; set => SetProperty(ref field, value); } = true;
+        public string SpellDisplayFormat { get; set => SetProperty(ref field, value); } = "{power} [{spell}]";
+        public ushort PoisonHue { get; set => SetProperty(ref field, value); } = 0x0044;
+        public ushort ParalyzedHue { get; set => SetProperty(ref field, value); } = 0x014C;
+        public ushort InvulnerableHue { get; set => SetProperty(ref field, value); } = 0x0030;
+        public ushort AltJournalBackgroundHue { get; set => SetProperty(ref field, value); } = 0x0000;
+        public ushort AltGridContainerBackgroundHue { get; set => SetProperty(ref field, value); } = 0x0000;
+        public bool OverridePartyAndGuildHue { get; set => SetProperty(ref field, value); } = false;
 
         // visual
-        public bool EnabledCriminalActionQuery { get; set; } = true;
-        public bool EnabledBeneficialCriminalActionQuery { get; set; }
-        public bool UseOldStatusGump { get; set; }
-        public bool StatusGumpBarMutuallyExclusive { get; set; } = true;
-        public int BackpackStyle { get; set; }
-        public bool HighlightGameObjects { get; set; }
-        public bool HighlightMobilesByParalize { get; set; } = true;
-        public bool HighlightMobilesByPoisoned { get; set; } = true;
-        public bool HighlightMobilesByInvul { get; set; } = true;
-        public bool ShowMobilesHP { get; set; }
-        public bool ShowTargetIndicator { get; set; }
-        public bool AutoAvoidObstacules { get; set; } = true;
-        public int MobileHPType { get; set; }     // 0 = %, 1 = line, 2 = both
-        public int MobileHPShowWhen { get; set; } // 0 = Always, 1 - <100%
-        public bool DrawRoofs { get; set; } = true;
-        public bool TreeToStumps { get; set; }
-        public bool EnableCaveBorder { get; set; }
-        public bool HideVegetation { get; set; }
-        public int FieldsType { get; set; } // 0 = normal, 1 = static, 2 = tile
-        public bool NoColorObjectsOutOfRange { get; set; }
-        public bool UseCircleOfTransparency { get; set; }
-        public int CircleOfTransparencyRadius { get; set; } = Constants.MAX_CIRCLE_OF_TRANSPARENCY_RADIUS / 2;
-        public int CircleOfTransparencyType { get; set; } // 0 = normal, 1 = like original client
-        public int VendorGumpHeight { get; set; } = 350;   //original vendor gump size
-        public float DefaultScale { get; set; } = 1.0f;
-        public bool EnableMousewheelScaleZoom { get; set; } = true;
-        public bool RestoreScaleAfterUnpressCtrl { get; set; }
-        public bool BandageSelfOld { get; set; } = true;
+        public bool EnabledCriminalActionQuery { get; set => SetProperty(ref field, value); } = true;
+        public bool EnabledBeneficialCriminalActionQuery { get; set => SetProperty(ref field, value); }
+        public bool UseOldStatusGump { get; set => SetProperty(ref field, value); }
+        public bool StatusGumpBarMutuallyExclusive { get; set => SetProperty(ref field, value); } = true;
+        public int BackpackStyle { get; set => SetProperty(ref field, value); }
+        public bool HighlightGameObjects { get; set => SetProperty(ref field, value); }
+        public bool HighlightMobilesByParalize { get; set => SetProperty(ref field, value); } = true;
+        public bool HighlightMobilesByPoisoned { get; set => SetProperty(ref field, value); } = true;
+        public bool HighlightMobilesByInvul { get; set => SetProperty(ref field, value); } = true;
+        public bool ShowMobilesHP { get; set => SetProperty(ref field, value); }
+        public bool ShowTargetIndicator { get; set => SetProperty(ref field, value); }
+        public bool AutoAvoidObstacules { get; set => SetProperty(ref field, value); } = true;
+        public int MobileHPType { get; set => SetProperty(ref field, value); }     // 0 = %, 1 = line, 2 = both
+        public int MobileHPShowWhen { get; set => SetProperty(ref field, value); } // 0 = Always, 1 - <100%
+        public bool DrawRoofs { get; set => SetProperty(ref field, value); } = true;
+        public bool TreeToStumps { get; set => SetProperty(ref field, value); }
+        public bool EnableCaveBorder { get; set => SetProperty(ref field, value); }
+        public bool HideVegetation { get; set => SetProperty(ref field, value); }
+        public int FieldsType { get; set => SetProperty(ref field, value); } // 0 = normal, 1 = static, 2 = tile
+        public bool NoColorObjectsOutOfRange { get; set => SetProperty(ref field, value); }
+        public bool UseCircleOfTransparency { get; set => SetProperty(ref field, value); }
+        public int CircleOfTransparencyRadius { get; set => SetProperty(ref field, value); } = Constants.MAX_CIRCLE_OF_TRANSPARENCY_RADIUS / 2;
+        public int CircleOfTransparencyType { get; set => SetProperty(ref field, value); } // 0 = normal, 1 = like original client
+        public int VendorGumpHeight { get; set => SetProperty(ref field, value); } = 350;   //original vendor gump size
+        public float DefaultScale { get; set => SetProperty(ref field, value); } = 1.0f;
+        public bool EnableMousewheelScaleZoom { get; set => SetProperty(ref field, value); } = true;
+        public bool RestoreScaleAfterUnpressCtrl { get; set => SetProperty(ref field, value); }
+        public bool BandageSelfOld { get; set => SetProperty(ref field, value); } = true;
 
         // Bandage Agent Settings
-        public bool EnableBandageAgent { get; set; } = false;
-        public int BandageAgentDelay { get; set; } = 3000;
-        public bool BandageAgentCheckForBuff { get; set; } = false;
-        public ushort BandageAgentGraphic { get; set; } = 0x0E21;
-        public bool BandageAgentUseNewPacket { get; set; } = true;
-        public bool BandageAgentCheckHidden { get; set; } = false;
-        public bool BandageAgentCheckPoisoned { get; set; } = false;
-        public int BandageAgentHPPercentage { get; set; } = 80;
-        public bool BandageAgentCheckInvul { get; set; } = true;
-        public bool BandageAgentBandageFriends { get; set; } = false;
-        public bool BandageAgentBandageAllies { get; set; } = false;
-        public bool BandageAgentUseDexFormula { get; set; } = false;
-        public bool BandageAgentDisableSelfHeal { get; set; } = false;
+        public bool EnableBandageAgent { get; set => SetProperty(ref field, value); } = false;
+        public int BandageAgentDelay { get; set => SetProperty(ref field, value); } = 3000;
+        public bool BandageAgentCheckForBuff { get; set => SetProperty(ref field, value); } = false;
+        public ushort BandageAgentGraphic { get; set => SetProperty(ref field, value); } = 0x0E21;
+        public bool BandageAgentUseNewPacket { get; set => SetProperty(ref field, value); } = true;
+        public bool BandageAgentCheckHidden { get; set => SetProperty(ref field, value); } = false;
+        public bool BandageAgentCheckPoisoned { get; set => SetProperty(ref field, value); } = false;
+        public int BandageAgentHPPercentage { get; set => SetProperty(ref field, value); } = 80;
+        public bool BandageAgentCheckInvul { get; set => SetProperty(ref field, value); } = true;
+        public bool BandageAgentBandageFriends { get; set => SetProperty(ref field, value); } = false;
+        public bool BandageAgentBandageAllies { get; set => SetProperty(ref field, value); } = false;
+        public bool BandageAgentUseDexFormula { get; set => SetProperty(ref field, value); } = false;
+        public bool BandageAgentDisableSelfHeal { get; set => SetProperty(ref field, value); } = false;
 
-        public bool EnableDeathScreen { get; set; } = true;
-        public bool EnableBlackWhiteEffect { get; set; } = true;
-        public ushort HiddenBodyHue { get; set; } = 0x038E;
-        public byte HiddenBodyAlpha { get; set; } = 40;
-        public int PlayerConstantAlpha { get; set; } = 100;
+        public bool EnableDeathScreen { get; set => SetProperty(ref field, value); } = true;
+        public bool EnableBlackWhiteEffect { get; set => SetProperty(ref field, value); } = true;
+        public ushort HiddenBodyHue { get; set => SetProperty(ref field, value); } = 0x038E;
+        public byte HiddenBodyAlpha { get; set => SetProperty(ref field, value); } = 40;
+        public int PlayerConstantAlpha { get; set => SetProperty(ref field, value); } = 100;
 
         // tooltip
-        public bool UseTooltip { get; set; } = true;
-        public ushort TooltipTextHue { get; set; } = 0xFFFF;
-        public int TooltipDelayBeforeDisplay { get; set; } = 250;
-        public int TooltipDisplayZoom { get; set; } = 100;
-        public int TooltipBackgroundOpacity { get; set; } = 70;
-        public byte TooltipFont { get; set; } = 1;
+        public bool UseTooltip { get; set => SetProperty(ref field, value); } = true;
+        public ushort TooltipTextHue { get; set => SetProperty(ref field, value); } = 0xFFFF;
+        public int TooltipDelayBeforeDisplay { get; set => SetProperty(ref field, value); } = 250;
+        public int TooltipDisplayZoom { get; set => SetProperty(ref field, value); } = 100;
+        public int TooltipBackgroundOpacity { get; set => SetProperty(ref field, value); } = 70;
+        public byte TooltipFont { get; set => SetProperty(ref field, value); } = 1;
 
         // movements
-        public bool EnablePathfind { get; set; } = true;
-        public bool UseShiftToPathfind { get; set; }
-        public bool PathfindSingleClick { get; set; }
-        public bool AlwaysRun { get; set; } = true;
-        public bool AlwaysRunUnlessHidden { get; set; } = true;
-        public bool HoldDownKeyTab { get; set; }
-        public bool HoldShiftForContext { get; set; } = false;
-        public bool HoldShiftToSplitStack { get; set; } = false;
+        public bool EnablePathfind { get; set => SetProperty(ref field, value); } = true;
+        public bool UseShiftToPathfind { get; set => SetProperty(ref field, value); }
+        public bool PathfindSingleClick { get; set => SetProperty(ref field, value); }
+        public bool AlwaysRun { get; set => SetProperty(ref field, value); } = true;
+        public bool AlwaysRunUnlessHidden { get; set => SetProperty(ref field, value); } = true;
+        public bool HoldDownKeyTab { get; set => SetProperty(ref field, value); }
+        public bool HoldShiftForContext { get; set => SetProperty(ref field, value); } = false;
+        public bool HoldShiftToSplitStack { get; set => SetProperty(ref field, value); } = false;
 
         // general
-        [JsonConverter(typeof(Point2Converter))] public Point WindowClientBounds { get; set; } = new Point(600, 480);
-        [JsonConverter(typeof(Point2Converter))] public Point ContainerDefaultPosition { get; set; } = new Point(24, 24);
-        [JsonConverter(typeof(Point2Converter))] public Point GameWindowPosition { get; set; } = new Point(10, 10);
-        public bool GameWindowLock { get; set; }
-        public bool GameWindowFullSize { get; set; }
-        public bool WindowBorderless { get; set; } = false;
-        [JsonConverter(typeof(Point2Converter))] public Point GameWindowSize { get; set; } = new Point(800, 680);
-        [JsonConverter(typeof(Point2Converter))] public Point TopbarGumpPosition { get; set; } = new Point(0, 0);
-        public bool TopbarGumpIsMinimized { get; set; }
-        public bool TopbarGumpIsDisabled { get; set; }
-        public bool UseAlternativeLights { get; set; }
-        public bool UseCustomLightLevel { get; set; }
-        public byte LightLevel { get; set; }
-        public int LightLevelType { get; set; } // 0 = absolute, 1 = minimum
-        public bool UseColoredLights { get; set; } = true;
-        public bool UseDarkNights { get; set; }
-        public int CloseHealthBarType { get; set; } = 2; // 0 = none, 1 == not exists, 2 == is dead
-        public bool ActivateChatAfterEnter { get; set; }
-        public bool ActivateChatAdditionalButtons { get; set; } = true;
-        public bool ActivateChatShiftEnterSupport { get; set; } = true;
-        public bool UseObjectsFading { get; set; } = true;
-        public bool HoldDownKeyAltToCloseAnchored { get; set; } = true;
-        public bool CloseAllAnchoredGumpsInGroupWithRightClick { get; set; } = false;
-        public bool HoldAltToMoveGumps { get; set; }
-        public byte JournalOpacity { get; set; } = 50;
-        public int JournalStyle { get; set; } = 0;
-        public bool HideScreenshotStoredInMessage { get; set; }
-        public bool UseModernPaperdoll { get; set; } = false;
-        public bool OpenModernPaperdollAtMinimizeLoc { get; set; } = false;
+        [JsonConverter(typeof(Point2Converter))] public Point WindowClientBounds { get; set => SetProperty(ref field, value); } = new Point(600, 480);
+        [JsonConverter(typeof(Point2Converter))] public Point ContainerDefaultPosition { get; set => SetProperty(ref field, value); } = new Point(24, 24);
+        [JsonConverter(typeof(Point2Converter))] public Point GameWindowPosition { get; set => SetProperty(ref field, value); } = new Point(10, 10);
+        public bool GameWindowLock { get; set => SetProperty(ref field, value); }
+        public bool GameWindowFullSize { get; set => SetProperty(ref field, value); }
+        public bool WindowBorderless { get; set => SetProperty(ref field, value); } = false;
+        [JsonConverter(typeof(Point2Converter))] public Point GameWindowSize { get; set => SetProperty(ref field, value); } = new Point(800, 680);
+        [JsonConverter(typeof(Point2Converter))] public Point TopbarGumpPosition { get; set => SetProperty(ref field, value); } = new Point(0, 0);
+        public bool TopbarGumpIsMinimized { get; set => SetProperty(ref field, value); }
+        public bool TopbarGumpIsDisabled { get; set => SetProperty(ref field, value); }
+        public bool UseAlternativeLights { get; set => SetProperty(ref field, value); }
+        public bool UseCustomLightLevel { get; set => SetProperty(ref field, value); }
+        public byte LightLevel { get; set => SetProperty(ref field, value); }
+        public int LightLevelType { get; set => SetProperty(ref field, value); } // 0 = absolute, 1 = minimum
+        public bool UseColoredLights { get; set => SetProperty(ref field, value); } = true;
+        public bool UseDarkNights { get; set => SetProperty(ref field, value); }
+        public int CloseHealthBarType { get; set => SetProperty(ref field, value); } = 2; // 0 = none, 1 == not exists, 2 == is dead
+        public bool ActivateChatAfterEnter { get; set => SetProperty(ref field, value); }
+        public bool ActivateChatAdditionalButtons { get; set => SetProperty(ref field, value); } = true;
+        public bool ActivateChatShiftEnterSupport { get; set => SetProperty(ref field, value); } = true;
+        public bool UseObjectsFading { get; set => SetProperty(ref field, value); } = true;
+        public bool HoldDownKeyAltToCloseAnchored { get; set => SetProperty(ref field, value); } = true;
+        public bool CloseAllAnchoredGumpsInGroupWithRightClick { get; set => SetProperty(ref field, value); } = false;
+        public bool HoldAltToMoveGumps { get; set => SetProperty(ref field, value); }
+        public byte JournalOpacity { get; set => SetProperty(ref field, value); } = 50;
+        public int JournalStyle { get; set => SetProperty(ref field, value); } = 0;
+        public bool HideScreenshotStoredInMessage { get; set => SetProperty(ref field, value); }
+        public bool UseModernPaperdoll { get; set => SetProperty(ref field, value); } = false;
+        public bool OpenModernPaperdollAtMinimizeLoc { get; set => SetProperty(ref field, value); } = false;
 
         // Experimental
-        public bool CastSpellsByOneClick { get; set; }
-        public bool BuffBarTime { get; set; }
-        public bool FastSpellsAssign { get; set; }
-        public bool AutoOpenDoors { get; set; } = true;
-        public bool SmoothDoors { get; set; } = true;
-        public bool AutoOpenCorpses { get; set; } = true;
-        public int AutoOpenCorpseRange { get; set; } = 2;
-        public int CorpseOpenOptions { get; set; } = 3;
-        public bool SkipEmptyCorpse { get; set; }
-        public bool AutoOpenOwnCorpse { get; set; } = true;
-        public bool DisableDefaultHotkeys { get; set; }
-        public bool DisableArrowBtn { get; set; }
-        public bool DisableTabBtn { get; set; }
-        public bool DisableCtrlQWBtn { get; set; }
-        public bool DisableAutoMove { get; set; }
-        public bool EnableDragSelect { get; set; }
-        public int DragSelectModifierKey { get; set; } // 0 = none, 1 = control, 2 = shift, 3 = alt
-        public int DragSelect_PlayersModifier { get; set; } = 0;
-        public int DragSelect_MonstersModifier { get; set; } = 0;
-        public int DragSelect_NameplateModifier { get; set; } = 0;
-        public bool OverrideContainerLocation { get; set; }
+        public bool CastSpellsByOneClick { get; set => SetProperty(ref field, value); }
+        public bool BuffBarTime { get; set => SetProperty(ref field, value); }
+        public bool FastSpellsAssign { get; set => SetProperty(ref field, value); }
+        public bool AutoOpenDoors { get; set => SetProperty(ref field, value); } = true;
+        public bool SmoothDoors { get; set => SetProperty(ref field, value); } = true;
+        public bool AutoOpenCorpses { get; set => SetProperty(ref field, value); } = true;
+        public int AutoOpenCorpseRange { get; set => SetProperty(ref field, value); } = 2;
+        public int CorpseOpenOptions { get; set => SetProperty(ref field, value); } = 3;
+        public bool SkipEmptyCorpse { get; set => SetProperty(ref field, value); }
+        public bool AutoOpenOwnCorpse { get; set => SetProperty(ref field, value); } = true;
+        public bool DisableDefaultHotkeys { get; set => SetProperty(ref field, value); }
+        public bool DisableArrowBtn { get; set => SetProperty(ref field, value); }
+        public bool DisableTabBtn { get; set => SetProperty(ref field, value); }
+        public bool DisableCtrlQWBtn { get; set => SetProperty(ref field, value); }
+        public bool DisableAutoMove { get; set => SetProperty(ref field, value); }
+        public bool EnableDragSelect { get; set => SetProperty(ref field, value); }
+        public int DragSelectModifierKey { get; set => SetProperty(ref field, value); } // 0 = none, 1 = control, 2 = shift, 3 = alt
+        public int DragSelect_PlayersModifier { get; set => SetProperty(ref field, value); } = 0;
+        public int DragSelect_MonstersModifier { get; set => SetProperty(ref field, value); } = 0;
+        public int DragSelect_NameplateModifier { get; set => SetProperty(ref field, value); } = 0;
+        public bool OverrideContainerLocation { get; set => SetProperty(ref field, value); }
 
-        public int OverrideContainerLocationSetting { get; set; } // 0 = container position, 1 = top right of screen, 2 = last dragged position, 3 = remember every container
+        public int OverrideContainerLocationSetting { get; set => SetProperty(ref field, value); } // 0 = container position, 1 = top right of screen, 2 = last dragged position, 3 = remember every container
 
-        [JsonConverter(typeof(Point2Converter))] public Point OverrideContainerLocationPosition { get; set; } = new Point(200, 200);
-        public bool HueContainerGumps { get; set; } = true;
-        public int DragSelectStartX { get; set; } = 100;
-        public int DragSelectStartY { get; set; } = 100;
-        public bool DragSelectAsAnchor { get; set; } = false;
-        public string LastActiveNameOverheadOption { get; set; } = "All";
-        public bool NameOverheadToggled { get; set; } = false;
-        public bool ShowTargetRangeIndicator { get; set; }
-        public bool PartyInviteGump { get; set; } = true;
-        public bool CustomBarsToggled { get; set; }
-        public bool CBBlackBGToggled { get; set; }
+        [JsonConverter(typeof(Point2Converter))] public Point OverrideContainerLocationPosition { get; set => SetProperty(ref field, value); } = new Point(200, 200);
+        public bool HueContainerGumps { get; set => SetProperty(ref field, value); } = true;
+        public int DragSelectStartX { get; set => SetProperty(ref field, value); } = 100;
+        public int DragSelectStartY { get; set => SetProperty(ref field, value); } = 100;
+        public bool DragSelectAsAnchor { get; set => SetProperty(ref field, value); } = false;
+        public string LastActiveNameOverheadOption { get; set => SetProperty(ref field, value); } = "All";
+        public bool NameOverheadToggled { get; set => SetProperty(ref field, value); } = false;
+        public bool ShowTargetRangeIndicator { get; set => SetProperty(ref field, value); }
+        public bool PartyInviteGump { get; set => SetProperty(ref field, value); } = true;
+        public bool CustomBarsToggled { get; set => SetProperty(ref field, value); }
+        public bool CBBlackBGToggled { get; set => SetProperty(ref field, value); }
 
-        public bool ShowInfoBar { get; set; }
-        public int InfoBarHighlightType { get; set; } // 0 = text colour changes, 1 = underline
+        public bool ShowInfoBar { get; set => SetProperty(ref field, value); }
+        public int InfoBarHighlightType { get; set => SetProperty(ref field, value); } // 0 = text colour changes, 1 = underline
 
-        public bool CounterBarEnabled { get; set; }
-        public bool CounterBarHighlightOnUse { get; set; }
-        public bool CounterBarHighlightOnAmount { get; set; }
-        public bool CounterBarDisplayAbbreviatedAmount { get; set; }
-        public int CounterBarAbbreviatedAmount { get; set; } = 1000;
-        public int CounterBarHighlightAmount { get; set; } = 5;
-        public int CounterBarCellSize { get; set; } = 40;
+        public bool CounterBarEnabled { get; set => SetProperty(ref field, value); }
+        public bool CounterBarHighlightOnUse { get; set => SetProperty(ref field, value); }
+        public bool CounterBarHighlightOnAmount { get; set => SetProperty(ref field, value); }
+        public bool CounterBarDisplayAbbreviatedAmount { get; set => SetProperty(ref field, value); }
+        public int CounterBarAbbreviatedAmount { get; set => SetProperty(ref field, value); } = 1000;
+        public int CounterBarHighlightAmount { get; set => SetProperty(ref field, value); } = 5;
+        public int CounterBarCellSize { get; set => SetProperty(ref field, value); } = 40;
 
         // title bar stats
-        public bool EnableTitleBarStats { get; set; } = false;
-        public TitleBarStatsMode TitleBarStatsMode { get; set; } = TitleBarStatsMode.Text;
-        public int CounterBarRows { get; set; } = 1;
-        public int CounterBarColumns { get; set; } = 5;
+        public bool EnableTitleBarStats { get; set => SetProperty(ref field, value); } = false;
+        public TitleBarStatsMode TitleBarStatsMode { get; set => SetProperty(ref field, value); } = TitleBarStatsMode.Text;
+        public int CounterBarRows { get; set => SetProperty(ref field, value); } = 1;
+        public int CounterBarColumns { get; set => SetProperty(ref field, value); } = 5;
 
-        public bool ShowSkillsChangedMessage { get; set; } = true;
-        public int ShowSkillsChangedDeltaValue { get; set; } = 1;
-        public bool ShowStatsChangedMessage { get; set; } = true;
+        public bool ShowSkillsChangedMessage { get; set => SetProperty(ref field, value); } = true;
+        public int ShowSkillsChangedDeltaValue { get; set => SetProperty(ref field, value); } = 1;
+        public bool ShowStatsChangedMessage { get; set => SetProperty(ref field, value); } = true;
 
 
-        public bool ShadowsEnabled { get; set; } = true;
-        public bool ShadowsStatics { get; set; } = true;
-        public int TerrainShadowsLevel { get; set; } = 15;
-        public int AuraUnderFeetType { get; set; } // 0 = NO, 1 = in warmode, 2 = ctrl+shift, 3 = always
-        public bool AuraOnMouse { get; set; } = true;
-        public bool AnimatedWaterEffect { get; set; } = false;
+        public bool ShadowsEnabled { get; set => SetProperty(ref field, value); } = true;
+        public bool ShadowsStatics { get; set => SetProperty(ref field, value); } = true;
+        public int TerrainShadowsLevel { get; set => SetProperty(ref field, value); } = 15;
+        public int AuraUnderFeetType { get; set => SetProperty(ref field, value); } // 0 = NO, 1 = in warmode, 2 = ctrl+shift, 3 = always
+        public bool AuraOnMouse { get; set => SetProperty(ref field, value); } = true;
+        public bool AnimatedWaterEffect { get; set => SetProperty(ref field, value); } = false;
 
-        public bool PartyAura { get; set; }
+        public bool PartyAura { get; set => SetProperty(ref field, value); }
 
-        public bool HideChatGradient { get; set; } = false;
+        public bool HideChatGradient { get; set => SetProperty(ref field, value); } = false;
 
-        public bool StandardSkillsGump { get; set; } = true;
+        public bool StandardSkillsGump { get; set => SetProperty(ref field, value); } = true;
 
-        public bool ShowNewMobileNameIncoming { get; set; } = true;
-        public bool ShowNewCorpseNameIncoming { get; set; } = true;
+        public bool ShowNewMobileNameIncoming { get; set => SetProperty(ref field, value); } = true;
+        public bool ShowNewCorpseNameIncoming { get; set => SetProperty(ref field, value); } = true;
 
-        public uint GrabBagSerial { get; set; }
+        public uint GrabBagSerial { get; set => SetProperty(ref field, value); }
 
-        public int GridLootType { get; set; } // 0 = none, 1 = only grid, 2 = both
+        public int GridLootType { get; set => SetProperty(ref field, value); } // 0 = none, 1 = only grid, 2 = both
 
-        public bool ReduceFPSWhenInactive { get; set; }
+        public bool ReduceFPSWhenInactive { get; set => SetProperty(ref field, value); }
 
-        public bool EnableVSync { get; set; } = true;
+        public bool EnableVSync { get; set => SetProperty(ref field, value); } = true;
 
-        public bool OverrideAllFonts { get; set; }
-        public bool OverrideAllFontsIsUnicode { get; set; } = true;
+        public bool OverrideAllFonts { get; set => SetProperty(ref field, value); }
+        public bool OverrideAllFontsIsUnicode { get; set => SetProperty(ref field, value); } = true;
 
-        public bool SallosEasyGrab { get; set; }
+        public bool SallosEasyGrab { get; set => SetProperty(ref field, value); }
 
-        public bool JournalDarkMode { get; set; }
+        public bool JournalDarkMode { get; set => SetProperty(ref field, value); }
 
-        public byte ContainersScale { get; set; } = 100;
+        public byte ContainersScale { get; set => SetProperty(ref field, value); } = 100;
 
-        public byte ContainerOpacity { get; set; } = 50;
+        public byte ContainerOpacity { get; set => SetProperty(ref field, value); } = 50;
 
-        public bool ScaleItemsInsideContainers { get; set; }
+        public bool ScaleItemsInsideContainers { get; set => SetProperty(ref field, value); }
 
-        public bool DoubleClickToLootInsideContainers { get; set; }
+        public bool DoubleClickToLootInsideContainers { get; set => SetProperty(ref field, value); }
 
-        public bool UseLargeContainerGumps { get; set; }
+        public bool UseLargeContainerGumps { get; set => SetProperty(ref field, value); }
 
-        public bool RelativeDragAndDropItems { get; set; }
+        public bool RelativeDragAndDropItems { get; set => SetProperty(ref field, value); }
 
-        public bool HighlightContainerWhenSelected { get; set; }
+        public bool HighlightContainerWhenSelected { get; set => SetProperty(ref field, value); }
 
-        public bool UseNewTargetSystem { get; set; } = true;
-        public bool UseKrEquipUnequipPacket { get; set; }
-        public bool ShowHouseContent { get; set; }
-        public bool SaveHealthbars { get; set; }
-        public bool TextFading { get; set; } = true;
+        public bool UseNewTargetSystem { get; set => SetProperty(ref field, value); } = true;
+        public bool UseKrEquipUnequipPacket { get; set => SetProperty(ref field, value); }
+        public bool ShowHouseContent { get; set => SetProperty(ref field, value); }
+        public bool SaveHealthbars { get; set => SetProperty(ref field, value); }
+        public bool TextFading { get; set => SetProperty(ref field, value); } = true;
 
-        public bool UseSmoothBoatMovement { get; set; }
+        public bool UseSmoothBoatMovement { get; set => SetProperty(ref field, value); }
 
-        public bool IgnoreStaminaCheck { get; set; }
+        public bool IgnoreStaminaCheck { get; set => SetProperty(ref field, value); }
 
-        public bool ShowJournalClient { get; set; } = true;
-        public bool ShowJournalObjects { get; set; } = true;
-        public bool ShowJournalSystem { get; set; } = true;
-        public bool ShowJournalGuildAlly { get; set; } = true;
+        public bool ShowJournalClient { get; set => SetProperty(ref field, value); } = true;
+        public bool ShowJournalObjects { get; set => SetProperty(ref field, value); } = true;
+        public bool ShowJournalSystem { get; set => SetProperty(ref field, value); } = true;
+        public bool ShowJournalGuildAlly { get; set => SetProperty(ref field, value); } = true;
 
-        public int WorldMapWidth { get; set; } = 400;
-        public int WorldMapHeight { get; set; } = 400;
-        public int WorldMapFont { get; set; } = 3;
-        public bool WorldMapFlipMap { get; set; } = true;
-        public bool WorldMapTopMost { get; set; }
-        public bool WorldMapFreeView { get; set; }
-        public bool WorldMapShowParty { get; set; } = true;
-        public int WorldMapZoomIndex { get; set; } = 4;
-        public bool WorldMapShowCoordinates { get; set; } = true;
-        public bool WorldMapShowMouseCoordinates { get; set; } = true;
-        public bool WorldMapShowCorpse { get; set; } = true;
-        public bool WorldMapShowSextantCoordinates { get; set; } = false;
-        public bool WorldMapShowMobiles { get; set; } = true;
-        public bool WorldMapShowPlayerName { get; set; } = true;
-        public bool WorldMapShowPlayerBar { get; set; } = true;
-        public bool WorldMapShowGroupName { get; set; } = true;
-        public bool WorldMapShowGroupBar { get; set; } = true;
-        public bool WorldMapShowMarkers { get; set; } = true;
-        public bool WorldMapShowMarkersNames { get; set; } = true;
-        public bool WorldMapShowMultis { get; set; } = true;
-        public string WorldMapHiddenMarkerFiles { get; set; } = string.Empty;
-        public string WorldMapHiddenZoneFiles { get; set; } = string.Empty;
-        public bool WorldMapShowGridIfZoomed { get; set; } = true;
-        public bool WorldMapAllowPositionalTarget { get; set; } = true;
+        public int WorldMapWidth { get; set => SetProperty(ref field, value); } = 400;
+        public int WorldMapHeight { get; set => SetProperty(ref field, value); } = 400;
+        public int WorldMapFont { get; set => SetProperty(ref field, value); } = 3;
+        public bool WorldMapFlipMap { get; set => SetProperty(ref field, value); } = true;
+        public bool WorldMapTopMost { get; set => SetProperty(ref field, value); }
+        public bool WorldMapFreeView { get; set => SetProperty(ref field, value); }
+        public bool WorldMapShowParty { get; set => SetProperty(ref field, value); } = true;
+        public int WorldMapZoomIndex { get; set => SetProperty(ref field, value); } = 4;
+        public bool WorldMapShowCoordinates { get; set => SetProperty(ref field, value); } = true;
+        public bool WorldMapShowMouseCoordinates { get; set => SetProperty(ref field, value); } = true;
+        public bool WorldMapShowCorpse { get; set => SetProperty(ref field, value); } = true;
+        public bool WorldMapShowSextantCoordinates { get; set => SetProperty(ref field, value); } = false;
+        public bool WorldMapShowMobiles { get; set => SetProperty(ref field, value); } = true;
+        public bool WorldMapShowPlayerName { get; set => SetProperty(ref field, value); } = true;
+        public bool WorldMapShowPlayerBar { get; set => SetProperty(ref field, value); } = true;
+        public bool WorldMapShowGroupName { get; set => SetProperty(ref field, value); } = true;
+        public bool WorldMapShowGroupBar { get; set => SetProperty(ref field, value); } = true;
+        public bool WorldMapShowMarkers { get; set => SetProperty(ref field, value); } = true;
+        public bool WorldMapShowMarkersNames { get; set => SetProperty(ref field, value); } = true;
+        public bool WorldMapShowMultis { get; set => SetProperty(ref field, value); } = true;
+        public string WorldMapHiddenMarkerFiles { get; set => SetProperty(ref field, value); } = string.Empty;
+        public string WorldMapHiddenZoneFiles { get; set => SetProperty(ref field, value); } = string.Empty;
+        public bool WorldMapShowGridIfZoomed { get; set => SetProperty(ref field, value); } = true;
+        public bool WorldMapAllowPositionalTarget { get; set => SetProperty(ref field, value); } = true;
 
         [JsonIgnore]
         public int WebMapServerPort
@@ -358,9 +387,8 @@ namespace ClassicUO.Configuration
             get;
             set
             {
-                if (field != value)
+                if (SetProperty(ref field, value))
                     Client.Settings?.SetAsync(SettingsScope.Global, Constants.SqlSettings.WEB_MAP_PORT, value);
-                field = value;
             }
         }
 
@@ -370,63 +398,62 @@ namespace ClassicUO.Configuration
             get;
             set
             {
-                if (field != value)
+                if (SetProperty(ref field, value))
                     Client.Settings?.SetAsync(SettingsScope.Global, Constants.SqlSettings.WEB_MAP_AUTO_START, value);
-                field = value;
             }
         }
 
-        public int AutoFollowDistance { get; set; } = 1;
-        public bool DisableAutoFollowAlt { get; set; } = false;
-        [JsonConverter(typeof(Point2Converter))] public Point ResizeJournalSize { get; set; } = new Point(410, 350);
-        public bool FollowingMode { get; set; } = false;
-        public uint FollowingTarget { get; set; }
-        public bool NamePlateHealthBar { get; set; } = true;
-        public byte NamePlateOpacity { get; set; } = 75;
-        public byte NamePlateHealthBarOpacity { get; set; } = 50;
-        public bool NamePlateHideAtFullHealth { get; set; }
-        public bool NamePlateHideAtFullHealthInWarmode { get; set; }
-        public byte NamePlateBorderOpacity { get; set; } = 50;
-        public bool NamePlateAvoidOverlap { get; set; }
+        public int AutoFollowDistance { get; set => SetProperty(ref field, value); } = 1;
+        public bool DisableAutoFollowAlt { get; set => SetProperty(ref field, value); } = false;
+        [JsonConverter(typeof(Point2Converter))] public Point ResizeJournalSize { get; set => SetProperty(ref field, value); } = new Point(410, 350);
+        public bool FollowingMode { get; set => SetProperty(ref field, value); } = false;
+        public uint FollowingTarget { get; set => SetProperty(ref field, value); }
+        public bool NamePlateHealthBar { get; set => SetProperty(ref field, value); } = true;
+        public byte NamePlateOpacity { get; set => SetProperty(ref field, value); } = 75;
+        public byte NamePlateHealthBarOpacity { get; set => SetProperty(ref field, value); } = 50;
+        public bool NamePlateHideAtFullHealth { get; set => SetProperty(ref field, value); }
+        public bool NamePlateHideAtFullHealthInWarmode { get; set => SetProperty(ref field, value); }
+        public byte NamePlateBorderOpacity { get; set => SetProperty(ref field, value); } = 50;
+        public bool NamePlateAvoidOverlap { get; set => SetProperty(ref field, value); }
 
-        public bool LeftAlignToolTips { get; set; }
-        public bool ForceCenterAlignTooltipMobiles { get; set; } = true;
+        public bool LeftAlignToolTips { get; set => SetProperty(ref field, value); }
+        public bool ForceCenterAlignTooltipMobiles { get; set => SetProperty(ref field, value); } = true;
 
-        public bool CorpseSingleClickLoot { get; set; }
+        public bool CorpseSingleClickLoot { get; set => SetProperty(ref field, value); }
 
-        public bool DisableSystemChat { get; set; }
+        public bool DisableSystemChat { get; set => SetProperty(ref field, value); }
 
-        public bool UsePromptPopup { get; set; } = true;
+        public bool UsePromptPopup { get; set => SetProperty(ref field, value); } = true;
 
-        public uint SetFavoriteMoveBagSerial { get; set; }
+        public uint SetFavoriteMoveBagSerial { get; set => SetProperty(ref field, value); }
 
         #region GRID CONTAINER
-        public bool UseGridLayoutContainerGumps { get; set; } = true;
-        public bool GridContainersDefaultToOldStyleView { get; set; } = false;
-        public int GridContainerSearchMode { get; set; } = 1;
-        public bool EnableGridContainerAnchor { get; set; } = false;
-        public byte GridBorderAlpha { get; set; } = 75;
-        public ushort GridBorderHue { get; set; } = 0;
-        public byte GridContainersScale { get; set; } = 100;
-        public bool GridContainerScaleItems { get; set; } = true;
-        public bool GridEnableContPreview { get; set; } = true;
-        public int Grid_BorderStyle { get; set; } = 0;
-        public int Grid_DefaultColumns { get; set; } = 5;
-        public int Grid_DefaultRows { get; set; } = 5;
-        public bool Grid_UseContainerHue { get; set; } = false;
-        public bool Grid_HideBorder { get; set; } = false;
+        public bool UseGridLayoutContainerGumps { get; set => SetProperty(ref field, value); } = true;
+        public bool GridContainersDefaultToOldStyleView { get; set => SetProperty(ref field, value); } = false;
+        public int GridContainerSearchMode { get; set => SetProperty(ref field, value); } = 1;
+        public bool EnableGridContainerAnchor { get; set => SetProperty(ref field, value); } = false;
+        public byte GridBorderAlpha { get; set => SetProperty(ref field, value); } = 75;
+        public ushort GridBorderHue { get; set => SetProperty(ref field, value); } = 0;
+        public byte GridContainersScale { get; set => SetProperty(ref field, value); } = 100;
+        public bool GridContainerScaleItems { get; set => SetProperty(ref field, value); } = true;
+        public bool GridEnableContPreview { get; set => SetProperty(ref field, value); } = true;
+        public int Grid_BorderStyle { get; set => SetProperty(ref field, value); } = 0;
+        public int Grid_DefaultColumns { get; set => SetProperty(ref field, value); } = 5;
+        public int Grid_DefaultRows { get; set => SetProperty(ref field, value); } = 5;
+        public bool Grid_UseContainerHue { get; set => SetProperty(ref field, value); } = false;
+        public bool Grid_HideBorder { get; set => SetProperty(ref field, value); } = false;
         #endregion
 
         #region COOLDOWNS
-        public int CoolDownX { get; set; } = 50;
-        public int CoolDownY { get; set; } = 50;
+        public int CoolDownX { get; set => SetProperty(ref field, value); } = 50;
+        public int CoolDownY { get; set => SetProperty(ref field, value); } = 50;
 
-        public List<ushort> Condition_Hue { get; set; } = new List<ushort>();
-        public List<string> Condition_Label { get; set; } = new List<string>();
-        public List<int> Condition_Duration { get; set; } = new List<int>();
-        public List<string> Condition_Trigger { get; set; } = new List<string>();
-        public List<int> Condition_Type { get; set; } = new List<int>();
-        public List<bool> Condition_ReplaceIfExists { get; set; } = new List<bool>();
+        public List<ushort> Condition_Hue { get; set => SetProperty(ref field, value); } = new List<ushort>();
+        public List<string> Condition_Label { get; set => SetProperty(ref field, value); } = new List<string>();
+        public List<int> Condition_Duration { get; set => SetProperty(ref field, value); } = new List<int>();
+        public List<string> Condition_Trigger { get; set => SetProperty(ref field, value); } = new List<string>();
+        public List<int> Condition_Type { get; set => SetProperty(ref field, value); } = new List<int>();
+        public List<bool> Condition_ReplaceIfExists { get; set => SetProperty(ref field, value); } = new List<bool>();
         public int CoolDownConditionCount
         {
             get
@@ -438,162 +465,162 @@ namespace ClassicUO.Configuration
         #endregion
 
         #region IMPROVED BUFF BAR
-        public bool UseImprovedBuffBar { get; set; } = true;
-        public ushort ImprovedBuffBarHue { get; set; } = 905;
+        public bool UseImprovedBuffBar { get; set => SetProperty(ref field, value); } = true;
+        public ushort ImprovedBuffBarHue { get; set => SetProperty(ref field, value); } = 905;
         #endregion
 
         #region DAMAGE NUMBER HUES
-        public ushort DamageHueSelf { get; set; } = 0x0034;
-        public ushort DamageHuePet { get; set; } = 0x0033;
-        public ushort DamageHueAlly { get; set; } = 0x0030;
-        public ushort DamageHueLastAttck { get; set; } = 0x1F;
-        public ushort DamageHueOther { get; set; } = 0x0021;
+        public ushort DamageHueSelf { get; set => SetProperty(ref field, value); } = 0x0034;
+        public ushort DamageHuePet { get; set => SetProperty(ref field, value); } = 0x0033;
+        public ushort DamageHueAlly { get; set => SetProperty(ref field, value); } = 0x0030;
+        public ushort DamageHueLastAttck { get; set => SetProperty(ref field, value); } = 0x1F;
+        public ushort DamageHueOther { get; set => SetProperty(ref field, value); } = 0x0021;
 
-        public bool ShowDPS { get; set; } = true;
+        public bool ShowDPS { get; set => SetProperty(ref field, value); } = true;
         #endregion
 
         #region GridHighlightingProps
-        public List<string> GridHighlight_Name { get; set; } = new List<string>();
-        public List<ushort> GridHighlight_Hue { get; set; } = new List<ushort>();
-        public List<List<string>> GridHighlight_PropNames { get; set; } = new List<List<string>>();
-        public List<List<int>> GridHighlight_PropMinVal { get; set; } = new List<List<int>>();
-        public bool GridHighlight_CorpseOnly { get; set; } = false;
-        public int GridHighlightSize { get; set; } = 1;
-        public bool GridHighlightProperties { get; set; } = true;
-        public bool GridHighlightShowRuleName { get; set; } = true;
-        public List<bool> GridHighlight_AcceptExtraProperties { get; set; } = new List<bool>();
-        public List<List<bool>> GridHighlight_IsOptionalProperties { get; set; } = new List<List<bool>>();
-        public List<List<string>> GridHighlight_ExcludeNegatives { get; set; } = new List<List<string>>();
-        public List<List<string>> GridHighlight_RequiredRarities { get; set; } = new();
-        public List<GridHighlightSetupEntry> GridHighlightSetup { get; set; } = new();
-        public List<string> ConfigurableProperties { get; set; } = new();
-        public List<string> ConfigurableResistances { get; set; } = new();
-        public List<string> ConfigurableNegatives { get; set; } = new();
-        public List<string> ConfigurableSuperSlayers { get; set; } = new();
-        public List<string> ConfigurableSlayers { get; set; } = new();
-        public List<string> ConfigurableRarities { get; set; } = new();
+        public List<string> GridHighlight_Name { get; set => SetProperty(ref field, value); } = new List<string>();
+        public List<ushort> GridHighlight_Hue { get; set => SetProperty(ref field, value); } = new List<ushort>();
+        public List<List<string>> GridHighlight_PropNames { get; set => SetProperty(ref field, value); } = new List<List<string>>();
+        public List<List<int>> GridHighlight_PropMinVal { get; set => SetProperty(ref field, value); } = new List<List<int>>();
+        public bool GridHighlight_CorpseOnly { get; set => SetProperty(ref field, value); } = false;
+        public int GridHighlightSize { get; set => SetProperty(ref field, value); } = 1;
+        public bool GridHighlightProperties { get; set => SetProperty(ref field, value); } = true;
+        public bool GridHighlightShowRuleName { get; set => SetProperty(ref field, value); } = true;
+        public List<bool> GridHighlight_AcceptExtraProperties { get; set => SetProperty(ref field, value); } = new List<bool>();
+        public List<List<bool>> GridHighlight_IsOptionalProperties { get; set => SetProperty(ref field, value); } = new List<List<bool>>();
+        public List<List<string>> GridHighlight_ExcludeNegatives { get; set => SetProperty(ref field, value); } = new List<List<string>>();
+        public List<List<string>> GridHighlight_RequiredRarities { get; set => SetProperty(ref field, value); } = new();
+        public List<GridHighlightSetupEntry> GridHighlightSetup { get; set => SetProperty(ref field, value); } = new();
+        public List<string> ConfigurableProperties { get; set => SetProperty(ref field, value); } = new();
+        public List<string> ConfigurableResistances { get; set => SetProperty(ref field, value); } = new();
+        public List<string> ConfigurableNegatives { get; set => SetProperty(ref field, value); } = new();
+        public List<string> ConfigurableSuperSlayers { get; set => SetProperty(ref field, value); } = new();
+        public List<string> ConfigurableSlayers { get; set => SetProperty(ref field, value); } = new();
+        public List<string> ConfigurableRarities { get; set => SetProperty(ref field, value); } = new();
 
         #endregion
 
         #region Modern paperdoll
-        public ushort ModernPaperDollHue { get; set; } = 0;
-        public ushort ModernPaperDollDurabilityHue { get; set; } = 32;
-        public int ModernPaperDoll_DurabilityPercent { get; set; } = 90;
-        [JsonConverter(typeof(Point2Converter))] public Point ModernPaperdollPosition { get; set; } = new Point(100, 100);
+        public ushort ModernPaperDollHue { get; set => SetProperty(ref field, value); } = 0;
+        public ushort ModernPaperDollDurabilityHue { get; set => SetProperty(ref field, value); } = 32;
+        public int ModernPaperDoll_DurabilityPercent { get; set => SetProperty(ref field, value); } = 90;
+        [JsonConverter(typeof(Point2Converter))] public Point ModernPaperdollPosition { get; set => SetProperty(ref field, value); } = new Point(100, 100);
         #endregion
 
         #region Health indicator
-        public float ShowHealthIndicatorBelow { get; set; } = 0.9f;
-        public bool EnableHealthIndicator { get; set; } = true;
-        public int HealthIndicatorWidth { get; set; } = 10;
+        public float ShowHealthIndicatorBelow { get; set => SetProperty(ref field, value); } = 0.9f;
+        public bool EnableHealthIndicator { get; set => SetProperty(ref field, value); } = true;
+        public int HealthIndicatorWidth { get; set => SetProperty(ref field, value); } = 10;
         #endregion
 
-        public ushort MainWindowBackgroundHue { get; set; } = 1;
+        public ushort MainWindowBackgroundHue { get; set => SetProperty(ref field, value); } = 1;
 
-        public int MoveMultiObjectDelay { get; set; } = 1000;
+        public int MoveMultiObjectDelay { get; set => SetProperty(ref field, value); } = 1000;
 
-        public bool SpellIcon_DisplayHotkey { get; set; } = true;
-        public ushort SpellIcon_HotkeyHue { get; set; } = 1;
+        public bool SpellIcon_DisplayHotkey { get; set => SetProperty(ref field, value); } = true;
+        public ushort SpellIcon_HotkeyHue { get; set => SetProperty(ref field, value); } = 1;
 
-        public int SpellIconScale { get; set; } = 100;
+        public int SpellIconScale { get; set => SetProperty(ref field, value); } = 100;
 
-        public bool EnableAlphaScrollingOnGumps { get; set; } = true;
+        public bool EnableAlphaScrollingOnGumps { get; set => SetProperty(ref field, value); } = true;
 
-        [JsonConverter(typeof(Point2Converter))] public Point WorldMapPosition { get; set; } = new Point(100, 100);
-        [JsonConverter(typeof(Point2Converter))] public Point PaperdollPosition { get; set; } = new Point(100, 100);
-        [JsonConverter(typeof(Point2Converter))] public Point JournalPosition { get; set; } = new Point(100, 100);
-        [JsonConverter(typeof(Point2Converter))] public Point StatusGumpPosition { get; set; } = new Point(100, 100);
-        [JsonConverter(typeof(Point2Converter))] public Point BackpackGridPosition { get; set; } = new Point(100, 100);
-        [JsonConverter(typeof(Point2Converter))] public Point BackpackGridSize { get; set; } = new Point(300, 300);
-        public bool WorldMapLocked { get; set; } = false;
-        public bool PaperdollLocked { get; set; } = false;
-        public bool JournalLocked { get; set; } = false;
-        public bool StatusGumpLocked { get; set; } = false;
-        public bool BackPackLocked { get; set; } = false;
+        [JsonConverter(typeof(Point2Converter))] public Point WorldMapPosition { get; set => SetProperty(ref field, value); } = new Point(100, 100);
+        [JsonConverter(typeof(Point2Converter))] public Point PaperdollPosition { get; set => SetProperty(ref field, value); } = new Point(100, 100);
+        [JsonConverter(typeof(Point2Converter))] public Point JournalPosition { get; set => SetProperty(ref field, value); } = new Point(100, 100);
+        [JsonConverter(typeof(Point2Converter))] public Point StatusGumpPosition { get; set => SetProperty(ref field, value); } = new Point(100, 100);
+        [JsonConverter(typeof(Point2Converter))] public Point BackpackGridPosition { get; set => SetProperty(ref field, value); } = new Point(100, 100);
+        [JsonConverter(typeof(Point2Converter))] public Point BackpackGridSize { get; set => SetProperty(ref field, value); } = new Point(300, 300);
+        public bool WorldMapLocked { get; set => SetProperty(ref field, value); } = false;
+        public bool PaperdollLocked { get; set => SetProperty(ref field, value); } = false;
+        public bool JournalLocked { get; set => SetProperty(ref field, value); } = false;
+        public bool StatusGumpLocked { get; set => SetProperty(ref field, value); } = false;
+        public bool BackPackLocked { get; set => SetProperty(ref field, value); } = false;
 
-        public bool DisplayPartyChatOverhead { get; set; } = true;
+        public bool DisplayPartyChatOverhead { get; set => SetProperty(ref field, value); } = true;
 
-        public string SelectedTTFJournalFont { get; set; } = "avadonian";
-        public int SelectedJournalFontSize { get; set; } = 20;
+        public string SelectedTTFJournalFont { get; set => SetProperty(ref field, value); } = "avadonian";
+        public int SelectedJournalFontSize { get; set => SetProperty(ref field, value); } = 20;
 
-        public string SelectedToolTipFont { get; set; } = "Roboto-Regular";
-        public int SelectedToolTipFontSize { get; set; } = 20;
+        public string SelectedToolTipFont { get; set => SetProperty(ref field, value); } = "Roboto-Regular";
+        public int SelectedToolTipFontSize { get; set => SetProperty(ref field, value); } = 20;
 
-        public string GameWindowSideChatFont { get; set; } = "avadonian";
-        public int GameWindowSideChatFontSize { get; set; } = 20;
+        public string GameWindowSideChatFont { get; set => SetProperty(ref field, value); } = "avadonian";
+        public int GameWindowSideChatFontSize { get; set => SetProperty(ref field, value); } = 20;
 
-        public string OverheadChatFont { get; set; } = "avadonian";
-        public int OverheadChatFontSize { get; set; } = 20;
-        public int OverheadChatWidth { get; set; } = 400;
+        public string OverheadChatFont { get; set => SetProperty(ref field, value); } = "avadonian";
+        public int OverheadChatFontSize { get; set => SetProperty(ref field, value); } = 20;
+        public int OverheadChatWidth { get; set => SetProperty(ref field, value); } = 400;
 
-        public string NamePlateFont { get; set; } = "avadonian";
-        public int NamePlateFontSize { get; set; } = 20;
+        public string NamePlateFont { get; set => SetProperty(ref field, value); } = "avadonian";
+        public int NamePlateFontSize { get; set => SetProperty(ref field, value); } = 20;
 
-        public string OptionsFont { get; set; } = "Roboto-Regular";
-        public int OptionsFontSize { get; set; } = 18;
+        public string OptionsFont { get; set => SetProperty(ref field, value); } = "Roboto-Regular";
+        public int OptionsFontSize { get; set => SetProperty(ref field, value); } = 18;
 
-        public int TextBorderSize { get; set; } = 1;
+        public int TextBorderSize { get; set => SetProperty(ref field, value); } = 1;
 
-        public uint SavedMountSerial { get; set; } = 0;
+        public uint SavedMountSerial { get; set => SetProperty(ref field, value); } = 0;
 
-        public uint SavedMainHandSerial { get; set; } = 0;
-        public uint SavedOffHandSerial { get; set; } = 0;
+        public uint SavedMainHandSerial { get; set => SetProperty(ref field, value); } = 0;
+        public uint SavedOffHandSerial { get; set => SetProperty(ref field, value); } = 0;
 
-        public bool UseModernShopGump { get; set; } = false;
+        public bool UseModernShopGump { get; set => SetProperty(ref field, value); } = false;
 
-        public int MaxJournalEntries { get; set; } = 250;
-        public int MaxSoundEntries { get; set; } = 250;
-        public bool HideJournalBorder { get; set; } = false;
-        public bool HideJournalTimestamp { get; set; } = false;
-        public bool HideJournalSystemPrefix { get; set; } = false;
+        public int MaxJournalEntries { get; set => SetProperty(ref field, value); } = 250;
+        public int MaxSoundEntries { get; set => SetProperty(ref field, value); } = 250;
+        public bool HideJournalBorder { get; set => SetProperty(ref field, value); } = false;
+        public bool HideJournalTimestamp { get; set => SetProperty(ref field, value); } = false;
+        public bool HideJournalSystemPrefix { get; set => SetProperty(ref field, value); } = false;
 
-        public int HealthLineSizeMultiplier { get; set; } = 1;
+        public int HealthLineSizeMultiplier { get; set => SetProperty(ref field, value); } = 1;
 
-        public bool OpenHealthBarForLastAttack { get; set; } = true;
+        public bool OpenHealthBarForLastAttack { get; set => SetProperty(ref field, value); } = true;
         [JsonConverter(typeof(Point2Converter))]
-        public Point LastTargetHealthBarPos { get; set; } = Point.Zero;
-        public ushort ToolTipBGHue { get; set; } = 0;
+        public Point LastTargetHealthBarPos { get; set => SetProperty(ref field, value); } = Point.Zero;
+        public ushort ToolTipBGHue { get; set => SetProperty(ref field, value); } = 0;
 
-        public string LastVersionHistoryShown { get; set; }
+        public string LastVersionHistoryShown { get; set => SetProperty(ref field, value); }
 
-        public int AdvancedSkillsGumpHeight { get; set; } = 510;
+        public int AdvancedSkillsGumpHeight { get; set => SetProperty(ref field, value); } = 510;
 
         #region ToolTip Overrides
-        public List<string> ToolTipOverride_SearchText { get; set; } = new List<string>() { "Physical Res", "Fire Resist", "Cold Resist", "Poison Resist", "Energy Resist", "Weapon Damage" };
-        public List<string> ToolTipOverride_NewFormat { get; set; } = new List<string>() { "/c[#8c733e]Physical Resist {1}%", "/c[red]Fire Resist {1}%", "/c[teal]Cold Resist {1}%", "/c[green]Poison Resist {1}%", "/c[purple]Energy Resist {1}%", "{0} /c[orange]{1}{4} /cd- /c[red]{2}{5}" };
-        public List<int> ToolTipOverride_MinVal1 { get; set; } = new List<int>() { -1, -1, -1, -1, -1, -1 };
-        public List<int> ToolTipOverride_MinVal2 { get; set; } = new List<int>() { -1, -1, -1, -1, -1, -1 };
-        public List<int> ToolTipOverride_MaxVal1 { get; set; } = new List<int>() { 100, 100, 100, 100, 100, 100 };
-        public List<int> ToolTipOverride_MaxVal2 { get; set; } = new List<int>() { 100, 100, 100, 100, 100, 100 };
-        public List<byte> ToolTipOverride_Layer { get; set; } = new List<byte>() { (byte)TooltipLayers.Any, (byte)TooltipLayers.Any, (byte)TooltipLayers.Any, (byte)TooltipLayers.Any, (byte)TooltipLayers.Any, (byte)TooltipLayers.Any };
+        public List<string> ToolTipOverride_SearchText { get; set => SetProperty(ref field, value); } = new List<string>() { "Physical Res", "Fire Resist", "Cold Resist", "Poison Resist", "Energy Resist", "Weapon Damage" };
+        public List<string> ToolTipOverride_NewFormat { get; set => SetProperty(ref field, value); } = new List<string>() { "/c[#8c733e]Physical Resist {1}%", "/c[red]Fire Resist {1}%", "/c[teal]Cold Resist {1}%", "/c[green]Poison Resist {1}%", "/c[purple]Energy Resist {1}%", "{0} /c[orange]{1}{4} /cd- /c[red]{2}{5}" };
+        public List<int> ToolTipOverride_MinVal1 { get; set => SetProperty(ref field, value); } = new List<int>() { -1, -1, -1, -1, -1, -1 };
+        public List<int> ToolTipOverride_MinVal2 { get; set => SetProperty(ref field, value); } = new List<int>() { -1, -1, -1, -1, -1, -1 };
+        public List<int> ToolTipOverride_MaxVal1 { get; set => SetProperty(ref field, value); } = new List<int>() { 100, 100, 100, 100, 100, 100 };
+        public List<int> ToolTipOverride_MaxVal2 { get; set => SetProperty(ref field, value); } = new List<int>() { 100, 100, 100, 100, 100, 100 };
+        public List<byte> ToolTipOverride_Layer { get; set => SetProperty(ref field, value); } = new List<byte>() { (byte)TooltipLayers.Any, (byte)TooltipLayers.Any, (byte)TooltipLayers.Any, (byte)TooltipLayers.Any, (byte)TooltipLayers.Any, (byte)TooltipLayers.Any };
         #endregion
 
-        public string TooltipHeaderFormat { get; set; } = "/c[yellow]{0}";
+        public string TooltipHeaderFormat { get; set => SetProperty(ref field, value); } = "/c[yellow]{0}";
 
-        public bool DisplaySkillBarOnChange { get; set; } = true;
-        public string SkillBarFormat { get; set; } = "{0}: {1} / {2}";
+        public bool DisplaySkillBarOnChange { get; set => SetProperty(ref field, value); } = true;
+        public string SkillBarFormat { get; set => SetProperty(ref field, value); } = "{0}: {1} / {2}";
 
-        public bool DisplayRadius { get; set; } = false;
-        public int DisplayRadiusDistance { get; set; } = 10;
-        public ushort DisplayRadiusHue { get; set; } = 22;
+        public bool DisplayRadius { get; set => SetProperty(ref field, value); } = false;
+        public int DisplayRadiusDistance { get; set => SetProperty(ref field, value); } = 10;
+        public ushort DisplayRadiusHue { get; set => SetProperty(ref field, value); } = 22;
 
-        public bool EnableSpellIndicators { get; set; } = true;
+        public bool EnableSpellIndicators { get; set => SetProperty(ref field, value); } = true;
 
-        public bool EnableAutoLoot { get; set; } = false;
-        public bool AutoLootHumanCorpses { get; set; } = false;
+        public bool EnableAutoLoot { get; set => SetProperty(ref field, value); } = false;
+        public bool AutoLootHumanCorpses { get; set => SetProperty(ref field, value); } = false;
 
-        public bool ItemDatabaseEnabled { get; set; } = true;
+        public bool ItemDatabaseEnabled { get; set => SetProperty(ref field, value); } = true;
 
         public static uint GumpsVersion { get; private set; }
 
         [JsonConverter(typeof(Point2Converter))]
-        public Point InfoBarSize { get; set; } = new Point(400, 20);
-        public bool InfoBarLocked { get; set; } = false;
-        public string InfoBarFont { get; set; } = "Roboto-Regular";
-        public int InfoBarFontSize { get; set; } = 18;
+        public Point InfoBarSize { get; set => SetProperty(ref field, value); } = new Point(400, 20);
+        public bool InfoBarLocked { get; set => SetProperty(ref field, value); } = false;
+        public string InfoBarFont { get; set => SetProperty(ref field, value); } = "Roboto-Regular";
+        public int InfoBarFontSize { get; set => SetProperty(ref field, value); } = 18;
 
-        public int LastJournalTab { get; set; } = 0;
-        public Dictionary<string, MessageType[]> JournalTabs { get; set; } = new Dictionary<string, MessageType[]>()
+        public int LastJournalTab { get; set => SetProperty(ref field, value); } = 0;
+        public Dictionary<string, MessageType[]> JournalTabs { get; set => SetProperty(ref field, value); } = new Dictionary<string, MessageType[]>()
         {
             { "All", new MessageType[] {
                 MessageType.Alliance, MessageType.Command, MessageType.Emote,
@@ -624,77 +651,88 @@ namespace ClassicUO.Configuration
             }
         };
 
-        public bool UseLastMovedCooldownPosition { get; set; } = true;
-        public bool CloseHealthBarIfAnchored { get; set; } = false;
+        public bool UseLastMovedCooldownPosition { get; set => SetProperty(ref field, value); } = true;
+        public bool CloseHealthBarIfAnchored { get; set => SetProperty(ref field, value); } = false;
 
         [JsonConverter(typeof(Point2Converter))]
-        public Point SkillProgressBarPosition { get; set; } = Point.Zero;
+        public Point SkillProgressBarPosition { get; set => SetProperty(ref field, value); } = Point.Zero;
 
-        public bool ForceResyncOnHang { get; set; } = false;
+        public bool ForceResyncOnHang { get; set => SetProperty(ref field, value); } = false;
 
-        public bool UseOneHPBarForLastAttack { get; set; } = true;
+        public bool UseOneHPBarForLastAttack { get; set => SetProperty(ref field, value); } = true;
 
-        public bool DisableMouseInteractionOverheadText { get; set; } = false;
+        public bool DisableMouseInteractionOverheadText { get; set => SetProperty(ref field, value); } = false;
 
-        public bool HiddenLayersEnabled { get; set; } = false;
-        public List<int> HiddenLayers { get; set; } = new List<int>();
-        public bool HideLayersForSelf { get; set; } = true;
+        public bool HiddenLayersEnabled { get; set => SetProperty(ref field, value); } = false;
+        public List<int> HiddenLayers { get; set => SetProperty(ref field, value); } = new List<int>();
+        public bool HideLayersForSelf { get; set => SetProperty(ref field, value); } = true;
 
-        public List<string> AutoOpenXmlGumps { get; set; } = new List<string>();
+        public List<string> AutoOpenXmlGumps { get; set => SetProperty(ref field, value); } = new List<string>();
 
-        public int ControllerMouseSensativity { get => Input.Mouse.ControllerSensativity; set => Input.Mouse.ControllerSensativity = value; }
+        public int ControllerMouseSensitivity
+        {
+            get => Input.Mouse.ControllerSensativity;
+            set
+            {
+                if (Input.Mouse.ControllerSensativity != value)
+                {
+                    Input.Mouse.ControllerSensativity = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
 
         [JsonConverter(typeof(Point2Converter))]
-        public Point PlayerOffset { get; set; } = new Point(0, 0);
+        public Point PlayerOffset { get; set => SetProperty(ref field, value); } = new Point(0, 0);
 
-        public float CameraSmoothingFactor { get; set; } = 0f;
+        public float CameraSmoothingFactor { get; set => SetProperty(ref field, value); } = 0f;
 
-        public double PaperdollScale { get; set; } = 1f;
+        public double PaperdollScale { get; set => SetProperty(ref field, value); } = 1f;
 
-        public uint SOSGumpID { get; set; } = 1915258020;
+        public uint SOSGumpID { get; set => SetProperty(ref field, value); } = 1915258020;
 
-        public bool ModernPaperdollAnchorEnabled { get; set; }
-        public bool JournalAnchorEnabled { get; set; } = false;
-        public bool EnableAutoLootProgressBar { get; set; } = true;
-        public bool UseWASDInsteadArrowKeys { get; set; }
-        public int NearbyLootGumpHeight { get; set; } = 550;
-        public bool ForceTooltipsOnOldClients { get; set; } = true;
-        public bool NearbyLootOpensHumanCorpses { get; set; }
-        public ushort TurnDelay { get; set; } = 100;
-        public bool SellAgentEnabled { get; set; }
-        public int SellAgentMaxUniques { get; set; } = 50;
-        public int SellAgentMaxItems { get; set; } = 0;
-        public bool BuyAgentEnabled { get; set; }
-        public int BuyAgentMaxUniques { get; set; } = 50;
-        public int BuyAgentMaxItems { get; set; } = 0;
-        public bool BuyAgentSubContainers { get; set; } = true;
-        public bool DisableTargetingGridContainers { get; set; }
-        public bool ControllerEnabled { get; set; } = true;
-        public bool EnableScavenger { get; set; } = true;
-        public bool CounterGumpLocked { get; set; }
-        public bool NearbyLootConcealsContainerOnOpen { get; set; } = true;
-        public bool SpellBar_ShowHotkeys { get; set; } = true;
-        public byte ForcedHouseTransparency { get;  set; } = 40;
-        public ushort ForcedTransparencyHouseTileHue { get; set; } = 0;
-        public bool ForceHouseTransparency { get; set; }
-        public ulong HideHudGumpFlags { get; set; }
-        public bool DisableGrayEnemies { get; set; }
-        public bool EnablePostProcessingEffects { get; set; }
-        public ushort PostProcessingType { get; set; }
-        public bool DisableHotkeys { get; set; }
-        public bool DisableDismountInWarMode { get; set; } = true;
-        public bool EnableASyncMapLoading { get; set; } = true;
+        public bool ModernPaperdollAnchorEnabled { get; set => SetProperty(ref field, value); }
+        public bool JournalAnchorEnabled { get; set => SetProperty(ref field, value); } = false;
+        public bool EnableAutoLootProgressBar { get; set => SetProperty(ref field, value); } = true;
+        public bool UseWASDInsteadArrowKeys { get; set => SetProperty(ref field, value); }
+        public int NearbyLootGumpHeight { get; set => SetProperty(ref field, value); } = 550;
+        public bool ForceTooltipsOnOldClients { get; set => SetProperty(ref field, value); } = true;
+        public bool NearbyLootOpensHumanCorpses { get; set => SetProperty(ref field, value); }
+        public ushort TurnDelay { get; set => SetProperty(ref field, value); } = 100;
+        public bool SellAgentEnabled { get; set => SetProperty(ref field, value); }
+        public int SellAgentMaxUniques { get; set => SetProperty(ref field, value); } = 50;
+        public int SellAgentMaxItems { get; set => SetProperty(ref field, value); } = 0;
+        public bool BuyAgentEnabled { get; set => SetProperty(ref field, value); }
+        public int BuyAgentMaxUniques { get; set => SetProperty(ref field, value); } = 50;
+        public int BuyAgentMaxItems { get; set => SetProperty(ref field, value); } = 0;
+        public bool BuyAgentSubContainers { get; set => SetProperty(ref field, value); } = true;
+        public bool DisableTargetingGridContainers { get; set => SetProperty(ref field, value); }
+        public bool ControllerEnabled { get; set => SetProperty(ref field, value); } = true;
+        public bool EnableScavenger { get; set => SetProperty(ref field, value); } = true;
+        public bool CounterGumpLocked { get; set => SetProperty(ref field, value); }
+        public bool NearbyLootConcealsContainerOnOpen { get; set => SetProperty(ref field, value); } = true;
+        public bool SpellBar_ShowHotkeys { get; set => SetProperty(ref field, value); } = true;
+        public byte ForcedHouseTransparency { get; set => SetProperty(ref field, value); } = 40;
+        public ushort ForcedTransparencyHouseTileHue { get; set => SetProperty(ref field, value); } = 0;
+        public bool ForceHouseTransparency { get; set => SetProperty(ref field, value); }
+        public ulong HideHudGumpFlags { get; set => SetProperty(ref field, value); }
+        public bool DisableGrayEnemies { get; set => SetProperty(ref field, value); }
+        public bool EnablePostProcessingEffects { get; set => SetProperty(ref field, value); }
+        public ushort PostProcessingType { get; set => SetProperty(ref field, value); }
+        public bool DisableHotkeys { get; set => SetProperty(ref field, value); }
+        public bool DisableDismountInWarMode { get; set => SetProperty(ref field, value); } = true;
+        public bool EnableASyncMapLoading { get; set => SetProperty(ref field, value); } = true;
 
         public string TazUOChatNick
         {
             get
             {
                 if (field == null)
-                    field = TazUOChatManager.GenerateFantasyName(2, 3);
+                    SetProperty(ref field, TazUOChatManager.GenerateFantasyName(2, 3));
 
                 return field;
             }
-            set;
+            set => SetProperty(ref field, value);
         }
 
         // SQL-backed settings — property implementations are source-generated into Profile.SqlSettings.g.cs
@@ -749,10 +787,8 @@ namespace ClassicUO.Configuration
             get;
             set
             {
-                if (field != value)
+                if (SetProperty(ref field, value))
                     _ = Client.Settings.SetAsync(SettingsScope.Global, Constants.SqlSettings.OUTLINE_NOTORIETIES, value);
-
-                field = value;
             }
         }
 
@@ -763,13 +799,11 @@ namespace ClassicUO.Configuration
             get;
             set
             {
-                if (field != value)
+                if (SetProperty(ref field, value))
                     _ = Client.Settings.SetAsync(SettingsScope.Global, Constants.SqlSettings.IRC_AUTO_CONNECT, value);
 
                 // if(value && !TazUOChatManager.Instance.IsConnected)
                 //     TazUOChatManager.Instance.Init();
-
-                field = value;
             }
         }
 

--- a/src/ClassicUO.Client/Configuration/ProfileManager.cs
+++ b/src/ClassicUO.Client/Configuration/ProfileManager.cs
@@ -1,5 +1,7 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
+using System;
+using System.ComponentModel;
 using System.IO;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.UI.Gumps.GridHighLight;
@@ -10,6 +12,17 @@ namespace ClassicUO.Configuration
 {
     internal static class ProfileManager
     {
+        /// <summary>
+        /// Occurs when the current <see cref="Profile"/> has changed.
+        /// Currently, this happens only during world creation/destruction, i.e., once per login.
+        /// </summary>
+        public static event EventHandler CurrentProfileChanged;
+
+        /// <summary>
+        /// Occurs when a property of the current <see cref="Profile"/> has changed.
+        /// </summary>
+        public static event PropertyChangedEventHandler CurrentProfilePropertyChanged;
+
         static ProfileManager()
         {
             // Subscribe to player creation event to load Char-scoped settings
@@ -20,7 +33,29 @@ namespace ClassicUO.Configuration
             // Load Char-scoped settings after player is created (when serial is available)
             CurrentProfile?.LoadCharScopedSettings();
 
-        public static Profile CurrentProfile { get; private set; }
+        public static Profile CurrentProfile
+        {
+            get;
+            private set
+            {
+                if (field == value)
+                    return;
+
+                // If we had a profile, unregister the event first
+                if (field != null)
+                    field.PropertyChanged -= OnCurrentProfilePropertyChanged;
+
+                field = value;
+
+                // Register the event on the new value
+                if (field != null)
+                    field.PropertyChanged += OnCurrentProfilePropertyChanged;
+
+                // Notify that the profile itself has changed (as opposed to a profile 'setting'
+                CurrentProfileChanged?.Invoke(null, EventArgs.Empty);
+            }
+        }
+
         public static string ProfilePath { get; private set; }
 
         public static string RootPath
@@ -106,5 +141,7 @@ namespace ClassicUO.Configuration
         }
 
         public static void UnLoadProfile() => CurrentProfile = null;
+
+        private static void OnCurrentProfilePropertyChanged(object sender, PropertyChangedEventArgs e) => CurrentProfilePropertyChanged?.Invoke(sender, e);
     }
 }

--- a/src/ClassicUO.Client/Game/GameActions.cs
+++ b/src/ClassicUO.Client/Game/GameActions.cs
@@ -4,6 +4,7 @@ using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.Managers;
+using ClassicUO.Game.Managers.SpellVisualRange;
 using ClassicUO.Game.Managers.Structs;
 using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI;

--- a/src/ClassicUO.Client/Game/GameObjects/PlayerMobile.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/PlayerMobile.cs
@@ -41,10 +41,6 @@ namespace ClassicUO.Game.GameObjects
                 }
             };
 
-
-            if(ProfileManager.CurrentProfile != null && ProfileManager.CurrentProfile.EnableSpellIndicators)
-                UIManager.Add(new CastTimerProgressBar(world));
-
             IsPlayer = true;
         }
 

--- a/src/ClassicUO.Client/Game/GameObjects/Views/LandView.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Views/LandView.cs
@@ -1,12 +1,10 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
-using ClassicUO.Assets;
-using ClassicUO.Configuration;
-using ClassicUO.Game.Managers;
 using ClassicUO.Renderer;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
+using ClassicUO.Game.Managers.SpellVisualRange;
 
 namespace ClassicUO.Game.GameObjects
 {

--- a/src/ClassicUO.Client/Game/GameObjects/Views/StaticView.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Views/StaticView.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using ClassicUO.Game.Data;
-using ClassicUO.Game.Managers;
+using ClassicUO.Game.Managers.SpellVisualRange;
 using ClassicUO.Game.Scenes;
 using ClassicUO.Renderer;
 using Microsoft.Xna.Framework;

--- a/src/ClassicUO.Client/Game/Managers/SpellVisualRange/SpellVisualRangeManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/SpellVisualRange/SpellVisualRangeManager.cs
@@ -4,15 +4,15 @@ using ClassicUO.Game.GameObjects;
 using Microsoft.Xna.Framework;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text.Json;
 using System.Threading.Tasks;
-using ClassicUO.Game.Managers.SpellVisualRange;
 using Timer = System.Timers.Timer;
 
-namespace ClassicUO.Game.Managers
+namespace ClassicUO.Game.Managers.SpellVisualRange
 {
     using Utility.Logging;
 
@@ -36,6 +36,11 @@ namespace ClassicUO.Game.Managers
 
         private bool isCasting { get; set; } = false;
         private SpellRangeInfo currentSpell { get; set; }
+
+        /// <summary>
+        /// An instance of a cast timer bar. May be null, depending on profile settings
+        /// </summary>
+        private static CastTimerProgressBar _castTimerBar;
 
         //Taken from Dust client
         private static readonly int[] stopAtClilocs = new int[]
@@ -105,14 +110,51 @@ namespace ClassicUO.Game.Managers
         public SpellRangeInfo GetCurrentSpell() => currentSpell;
 
         #region Load and unload
-        public void OnSceneLoad() => EventSink.RawMessageReceived += OnRawMessageReceived;
+
+        public void OnSceneLoad()
+        {
+            EventSink.RawMessageReceived += OnRawMessageReceived;
+
+            // Register a settings listener so we can dynamically enable/disable the spell progress bar
+            ProfileManager.CurrentProfilePropertyChanged += UpdateSpellProgressBarPresence;
+            UpdateSpellProgressBarPresence(null, new PropertyChangedEventArgs(nameof(Profile.EnableSpellIndicators)));
+        }
 
         public void OnSceneUnload()
         {
             EventSink.RawMessageReceived -= OnRawMessageReceived;
+
+            // Remove settings listener. Leave gump destruction to UI Mgr. disposal.
+            ProfileManager.CurrentProfilePropertyChanged -= UpdateSpellProgressBarPresence;
+
             instance = null;
+
         }
         #endregion
+
+        /// <summary>
+        /// Adds/removes the spell progress bar, depending on current configuration
+        /// </summary>
+        /// <param name="sender">The event's source; Effectivly always null</param>
+        /// <param name="e">The event args. Used to ignore irrelevant updates</param>
+        private void UpdateSpellProgressBarPresence(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName != nameof(Profile.EnableSpellIndicators))
+                return;
+
+            if (ProfileManager.CurrentProfile?.EnableSpellIndicators != true)
+            {
+                _castTimerBar?.Dispose();
+                _castTimerBar = null;
+                return;
+            }
+
+            if (_castTimerBar is { IsDisposed: false })
+                return;
+
+            _castTimerBar = new CastTimerProgressBar(World);
+            UIManager.Add(_castTimerBar);
+        }
 
         public bool IsTargetingAfterCasting()
         {

--- a/src/ClassicUO.Client/Game/Managers/UIManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/UIManager.cs
@@ -473,22 +473,22 @@ namespace ClassicUO.Game.Managers
 
         public static void Add(IGui gump, bool front = true)
         {
-            if (!gump.IsDisposed)
+            if (gump.IsDisposed)
+                return;
+
+            if (front)
             {
-                if (front)
-                {
-                    Gumps.AddFirst(gump);
-                    TopMostControl = gump; // Set the gump as the top-most so Myra's aware of it
-                }
-                else
-                {
-                    Gumps.AddLast(gump);
-                }
-
-                _needSort = Gumps.Count > 1;
-
-                RegisterGump(gump);
+                Gumps.AddFirst(gump);
+                TopMostControl = gump; // Set the gump as the top-most so Myra's aware of it
             }
+            else
+            {
+                Gumps.AddLast(gump);
+            }
+
+            _needSort = Gumps.Count > 1;
+
+            RegisterGump(gump);
         }
 
         public static void Clear()

--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -20,6 +20,7 @@ using SDL3;
 using System;
 using System.Collections.Generic;
 using System.Net.Sockets;
+using ClassicUO.Game.Managers.SpellVisualRange;
 using ClassicUO.Game.Map;
 using ClassicUO.Game.UI.Gumps.GridHighLight;
 using ClassicUO.LegionScripting;

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
@@ -4334,7 +4334,7 @@ namespace ClassicUO.Game.UI.Gumps
             (
                 new SliderWithLabel
                 (lang.GetTazUO.MouseSesitivity, 0, ThemeSettings.SLIDER_WIDTH, 1, 20,
-                    profile.ControllerMouseSensitivity, (i) => { profile.ControllerMouseSensitivity = i; }),
+                    profile.ControllerMouseSensativity, (i) => { profile.ControllerMouseSensativity = i; }),
                 true, page
             );
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
@@ -16,6 +16,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using ClassicUO.Common.Enums;
+using ClassicUO.Game.Managers.SpellVisualRange;
 using ClassicUO.Game.UI.Gumps.GridHighLight;
 using static ClassicUO.Configuration.ProfileManager;
 
@@ -4333,7 +4334,7 @@ namespace ClassicUO.Game.UI.Gumps
             (
                 new SliderWithLabel
                 (lang.GetTazUO.MouseSesitivity, 0, ThemeSettings.SLIDER_WIDTH, 1, 20,
-                    profile.ControllerMouseSensativity, (i) => { profile.ControllerMouseSensativity = i; }),
+                    profile.ControllerMouseSensitivity, (i) => { profile.ControllerMouseSensitivity = i; }),
                 true, page
             );
 

--- a/src/ClassicUO.Client/Input/Mouse.cs
+++ b/src/ClassicUO.Client/Input/Mouse.cs
@@ -153,7 +153,7 @@ namespace ClassicUO.Input
 
         public static bool MouseInWindow { get; set; }
 
-        public static int ControllerSensativity { get; set; } = 10;
+        public static int ControllerSensitivity { get; set; } = 10;
 
         private static bool _isWarpingMouse = false;
 
@@ -180,8 +180,8 @@ namespace ClassicUO.Input
 
                 if (gamePadState.IsConnected && gamePadState.ThumbSticks.Right != Vector2.Zero)
                 {
-                    Position.X += (int)(ControllerSensativity * gamePadState.ThumbSticks.Right.X);
-                    Position.Y -= (int)(ControllerSensativity * gamePadState.ThumbSticks.Right.Y);
+                    Position.X += (int)(ControllerSensitivity * gamePadState.ThumbSticks.Right.X);
+                    Position.Y -= (int)(ControllerSensitivity * gamePadState.ThumbSticks.Right.Y);
 
                     _isWarpingMouse = true;
                     SDL.SDL_WarpMouseInWindow(Client.Game.Window.Handle, Position.X, Position.Y);

--- a/src/ClassicUO.Client/Network/PacketHandlers/DisplayClilocString.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers/DisplayClilocString.cs
@@ -4,6 +4,7 @@ using ClassicUO.Game;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.Managers;
+using ClassicUO.Game.Managers.SpellVisualRange;
 using ClassicUO.Game.UI;
 using ClassicUO.Game.UI.Gumps;
 using ClassicUO.IO;

--- a/src/ClassicUO.Client/Network/PacketHandlers/UpdateHitpoints.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers/UpdateHitpoints.cs
@@ -1,6 +1,7 @@
 using ClassicUO.Game;
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.Managers;
+using ClassicUO.Game.Managers.SpellVisualRange;
 using ClassicUO.IO;
 
 namespace ClassicUO.Network.PacketHandlers;

--- a/src/ClassicUO.SourceGenerators/SqlSettingGenerator.cs
+++ b/src/ClassicUO.SourceGenerators/SqlSettingGenerator.cs
@@ -272,8 +272,11 @@ namespace ClassicUO.Configuration
                 sb.AppendLine("            set");
                 sb.AppendLine("            {");
                 sb.AppendLine("                if (field != value)");
+                sb.AppendLine("                {");
                 sb.AppendLine($"                    _ = Client.Settings.SetAsync(SettingsScope.{scopeName}, \"{m.Key}\", value);");
-                sb.AppendLine("                field = value;");
+                sb.AppendLine("                    field = value;");
+                sb.AppendLine("                    OnPropertyChanged();");
+                sb.AppendLine("                }");
                 sb.AppendLine("            }");
 
                 if (IsNonDefaultValue(m.TypeName, m.DefaultValueLiteral))


### PR DESCRIPTION
## Description
Addresses an issue in which the `CastTimerProgressBar` is never shown, regardless of setting

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Documentation update

## Testing
Local + debugging

## Additional Notes

* Rendered `Profile` observable to allow listening in on configuration changes
* Changes to the `EnableSpellIndicators` setting no longer require a logout/login to take effect
* Aligned the namespace for `SpellVisuralRangeManager`
* Minor code cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Spell cast progress indicator can now be dynamically toggled based on profile settings.

* **Bug Fixes**
  * Fixed controller mouse sensitivity slider to properly apply setting changes.

* **Refactor**
  * Enhanced internal property notification system for improved real-time responsiveness to setting changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->