### PR TITLE
feat: block house stairs in war mode + disable gargoyle flying animation

### DIFF
--- a/src/ClassicUO.Client/Configuration/Language.cs
+++ b/src/ClassicUO.Client/Configuration/Language.cs
@@ -706,5 +706,9 @@ namespace ClassicUO.Configuration
         public string SetQuickCureSpell { get; set; } = "Set cure spell";
         public string QuickSpellTooltip { get; set; } = "These are used on health-bars for party members/pets.";
         public string SingleClickLastTarg { get; set; } = "Single clicking a mobile will set it as last target.";
+        public string BlockStairsInWar { get; set; } = "Block stairs in war mode";
+        public string BlockStairsInWarTooltip { get; set; } = "Prevent walking on stairs or Z-changing tiles while in war mode.";
+        public string DisableGargoyleFlying { get; set; } = "Disable gargoyle flying animation";
+        public string DisableGargoyleFlyingTooltip { get; set; } = "Hides the wing flapping animation of flying gargoyles (client-side only).";
     }
 }

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -322,6 +322,10 @@ namespace ClassicUO.Configuration
 
         public bool IgnoreStaminaCheck { get; set; } = false;
 
+        public bool BlockStairsInWarMode { get; set; }
+
+        public bool DisableGargoyleFlyingAnim { get; set; }
+
         public bool ShowJournalClient { get; set; } = true;
         public bool ShowJournalObjects { get; set; } = true;
         public bool ShowJournalSystem { get; set; } = true;

--- a/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
@@ -518,7 +518,7 @@ namespace ClassicUO.Game.GameObjects
                         return;
                     }
 
-                    if (IsGargoyle && IsFlying)
+                    if (IsGargoyle && IsFlying && !ProfileManager.CurrentProfile.DisableGargoyleFlyingAnim)
                     {
                         if (RandomHelper.GetValue(0, 2) != 0)
                         {
@@ -990,7 +990,7 @@ namespace ClassicUO.Game.GameObjects
 
             Point p = RealScreenPosition;
 
-            if (IsGargoyle && IsFlying)
+            if (IsGargoyle && IsFlying && !ProfileManager.CurrentProfile.DisableGargoyleFlyingAnim)
             {
                 p.Y -= 22;
             }

--- a/src/ClassicUO.Client/Game/GameObjects/MobileAnimation.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/MobileAnimation.cs
@@ -6,6 +6,7 @@ using ClassicUO.Game.Data;
 using ClassicUO.Assets;
 using ClassicUO.Utility;
 using ClassicUO.Renderer.Animations;
+using ClassicUO.Configuration;
 
 namespace ClassicUO.Game.GameObjects
 {
@@ -1152,7 +1153,7 @@ namespace ClassicUO.Game.GameObjects
                                     result = 25;
                                 }
                             }
-                            else if (mobile.IsGargoyle && mobile.IsFlying) // TODO: what's up when it is dead?
+                            else if (mobile.IsGargoyle && mobile.IsFlying && !ProfileManager.CurrentProfile.DisableGargoyleFlyingAnim) // TODO: what's up when it is dead?
                             {
                                 if (mobile.InWarMode)
                                 {
@@ -1253,7 +1254,7 @@ namespace ClassicUO.Game.GameObjects
                                                     }
                                                 }
                                             }
-                                            else if (mobile.IsGargoyle && mobile.IsFlying)
+                                            else if (mobile.IsGargoyle && mobile.IsFlying && !ProfileManager.CurrentProfile.DisableGargoyleFlyingAnim)
                                             {
                                                 result = 64;
                                             }
@@ -1290,7 +1291,7 @@ namespace ClassicUO.Game.GameObjects
                         if ((flags & AnimationFlags.UseUopAnimation) != 0)
                         {
                             // i'm not sure here if it's necessary the isgargoyle
-                            if (mobile.IsGargoyle && mobile.IsFlying)
+                            if (mobile.IsGargoyle && mobile.IsFlying && !ProfileManager.CurrentProfile.DisableGargoyleFlyingAnim)
                             {
                                 if (isRun)
                                 {
@@ -1365,7 +1366,7 @@ namespace ClassicUO.Game.GameObjects
 
                                 if (hand2Graphic < 0x0240 || hand2Graphic > 0x03E1)
                                 {
-                                    if (mobile.IsGargoyle && mobile.IsFlying)
+                                    if (mobile.IsGargoyle && mobile.IsFlying && !ProfileManager.CurrentProfile.DisableGargoyleFlyingAnim)
                                     {
                                         if (isRun)
                                         {
@@ -1394,7 +1395,7 @@ namespace ClassicUO.Game.GameObjects
                                     {
                                         if (HAND2_BASE_ANIMID[i] == hand2Graphic)
                                         {
-                                            if (mobile.IsGargoyle && mobile.IsFlying)
+                                            if (mobile.IsGargoyle && mobile.IsFlying && !ProfileManager.CurrentProfile.DisableGargoyleFlyingAnim)
                                             {
                                                 if (isRun)
                                                 {
@@ -1423,7 +1424,7 @@ namespace ClassicUO.Game.GameObjects
                                 }
                             }
                         }
-                        else if (mobile.IsGargoyle && mobile.IsFlying)
+                        else if (mobile.IsGargoyle && mobile.IsFlying && !ProfileManager.CurrentProfile.DisableGargoyleFlyingAnim)
                         {
                             result = 62;
                         }
@@ -2047,7 +2048,7 @@ namespace ClassicUO.Game.GameObjects
                     {
                         case 1:
                         case 2:
-                            if (mobile.IsGargoyle && mobile.IsFlying)
+                            if (mobile.IsGargoyle && mobile.IsFlying && !ProfileManager.CurrentProfile.DisableGargoyleFlyingAnim)
                             {
                                 return 76;
                             }
@@ -2055,7 +2056,7 @@ namespace ClassicUO.Game.GameObjects
                             return 17;
                     }
 
-                    if (mobile.IsGargoyle && mobile.IsFlying)
+                    if (mobile.IsGargoyle && mobile.IsFlying && !ProfileManager.CurrentProfile.DisableGargoyleFlyingAnim)
                     {
                         return 75;
                     }

--- a/src/ClassicUO.Client/Game/Pathfinder.cs
+++ b/src/ClassicUO.Client/Game/Pathfinder.cs
@@ -453,6 +453,24 @@ namespace ClassicUO.Game
             return maxZ;
         }
 
+        private bool IsHouseStairTile(int x, int y)
+        {
+            GameObject tile = _world.Map.GetTile(x, y, false);
+            if (tile == null) return false;
+            GameObject obj = tile;
+            while (obj.TPrevious != null) obj = obj.TPrevious;
+            for (; obj != null; obj = obj.TNext)
+            {
+                if (obj is Multi m)
+                {
+                    ref var data = ref Client.Game.UO.FileManager.TileData.StaticData[m.Graphic];
+                    if ((data.IsSurface || data.IsBridge) && data.Height > 0)
+                        return true;
+                }
+            }
+            return false;
+        }
+
         public bool CalculateNewZ(int x, int y, ref sbyte z, int direction)
         {
             int stepState = (int)PATH_STEP_STATE.PSS_NORMAL;
@@ -677,6 +695,13 @@ namespace ClassicUO.Game
                 GetNewXY((byte)direction, ref newX, ref newY);
             bool passed = CalculateNewZ(newX, newY, ref newZ, (byte)direction);
 
+            if (passed && ProfileManager.CurrentProfile.BlockStairsInWarMode &&
+                _world.Player != null && _world.Player.InWarMode &&
+                IsHouseStairTile(newX, newY))
+            {
+                passed = false;
+            }
+
             if ((sbyte)direction % 2 != 0)
             {
                 if (passed)
@@ -702,6 +727,12 @@ namespace ClassicUO.Game
                         newDirection = (byte)(((byte)direction + _dirOffset[i]) % 8);
                         GetNewXY(newDirection, ref newX, ref newY);
                         passed = CalculateNewZ(newX, newY, ref newZ, newDirection);
+                        if (passed && ProfileManager.CurrentProfile.BlockStairsInWarMode &&
+                            _world.Player != null && _world.Player.InWarMode &&
+                            IsHouseStairTile(newX, newY))
+                        {
+                            passed = false;
+                        }
                     }
                 }
             }

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/GeneralTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/GeneralTabContent.cs
@@ -98,6 +98,12 @@ public static class GeneralTabContent
                 if (b) World.Instance?.Weather.Reset();
             }, lang.DisableWeather, lang.DisableWeatherTooltip));
 
+        rightSide.Widgets.Add(MyraCheckButton.CreateWithCallback(profile.BlockStairsInWarMode,
+            b => profile.BlockStairsInWarMode = b, lang.BlockStairsInWar, lang.BlockStairsInWarTooltip));
+
+        rightSide.Widgets.Add(MyraCheckButton.CreateWithCallback(profile.DisableGargoyleFlyingAnim,
+            b => profile.DisableGargoyleFlyingAnim = b, lang.DisableGargoyleFlying, lang.DisableGargoyleFlyingTooltip));
+
         var healLabel = new MyraLabel(SpellDefinition.FullIndexGetSpell(profile.QuickHealSpell)?.Name ??
                                       profile.QuickHealSpell.ToString(), MyraLabel.TextStyle.P) { Tooltip = lang.QuickSpellTooltip };
 


### PR DESCRIPTION
## Changes

### Block stairs in war mode
- Adds option in Assistant → General to prevent walking on stairs or Z-changing tiles while in war mode
- New `IsHouseStairTile()` method in Pathfinder.cs

### Disable gargoyle flying animation
- Client-side checkbox to disable wing flapping animation of flying gargoyles
- Uses normal walking/standing animations instead of flying ones

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration toggle to disable gargoyle flying animation, accessible via the Assistant configuration interface
  * Added configuration toggle to block stair movement when in war mode, accessible via the Assistant configuration interface
  * Both new toggles include detailed tooltips explaining the behavior and effects of each setting on gameplay mechanics

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PlayTazUO/TazUO/pull/478?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->