### PR TITLE
feat: Allow dropping items on minimized grid containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ All notable changes to TazUO will be recorded here.
 
 ### Features
 * Pet support for the bandage agent - [P.R 485](https://github.com/PlayTazUO/TazUO/pull/485) ([yuval-po](https://github.com/yuval-po))
+* Allow dropping of items onto minimized grid containers - [P.R 487](https://github.com/PlayTazUO/TazUO/pull/487) ([yuval-po](https://github.com/yuval-po))
 
 ### Fixes
 * Mouse wheel macros hijack scroll from shop gumps - [P.R 479](https://github.com/PlayTazUO/TazUO/pull/479) ([yuval-po](https://github.com/yuval-po))
+* Grid container label missing updates - [P.R 487](https://github.com/PlayTazUO/TazUO/pull/487) ([yuval-po](https://github.com/yuval-po))
 
 ---
 

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.2.1</AssemblyVersion>
-    <FileVersion>5.2.1</FileVersion>
+    <AssemblyVersion>5.2.2</AssemblyVersion>
+    <FileVersion>5.2.2</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
@@ -309,9 +309,9 @@ namespace ClassicUO.Game.UI.Gumps
                 CanMove = true
             };
             _background.MouseDoubleClick += OnMinimizeToggleDoubleClick;
+            _background.MouseUp += OnBackgroundMouseUp;
 
-            _backgroundTexture = new GumpPicTiled(0);
-            _backgroundTexture.CanMove = true;
+            _backgroundTexture = new GumpPicTiled(0) { CanMove = true };
             _backgroundTexture.MouseDoubleClick += OnMinimizeToggleDoubleClick;
             #endregion
 
@@ -531,7 +531,6 @@ namespace ClassicUO.Game.UI.Gumps
                 _heightBeforeMinimize = Height;
 
                 SwitchPositionState(false);
-
                 SetControlsVisibility(false);
 
                 // Resize to minimal height (just the label area + border)
@@ -807,8 +806,6 @@ namespace ClassicUO.Game.UI.Gumps
                 return;
             }
 
-            UpdateContainerNameLabel();
-
             if (_autoSortContainer)
                 overrideSort = true;
 
@@ -817,6 +814,9 @@ namespace ClassicUO.Game.UI.Gumps
                 : GridSlotManager.GetItemsInContainer(World, Container, _sortMode, overrideSort);
 
             SlotManager.RebuildContainer(sortedContents, _searchBox.Text, overrideSort);
+
+            // Update name AFTER slot manager rebuild, or we get stale data
+            UpdateContainerNameLabel();
             InvalidateContents = false;
         }
 
@@ -824,6 +824,30 @@ namespace ClassicUO.Game.UI.Gumps
         {
             if (InvalidateContents && !IsDisposed)
                 UpdateItems();
+        }
+
+        /// <summary>
+        /// Occurs when a mouse up even is issued on the background pane.
+        /// The background panel is the one holding the container's name and is
+        /// the only visible part when minimized.
+        /// </summary>
+        /// <param name="_">The event's sender. Ignored</param>
+        /// <param name="e">The mouse event's arguments</param>
+        private void OnBackgroundMouseUp(object _, MouseEventArgs e)
+        {
+            // Check whether we're trying to drop an item on the background
+            if (e.Button != MouseButtonType.Left || !_background.MouseIsOver || !Client.Game.UO.GameCursor.ItemHold.Enabled)
+                return;
+
+            // Issue a direct drop item command and let the underlying `UpdateContainerItem`
+            // mechanisms take care of actual placement
+            GameActions.DropItem(
+                Client.Game.UO.GameCursor.ItemHold.Serial,
+                0xFFFF,
+                0xFFFF,
+                0,
+                LocalSerial
+            );
         }
 
         protected override void OnMouseExit(int x, int y)
@@ -897,6 +921,15 @@ namespace ClassicUO.Game.UI.Gumps
 
             if (SlotManager != null && !_skipSave && SlotManager.ItemPositions.Count > 0 && !_isCorpse)
                 _gridContainerEntry.UpdateSaveDataEntry(this);
+
+            if (_background != null)
+            {
+                _background.MouseDoubleClick -= OnMinimizeToggleDoubleClick;
+                _background.MouseUp -= OnBackgroundMouseUp;
+            }
+
+            if (_backgroundTexture != null)
+                _backgroundTexture.MouseDoubleClick -= OnMinimizeToggleDoubleClick;
 
             base.Dispose();
         }

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
@@ -324,6 +324,7 @@ namespace ClassicUO.Game.UI.Gumps
                 CanMove = true
             };
             _containerNameLabel.MouseDoubleClick += OnMinimizeToggleDoubleClick;
+            _containerNameLabel.MouseUp += OnBackgroundMouseUp;
 
             _searchBox = new StbTextBox(0xFF, 20, 0, true, FontStyle.None, 0x0481)
             {
@@ -831,12 +832,16 @@ namespace ClassicUO.Game.UI.Gumps
         /// The background panel is the one holding the container's name and is
         /// the only visible part when minimized.
         /// </summary>
-        /// <param name="_">The event's sender. Ignored</param>
+        /// <param name="sender">The event's sender. May be the background, title label, etc.</param>
         /// <param name="e">The mouse event's arguments</param>
-        private void OnBackgroundMouseUp(object _, MouseEventArgs e)
+        private void OnBackgroundMouseUp(object sender, MouseEventArgs e)
         {
             // Check whether we're trying to drop an item on the background
-            if (e.Button != MouseButtonType.Left || !_background.MouseIsOver || !Client.Game.UO.GameCursor.ItemHold.Enabled)
+            if (e.Button != MouseButtonType.Left || !Client.Game.UO.GameCursor.ItemHold.Enabled)
+                return;
+
+            // Verify the sender is actually what we expect it to be
+            if (sender is not Control { MouseIsOver: true })
                 return;
 
             // Issue a direct drop item command and let the underlying `UpdateContainerItem`
@@ -922,6 +927,7 @@ namespace ClassicUO.Game.UI.Gumps
             if (SlotManager != null && !_skipSave && SlotManager.ItemPositions.Count > 0 && !_isCorpse)
                 _gridContainerEntry.UpdateSaveDataEntry(this);
 
+            // Dispose of the event handlers
             if (_background != null)
             {
                 _background.MouseDoubleClick -= OnMinimizeToggleDoubleClick;
@@ -930,6 +936,9 @@ namespace ClassicUO.Game.UI.Gumps
 
             if (_backgroundTexture != null)
                 _backgroundTexture.MouseDoubleClick -= OnMinimizeToggleDoubleClick;
+
+            if (_containerNameLabel != null)
+                _containerNameLabel.MouseUp -= OnBackgroundMouseUp;
 
             base.Dispose();
         }


### PR DESCRIPTION
## Description
* Allow dropping of items onto minimized grid containers
* Ensure grid container label is properly updated when item count changes

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing
Local

## Additional Notes
* Raised on [Discord](https://discord.com/channels/1344851225538986064/1345866311716311080/1510598138652786729)
* Added event handler detachment to disposal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Items can now be dropped onto container backgrounds, including minimized containers
- Container name labels now correctly reflect current contents

<!-- end of auto-generated comment: release notes by coderabbit.ai -->