### PR TITLE
fix: Allow resetting outline color via SetOutlineColor API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to TazUO will be recorded here.
 * Allow deletion of individual pieces of house stairs - [P.R 466](https://github.com/PlayTazUO/TazUO/pull/466) ([yuval-po](https://github.com/yuval-po))
 * Add missing Shirt and Kilt slot to paperdoll - [P.R 467](https://github.com/PlayTazUO/TazUO/pull/467) ([yuval-po](https://github.com/yuval-po))
 * Two Modern Paperdoll issues (closure and context menus) - [P.R 468](https://github.com/PlayTazUO/TazUO/pull/468) ([yuval-po](https://github.com/yuval-po))
+* Allow resetting of outline color via the SetOutlineColor API - [P.R 471](https://github.com/PlayTazUO/TazUO/pull/471) ([yuval-po](https://github.com/yuval-po))
 
 ## V5.1.0
 

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.1.15</AssemblyVersion>
-    <FileVersion>5.1.15</FileVersion>
+    <AssemblyVersion>5.1.16</AssemblyVersion>
+    <FileVersion>5.1.16</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/Managers/MainThreadQueue.cs
+++ b/src/ClassicUO.Client/Game/Managers/MainThreadQueue.cs
@@ -11,13 +11,13 @@ public static class MainThreadQueue
     private static ConcurrentQueue<(Action Action, CancellationToken? Token)> _queuedActions { get; } = new();
 
     /// <summary>
-    /// Must be called from main thread
+    ///     Must be called from main thread
     /// </summary>
     public static void Load() => _threadId = Thread.CurrentThread.ManagedThreadId;
 
     /// <summary>
-    /// This will not wait for the action to complete.
-    /// If a cancellation token is provided, the action will be skipped at execution time if cancelled.
+    ///     This will not wait for the action to complete.
+    ///     If a cancellation token is provided, the action will be skipped at execution time if cancelled.
     /// </summary>
     public static void EnqueueAction(Action action, CancellationToken? cancellationToken = null)
         => _queuedActions.Enqueue((action, cancellationToken));
@@ -70,8 +70,20 @@ public static class MainThreadQueue
     ///     If the current thread is the main thread, the function will run immediately as-is,
     ///     otherwise, the function will be dispatched and waited for.
     ///     Any exceptions raised on the main thread's context will be captured and bubbled back.
-    ///     If a cancellation token is provided and already cancelled, returns default without executing.
+    ///     If a cancellation token is provided and already canceled, returns default without executing.
     /// </summary>
+    /// <param name="func">The function to invoke on the main-thread</param>
+    /// <param name="cancellationToken">
+    ///     <para>
+    ///         A token that can be used to cancel the task.
+    ///     </para>
+    ///     <para>
+    ///         Note that once the task has started executing, cancellation will not interrupt it but will prevent further
+    ///         waiting for the result.
+    ///     </para>
+    /// </param>
+    /// <typeparam name="T">The type of result being returned</typeparam>
+    /// <returns>The result of the given function, as returned from the main-thread</returns>
     public static T BubblingInvokeOnMainThread<T>(Func<T> func, CancellationToken? cancellationToken = null)
     {
         if (cancellationToken?.IsCancellationRequested == true) return default;
@@ -79,8 +91,45 @@ public static class MainThreadQueue
     }
 
     /// <summary>
-    /// This will wait for the returned result.
-    /// If a cancellation token is provided and already cancelled, returns default without executing.
+    ///     Dispatches a given function for execution on the MainThread.
+    ///     If the current thread is the main thread, the function will run immediately as-is,
+    ///     otherwise, the function will be dispatched and waited for.
+    ///     Any exceptions raised on the main thread's context will be captured and bubbled back.
+    ///     If a cancellation token is provided and already canceled, returns default without executing.
+    /// </summary>
+    /// <param name="action">The action to invoke on the main-thread</param>
+    /// <param name="cancellationToken">
+    ///     <para>
+    ///         A token that can be used to cancel the task.
+    ///     </para>
+    ///     <para>
+    ///         Note that once the task has started executing, cancellation will not interrupt it but will prevent further
+    ///         waiting for the result.
+    ///     </para>
+    /// </param>
+    public static void BubblingInvokeOnMainThread(Action action, CancellationToken? cancellationToken = null)
+    {
+        if (cancellationToken?.IsCancellationRequested == true)
+            return;
+
+        if (_isMainThread)
+        {
+            action();
+            return;
+        }
+
+        // A fake return to fit the signature
+        _ = BubblingDispatchToMainThread(() =>
+            {
+                action();
+                return true;
+            }, cancellationToken
+        );
+    }
+
+    /// <summary>
+    ///     This will wait for the returned result.
+    ///     If a cancellation token is provided and already cancelled, returns default without executing.
     /// </summary>
     public static T InvokeOnMainThread<T>(Func<T> func, CancellationToken? cancellationToken = null)
     {
@@ -119,8 +168,8 @@ public static class MainThreadQueue
     }
 
     /// <summary>
-    /// This will not wait for the returned result.
-    /// If a cancellation token is provided, the action is skipped at execution time if canceled.
+    ///     This will not wait for the returned result.
+    ///     If a cancellation token is provided, the action is skipped at execution time if canceled.
     /// </summary>
     public static void InvokeOnMainThread(Action action, CancellationToken? cancellationToken = null)
     {
@@ -135,15 +184,13 @@ public static class MainThreadQueue
     }
 
     /// <summary>
-    /// Must only be called on the main thread
+    ///     Must only be called on the main thread
     /// </summary>
     public static void ProcessQueue()
     {
         while (_queuedActions.TryDequeue(out (Action Action, CancellationToken? Token) item))
-        {
             if (item.Token?.IsCancellationRequested != true)
                 item.Action();
-        }
     }
 
     public static void Reset()

--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiGameObject.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiGameObject.cs
@@ -85,19 +85,23 @@ public class ApiGameObject
     public int Distance => MainThreadQueue.InvokeOnMainThread(() => _gameObject?.Distance ?? 0);
 
     /// <summary>
-    /// Set an objects outline color using html hex colors.
+    /// Set an object's outline color using HTML hex colors.
     /// Example:
     /// ```py
     /// API.Player.SetOutlineColor("#105510")
+    /// API.Player.SetOutlineColor(None)
     /// ```
     /// </summary>
-    /// <param name="htmlColor"></param>
+    /// <param name="htmlColor">The color to set. Pass <c>null</c> to remove the outline.</param>
     public void SetOutlineColor(string htmlColor)
     {
         if (_gameObject == null || _gameObject.IsDestroyed)
             return;
 
-        MainThreadQueue.InvokeOnMainThread(() => { _gameObject.OutlineColor = htmlColor.FromHtmlHex(); });
+        MainThreadQueue.InvokeOnMainThread(() =>
+        {
+            _gameObject.OutlineColor = string.IsNullOrWhiteSpace(htmlColor) ? null : htmlColor.FromHtmlHex();
+        });
     }
 
     /// <summary>

--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiGameObject.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiGameObject.cs
@@ -93,12 +93,12 @@ public class ApiGameObject
     /// ```
     /// </summary>
     /// <param name="htmlColor">The color to set. Pass <c>null</c> to remove the outline.</param>
-    public void SetOutlineColor(string htmlColor)
+    public void SetOutlineColor(string htmlColor = null)
     {
         if (_gameObject == null || _gameObject.IsDestroyed)
             return;
 
-        MainThreadQueue.InvokeOnMainThread(() =>
+        MainThreadQueue.BubblingInvokeOnMainThread(() =>
         {
             _gameObject.OutlineColor = string.IsNullOrWhiteSpace(htmlColor) ? null : htmlColor.FromHtmlHex();
         });

--- a/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
@@ -1271,7 +1271,7 @@ namespace ClassicUO.LegionScripting
         /// Say a message outloud.
         /// Example:
         /// ```py
-        /// API.Say("Hello friend!")
+        /// API.Msg("Hello friend!")
         /// ```
         /// </summary>
         /// <param name="message">The message to say</param>

--- a/src/ClassicUO.Client/LegionScripting/docs/API.py
+++ b/src/ClassicUO.Client/LegionScripting/docs/API.py
@@ -40,7 +40,7 @@ class ApiGameObject:
     IsDestroyed: bool = None
     __class__: str = None
 
-    def SetOutlineColor(self, htmlColor: "str") -> None:
+    def SetOutlineColor(self, htmlColor: "str" = None) -> None:
         """
          Set an object's outline color using HTML hex colors.
          Example:

--- a/src/ClassicUO.Client/LegionScripting/docs/API.py
+++ b/src/ClassicUO.Client/LegionScripting/docs/API.py
@@ -42,10 +42,11 @@ class ApiGameObject:
 
     def SetOutlineColor(self, htmlColor: "str") -> None:
         """
-         Set an objects outline color using html hex colors.
+         Set an object's outline color using HTML hex colors.
          Example:
          ```py
          API.Player.SetOutlineColor("#105510")
+         API.Player.SetOutlineColor(None)
          ```
         
         """
@@ -1616,7 +1617,7 @@ def Msg(message: "str") -> None:
      Say a message outloud.
      Example:
      ```py
-     API.Say("Hello friend!")
+     API.Msg("Hello friend!")
      ```
     
     """

--- a/src/ClassicUO.Client/LegionScripting/docs/ApiGameObject.md
+++ b/src/ClassicUO.Client/LegionScripting/docs/ApiGameObject.md
@@ -75,10 +75,11 @@ description:  Base class for all Python-accessible game world objects.  Encapsul
 ## Methods
 ### SetOutlineColor
 `(htmlColor)`
- Set an objects outline color using html hex colors.
+ Set an object's outline color using HTML hex colors.
  Example:
  ```py
  API.Player.SetOutlineColor("#105510")
+ API.Player.SetOutlineColor(None)
  ```
 
 
@@ -86,7 +87,7 @@ description:  Base class for all Python-accessible game world objects.  Encapsul
 
 | Name | Type | Optional | Description |
 | --- | --- | --- | --- |
-| `htmlColor` | `string` | ❌ No |  |
+| `htmlColor` | `string` | ❌ No | The color to set. Pass `null` to remove the outline. |
 
 **Return Type:** `void` *(Does not return anything)*
 

--- a/src/ClassicUO.Client/LegionScripting/docs/ApiGameObject.md
+++ b/src/ClassicUO.Client/LegionScripting/docs/ApiGameObject.md
@@ -87,7 +87,7 @@ description:  Base class for all Python-accessible game world objects.  Encapsul
 
 | Name | Type | Optional | Description |
 | --- | --- | --- | --- |
-| `htmlColor` | `string` | ❌ No | The color to set. Pass `null` to remove the outline. |
+| `htmlColor` | `string` | ✅ Yes | The color to set. Pass `null` to remove the outline. |
 
 **Return Type:** `void` *(Does not return anything)*
 

--- a/src/ClassicUO.Client/LegionScripting/docs/LegionAPI.md
+++ b/src/ClassicUO.Client/LegionScripting/docs/LegionAPI.md
@@ -21,7 +21,7 @@ You can now type `-updateapi` in game to download the latest API.py file.
 
 [Additional notes](../notes/)  
 
-*This was generated on `4/22/26`.*
+*This was generated on `5/21/26`.*
 
 ## Properties
 ### `Events`
@@ -981,7 +981,7 @@ You can now type `-updateapi` in game to download the latest API.py file.
  Say a message outloud.
  Example:
  ```py
- API.Say("Hello friend!")
+ API.Msg("Hello friend!")
  ```
 
 


### PR DESCRIPTION
## Description
Allow resetting of object highlighting via the `SetOutlineColor` API

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing
Local

## Additional Notes
* [Discord discussion](https://discord.com/channels/1344851225538986064/1344855384459972638/1507104828478984315)
* Fixed a documentation typo in `Msg` API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SetOutlineColor method now supports removing outlines by passing None or null values.

* **Bug Fixes**
  * Corrected API documentation examples for messaging functions.

* **Documentation**
  * Updated scripting API documentation with clarified method parameters and usage examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PlayTazUO/TazUO/pull/471?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->