### PR TITLE
Unminimize and bring grid container to front when reopened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to TazUO will be recorded here.
 * Add overhead message filter option - [P.R 494](https://github.com/PlayTazUO/TazUO/pull/494) ([bittiez](https://github.com/bittiez))
 * Color picker gump now dynamically calculates page count based on loaded hues. Updated shader slightly for supporting hues past 3k. - [P.R 496](https://github.com/PlayTazUO/TazUO/pull/496) ([bittiez](https://github.com/bittiez))
 * Add option to skip server select & reorganized login gump - [P.R 498](https://github.com/PlayTazUO/TazUO/pull/498) ([bittiez](https://github.com/bittiez))
+* Opening an already open grid container will now unminimize it if minimized and bring it to the front - [P.R 502](https://github.com/PlayTazUO/TazUO/pull/502) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
 * Mouse wheel macros hijack scroll from shop gumps - [P.R 479](https://github.com/PlayTazUO/TazUO/pull/479) ([yuval-po](https://github.com/yuval-po))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.2.5</AssemblyVersion>
-    <FileVersion>5.2.5</FileVersion>
+    <AssemblyVersion>5.2.6</AssemblyVersion>
+    <FileVersion>5.2.6</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
@@ -1178,7 +1178,12 @@ namespace ClassicUO.Game.UI.Gumps
         {
             GridContainer gridContainer = UIManager.GetGump<GridContainer>(serial);
             if (gridContainer != null)
+            {
+                if (gridContainer.IsMinimized)
+                    gridContainer.IsMinimized = false;
+                gridContainer.BringOnTop();
                 gridContainer.RequestUpdateContents();
+            }
             else
                 UIManager.Add(new GridContainer(World.Instance, serial, graphic));
         }


### PR DESCRIPTION
If a grid container is already open but minimized, opening it again will now restore it and bring it to the front instead of only updating contents.

## Description
Brief description of the changes made.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update