### PR TITLE
fix: Standardize game window title

### DIFF
--- a/src/ClassicUO.Client/GameController.cs
+++ b/src/ClassicUO.Client/GameController.cs
@@ -61,6 +61,8 @@ namespace ClassicUO
         }
 #endif
 
+        private static string DefaultWindowTitle => $"[TazUO - {CUOEnviroment.Version}]";
+
         public GameController(IPluginHost pluginHost)
         {
             GraphicManager = new GraphicsDeviceManager(this);
@@ -75,7 +77,7 @@ namespace ClassicUO
 
             Window.ClientSizeChanged += WindowOnClientSizeChanged;
             Window.AllowUserResizing = true;
-            Window.Title = $"TazUO - {CUOEnviroment.Version}";
+            Window.Title = DefaultWindowTitle;
             IsMouseVisible = Settings.GlobalSettings.RunMouseInASeparateThread;
 
             IsFixedTimeStep = false; // Settings.GlobalSettings.FixedTimeStep;
@@ -267,7 +269,7 @@ namespace ClassicUO
 #if DEV_BUILD
                 Window.Title = $"TazUO [dev] - {CUOEnviroment.Version}";
 #else
-                Window.Title = $"[TazUO {CUOEnviroment.Version}]";
+                Window.Title = DefaultWindowTitle;
 #endif
             }
             else
@@ -275,7 +277,7 @@ namespace ClassicUO
 #if DEV_BUILD
                 Window.Title = $"{title} - TazUO [dev] - {CUOEnviroment.Version}";
 #else
-                Window.Title = $"{title} - [TazUO {CUOEnviroment.Version}]";
+                Window.Title = $"{title} - {DefaultWindowTitle}";
 #endif
             }
         }


### PR DESCRIPTION
## Description
Standardize client window title to ` $"[TazUO - {CUOEnviroment.Version}]"`

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing
Cursory login/logout

## Additional Notes

* OCD fix. [Discord message here](https://discord.com/channels/1344851225538986064/1345866311716311080/1503349409050660994)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized window title formatting for consistency across the application.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PlayTazUO/TazUO/pull/465)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->