### PR TITLE
fix: Issue #470 (Gump vs Macro input conflict)

### DIFF
--- a/src/ClassicUO.Client/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameSceneInputHandler.cs
@@ -1221,7 +1221,11 @@ namespace ClassicUO.Game.Scenes
                 }
             }
 
-            if (CanExecuteMacro())
+            // There's a bit of an edge case here - if the control is 'scrollable',
+            // we may want to direct the input to it, rather than execute a macro.
+            // Since it's basically impossible to know, from this vantage point, what gump we're looking at,
+            // this check specifically targets the Shop Gump. This is the least invasive, if imperfect solution right now.
+            if (CanExecuteMacro() && UIManager.TopMostControl is not ShopGump)
             {
                 Macro macro = _world.Macros.FindMacro(up, Keyboard.Alt, Keyboard.Ctrl, Keyboard.Shift);
 


### PR DESCRIPTION
## Description
Fixes an issue in which mouse-wheel macros take precedence over shop gumps

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update


## Additional Notes
* Not a perfect fix; This targets only shop gumps to avoid behavioral changes and potential interference with player macros.
* Closes #470

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where mouse wheel actions would incorrectly trigger macros while a shop window is open.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PlayTazUO/TazUO/pull/479?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->