### PR TITLE
Server-driven dynamic map definitions

### DIFF
--- a/src/ClassicUO.Assets/MapLoader.cs
+++ b/src/ClassicUO.Assets/MapLoader.cs
@@ -22,6 +22,8 @@ namespace ClassicUO.Assets
         // cannot be a const, due to UOLive implementation
         public static int MAPS_COUNT = 6;
 
+        public static (int width, int height)[] ServerMapDefinitions { get; private set; }
+
         public MapLoader(UOFileManager fileManager) : base(fileManager)
         {
         }
@@ -247,6 +249,70 @@ namespace ClassicUO.Assets
             _filesMap.CopyTo(_currentMapFiles, 0);
             _filesIdxStatics.CopyTo(_currentIdxStaticsFiles, 0);
             _filesStatics.CopyTo(_currentStaticsFiles, 0);
+        }
+
+        protected static void StoreServerMapDefinitions((int index, int width, int height)[] defs, int count)
+        {
+            var store = new (int width, int height)[count];
+
+            foreach ((int index, int width, int height) in defs)
+            {
+                if (index < 0 || index >= count || width <= 0 || height <= 0)
+                {
+                    continue;
+                }
+
+                store[index] = (width, height);
+            }
+
+            ServerMapDefinitions = store;
+        }
+
+        public virtual void ApplyServerMapDefinitions((int index, int width, int height)[] defs, int count)
+        {
+            if (defs == null || count <= 0)
+            {
+                return;
+            }
+
+            count = Math.Max(count, MAPS_COUNT);
+
+            StoreServerMapDefinitions(defs, count);
+
+            int[] widths = new int[count];
+            int[] heights = new int[count];
+
+            int existing = MapsDefaultSize.GetLength(0);
+
+            for (int i = 0; i < count && i < existing; i++)
+            {
+                widths[i] = MapsDefaultSize[i, 0];
+                heights[i] = MapsDefaultSize[i, 1];
+            }
+
+            foreach ((int index, int width, int height) in defs)
+            {
+                if (index < 0 || index >= count || width <= 0 || height <= 0)
+                {
+                    continue;
+                }
+
+                widths[index] = width;
+                heights[index] = height;
+            }
+
+            string[] parts = new string[count];
+
+            for (int i = 0; i < count; i++)
+            {
+                parts[i] = $"{widths[i]},{heights[i]}";
+            }
+
+            MapsLayouts = string.Join(";", parts);
+
+            Log.Trace($"Applying server map definitions [count: {count}] -> {MapsLayouts}");
+
+            Load();
         }
 
         public unsafe void LoadMap(int i, bool useXFiles = false)

--- a/src/ClassicUO.Assets/MapLoader.cs
+++ b/src/ClassicUO.Assets/MapLoader.cs
@@ -251,6 +251,21 @@ namespace ClassicUO.Assets
             _filesStatics.CopyTo(_currentStaticsFiles, 0);
         }
 
+        protected static int GetMapCount((int index, int width, int height)[] defs)
+        {
+            int maxIndex = -1;
+
+            foreach (var d in defs)
+            {
+                if (d.index > maxIndex)
+                {
+                    maxIndex = d.index;
+                }
+            }
+
+            return maxIndex + 1;
+        }
+
         protected static void StoreServerMapDefinitions((int index, int width, int height)[] defs, int count)
         {
             var store = new (int width, int height)[count];
@@ -268,9 +283,16 @@ namespace ClassicUO.Assets
             ServerMapDefinitions = store;
         }
 
-        public virtual void ApplyServerMapDefinitions((int index, int width, int height)[] defs, int count)
+        public virtual void ApplyServerMapDefinitions((int index, int width, int height)[] defs)
         {
-            if (defs == null || count <= 0)
+            if (defs == null)
+            {
+                return;
+            }
+
+            int count = GetMapCount(defs);
+
+            if (count <= 0)
             {
                 return;
             }
@@ -284,10 +306,11 @@ namespace ClassicUO.Assets
 
             int existing = MapsDefaultSize.GetLength(0);
 
-            for (int i = 0; i < count && i < existing; i++)
+            for (int i = 0; i < count; i++)
             {
-                widths[i] = MapsDefaultSize[i, 0];
-                heights[i] = MapsDefaultSize[i, 1];
+                int src = i < existing ? i : 0;
+                widths[i] = MapsDefaultSize[src, 0];
+                heights[i] = MapsDefaultSize[src, 1];
             }
 
             foreach ((int index, int width, int height) in defs)

--- a/src/ClassicUO.Client/Game/UltimaLive.cs
+++ b/src/ClassicUO.Client/Game/UltimaLive.cs
@@ -313,6 +313,48 @@ namespace ClassicUO.Game
                     break;
                 }
 
+                case 0x10: //dynamic map definitions
+                {
+                    if (p.Length < 15)
+                    {
+                        return;
+                    }
+
+                    p.Seek(14);
+                    byte mapCount = p.ReadUInt8();
+
+                    var defs = new (int index, int width, int height)[mapCount];
+                    int maxIndex = -1;
+
+                    for (int i = 0; i < mapCount; i++)
+                    {
+                        int index = p.ReadUInt8();
+                        int width = p.ReadUInt16BE();
+                        int height = p.ReadUInt16BE();
+
+                        defs[i] = (index, width, height);
+
+                        if (index > maxIndex)
+                        {
+                            maxIndex = index;
+                        }
+                    }
+
+                    if (maxIndex < 0)
+                    {
+                        return;
+                    }
+
+                    Client.Game.UO.FileManager.Maps.ApplyServerMapDefinitions(defs, maxIndex + 1);
+
+                    if (world != null && world.InGame)
+                    {
+                        world.ReloadCurrentMap();
+                    }
+
+                    break;
+                }
+
                 case 0x01: //map definition update
                 {
                     if (_UL == null)
@@ -732,13 +774,37 @@ namespace ClassicUO.Game
                 _feedCancel = new CancellationTokenSource();
                 NumMaps = maps;
                 ushort[,] old = _UL.MapSizeWrapSize;
+
+                int[,] previous = fileManager.Maps?.MapsDefaultSize;
+                int previousLen = previous?.GetLength(0) ?? 0;
+                var serverDefs = ServerMapDefinitions;
+                int serverLen = serverDefs?.Length ?? 0;
+
                 MapsDefaultSize = new int[NumMaps, 2];
 
                 for (int i = 0; i < NumMaps; i++)
                 {
                     for (int x = 0; x < 2; x++)
                     {
-                        MapsDefaultSize[i, x] = i < old.GetLength(0) ? old[i, x] : old[0, x];
+                        int ulSize = i < old.GetLength(0) ? old[i, x] : 0;
+                        int serverSize = i < serverLen ? (x == 0 ? serverDefs[i].width : serverDefs[i].height) : 0;
+
+                        if (ulSize > 0)
+                        {
+                            MapsDefaultSize[i, x] = ulSize;
+                        }
+                        else if (serverSize > 0)
+                        {
+                            MapsDefaultSize[i, x] = serverSize;
+                        }
+                        else if (i < previousLen && previous[i, x] > 0)
+                        {
+                            MapsDefaultSize[i, x] = previous[i, x];
+                        }
+                        else
+                        {
+                            MapsDefaultSize[i, x] = old.GetLength(0) > 0 ? old[0, x] : 0;
+                        }
                     }
 
                     MapBlocksSize[i, 0] = MapsDefaultSize[i, 0] >> 3;
@@ -842,6 +908,16 @@ namespace ClassicUO.Game
                     throw new FileNotFoundException($"No maps, staidx or statics found on {_UL.ShardName}.");
                 }
 
+                for (int i = 0; i < NumMaps; i++)
+                {
+                    if (_filesMap[i] != null || _UL._ValidMaps.Contains(i))
+                    {
+                        continue;
+                    }
+
+                    LoadVanillaMapFiles(i);
+                }
+
                 _filesMap.CopyTo(_currentMapFiles, 0);
                 _filesIdxStatics.CopyTo(_currentIdxStaticsFiles, 0);
                 _filesStatics.CopyTo(_currentStaticsFiles, 0);
@@ -853,6 +929,82 @@ namespace ClassicUO.Game
                     MapBlocksSize[i, 1] = MapsDefaultSize[i, 1] >> 3;
                     //on ultimalive map always preload
                     LoadMap(i);
+                }
+            }
+
+            public override void ApplyServerMapDefinitions((int index, int width, int height)[] defs, int count)
+            {
+                if (defs == null || count <= 0)
+                {
+                    return;
+                }
+
+                count = Math.Max(count, (int)NumMaps);
+
+                StoreServerMapDefinitions(defs, count);
+
+                foreach ((int index, int width, int height) in defs)
+                {
+                    if (index < 0 || index >= MapsDefaultSize.GetLength(0) || width <= 0 || height <= 0)
+                    {
+                        continue;
+                    }
+
+                    if (_UL._ValidMaps.Contains(index))
+                    {
+                        continue;
+                    }
+
+                    MapsDefaultSize[index, 0] = width;
+                    MapsDefaultSize[index, 1] = height;
+                    MapBlocksSize[index, 0] = width >> 3;
+                    MapBlocksSize[index, 1] = height >> 3;
+
+                    if (_filesMap[index] == null)
+                    {
+                        LoadVanillaMapFiles(index);
+                    }
+
+                    _currentMapFiles[index] = _filesMap[index];
+                    _currentStaticsFiles[index] = _filesStatics[index];
+                    _currentIdxStaticsFiles[index] = _filesIdxStatics[index];
+
+                    BlockData[index] = null;
+                }
+            }
+
+            private void LoadVanillaMapFiles(int i)
+            {
+                string path = FileManager.GetUOFilePath($"map{i}LegacyMUL.uop");
+
+                if (FileManager.IsUOPInstallation && File.Exists(path))
+                {
+                    var uop = new UOFileUop(path, $"build/map{i}legacymul/{{0:D8}}.dat");
+                    uop.FillEntries();
+                    _filesMap[i] = uop;
+                }
+                else
+                {
+                    path = FileManager.GetUOFilePath($"map{i}.mul");
+
+                    if (File.Exists(path))
+                    {
+                        _filesMap[i] = new UOFileMul(path);
+                    }
+                }
+
+                path = FileManager.GetUOFilePath($"statics{i}.mul");
+
+                if (File.Exists(path))
+                {
+                    _filesStatics[i] = new UOFileMul(path);
+                }
+
+                path = FileManager.GetUOFilePath($"staidx{i}.mul");
+
+                if (File.Exists(path))
+                {
+                    _filesIdxStatics[i] = new UOFileMul(path);
                 }
             }
 

--- a/src/ClassicUO.Client/Game/UltimaLive.cs
+++ b/src/ClassicUO.Client/Game/UltimaLive.cs
@@ -324,7 +324,6 @@ namespace ClassicUO.Game
                     byte mapCount = p.ReadUInt8();
 
                     var defs = new (int index, int width, int height)[mapCount];
-                    int maxIndex = -1;
 
                     for (int i = 0; i < mapCount; i++)
                     {
@@ -333,19 +332,9 @@ namespace ClassicUO.Game
                         int height = p.ReadUInt16BE();
 
                         defs[i] = (index, width, height);
-
-                        if (index > maxIndex)
-                        {
-                            maxIndex = index;
-                        }
                     }
 
-                    if (maxIndex < 0)
-                    {
-                        return;
-                    }
-
-                    Client.Game.UO.FileManager.Maps.ApplyServerMapDefinitions(defs, maxIndex + 1);
+                    Client.Game.UO.FileManager.Maps.ApplyServerMapDefinitions(defs);
 
                     if (world != null && world.InGame)
                     {
@@ -932,9 +921,16 @@ namespace ClassicUO.Game
                 }
             }
 
-            public override void ApplyServerMapDefinitions((int index, int width, int height)[] defs, int count)
+            public override void ApplyServerMapDefinitions((int index, int width, int height)[] defs)
             {
-                if (defs == null || count <= 0)
+                if (defs == null)
+                {
+                    return;
+                }
+
+                int count = GetMapCount(defs);
+
+                if (count <= 0)
                 {
                     return;
                 }

--- a/src/ClassicUO.Client/Game/World.cs
+++ b/src/ClassicUO.Client/Game/World.cs
@@ -211,6 +211,37 @@ namespace ClassicUO.Game
 
         public bool InGame => Player != null && Map != null;
 
+        public void ReloadCurrentMap()
+        {
+            if (Map == null)
+                return;
+
+            int index = Map.Index;
+
+            InternalMapChangeClear(true);
+
+            ushort x = Player.X;
+            ushort y = Player.Y;
+            sbyte z = Player.Z;
+
+            Map.Destroy();
+            Map = null;
+
+            if (index < 0 || index >= MapLoader.MAPS_COUNT)
+                index = 0;
+
+            Client.Game.UO.FileManager.Maps.LoadMap(index, ClientFeatures.Flags.HasFlag(CharacterListFlags.CLF_UNLOCK_FELUCCA_AREAS));
+            Map = new Map.Map(this, index);
+
+            Player.SetInWorldTile(x, y, z);
+            Player.ClearSteps();
+
+            if (Client.Game.UO.GameCursor != null)
+            {
+                Client.Game.UO.GameCursor.Graphic = 0xFFFF;
+            }
+        }
+
         public IsometricLight Light { get; } = new IsometricLight
         {
             Overall = 0,


### PR DESCRIPTION
## Description
Adds a lightweight map-definitions command (0x10) on the UltimaLive 0x3F packet so a server can advertise its map count and per-facet dimensions on login, letting clients load additional or non-standard maps at the correct size. The packet is frame-safe and server-initiated, so no client configuration or handshake is required.

Dimensions are applied via MapLoader.ApplyServerMapDefinitions and persisted in MapLoader.ServerMapDefinitions; World.ReloadCurrentMap rebuilds the active facet if it changes in-game. ULMapLoader honors these definitions and loads the player's normal files for facets it does not manage, so UltimaLive keeps working when additional maps are present.

Requires server side implementation. Example at: https://github.com/Jascen/ultima-memento/pull/36

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing
1. Add a map6.mul with accompanying statics6/staidx6 to the client and server folders.
2. Ensure you add the [DynamicMapDefinitions.cs‎](https://github.com/Jascen/ultima-memento/pull/36/changes#diff-5baaa625d4eb0e29ef6da8c1afc41483be0415a88ac0ee824f20d82a35b084cc) to your server.
3. Register your map in MapDefinitions.cs
    - `RegisterMap( 7, 6, 6, 2560, 2048, 1, "YourLand",		MapRules.LodorRules | MapRules.FreeMovement); `
4. Load into server and `[set map 6` - or whatever number your map is.

## Screenshots (if applicable)
N/A

## Additional Notes
This requires a small change to the server to ensure the custom packet is set. That has been written in the Memento repository and can be viewed there if necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic server-driven map sizes: maps can be resized/overridden at runtime from server definitions without restarting the client.
  * In-game map reload: reload the current map while preserving player position, state, and progress.

* **Improvements**
  * Better runtime handling of missing or legacy map files for smoother map updates and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->