### PR TITLE
fix: Rabbit nitpicks

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
@@ -4795,16 +4795,25 @@ namespace ClassicUO.Game.UI.Gumps
             const int comboBoxMaxWidth = 300;
 
             // Fallback to embedded fonts if we've gotten nothing here, for some reason.
-            string[] options = fontNames?.Length > 0 ? fontNames : EmbeddedFontNames.Names.ToArray();
+            string[] options;
+            int comboBoxWidth;
+            if (fontNames?.Length > 0)
+            {
+                options = fontNames;
+                // Guesstimate the combo's width based on the longest font name, otherwise we get bad wrapping/truncations.
+                // Definitely not a "pretty" solution but works well enough until we overhaul the settings pages.
+                comboBoxWidth = Math.Min(maxFontNameLength * 8, comboBoxMaxWidth);
+            }
+            else
+            {
+                options = EmbeddedFontNames.Names.ToArray();
+                comboBoxWidth = comboBoxMaxWidth;
+            }
 
             // Make sure the index is never out-of-bounds;
             // This can technically happen if a profile is moved to a machine that lacks the currently selected font.
             // Ideally, we'd want some 'warning' marker in the UI, but that's for a later time.
             int selectedFontInd = Math.Clamp(Array.IndexOf(options, selectedFont), 0, options.Length - 1);
-
-            // Guesstimate the combo's width based on the longest font name, otherwise we get bad wrapping/truncations.
-            // Definitely not a "pretty" solution but works well enough until we overhaul the settings pages.
-            int comboBoxWidth = Math.Min(maxFontNameLength * 8, comboBoxMaxWidth);
 
             return new ComboBoxWithLabel(
                 World,

--- a/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
@@ -236,8 +236,12 @@ namespace ClassicUO.LegionScripting
             // Dispose of any timed callbacks
             foreach (TimedCallback callback in _timedCallbacks.Values)
             {
-                callback.Timer?.Stop();
-                callback.Timer?.Dispose();
+                lock (callback)
+                {
+                    callback.IsCancellationRequested = true;
+                    callback.Timer?.Stop();
+                    callback.Timer?.Dispose();
+                }
             }
             _timedCallbacks.Clear();
 


### PR DESCRIPTION
## Description
fix: Additional Rabbit nitpicks prior to merge

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Additional Notes
Additional Rabbit nitpicks pertaining to https://github.com/PlayTazUO/TazUO/pull/481

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved font selector stability and fallback behavior when custom fonts are unavailable.
  * Enhanced thread-safety for scripting callback timers to prevent potential race conditions and crashes during cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PlayTazUO/TazUO/pull/483?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->