### PR TITLE
Add option to skip server select & reorganized login gump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to TazUO will be recorded here.
 * Auto focus and enter to submit support added to prompt input window - [P.R 486](https://github.com/PlayTazUO/TazUO/pull/486) ([bittiez](https://github.com/bittiez))
 * Add overhead message filter option - [P.R 494](https://github.com/PlayTazUO/TazUO/pull/494) ([bittiez](https://github.com/bittiez))
 * Color picker gump now dynamically calculates page count based on loaded hues. Updated shader slightly for supporting hues past 3k. - [P.R 496](https://github.com/PlayTazUO/TazUO/pull/496) ([bittiez](https://github.com/bittiez))
+* Add option to skip server select & reorganized login gump - [P.R 498](https://github.com/PlayTazUO/TazUO/pull/498) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
 * Mouse wheel macros hijack scroll from shop gumps - [P.R 479](https://github.com/PlayTazUO/TazUO/pull/479) ([yuval-po](https://github.com/yuval-po))

--- a/src/ClassicUO.Client/Client.cs
+++ b/src/ClassicUO.Client/Client.cs
@@ -13,6 +13,7 @@ using SDL3;
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace ClassicUO
 {
@@ -103,6 +104,8 @@ namespace ClassicUO
 
         private void LoadUOFiles()
         {
+            Task<bool> skipServerSelectTask = Client.Settings.GetAsync(SettingsScope.Global, Constants.SqlSettings.SKIP_SERVER_SELECTION, false);
+
             string clientPath = Settings.GlobalSettings.UltimaOnlineDirectory;
             Log.Trace($"Ultima Online installation folder: {clientPath}");
 
@@ -179,6 +182,9 @@ namespace ClassicUO
             {
                 Protocol |= ClientFlags.CF_SA;
             }
+
+            skipServerSelectTask.Wait();
+            Settings.GlobalSettings.SkipServerSelect = skipServerSelectTask.Result;
 
             Log.Trace($"Client path: '{clientPath}'");
             Log.Trace($"Client version: {clientVersion}");

--- a/src/ClassicUO.Client/Configuration/Settings.cs
+++ b/src/ClassicUO.Client/Configuration/Settings.cs
@@ -101,6 +101,8 @@ namespace ClassicUO.Configuration
 
         [JsonPropertyName("plugins")] public string[] Plugins { get; set; } = { "" };
 
+        [JsonIgnore] public bool SkipServerSelect { get; set; }
+
         public static string GetSettingsFilepath()
         {
             if (CustomSettingsFilepath != null)

--- a/src/ClassicUO.Client/Game/Constants.cs
+++ b/src/ClassicUO.Client/Game/Constants.cs
@@ -134,6 +134,7 @@ namespace ClassicUO.Game
             public const string PATH_Z_LEVEL = "path_z_level";
             public const string SINGLE_CLICK_SET_LAST_TARG = "single_click_set_last_targ";
             public const string OVERHEAD_MESSAGE_TYPES_HIDDEN = "overhead_message_types_shown";
+            public const string SKIP_SERVER_SELECTION = "skip_server_selection";
         }
     }
 }

--- a/src/ClassicUO.Client/Game/UI/Gumps/Login/LoginGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/Login/LoginGump.cs
@@ -11,8 +11,7 @@ using ClassicUO.Resources;
 using ClassicUO.Utility;
 using Microsoft.Xna.Framework;
 using SDL3;
-using System.Collections.Generic;
-using System.IO;
+using ClassicUO.Utility.Platforms;
 
 namespace ClassicUO.Game.UI.Gumps.Login
 {
@@ -141,25 +140,6 @@ namespace ClassicUO.Game.UI.Gumps.Login
 
                 Add
                 (
-                    new Label($"UO Version {Settings.GlobalSettings.ClientVersion}.", false, 0x034E, font: 9)
-                    {
-                        X = 286,
-                        Y = 453
-                    }
-                );
-
-                Add
-                (
-                    new Label(string.Format("TazUO Version {0}", CUOEnviroment.Version), false, 0x034E, font: 9)
-                    {
-                        X = 286,
-                        Y = 465
-                    }
-                );
-
-
-                Add
-                (
                     _checkboxAutologin = new Checkbox
                     (
                         0x00D2,
@@ -238,25 +218,6 @@ namespace ClassicUO.Game.UI.Gumps.Login
                 offsetX = 218;
                 offsetY = 283;
                 offtextY = 50;
-
-
-                Add
-                (
-                    new Label($"UO Version {Settings.GlobalSettings.ClientVersion}.", false, 0x0481, font: 9)
-                    {
-                        X = 286,
-                        Y = 453
-                    }
-                );
-
-                Add
-                (
-                    new Label(string.Format("TazUO Version {0}", CUOEnviroment.Version), false, 0x0481, font: 9)
-                    {
-                        X = 286,
-                        Y = 465
-                    }
-                );
 
                 if (Settings.GlobalSettings.CustomServer == Settings.CustomServers.Eventine)
                 {
@@ -400,89 +361,6 @@ namespace ClassicUO.Game.UI.Gumps.Login
             _checkboxSaveAccount.IsChecked = Settings.GlobalSettings.SaveAccount;
             _checkboxAutologin.IsChecked = Settings.GlobalSettings.AutoLogin;
 
-
-            Add
-            (
-                new HtmlControl
-                (
-                    505,
-                    420,
-                    150,
-                    15,
-                    false,
-                    false,
-                    false,
-                    "<body link=\"#FF00FF00\" vlink=\"#FF00FF00\" ><a href=\"https://www.classicuo.eu/support.php\">Support ClassicUO!",
-                    0x32,
-                    true,
-                    isunicode: true,
-                    style: FontStyle.BlackBorder
-                )
-            );
-
-
-            Add
-            (
-                new HtmlControl
-                (
-                    505,
-                    440,
-                    100,
-                    15,
-                    false,
-                    false,
-                    false,
-                    "<body link=\"#FF00FF00\" vlink=\"#FF00FF00\" ><a href=\"https://www.classicuo.eu\">CUO Website",
-                    0x32,
-                    true,
-                    isunicode: true,
-                    style: FontStyle.BlackBorder
-                )
-            );
-
-            Add
-            (
-                new HtmlControl
-                (
-                    505,
-                    460,
-                    100,
-                    15,
-                    false,
-                    false,
-                    false,
-                    "<body link=\"#FF00FF00\" vlink=\"#FF00FF00\" ><a href=\"https://discord.gg/VdyCpjQ\">CUO Discord",
-                    0x32,
-                    true,
-                    isunicode: true,
-                    style: FontStyle.BlackBorder
-                )
-            );
-
-            TextBox _;
-            HitBox _hit;
-            var options = TextBox.RTLOptions.Default();
-            options.Width = 200;
-            Add(_ = TextBox.GetOne("TazUO Wiki", TrueTypeLoader.EMBEDDED_FONT, 15, Color.Orange, options));
-            _.X = 30;
-            _.Y = 420;
-            _.AcceptMouseInput = true;
-            Add(_hit = new HitBox(_.X, _.Y, _.MeasuredSize.X, _.MeasuredSize.Y));
-            _hit.MouseUp += (s, e) =>
-            {
-                Utility.Platforms.PlatformHelper.LaunchBrowser("https://github.com/PlayTazUO/TazUO/wiki");
-            };
-
-            Add(_ = TextBox.GetOne("TazUO Discord", TrueTypeLoader.EMBEDDED_FONT, 15, Color.Orange, options));
-            _.X = 30;
-            _.Y = 440;
-            _.AcceptMouseInput = true;
-            Add(_hit = new HitBox(_.X, _.Y, _.MeasuredSize.X, _.MeasuredSize.Y));
-            _hit.MouseUp += (s, e) =>
-            {
-                Utility.Platforms.PlatformHelper.LaunchBrowser("https://discord.gg/QvqzkB95G4");
-            };
-
             var loginmusic_checkbox = new Checkbox
             (
                 0x00D2,
@@ -541,6 +419,59 @@ namespace ClassicUO.Game.UI.Gumps.Login
             {
                 _textboxAccount.SetKeyboardFocus();
             }
+
+            Add
+            (
+                new Label($"UO Version {Settings.GlobalSettings.ClientVersion}.", false, 0x034E, font: 9)
+                {
+                    X = 286,
+                    Y = 453
+                }
+            );
+
+            Add
+            (
+                new Label(string.Format("TazUO Version {0}", CUOEnviroment.Version), false, 0x034E, font: 9)
+                {
+                    X = 286,
+                    Y = 465
+                }
+            );
+
+            var optionsButton = new NiceButton(5, 5, 80, 30, ButtonAction.Default, "Options") { IsSelectable = false, BackgroundColor = new Color(0.7f, 0.7f, 0.7f, 0.7f) };
+            optionsButton.MouseDown += (s,e) =>
+            {
+                ContextMenuControl c = GenOptionsContext();
+                optionsButton.ContextMenu = c;
+                c.Show();
+            };
+            Add(optionsButton);
+        }
+
+        private ContextMenuControl GenOptionsContext()
+        {
+            var c = new ContextMenuControl(this);
+            c.Add(new ContextMenuItemEntry("Skip Server Select? (When only 1 server is available)", () =>
+            {
+                _ = Client.Settings.SetAsync(SettingsScope.Global, Constants.SqlSettings.SKIP_SERVER_SELECTION, !Settings.GlobalSettings.SkipServerSelect);
+            }, true, Settings.GlobalSettings.SkipServerSelect));
+
+            c.Add(new ContextMenuItemEntry("TazUO Website", () =>
+            {
+                PlatformHelper.LaunchBrowser("https://tazuo.org");
+            }, true, false));
+
+            c.Add(new ContextMenuItemEntry("TazUO Discord", () =>
+            {
+                PlatformHelper.LaunchBrowser("https://discord.gg/QvqzkB95G4");
+            }, true, false));
+
+            c.Add(new ContextMenuItemEntry("CUO Website", () =>
+            {
+                PlatformHelper.LaunchBrowser("https://www.classicuo.eu");
+            }, true, false));
+
+            return c;
         }
 
         protected override void OnControllerButtonUp(SDL.SDL_GamepadButton button)

--- a/src/ClassicUO.Client/Network/LoginHandshake.cs
+++ b/src/ClassicUO.Client/Network/LoginHandshake.cs
@@ -171,6 +171,12 @@ namespace ClassicUO.Network
             }
 
             SetLoginStep(LoginSteps.ServerSelection);
+
+            if (Settings.GlobalSettings.SkipServerSelect && Servers.Length == 1 && CurrentLoginStep == LoginSteps.ServerSelection) //Double check server selection, the previous call may initiate auto login and already select one
+            {      
+                SelectServer((byte)Servers[0].Index, Servers[0].Name);
+                return;
+            }
         }
 
         public event NotifierEventHandler ReceiveCharacterListNotifier;


### PR DESCRIPTION
## Description
Add option to skip server select & reorganized login gump

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing
Opening the game and logging in with enabled.

## Screenshots (if applicable)
<img width="451" height="148" alt="Screenshot 2026-06-08 at 7 00 01 AM" src="https://github.com/user-attachments/assets/6b8f8198-2e02-4376-ac19-a4ec2383ce8b" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skip Server Selection: New option to automatically select the only available server during login when enabled, streamlining the login experience for single-server connections.
  * Options Menu: Login interface reorganized with new Options button providing centralized access to client settings and external community links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->