### PR TITLE
Update shader and dynamically calc pages in color picker gump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to TazUO will be recorded here.
 * Allow dropping of items onto minimized grid containers - [P.R 487](https://github.com/PlayTazUO/TazUO/pull/487) ([yuval-po](https://github.com/yuval-po))
 * Auto focus and enter to submit support added to prompt input window - [P.R 486](https://github.com/PlayTazUO/TazUO/pull/486) ([bittiez](https://github.com/bittiez))
 * Add overhead message filter option - [P.R 494](https://github.com/PlayTazUO/TazUO/pull/494) ([bittiez](https://github.com/bittiez))
+* Color picker gump now dynamically calculates page count based on loaded hues. Updated shader slightly for supporting hues past 3k. - [P.R 496](https://github.com/PlayTazUO/TazUO/pull/496) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
 * Mouse wheel macros hijack scroll from shop gumps - [P.R 479](https://github.com/PlayTazUO/TazUO/pull/479) ([yuval-po](https://github.com/yuval-po))

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernColorPicker.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernColorPicker.cs
@@ -45,7 +45,7 @@ namespace ClassicUO.Game.UI.Gumps
 
         public ModernColorPicker(World world, Action<ushort> hueChanged, uint serial = 0) : base(world, 0, 0)
         {
-            _pages = Client.Game.UO.FileManager.Hues.HuesCount / (ROWS * COLUMNS);
+            _pages = (int)Math.Ceiling((double)(Client.Game.UO.FileManager.Hues.HuesCount / (ROWS * COLUMNS)));
             CanCloseWithRightClick = true;
             CanMove = true;
             AcceptMouseInput = true;

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernColorPicker.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernColorPicker.cs
@@ -19,6 +19,7 @@ namespace ClassicUO.Game.UI.Gumps
 
         private const int ROWS = 20;
         private const int COLUMNS = 10;
+        private int _pages = 14;
         private readonly Action<ushort> hueChanged;
         private readonly uint serial;
         private int _cPage = 0;
@@ -29,10 +30,10 @@ namespace ClassicUO.Game.UI.Gumps
             {
                 if (value < 0)
                 {
-                    _cPage = 14;
+                    _cPage = _pages;
                     return;
                 }
-                if (value > 14)
+                if (value > _pages)
                 {
                     _cPage = 0;
                     return;
@@ -44,6 +45,7 @@ namespace ClassicUO.Game.UI.Gumps
 
         public ModernColorPicker(World world, Action<ushort> hueChanged, uint serial = 0) : base(world, 0, 0)
         {
+            _pages = Client.Game.UO.FileManager.Hues.HuesCount / (ROWS * COLUMNS);
             CanCloseWithRightClick = true;
             CanMove = true;
             AcceptMouseInput = true;

--- a/src/ClassicUO.Renderer/shaders/IsometricWorld.fx
+++ b/src/ClassicUO.Renderer/shaders/IsometricWorld.fx
@@ -53,7 +53,8 @@ float3 get_rgb(float gray, float hue)
 
     float xPos = hueStart + gray / HUE_COLUMNS;
     xPos = clamp(xPos, hueStart + halfPixelX, hueStart + hueColumnWidth - halfPixelX);
-    float yPos = (hue % HUES_PER_TEXTURE) / (HUES_PER_TEXTURE - 1);
+    //float yPos = (hue % HUES_PER_TEXTURE) / (HUES_PER_TEXTURE - 1);
+	float yPos = ((float)(hue % HUES_PER_TEXTURE)) / (float)(HUES_PER_TEXTURE - 1);
     return tex2D(HueSampler0, float2(xPos, yPos)).rgb;
 }
 


### PR DESCRIPTION
## Description
Update shader and dynamically calc pages in color picker gump

This adds, or at least allows you to see, support for addition hues past 3,000

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing
Tested in game with hue file that has hues past 3,000

## Screenshots (if applicable)
<img width="232" height="424" alt="Screenshot 2026-06-04 at 7 35 02 AM" src="https://github.com/user-attachments/assets/ff71aa99-4306-4c1c-83dc-b2cfa77ec712" />


## Additional Notes
The compiled shader output did not actually change so we may have already supported the hues but had no way of viewing them?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved color picker to dynamically adapt to hue count data.
  * Enhanced shader computation for improved rendering precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->