### PR TITLE
fix: House builder stair erasure behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to TazUO will be recorded here.
 * Crash when using the Plugin API's UsePrimaryAbility/UseSecondaryAbility methods - [P.R 461](https://github.com/PlayTazUO/TazUO/pull/461) ([yuval-po](https://github.com/yuval-po))
 * HTML control text dispalyed in GridLootGump name label in UO POL based servers - [P.R 462](https://github.com/PlayTazUO/TazUO/pull/462) ([yuval-po](https://github.com/yuval-po) & [bittiez](https://github.com/bittiez))
 * Spell progress indicator never shows - [P.R 464](https://github.com/PlayTazUO/TazUO/pull/464) ([yuval-po](https://github.com/yuval-po))
+* Allow deletion of individual pieces of house stairs - [P.R 466](https://github.com/PlayTazUO/TazUO/pull/466) ([yuval-po](https://github.com/yuval-po))
 * Add missing Shirt and Kilt slot to paperdoll - [P.R 467](https://github.com/PlayTazUO/TazUO/pull/467) ([yuval-po](https://github.com/yuval-po))
 * Two Modern Paperdoll issues (closure and context menus) - [P.R 468](https://github.com/PlayTazUO/TazUO/pull/468) ([yuval-po](https://github.com/yuval-po))
 

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.1.14</AssemblyVersion>
-    <FileVersion>5.1.14</FileVersion>
+    <AssemblyVersion>5.1.15</AssemblyVersion>
+    <FileVersion>5.1.15</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Common/Point3D.cs
+++ b/src/ClassicUO.Client/Common/Point3D.cs
@@ -1,3 +1,9 @@
 namespace ClassicUO.Common;
 
+/// <summary>
+/// Represents a 3D point in the world
+/// </summary>
+/// <param name="X">The X coordinate of the point</param>
+/// <param name="Y">The Y coordinate of the point</param>
+/// <param name="Z">The Z coordinate of the point</param>
 public record struct Point3D(int X, int Y, int Z);

--- a/src/ClassicUO.Client/Common/Point3D.cs
+++ b/src/ClassicUO.Client/Common/Point3D.cs
@@ -1,0 +1,3 @@
+namespace ClassicUO.Common;
+
+public record struct Point3D(int X, int Y, int Z);

--- a/src/ClassicUO.Client/Game/Managers/HouseCustomizationManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/HouseCustomizationManager.cs
@@ -29,6 +29,8 @@ namespace ClassicUO.Game.Managers
 
     public sealed class HouseCustomizationManager
     {
+        private const int FLOOR_HEIGHT = 20;
+
         public readonly List<CustomHouseWallCategory> Walls = new List<CustomHouseWallCategory>();
         public readonly List<CustomHouseFloor> Floors = new List<CustomHouseFloor>();
         public readonly List<CustomHouseDoor> Doors = new List<CustomHouseDoor>();
@@ -121,9 +123,13 @@ namespace ClassicUO.Game.Managers
 
             MaxComponets = FloorCount * (componentsOnFloor + 2 * (plotWidth + plotHeight) - 4) - (int) (FloorCount * componentsOnFloor * -0.25) + 2 * plotWidth + 3 * plotHeight - 5;
 
-            MaxFixtures = MaxComponets / 20;
+            MaxFixtures = MaxComponets / FLOOR_HEIGHT;
         }
 
+        /// <summary>
+        /// Generates the visual state and validates the placement of all components in the custom house.
+        /// This includes identifying floors, stairs, roofs, and fixtures, and updating their rendering state based on visibility settings.
+        /// </summary>
         public void GenerateFloorPlace()
         {
             Item foundationItem = _world.Items.Get(Serial);
@@ -133,6 +139,7 @@ namespace ClassicUO.Game.Managers
                 return;
             }
 
+            // Clear previously generated internal components
             house.ClearCustomHouseComponents(CUSTOM_HOUSE_MULTI_OBJECT_FLAGS.CHMOF_GENERIC_INTERNAL);
 
             foreach (Multi item in house.Components)
@@ -148,18 +155,19 @@ namespace ClassicUO.Game.Managers
 
                 bool ignore = false;
 
+                // Determine which floor the item belongs to
                 for (int i = 0; i < 4; i++)
                 {
                     int offset = 0 /*i != 0 ? 0 : 7*/;
 
-                    if (itemZ >= floorZ - offset && itemZ < floorZ + 20)
+                    if (itemZ >= floorZ - offset && itemZ < floorZ + FLOOR_HEIGHT)
                     {
                         currentFloor = i;
 
                         break;
                     }
 
-                    floorZ += 20;
+                    floorZ += FLOOR_HEIGHT;
                 }
 
                 if (currentFloor == -1)
@@ -173,6 +181,7 @@ namespace ClassicUO.Game.Managers
 
                 CUSTOM_HOUSE_MULTI_OBJECT_FLAGS state = item.State;
 
+                // Identify if the item is a floor and update its vision state
                 if (floorCheck1 != -1 && floorCheck2 != -1)
                 {
                     state |= CUSTOM_HOUSE_MULTI_OBJECT_FLAGS.CHMOF_FLOOR;
@@ -189,6 +198,7 @@ namespace ClassicUO.Game.Managers
                 }
                 else
                 {
+                    // Identify other component types (stairs, roofs, fixtures)
                     (int stairCheck1, int stairCheck2) = SeekGraphicInCustomHouseObjectList(Stairs, item.Graphic);
 
                     if (stairCheck1 != -1 && stairCheck2 != -1)
@@ -223,6 +233,7 @@ namespace ClassicUO.Game.Managers
                         }
                     }
 
+                    // Apply general vision states for non-floor content
                     if (!ignore)
                     {
                         if (FloorVisionState[currentFloor] == (int) CUSTOM_HOUSE_FLOOR_VISION_STATE.CHGVS_HIDE_CONTENT)
@@ -315,13 +326,14 @@ namespace ClassicUO.Game.Managers
             var validatedFloors = new List<Point>();
             for (int i = 0; i < FloorCount; i++)
             {
-                int minZ = foundationItem.Z + 7 + i * 20;
-                int maxZ = minZ + 20;
+                int minZ = foundationItem.Z + 7 + i * FLOOR_HEIGHT;
+                int maxZ = minZ + FLOOR_HEIGHT;
 
                 for (int j = 0; j < 2; j++)
                 {
                     validatedFloors.Clear();
 
+                    // First pass: validate items on each floor
                     for (int x = _bounds.X; x < EndPos.X + 1; x++)
                     {
                         for (int y = _bounds.Y; y < EndPos.Y + 1; y++)
@@ -387,6 +399,7 @@ namespace ClassicUO.Game.Managers
 
                     if (i != 0 && j == 0)
                     {
+                        // Re-validate floor items based on connectivity (validatedFloors)
                         foreach (Point point in validatedFloors)
                         {
                             IEnumerable<Multi> multi = house.GetMultiAt(point.X, point.Y);
@@ -405,6 +418,7 @@ namespace ClassicUO.Game.Managers
                             }
                         }
 
+                        // Fill in floor gaps for validation
                         for (int x = _bounds.X; x < EndPos.X + 1; x++)
                         {
                             int minY = 0, maxY = 0;
@@ -623,7 +637,7 @@ namespace ClassicUO.Game.Managers
                 }
             }
 
-            z = foundationItem.Z + 7 + 20;
+            z = foundationItem.Z + 7 + FLOOR_HEIGHT;
 
             ushort color = 0x0051;
 
@@ -651,399 +665,533 @@ namespace ClassicUO.Game.Managers
                 }
 
                 color += 5;
-                z += 20;
+                z += FLOOR_HEIGHT;
             }
 
         }
 
+        /// <summary>
+        /// Handles the target event when clicking on the world during house customization.
+        /// This can either seek a tile graphic, erase an existing component, or build a new one.
+        /// </summary>
+        /// <param name="place">The game object that was targeted.</param>
         public void OnTargetWorld(GameObject place)
         {
-            if (place == null /*&& place is Multi m*/)
+            // Check whether the action is in the house's premises
+            if (place == null || !_bounds.Contains(place.X, place.Y))
+                return;
+
+            if (SeekTile && place is Multi)
             {
+                SeekGraphic(place.Graphic);
                 return;
             }
 
-            if (!_bounds.Contains(place.X, place.Y))
+            // Apply a minor offset for roof tiles
+            int zOffset = CurrentFloor == 1 ? -7 : -3;
+            if (place.Z < _world.Player.Z + zOffset || place.Z >= _world.Player.Z + FLOOR_HEIGHT)
                 return;
 
-            // apply a minor offset for roof tiles
-            int zOffset = -3;
+            Item foundationItem = _world.Items.Get(Serial);
+            if (foundationItem == null || !_world.HouseManager.TryGetHouse(Serial, out House house))
+                return;
+
+            if (Erasing && !ProcessErasing(place, house, foundationItem))
+                return;
 
             HouseCustomizationGump gump = UIManager.GetGump<HouseCustomizationGump>(Serial);
+            if (SelectedGraphic != 0)
+                ProcessBuilding(place, house, foundationItem, gump);
 
-            if (CurrentFloor == 1)
+            GenerateFloorPlace();
+            gump.Update();
+        }
+
+        /// <summary>
+        /// Processes the erasure of a component at the targeted location.
+        /// </summary>
+        /// <param name="place">The targeted game object to erase.</param>
+        /// <param name="house">The house object containing the component.</param>
+        /// <param name="foundationItem">The foundation item of the house.</param>
+        /// <returns>True if erasure was processed; otherwise, false.</returns>
+        private bool ProcessErasing(GameObject place, House house, Item foundationItem)
+        {
+            if (place is not Multi)
+                return false;
+
+            if (!CanEraseHere(place, out CUSTOM_HOUSE_BUILD_TYPE type))
+                return true;
+
+            IEnumerable<Multi> multi = house.GetMultiAt(place.X, place.Y);
+
+            if (multi?.Any() != true)
+                return false;
+
+            int z = 7 + (CurrentFloor - 1) * FLOOR_HEIGHT;
+
+            // Adjust Z for stair or roof erasure to match the target's actual Z
+            if (type is CUSTOM_HOUSE_BUILD_TYPE.CHBT_STAIR or CUSTOM_HOUSE_BUILD_TYPE.CHBT_ROOF)
+                z = place.Z - (foundationItem.Z + z) + z;
+
+            switch (type)
             {
-                zOffset = -7;
+                case CUSTOM_HOUSE_BUILD_TYPE.CHBT_STAIR:
+                    EraseStair(place, house, foundationItem, z);
+                    break;
+                case CUSTOM_HOUSE_BUILD_TYPE.CHBT_ROOF:
+                    EraseRoof(place, foundationItem, z);
+                    break;
+                default:
+                    EraseItem(place, foundationItem, z);
+                    break;
             }
 
-            if (SeekTile)
+            return true;
+        }
+
+        /// <summary>
+        /// Erases a stair component, potentially deleting the entire stair group if requested.
+        /// </summary>
+        /// <param name="place">The targeted stair piece.</param>
+        /// <param name="house">The house object.</param>
+        /// <param name="foundationItem">The foundation item.</param>
+        /// <param name="z">The relative Z coordinate for erasure.</param>
+        /// <param name="deleteEntireGroup">If true, attempts to find and delete all connected stair pieces.</param>
+        private void EraseStair(GameObject place, House house, Item foundationItem, int z, bool deleteEntireGroup = false)
+        {
+            List<Multi> stairPieces;
+
+            if (deleteEntireGroup)
             {
-                if (place is Multi)
+                int stairFloorBase = GetStairFloorBase(place, foundationItem);
+                (List<Multi> sameX, List<Multi> sameY) = CollectPotentialStairPieces(house, place, stairFloorBase);
+                stairPieces = FindStairGroup(place, sameX, sameY);
+            }
+            else
+                stairPieces = [];
+
+            DeleteStairPieces(place, foundationItem, stairPieces, z);
+        }
+
+        /// <summary>
+        /// Calculates the base Z coordinate of the floor containing the targeted stair piece.
+        /// </summary>
+        /// <param name="place">The stair piece.</param>
+        /// <param name="foundationItem">The house foundation item.</param>
+        /// <returns>The base Z coordinate of the floor.</returns>
+        private int GetStairFloorBase(GameObject place, Item foundationItem)
+        {
+            int floorBase = foundationItem.Z;
+            for (int f = 0; f < FloorCount; f++)
+            {
+                int fz = floorBase + 7 + f * FLOOR_HEIGHT;
+                if (place.Z >= fz && place.Z < fz + FLOOR_HEIGHT)
+                    return fz;
+            }
+
+            return floorBase;
+        }
+
+        /// <summary>
+        /// Collects all custom stair pieces on the same floor and X or Y axis as the targeted piece.
+        /// </summary>
+        /// <param name="house">The house object.</param>
+        /// <param name="place">The targeted stair piece.</param>
+        /// <param name="stairFloorBase">The base Z coordinate of the floor.</param>
+        /// <returns>A tuple containing lists of pieces on the same X and Y axis.</returns>
+        private static (List<Multi> sameX, List<Multi> sameY) CollectPotentialStairPieces(House house, GameObject place, int stairFloorBase)
+        {
+            var sameX = new List<Multi>();
+            var sameY = new List<Multi>();
+
+            foreach (Multi comp in house.Components)
+            {
+                if (comp.IsDestroyed || !comp.IsCustom || (comp.State & CUSTOM_HOUSE_MULTI_OBJECT_FLAGS.CHMOF_STAIR) == 0)
+                    continue;
+
+                if (comp.Z < stairFloorBase || comp.Z >= stairFloorBase + FLOOR_HEIGHT)
+                    continue;
+
+                if (comp.X == place.X)
+                    sameX.Add(comp);
+
+                if (comp.Y == place.Y)
+                    sameY.Add(comp);
+            }
+
+            return (sameX, sameY);
+        }
+
+        /// <summary>
+        /// Identifies the group of stair pieces that form a continuous staircase around the targeted piece.
+        /// </summary>
+        /// <param name="place">The targeted stair piece.</param>
+        /// <param name="sameX">Stair pieces on the same X axis.</param>
+        /// <param name="sameY">Stair pieces on the same Y axis.</param>
+        /// <returns>A list of stair pieces belonging to the same group.</returns>
+        private List<Multi> FindStairGroup(GameObject place, List<Multi> sameX, List<Multi> sameY)
+        {
+            var stairPieces = new List<Multi>();
+            int bestStart;
+
+            // Staircases usually span 4 tiles; find which axis they are aligned on
+            if (sameX.Count >= sameY.Count && sameX.Count > 0)
+            {
+                bestStart = FindBestStairWindow(place.Y, sameX, p => p.Y);
+
+                foreach (Multi p in sameX)
                 {
-                    SeekGraphic(place.Graphic);
+                    if (p.Y >= bestStart && p.Y <= bestStart + 3)
+                        stairPieces.Add(p);
+                }
+                return stairPieces;
+            }
+
+            if (sameY.Count <= 0)
+                return stairPieces;
+
+            bestStart = FindBestStairWindow(place.X, sameY, p => p.X);
+            stairPieces.AddRange(sameY.Where(p => p.X >= bestStart && p.X <= bestStart + 3));
+
+            return stairPieces;
+        }
+
+        /// <summary>
+        /// Finds the best 4-tile window along an axis that contains the most stair pieces, centered around the target coordinate.
+        /// </summary>
+        /// <param name="targetCoord">The coordinate of the targeted piece.</param>
+        /// <param name="pieces">The list of pieces to search.</param>
+        /// <param name="getCoord">A function to extract the relevant coordinate from a piece.</param>
+        /// <returns>The starting coordinate of the best 4-tile window.</returns>
+        private static int FindBestStairWindow(int targetCoord, List<Multi> pieces, Func<Multi, int> getCoord)
+        {
+            int bestCount = 0;
+            int bestStart = targetCoord;
+
+            // Iterate through possible 4-tile windows that could contain the target coordinate
+            for (int start = targetCoord - 3; start <= targetCoord; start++)
+            {
+                int count = 0;
+
+                foreach (Multi p in pieces)
+                {
+                    int coord = getCoord(p);
+                    if (coord >= start && coord <= start + 3)
+                        count++;
+                }
+
+                if (count > bestCount)
+                {
+                    bestCount = count;
+                    bestStart = start;
                 }
             }
-            else if (place.Z >= _world.Player.Z + zOffset && place.Z < _world.Player.Z + 20)
+
+            return bestStart;
+        }
+
+        /// <summary>
+        /// Deletes the specified stair pieces from the house.
+        /// </summary>
+        /// <param name="place">The targeted stair piece.</param>
+        /// <param name="foundationItem">The house foundation item.</param>
+        /// <param name="stairPieces">The group of stair pieces to delete.</param>
+        /// <param name="z">The relative Z coordinate for erasure.</param>
+        private void DeleteStairPieces(GameObject place, Item foundationItem, List<Multi> stairPieces, int z)
+        {
+            bool isCombined = IsCombinedStaircase(stairPieces);
+
+            if (isCombined)
             {
-                Item foundationItem = _world.Items.Get(Serial);
+                int currentFloorOffset = 7 + (CurrentFloor - 1) * FLOOR_HEIGHT;
 
-                if (foundationItem == null || !_world.HouseManager.TryGetHouse(Serial, out House house))
+                foreach (Multi piece in stairPieces)
                 {
-                    return;
+                    // Calculate relative Z for each piece in the group
+                    int pz = piece.Z - (foundationItem.Z + currentFloorOffset) + currentFloorOffset;
+                    AsyncNetClient.Socket.Send_CustomHouseDeleteItem(_world, piece.Graphic, piece.X - foundationItem.X, piece.Y - foundationItem.Y, pz);
+                    piece.Destroy();
                 }
-
-                if (Erasing)
-                {
-                    if (!(place is Multi))
-                    {
-                        return;
-                    }
-
-                    if (CanEraseHere(place, out CUSTOM_HOUSE_BUILD_TYPE type))
-                    {
-                        IEnumerable<Multi> multi = house.GetMultiAt(place.X, place.Y);
-
-                        if (multi == null || !multi.Any())
-                        {
-                            return;
-                        }
-
-                        int z = 7 + (CurrentFloor - 1) * 20;
-
-                        if (type == CUSTOM_HOUSE_BUILD_TYPE.CHBT_STAIR || type == CUSTOM_HOUSE_BUILD_TYPE.CHBT_ROOF)
-                        {
-                            z = place.Z - (foundationItem.Z + z) + z;
-                        }
-
-                        if (type == CUSTOM_HOUSE_BUILD_TYPE.CHBT_STAIR)
-                        {
-                            int floorBase = foundationItem.Z;
-                            int stairFloorBase = floorBase;
-
-                            for (int f = 0; f < FloorCount; f++)
-                            {
-                                int fz = floorBase + 7 + f * 20;
-
-                                if (place.Z >= fz && place.Z < fz + 20)
-                                {
-                                    stairFloorBase = fz;
-                                    break;
-                                }
-                            }
-
-                            if (place.Z < floorBase + 7)
-                                stairFloorBase = floorBase;
-
-                            // Collect stair pieces sharing same X (N/S) or same Y (E/W) with clicked piece
-                            var sameXPieces = new List<Multi>();
-                            var sameYPieces = new List<Multi>();
-
-                            foreach (Multi comp in house.Components)
-                            {
-                                if (comp.IsDestroyed || !comp.IsCustom)
-                                    continue;
-
-                                if ((comp.State & CUSTOM_HOUSE_MULTI_OBJECT_FLAGS.CHMOF_STAIR) == 0)
-                                    continue;
-
-                                if (comp.Z < stairFloorBase || comp.Z >= stairFloorBase + 20)
-                                    continue;
-
-                                if (comp.X == place.X)
-                                    sameXPieces.Add(comp);
-
-                                if (comp.Y == place.Y)
-                                    sameYPieces.Add(comp);
-                            }
-
-                            // Determine orientation by piece count, then find exact 4-tile group
-                            var stairPieces = new List<Multi>();
-
-                            if (sameXPieces.Count >= sameYPieces.Count && sameXPieces.Count > 0)
-                            {
-                                // N/S orientation - find best 4-consecutive-Y window containing place.Y
-                                int bestCount = 0;
-                                int bestStart = place.Y;
-
-                                for (int startY = place.Y - 3; startY <= place.Y; startY++)
-                                {
-                                    int count = 0;
-
-                                    foreach (Multi p in sameXPieces)
-                                    {
-                                        if (p.Y >= startY && p.Y <= startY + 3)
-                                            count++;
-                                    }
-
-                                    if (count > bestCount)
-                                    {
-                                        bestCount = count;
-                                        bestStart = startY;
-                                    }
-                                }
-
-                                foreach (Multi p in sameXPieces)
-                                {
-                                    if (p.Y >= bestStart && p.Y <= bestStart + 3)
-                                        stairPieces.Add(p);
-                                }
-                            }
-                            else if (sameYPieces.Count > 0)
-                            {
-                                // E/W orientation - find best 4-consecutive-X window containing place.X
-                                int bestCount = 0;
-                                int bestStart = place.X;
-
-                                for (int startX = place.X - 3; startX <= place.X; startX++)
-                                {
-                                    int count = 0;
-
-                                    foreach (Multi p in sameYPieces)
-                                    {
-                                        if (p.X >= startX && p.X <= startX + 3)
-                                            count++;
-                                    }
-
-                                    if (count > bestCount)
-                                    {
-                                        bestCount = count;
-                                        bestStart = startX;
-                                    }
-                                }
-
-                                foreach (Multi p in sameYPieces)
-                                {
-                                    if (p.X >= bestStart && p.X <= bestStart + 3)
-                                        stairPieces.Add(p);
-                                }
-                            }
-
-                            // Combined staircases have pieces at multiple Z levels (0/5/10/15 offsets).
-                            // Single stairs are all at one Z. Only group-delete for combined staircases.
-                            bool isCombined = false;
-
-                            if (stairPieces.Count > 1)
-                            {
-                                int firstZ = stairPieces[0].Z;
-
-                                for (int i = 1; i < stairPieces.Count; i++)
-                                {
-                                    if (stairPieces[i].Z != firstZ)
-                                    {
-                                        isCombined = true;
-                                        break;
-                                    }
-                                }
-                            }
-
-                            if (isCombined)
-                            {
-                                foreach (Multi piece in stairPieces)
-                                {
-                                    int pz = piece.Z - (foundationItem.Z + (7 + (CurrentFloor - 1) * 20)) + (7 + (CurrentFloor - 1) * 20);
-
-                                    AsyncNetClient.Socket.Send_CustomHouseDeleteItem(_world, piece.Graphic, piece.X - foundationItem.X, piece.Y - foundationItem.Y, pz);
-                                    piece.Destroy();
-                                }
-                            }
-                            else
-                            {
-                                AsyncNetClient.Socket.Send_CustomHouseDeleteItem(_world, place.Graphic, place.X - foundationItem.X, place.Y - foundationItem.Y, z);
-                                place.Destroy();
-                            }
-                        }
-                        else if (type == CUSTOM_HOUSE_BUILD_TYPE.CHBT_ROOF)
-                        {
-                            AsyncNetClient.Socket.Send_CustomHouseDeleteRoof(_world, place.Graphic, place.X - foundationItem.X, place.Y - foundationItem.Y, z);
-                            place.Destroy();
-                        }
-                        else
-                        {
-                            AsyncNetClient.Socket.Send_CustomHouseDeleteItem(_world, place.Graphic, place.X - foundationItem.X, place.Y - foundationItem.Y, z);
-                            place.Destroy();
-                        }
-                    }
-                }
-                else if (SelectedGraphic != 0)
-                {
-                    var list = new List<CustomBuildObject>();
-
-                    if (CanBuildHere(list, out CUSTOM_HOUSE_BUILD_TYPE type) && list.Count > 0)
-                    {
-                        //if (type != CUSTOM_HOUSE_BUILD_TYPE.CHBT_STAIR && !(place is Multi))
-                        //    return;
-
-                        int placeX = place.X;
-                        int placeY = place.Y;
-
-                        if (type == CUSTOM_HOUSE_BUILD_TYPE.CHBT_STAIR && CombinedStair)
-                        {
-                            if (gump.Page >= 0 && gump.Page < Stairs.Count)
-                            {
-                                CustomHouseStair stair = Stairs[gump.Page];
-
-                                ushort graphic = 0;
-
-                                if (SelectedGraphic == stair.North)
-                                {
-                                    graphic = (ushort) stair.MultiNorth;
-                                }
-                                else if (SelectedGraphic == stair.East)
-                                {
-                                    graphic = (ushort) stair.MultiEast;
-                                }
-                                else if (SelectedGraphic == stair.South)
-                                {
-                                    graphic = (ushort) stair.MultiSouth;
-                                }
-                                else if (SelectedGraphic == stair.West)
-                                {
-                                    graphic = (ushort) stair.MultiWest;
-                                }
-
-                                if (graphic != 0)
-                                {
-                                    AsyncNetClient.Socket.Send_CustomHouseAddStair(_world, graphic, placeX - foundationItem.X, placeY - foundationItem.Y);
-                                }
-                            }
-                        }
-                        else
-                        {
-                            CustomBuildObject item = list[0];
-
-                            int x = placeX - foundationItem.X + item.X;
-                            int y = placeY - foundationItem.Y + item.Y;
-                            IEnumerable<Multi> multi = house.GetMultiAt(placeX + item.X, placeY + item.Y);
-
-                            if (multi.Any() || type == CUSTOM_HOUSE_BUILD_TYPE.CHBT_STAIR)
-                            {
-                                if (!CombinedStair)
-                                {
-                                    int minZ = foundationItem.Z + 7 + (CurrentFloor - 1) * 20;
-                                    int maxZ = minZ + 20;
-
-                                    if (CurrentFloor == 1)
-                                    {
-                                        minZ -= 7;
-                                    }
-
-                                    foreach (Multi multiObject in multi)
-                                    {
-                                        int testMinZ = minZ;
-
-                                        if ((multiObject.State & CUSTOM_HOUSE_MULTI_OBJECT_FLAGS.CHMOF_ROOF) != 0)
-                                        {
-                                            testMinZ -= 3;
-                                        }
-
-                                        if (multiObject.Z < testMinZ || multiObject.Z >= maxZ || !multiObject.IsCustom || (multiObject.State & CUSTOM_HOUSE_MULTI_OBJECT_FLAGS.CHMOF_GENERIC_INTERNAL) != 0 /*|| (multiObject.State & CUSTOM_HOUSE_MULTI_OBJECT_FLAGS.CHMOF_DONT_REMOVE) != 0*/
-                                           )
-                                        {
-                                            continue;
-                                        }
-
-                                        if (type == CUSTOM_HOUSE_BUILD_TYPE.CHBT_STAIR)
-                                        {
-                                            if ((multiObject.State & CUSTOM_HOUSE_MULTI_OBJECT_FLAGS.CHMOF_STAIR) != 0)
-                                            {
-                                                multiObject.Destroy();
-                                            }
-                                        }
-                                        else if (type == CUSTOM_HOUSE_BUILD_TYPE.CHBT_ROOF)
-                                        {
-                                            if ((multiObject.State & CUSTOM_HOUSE_MULTI_OBJECT_FLAGS.CHMOF_ROOF) != 0)
-                                            {
-                                                multiObject.Destroy();
-                                            }
-                                        }
-                                        else if (type == CUSTOM_HOUSE_BUILD_TYPE.CHBT_FLOOR)
-                                        {
-                                            if ((multiObject.State & (CUSTOM_HOUSE_MULTI_OBJECT_FLAGS.CHMOF_FLOOR | CUSTOM_HOUSE_MULTI_OBJECT_FLAGS.CHMOF_FIXTURE)) != 0)
-                                            {
-                                                multiObject.Destroy();
-                                            }
-                                        }
-                                        else
-                                        {
-                                            if ((multiObject.State & (CUSTOM_HOUSE_MULTI_OBJECT_FLAGS.CHMOF_STAIR | CUSTOM_HOUSE_MULTI_OBJECT_FLAGS.CHMOF_ROOF | CUSTOM_HOUSE_MULTI_OBJECT_FLAGS.CHMOF_FLOOR | CUSTOM_HOUSE_MULTI_OBJECT_FLAGS.CHMOF_DONT_REMOVE)) == 0)
-                                            {
-                                                multiObject.Destroy();
-                                            }
-                                        }
-                                    }
-
-                                    // todo: remove foundation if no components
-                                }
-
-                                if (type == CUSTOM_HOUSE_BUILD_TYPE.CHBT_ROOF)
-                                {
-                                    AsyncNetClient.Socket.Send_CustomHouseAddRoof(_world, item.Graphic, x, y, item.Z);
-                                }
-                                else
-                                {
-                                    AsyncNetClient.Socket.Send_CustomHouseAddItem(_world, item.Graphic, x, y);
-                                }
-                            }
-                        }
-
-                        int xx = placeX - foundationItem.X;
-                        int yy = placeY - foundationItem.Y;
-                        int z = foundationItem.Z + 7 + (CurrentFloor - 1) * 20;
-
-                        if (type == CUSTOM_HOUSE_BUILD_TYPE.CHBT_STAIR && !CombinedStair)
-                        {
-                            z = foundationItem.Z;
-                        }
-
-                        foreach (CustomBuildObject item in list)
-                        {
-                            house.Add
-                            (
-                                item.Graphic,
-                                0,
-                                (ushort) (foundationItem.X + xx + item.X),
-                                (ushort) (foundationItem.Y + yy + item.Y),
-                                (sbyte) (z + item.Z),
-                                true,
-                                false
-                            );
-                        }
-                    }
-                }
-
-                GenerateFloorPlace();
-                gump.Update();
+            }
+            else
+            {
+                AsyncNetClient.Socket.Send_CustomHouseDeleteItem(_world, place.Graphic, place.X - foundationItem.X, place.Y - foundationItem.Y, z);
+                place.Destroy();
             }
         }
 
+        /// <summary>
+        /// Determines if the given stair pieces form a combined (multi-level) staircase.
+        /// </summary>
+        /// <param name="stairPieces">The list of stair pieces to check.</param>
+        /// <returns>True if they form a combined staircase; otherwise, false.</returns>
+        private bool IsCombinedStaircase(List<Multi> stairPieces)
+        {
+            if (stairPieces.Count <= 1)
+            {
+                return false;
+            }
+
+            int firstZ = stairPieces[0].Z;
+
+            for (int i = 1; i < stairPieces.Count; i++)
+            {
+                if (stairPieces[i].Z != firstZ)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Sends a request to erase a roof component.
+        /// </summary>
+        /// <param name="place">The roof component to erase.</param>
+        /// <param name="foundationItem">The house foundation item.</param>
+        /// <param name="z">The relative Z coordinate.</param>
+        private void EraseRoof(GameObject place, Item foundationItem, int z)
+        {
+            AsyncNetClient.Socket.Send_CustomHouseDeleteRoof(_world, place.Graphic, place.X - foundationItem.X, place.Y - foundationItem.Y, z);
+            place.Destroy();
+        }
+
+        /// <summary>
+        /// Sends a request to erase a general item component.
+        /// </summary>
+        /// <param name="place">The item component to erase.</param>
+        /// <param name="foundationItem">The house foundation item.</param>
+        /// <param name="z">The relative Z coordinate.</param>
+        private void EraseItem(GameObject place, Item foundationItem, int z)
+        {
+            AsyncNetClient.Socket.Send_CustomHouseDeleteItem(_world, place.Graphic, place.X - foundationItem.X, place.Y - foundationItem.Y, z);
+            place.Destroy();
+        }
+
+        /// <summary>
+        /// Processes building a new component at the targeted location.
+        /// </summary>
+        /// <param name="place">The targeted game object (used for coordinates).</param>
+        /// <param name="house">The house object.</param>
+        /// <param name="foundationItem">The house foundation item.</param>
+        /// <param name="gump">The house customization gump.</param>
+        private void ProcessBuilding(GameObject place, House house, Item foundationItem, HouseCustomizationGump gump)
+        {
+            var list = new List<CustomBuildObject>();
+
+            if (!CanBuildHere(list, out CUSTOM_HOUSE_BUILD_TYPE type) || list.Count <= 0)
+            {
+                return;
+            }
+
+            int placeX = place.X;
+            int placeY = place.Y;
+
+            if (type == CUSTOM_HOUSE_BUILD_TYPE.CHBT_STAIR && CombinedStair)
+            {
+                BuildCombinedStair(foundationItem, gump, placeX, placeY);
+            }
+            else
+            {
+                BuildItem(place, house, foundationItem, list, type);
+            }
+
+            int xx = placeX - foundationItem.X;
+            int yy = placeY - foundationItem.Y;
+            int z = foundationItem.Z + 7 + (CurrentFloor - 1) * FLOOR_HEIGHT;
+
+            if (type == CUSTOM_HOUSE_BUILD_TYPE.CHBT_STAIR && !CombinedStair)
+            {
+                z = foundationItem.Z;
+            }
+
+            AddBuiltObjectsToHouse(house, foundationItem, list, xx, yy, z);
+        }
+
+        /// <summary>
+        /// Adds a list of built objects to the house's internal component list for rendering.
+        /// </summary>
+        /// <param name="house">The house object.</param>
+        /// <param name="foundationItem">The house foundation item.</param>
+        /// <param name="list">The list of objects to add.</param>
+        /// <param name="xx">Relative X offset from foundation.</param>
+        /// <param name="yy">Relative Y offset from foundation.</param>
+        /// <param name="z">Absolute Z base coordinate.</param>
+        private void AddBuiltObjectsToHouse(House house, Item foundationItem, List<CustomBuildObject> list, int xx, int yy, int z)
+        {
+            foreach (CustomBuildObject item in list)
+            {
+                house.Add
+                (
+                    item.Graphic,
+                    0,
+                    (ushort)(foundationItem.X + xx + item.X),
+                    (ushort)(foundationItem.Y + yy + item.Y),
+                    (sbyte)(z + item.Z),
+                    true,
+                    false
+                );
+            }
+        }
+
+        /// <summary>
+        /// Sends a request to build a combined (multi-tile) staircase.
+        /// </summary>
+        /// <param name="foundationItem">The house foundation item.</param>
+        /// <param name="gump">The house customization gump.</param>
+        /// <param name="placeX">The target X coordinate.</param>
+        /// <param name="placeY">The target Y coordinate.</param>
+        private void BuildCombinedStair(Item foundationItem, HouseCustomizationGump gump, int placeX, int placeY)
+        {
+            if (gump.Page < 0 || gump.Page >= Stairs.Count)
+                return;
+
+            CustomHouseStair stair = Stairs[gump.Page];
+            ushort graphic = 0;
+
+            if (SelectedGraphic == stair.North)
+                graphic = (ushort)stair.MultiNorth;
+            else if (SelectedGraphic == stair.East)
+                graphic = (ushort)stair.MultiEast;
+            else if (SelectedGraphic == stair.South)
+                graphic = (ushort)stair.MultiSouth;
+            else if (SelectedGraphic == stair.West)
+                graphic = (ushort)stair.MultiWest;
+
+            if (graphic != 0)
+                AsyncNetClient.Socket.Send_CustomHouseAddStair(_world, graphic, placeX - foundationItem.X, placeY - foundationItem.Y);
+        }
+
+        /// <summary>
+        /// Builds a single item or non-combined stair piece.
+        /// </summary>
+        /// <param name="place">The targeted game object.</param>
+        /// <param name="house">The house object.</param>
+        /// <param name="foundationItem">The house foundation item.</param>
+        /// <param name="list">The list of objects to build.</param>
+        /// <param name="type">The type of build action.</param>
+        private void BuildItem(GameObject place, House house, Item foundationItem, List<CustomBuildObject> list, CUSTOM_HOUSE_BUILD_TYPE type)
+        {
+            CustomBuildObject item = list[0];
+            int x = place.X - foundationItem.X + item.X;
+            int y = place.Y - foundationItem.Y + item.Y;
+            IEnumerable<Multi> multiAtTarget = house.GetMultiAt(place.X + item.X, place.Y + item.Y);
+
+            if (!multiAtTarget.Any() && type != CUSTOM_HOUSE_BUILD_TYPE.CHBT_STAIR)
+                return;
+
+            if (!CombinedStair)
+                ClearExistingItemsForBuild(foundationItem, multiAtTarget, type);
+
+            SendBuildRequest(item, type, x, y);
+        }
+
+        /// <summary>
+        /// Clears existing custom items at the target location that would conflict with a new build.
+        /// </summary>
+        /// <param name="foundationItem">The house foundation item.</param>
+        /// <param name="multiAtTarget">The collection of components at the target location.</param>
+        /// <param name="type">The type of build action.</param>
+        private void ClearExistingItemsForBuild(Item foundationItem, IEnumerable<Multi> multiAtTarget, CUSTOM_HOUSE_BUILD_TYPE type)
+        {
+            int minZ = foundationItem.Z + 7 + (CurrentFloor - 1) * FLOOR_HEIGHT;
+            int maxZ = minZ + FLOOR_HEIGHT;
+
+            if (CurrentFloor == 1)
+                minZ -= 7;
+
+            foreach (Multi multiObject in multiAtTarget)
+            {
+                if (ShouldClearItem(multiObject, type, minZ, maxZ))
+                {
+                    multiObject.Destroy();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Determines if a specific component should be cleared to make room for a new build of the specified type.
+        /// </summary>
+        /// <param name="multiObject">The existing component to check.</param>
+        /// <param name="type">The type of build action.</param>
+        /// <param name="minZ">The floor's minimum Z.</param>
+        /// <param name="maxZ">The floor's maximum Z.</param>
+        /// <returns>True if the item should be cleared; otherwise, false.</returns>
+        private static bool ShouldClearItem(Multi multiObject, CUSTOM_HOUSE_BUILD_TYPE type, int minZ, int maxZ)
+        {
+            int testMinZ = minZ;
+
+            if ((multiObject.State & CUSTOM_HOUSE_MULTI_OBJECT_FLAGS.CHMOF_ROOF) != 0)
+                testMinZ -= 3;
+
+            if (multiObject.Z < testMinZ || multiObject.Z >= maxZ || !multiObject.IsCustom || (multiObject.State & CUSTOM_HOUSE_MULTI_OBJECT_FLAGS.CHMOF_GENERIC_INTERNAL) != 0)
+                return false;
+
+            return type switch
+            {
+                CUSTOM_HOUSE_BUILD_TYPE.CHBT_STAIR => (multiObject.State & CUSTOM_HOUSE_MULTI_OBJECT_FLAGS.CHMOF_STAIR) != 0,
+                CUSTOM_HOUSE_BUILD_TYPE.CHBT_ROOF => (multiObject.State & CUSTOM_HOUSE_MULTI_OBJECT_FLAGS.CHMOF_ROOF) != 0,
+                CUSTOM_HOUSE_BUILD_TYPE.CHBT_FLOOR => (multiObject.State & (CUSTOM_HOUSE_MULTI_OBJECT_FLAGS.CHMOF_FLOOR | CUSTOM_HOUSE_MULTI_OBJECT_FLAGS.CHMOF_FIXTURE)) != 0,
+                _ => (multiObject.State & (
+                    CUSTOM_HOUSE_MULTI_OBJECT_FLAGS.CHMOF_STAIR |
+                    CUSTOM_HOUSE_MULTI_OBJECT_FLAGS.CHMOF_ROOF |
+                    CUSTOM_HOUSE_MULTI_OBJECT_FLAGS.CHMOF_FLOOR |
+                    CUSTOM_HOUSE_MULTI_OBJECT_FLAGS.CHMOF_DONT_REMOVE)
+                ) == 0
+            };
+        }
+
+        /// <summary>
+        /// Sends a network request to build a custom house component.
+        /// </summary>
+        /// <param name="item">The object to build.</param>
+        /// <param name="type">The type of build action.</param>
+        /// <param name="x">The relative X coordinate.</param>
+        /// <param name="y">The relative Y coordinate.</param>
+        private void SendBuildRequest(CustomBuildObject item, CUSTOM_HOUSE_BUILD_TYPE type, int x, int y)
+        {
+            if (type == CUSTOM_HOUSE_BUILD_TYPE.CHBT_ROOF)
+                AsyncNetClient.Socket.Send_CustomHouseAddRoof(_world, item.Graphic, x, y, item.Z);
+            else
+                AsyncNetClient.Socket.Send_CustomHouseAddItem(_world, item.Graphic, x, y);
+        }
+
+        /// <summary>
+        /// Seeks a graphic in the available customization lists and updates the UI state if found.
+        /// </summary>
+        /// <param name="graphic">The graphic to seek.</param>
         private void SeekGraphic(ushort graphic)
         {
             CUSTOM_HOUSE_GUMP_STATE state = 0;
             (int res1, int res2) = ExistsInList(ref state, graphic);
 
-            if (res1 != -1 && res2 != -1)
+            if (res1 == -1 || res2 == -1)
+                return;
+
+            State = state;
+            HouseCustomizationGump gump = UIManager.GetGump<HouseCustomizationGump>(Serial);
+
+            if (State is CUSTOM_HOUSE_GUMP_STATE.CHGS_WALL or CUSTOM_HOUSE_GUMP_STATE.CHGS_ROOF or CUSTOM_HOUSE_GUMP_STATE.CHGS_MISC)
             {
-                State = state;
-                HouseCustomizationGump gump = UIManager.GetGump<HouseCustomizationGump>(Serial);
-
-                if (State == CUSTOM_HOUSE_GUMP_STATE.CHGS_WALL || State == CUSTOM_HOUSE_GUMP_STATE.CHGS_ROOF || State == CUSTOM_HOUSE_GUMP_STATE.CHGS_MISC)
-                {
-                    Category = res1;
-                    gump.Page = res2;
-                }
-                else
-                {
-                    Category = -1;
-                    gump.Page = res1;
-                }
-
-                gump.UpdateMaxPage();
-                SetTargetMulti();
-                SelectedGraphic = graphic;
-                gump.Update();
+                Category = res1;
+                gump.Page = res2;
             }
+            else
+            {
+                Category = -1;
+                gump.Page = res1;
+            }
+
+            gump.UpdateMaxPage();
+            SetTargetMulti();
+            SelectedGraphic = graphic;
+            gump.Update();
         }
 
+        /// <summary>
+        /// Resets the targeting state for custom house building.
+        /// </summary>
         public void SetTargetMulti()
         {
             _world.TargetManager.SetTargetingMulti
@@ -1062,6 +1210,13 @@ namespace ClassicUO.Game.Managers
             CombinedStair = false;
         }
 
+        /// <summary>
+        /// Validates if the currently selected component can be built at the current targeting location.
+        /// This method checks for component limits, floor restrictions, and collisions with existing components.
+        /// </summary>
+        /// <param name="list">A list to be populated with the components to be built.</param>
+        /// <param name="type">Outputs the identified build type.</param>
+        /// <returns>True if building is allowed; otherwise, false.</returns>
         public bool CanBuildHere(List<CustomBuildObject> list, out CUSTOM_HOUSE_BUILD_TYPE type)
         {
             type = CUSTOM_HOUSE_BUILD_TYPE.CHBT_NORMAL;
@@ -1078,6 +1233,7 @@ namespace ClassicUO.Game.Managers
 
             bool result = true;
 
+            // Handle combined staircase building logic
             if (CombinedStair)
             {
                 if (Components + 10 > MaxComponets || CurrentFloor >= FloorCount)
@@ -1102,6 +1258,7 @@ namespace ClassicUO.Game.Managers
 
                 CustomHouseStair item = Stairs[res1];
 
+                // Add all pieces of the multi-tile staircase to the build list
                 if (SelectedGraphic == item.North)
                 {
                     list.Add(new CustomBuildObject { Graphic = (ushort)item.Block, X = 0, Y = -3, Z = 0 });
@@ -1163,6 +1320,7 @@ namespace ClassicUO.Game.Managers
             }
             else
             {
+                // Check if building a door or teleport (fixtures)
                 (int fixCheck1, int fixCheck2) = SeekGraphicInCustomHouseObjectList(Doors, SelectedGraphic);
 
                 bool isFixture = false;
@@ -1225,8 +1383,8 @@ namespace ClassicUO.Game.Managers
                 if (!_bounds.Contains(gobj.X, gobj.Y))
                     return false;
 
-                int minZ = foundationItem.Z + 0 + (CurrentFloor - 1) * 20;
-                int maxZ = minZ + 20;
+                int minZ = foundationItem.Z + 0 + (CurrentFloor - 1) * FLOOR_HEIGHT;
+                int maxZ = minZ + FLOOR_HEIGHT;
 
                 // var boundsOffset = State != CUSTOM_HOUSE_GUMP_STATE.CHGS_WALL ? 1 : 0;
 
@@ -1274,7 +1432,7 @@ namespace ClassicUO.Game.Managers
                             if (!multi.IsCustom)
                                 continue;
 
-                            int collisionMaxZ = (type == CUSTOM_HOUSE_BUILD_TYPE.CHBT_STAIR && CombinedStair) ? maxZ + 20 : maxZ;
+                            int collisionMaxZ = (type == CUSTOM_HOUSE_BUILD_TYPE.CHBT_STAIR && CombinedStair) ? maxZ + FLOOR_HEIGHT : maxZ;
 
                             if ((multi.State & CUSTOM_HOUSE_MULTI_OBJECT_FLAGS.CHMOF_GENERIC_INTERNAL) == 0 && multi.Z >= minZ && multi.Z < collisionMaxZ)
                             {
@@ -1297,6 +1455,12 @@ namespace ClassicUO.Game.Managers
             return result;
         }
 
+        /// <summary>
+        /// Determines if a component can be erased at the targeted location.
+        /// </summary>
+        /// <param name="place">The game object to check for erasure.</param>
+        /// <param name="type">Outputs the identified build type of the component at the location.</param>
+        /// <returns>True if erasure is allowed; otherwise, false.</returns>
         public bool CanEraseHere(GameObject place, out CUSTOM_HOUSE_BUILD_TYPE type)
         {
             type = CUSTOM_HOUSE_BUILD_TYPE.CHBT_NORMAL;
@@ -1333,6 +1497,12 @@ namespace ClassicUO.Game.Managers
             return false;
         }
 
+        /// <summary>
+        /// Checks if a graphic exists in any of the custom house component lists and returns its location.
+        /// </summary>
+        /// <param name="state">The gump state corresponding to the component type found.</param>
+        /// <param name="graphic">The graphic to search for.</param>
+        /// <returns>A tuple containing the category index and item index (or page index).</returns>
         public (int, int) ExistsInList(ref CUSTOM_HOUSE_GUMP_STATE state, ushort graphic)
         {
             (int res1, int res2) = SeekGraphicInCustomHouseObjectListWithCategory<CustomHouseWall, CustomHouseWallCategory>(Walls, graphic);
@@ -1401,6 +1571,15 @@ namespace ClassicUO.Game.Managers
             return (res1, res2);
         }
 
+        /// <summary>
+        /// Validates if a graphic can be placed at the specified coordinates within a bounding rectangle.
+        /// This checks for plot boundaries and specific placement rules (e.g. CanGoN, CanGoW).
+        /// </summary>
+        /// <param name="rect">The bounding rectangle of the house.</param>
+        /// <param name="graphic">The graphic to place.</param>
+        /// <param name="x">The X coordinate.</param>
+        /// <param name="y">The Y coordinate.</param>
+        /// <returns>True if placement is valid; otherwise, false.</returns>
         private bool ValidateItemPlace(Rectangle rect, ushort graphic, int x, int y)
         {
             if (!rect.Contains(x, y))
@@ -1433,6 +1612,16 @@ namespace ClassicUO.Game.Managers
             return true;
         }
 
+        /// <summary>
+        /// Performs structural validation for a specific multi component within a floor's Z range.
+        /// This ensures items are properly supported and follow house building rules.
+        /// </summary>
+        /// <param name="foundationItem">The house foundation item.</param>
+        /// <param name="item">The multi component to validate.</param>
+        /// <param name="minZ">The floor's minimum Z.</param>
+        /// <param name="maxZ">The floor's maximum Z.</param>
+        /// <param name="validatedFloors">A list of points representing validated floor tiles.</param>
+        /// <returns>True if the component's placement is structurally valid; otherwise, false.</returns>
         public bool ValidateItemPlace(Item foundationItem, Multi item, int minZ, int maxZ, List<Point> validatedFloors)
         {
             if (item == null || !_world.HouseManager.TryGetHouse(foundationItem, out House house) || !item.IsCustom)
@@ -1460,24 +1649,24 @@ namespace ClassicUO.Game.Managers
                     foundationItem,
                     house,
                     house.GetMultiAt(item.X, item.Y),
-                    minZ - 20,
-                    maxZ - 20,
+                    minZ - FLOOR_HEIGHT,
+                    maxZ - FLOOR_HEIGHT,
                     (int) CUSTOM_HOUSE_VALIDATE_CHECK_FLAGS.CHVCF_DIRECT_SUPPORT
                 ) || ValidatePlaceStructure
                 (
                     foundationItem,
                     house,
                     house.GetMultiAt(item.X - 1, item.Y),
-                    minZ - 20,
-                    maxZ - 20,
+                    minZ - FLOOR_HEIGHT,
+                    maxZ - FLOOR_HEIGHT,
                     (int) (CUSTOM_HOUSE_VALIDATE_CHECK_FLAGS.CHVCF_DIRECT_SUPPORT | CUSTOM_HOUSE_VALIDATE_CHECK_FLAGS.CHVCF_CANGO_W)
                 ) || ValidatePlaceStructure
                 (
                     foundationItem,
                     house,
                     house.GetMultiAt(item.X, item.Y - 1),
-                    minZ - 20,
-                    maxZ - 20,
+                    minZ - FLOOR_HEIGHT,
+                    maxZ - FLOOR_HEIGHT,
                     (int) (CUSTOM_HOUSE_VALIDATE_CHECK_FLAGS.CHVCF_DIRECT_SUPPORT | CUSTOM_HOUSE_VALIDATE_CHECK_FLAGS.CHVCF_CANGO_N)
                 ))
                 {
@@ -1682,7 +1871,7 @@ namespace ClassicUO.Game.Managers
 
             if (minZ > foundationItem.Z + 7)
             {
-                int belowMinZ = minZ - 20;
+                int belowMinZ = minZ - FLOOR_HEIGHT;
 
                 // 1) Check same position on the floor below for wall-type support.
                 bool foundAnyWallBelow = false;
@@ -1775,6 +1964,17 @@ namespace ClassicUO.Game.Managers
             return true;
         }
 
+        /// <summary>
+        /// Validates the structural integrity of a group of multi components.
+        /// This method checks if components have proper support based on their type and placement rules.
+        /// </summary>
+        /// <param name="foundationItem">The house foundation item.</param>
+        /// <param name="house">The house object.</param>
+        /// <param name="multi">The collection of multi components to validate.</param>
+        /// <param name="minZ">The floor's minimum Z.</param>
+        /// <param name="maxZ">The floor's maximum Z.</param>
+        /// <param name="flags">Validation flags that define what kind of support is being checked.</param>
+        /// <returns>True if the structure is valid according to the provided flags; otherwise, false.</returns>
         public bool ValidatePlaceStructure
         (
             Item foundationItem,
@@ -1999,6 +2199,14 @@ namespace ClassicUO.Game.Managers
         }
 
 
+        /// <summary>
+        /// Seeks a graphic in a list of custom house object categories.
+        /// </summary>
+        /// <typeparam name="T">The type of custom house object.</typeparam>
+        /// <typeparam name="U">The type of custom house object category.</typeparam>
+        /// <param name="list">The list of categories to search.</param>
+        /// <param name="graphic">The graphic to search for.</param>
+        /// <returns>A tuple containing the category index and item index if found; otherwise, (-1, -1).</returns>
         private static (int, int) SeekGraphicInCustomHouseObjectListWithCategory<T, U>(List<U> list, ushort graphic) where T : CustomHouseObject where U : CustomHouseObjectCategory<T>
         {
             for (int i = 0; i < list.Count; i++)
@@ -2019,6 +2227,13 @@ namespace ClassicUO.Game.Managers
             return (-1, -1);
         }
 
+        /// <summary>
+        /// Seeks a graphic in a list of custom house objects.
+        /// </summary>
+        /// <typeparam name="T">The type of custom house object.</typeparam>
+        /// <param name="list">The list of objects to search.</param>
+        /// <param name="graphic">The graphic to search for.</param>
+        /// <returns>A tuple containing the object index and internal index if found; otherwise, (-1, -1).</returns>
         private static (int, int) SeekGraphicInCustomHouseObjectList<T>(List<T> list, ushort graphic) where T : CustomHouseObject
         {
             for (int i = 0; i < list.Count; i++)

--- a/src/ClassicUO.Client/Game/Managers/HouseCustomizationManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/HouseCustomizationManager.cs
@@ -7,9 +7,8 @@ using System.Linq;
 using ClassicUO.Assets;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.GameObjects;
-using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Gumps;
-using ClassicUO.IO;
+using ClassicUO.Input;
 using ClassicUO.Network;
 using Microsoft.Xna.Framework;
 
@@ -736,7 +735,9 @@ namespace ClassicUO.Game.Managers
             switch (type)
             {
                 case CUSTOM_HOUSE_BUILD_TYPE.CHBT_STAIR:
-                    EraseStair(place, house, foundationItem, z);
+                    // When holding Ctrl, we delete only the specific stair piece, otherwise, we delete the entire stair group
+                    // This preserves existing, most-compatible behavior while still supporting newer servers that allow for individual pieces to be removed.
+                    EraseStair(place, house, foundationItem, z, !Keyboard.Ctrl);
                     break;
                 case CUSTOM_HOUSE_BUILD_TYPE.CHBT_ROOF:
                     EraseRoof(place, foundationItem, z);
@@ -750,14 +751,20 @@ namespace ClassicUO.Game.Managers
         }
 
         /// <summary>
-        /// Erases a stair component, potentially deleting the entire stair group if requested.
+        ///     Erases a stair component, potentially deleting the entire stair group if requested.
         /// </summary>
         /// <param name="place">The targeted stair piece.</param>
         /// <param name="house">The house object.</param>
         /// <param name="foundationItem">The foundation item.</param>
         /// <param name="z">The relative Z coordinate for erasure.</param>
-        /// <param name="deleteEntireGroup">If true, attempts to find and delete all connected stair pieces.</param>
-        private void EraseStair(GameObject place, House house, Item foundationItem, int z, bool deleteEntireGroup = false)
+        /// <param name="deleteEntireGroup">
+        ///     <para>If true, attempts to find and delete all connected stair pieces.</para>
+        ///     <para>
+        ///         Note that this logic has a "life of its own" and may not always behave the same way.
+        ///         Something to improve upon, perhaps.
+        ///     </para>
+        /// </param>
+        private void EraseStair(GameObject place, House house, Item foundationItem, int z, bool deleteEntireGroup = true)
         {
             List<Multi> stairPieces;
 

--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -1074,37 +1074,55 @@ namespace ClassicUO.Game.Scenes
             }
 
             if (_isMouseLeftDown && !Client.Game.UO.GameCursor.ItemHold.Enabled)
+                UpdateWhenLeftClickHeld();
+        }
+
+        /// <summary>
+        /// Handles updates performed when the left mouse button is held.
+        /// This method manages interactions with game objects while the left mouse button is being held down,
+        /// including custom house modifications and item pickup behaviors.
+        /// </summary>
+        /// <remarks>
+        /// - In the context of custom house building, it processes object selection and placement in real-time.
+        /// - Prevents repeated interactions on the same object or position to avoid duplicate actions.
+        /// - Implements a delay mechanism for placing objects in house customization for better user experience.
+        /// - Handles item pickup if an item is selected under specific conditions.
+        /// </remarks>
+        private void UpdateWhenLeftClickHeld()
+        {
+            if (
+                _world.CustomHouseManager != null
+                && _world.CustomHouseManager.SelectedGraphic != 0
+                && !_world.CustomHouseManager.SeekTile
+                && !_world.CustomHouseManager.Erasing
+                && Time.Ticks > _timeToPlaceMultiInHouseCustomization
+            )
             {
-                if (
-                    _world.CustomHouseManager != null
-                    && _world.CustomHouseManager.SelectedGraphic != 0
-                    && !_world.CustomHouseManager.SeekTile
-                    && !_world.CustomHouseManager.Erasing
-                    && Time.Ticks > _timeToPlaceMultiInHouseCustomization
-                )
-                {
-                    if (
-                        SelectedObject.Object is GameObject obj
-                        && (
-                            obj.X != _lastSelectedMultiPositionInHouseCustomization.X
-                            || obj.Y != _lastSelectedMultiPositionInHouseCustomization.Y
-                        )
-                    )
-                    {
-                        _world.CustomHouseManager.OnTargetWorld(obj);
-                        _timeToPlaceMultiInHouseCustomization = Time.Ticks + 50;
-                        _lastSelectedMultiPositionInHouseCustomization.X = obj.X;
-                        _lastSelectedMultiPositionInHouseCustomization.Y = obj.Y;
-                    }
-                }
-                else if (Time.Ticks - _holdMouse2secOverItemTime >= 1000)
-                {
-                    if (SelectedObject.Object is Item it && GameActions.PickUp(_world, it.Serial, 0, 0))
-                    {
-                        _isMouseLeftDown = false;
-                        _holdMouse2secOverItemTime = 0;
-                    }
-                }
+                // Null/Type guard
+                if (SelectedObject.Object is not GameObject obj)
+                    return;
+
+                // Guard against multiple clicks to on the exact same entity
+                if (obj.X == _lastSelectedMultiPositionInHouseCustomization.X &&
+                    obj.Y == _lastSelectedMultiPositionInHouseCustomization.Y &&
+                    obj.Z == _lastSelectedMultiPositionInHouseCustomization.Z
+                   )
+                    return;
+
+                _world.CustomHouseManager.OnTargetWorld(obj);
+                _timeToPlaceMultiInHouseCustomization = Time.Ticks + 50;
+                _lastSelectedMultiPositionInHouseCustomization.X = obj.X;
+                _lastSelectedMultiPositionInHouseCustomization.Y = obj.Y;
+                return;
+            }
+
+            if (Time.Ticks - _holdMouse2secOverItemTime < 1000)
+                return;
+
+            if (SelectedObject.Object is Item it && GameActions.PickUp(_world, it.Serial, 0, 0))
+            {
+                _isMouseLeftDown = false;
+                _holdMouse2secOverItemTime = 0;
             }
         }
 

--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -20,6 +20,7 @@ using SDL3;
 using System;
 using System.Collections.Generic;
 using System.Net.Sockets;
+using ClassicUO.Common;
 using ClassicUO.Game.Managers.SpellVisualRange;
 using ClassicUO.Game.Map;
 using ClassicUO.Game.UI.Gumps.GridHighLight;
@@ -64,7 +65,7 @@ namespace ClassicUO.Game.Scenes
         private bool _forceStopScene;
         private HealthLinesManager _healthLinesManager;
 
-        private Point _lastSelectedMultiPositionInHouseCustomization;
+        private Point3D _lastSelectedMultiPositionInHouseCustomization;
         private int _lightCount;
         private readonly LightData[] _lights = new LightData[
             LightsLoader.MAX_LIGHTS_DATA_INDEX_COUNT

--- a/src/ClassicUO.Client/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameSceneInputHandler.cs
@@ -15,6 +15,7 @@ using Microsoft.Xna.Framework;
 using SDL3;
 using MathHelper = ClassicUO.Utility.MathHelper;
 using ClassicUO.Assets;
+using ClassicUO.Common;
 using ClassicUO.Common.Enums;
 using ClassicUO.Game.UI.Controls;
 
@@ -441,55 +442,70 @@ namespace ClassicUO.Game.Scenes
 
             if (_world.CustomHouseManager != null)
             {
-                _isMouseLeftDown = true;
+                HandleHouseManagerMouseDown();
+                return true;
+            }
 
-                if (
-                    _world.TargetManager.IsTargeting
-                    && _world.TargetManager.TargetingState == CursorTarget.MultiPlacement
-                    && (
-                        _world.CustomHouseManager.SelectedGraphic != 0
-                        || _world.CustomHouseManager.Erasing
-                        || _world.CustomHouseManager.SeekTile
-                    )
-                    && SelectedObject.Object is GameObject obj
-                    && (
-                        obj.X != _lastSelectedMultiPositionInHouseCustomization.X
-                        || obj.Y != _lastSelectedMultiPositionInHouseCustomization.Y
-                    )
-                )
+            SelectedObject.LastLeftDownObject = SelectedObject.Object;
+
+            if (ProfileManager.CurrentProfile.EnableDragSelect && DragSelectModifierActive())
+            {
+                if (CanDragSelectOnObject(SelectedObject.Object as GameObject))
                 {
-                    _world.CustomHouseManager.OnTargetWorld(obj);
-                    _timeToPlaceMultiInHouseCustomization = Time.Ticks + 50;
-                    _lastSelectedMultiPositionInHouseCustomization.X = obj.X;
-                    _lastSelectedMultiPositionInHouseCustomization.Y = obj.Y;
+                    _selectionStart = Mouse.Position;
+                    _isSelectionActive = true;
                 }
             }
             else
             {
-                SelectedObject.LastLeftDownObject = SelectedObject.Object;
-
-                if (ProfileManager.CurrentProfile.EnableDragSelect && DragSelectModifierActive())
-                {
-                    if (CanDragSelectOnObject(SelectedObject.Object as GameObject))
-                    {
-                        _selectionStart = Mouse.Position;
-                        _isSelectionActive = true;
-                    }
-                }
-                else
-                {
-                    _isMouseLeftDown = true;
-                    _holdMouse2secOverItemTime = Time.Ticks;
-                }
-
-                if (UIManager.TopMostControl is MyraControl)
-                    UIManager.TopMostControl = null;
-
-                if (ProfileManager.CurrentProfile.SingleClickMobileSetsLastTarget && SelectedObject.Object is Mobile m)
-                    World.Instance.TargetManager.LastTargetInfo.SetEntity(m);
+                _isMouseLeftDown = true;
+                _holdMouse2secOverItemTime = Time.Ticks;
             }
 
+            if (UIManager.TopMostControl is MyraControl)
+                UIManager.TopMostControl = null;
+
+            if (ProfileManager.CurrentProfile.SingleClickMobileSetsLastTarget && SelectedObject.Object is Mobile m)
+                World.Instance.TargetManager.LastTargetInfo.SetEntity(m);
+
             return true;
+        }
+
+        /// <summary>
+        /// Handles the mouse down event when the house customization manager is open
+        /// </summary>
+        private void HandleHouseManagerMouseDown()
+        {
+            _isMouseLeftDown = true;
+
+            // Check if this is indeed a house customization operation
+            if (!_world.TargetManager.IsTargeting || _world.TargetManager.TargetingState != CursorTarget.MultiPlacement)
+                return;
+
+            // Check if this is an operation that actually needs to be forwarded to the manager
+            if (_world.CustomHouseManager.SelectedGraphic == 0 && !_world.CustomHouseManager.Erasing &&
+                !_world.CustomHouseManager.SeekTile)
+                return;
+
+            // Null/Type guard
+            if (SelectedObject.Object is not GameObject obj)
+                return;
+
+            // Guard against multiple clicks to on the exact same entity
+            if (obj.X == _lastSelectedMultiPositionInHouseCustomization.X &&
+                obj.Y == _lastSelectedMultiPositionInHouseCustomization.Y &&
+                obj.Z == _lastSelectedMultiPositionInHouseCustomization.Z
+               )
+                return;
+
+            // Record the last position
+            _lastSelectedMultiPositionInHouseCustomization = new Point3D(obj.X, obj.Y, obj.Z);
+
+            // Dispatch the event
+            _world.CustomHouseManager.OnTargetWorld(obj);
+
+            // Add a delay to normalize placement behavior
+            _timeToPlaceMultiInHouseCustomization = Time.Ticks + 50;
         }
 
         private bool OnLeftMouseUp()


### PR DESCRIPTION
## Description
Disables the stair grouping/clumping behavior from the `HouseCustomizationManager`.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Code refactoring
- [x] Documentation update

## Testing
Local/Builder test

## Additional Notes

* The grouping behavior can be re-instated via a parameter, for future compatibility

* Includes an additional fix when using the customization manager where the `Z` axis was not considered for equity, causing certain clicks to not be dispatched to the manager.

* This refactor includes an LLM based break down of existing monolithic methods.
  Methods were first broken down using automation and subsequently manually inspected and cleaned.
  There was no attempt to modify the governing logic, aside the previously stated bug fixes.

* Raised via support at [Discord thread](https://discord.com/channels/1344851225538986064/1503078828572938291)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * House customization now supports explicit floor (Z) positioning for multi-floor placement.

* **Refactor**
  * Overhauled house-building flow for clearer placement/erasure handling and consolidated floor-based calculations.
  * Extracted and reorganized mouse/left-click handling during customization for cleaner control flow.

* **Bug Fixes**
  * Improved duplicate-click prevention across X/Y/Z to reduce accidental repeated placements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PlayTazUO/TazUO/pull/466)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->