### PR TITLE
Center script manager window when reopened via toolbar button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to TazUO will be recorded here.
 * Color picker gump now dynamically calculates page count based on loaded hues. Updated shader slightly for supporting hues past 3k. - [P.R 496](https://github.com/PlayTazUO/TazUO/pull/496) ([bittiez](https://github.com/bittiez))
 * Add option to skip server select & reorganized login gump - [P.R 498](https://github.com/PlayTazUO/TazUO/pull/498) ([bittiez](https://github.com/bittiez))
 * Opening an already open grid container will now unminimize it if minimized and bring it to the front - [P.R 502](https://github.com/PlayTazUO/TazUO/pull/502) ([bittiez](https://github.com/bittiez))
+* Script manager and assistant windows now re-center when reopened via toolbar button instead of closing/reopening - [P.R 503](https://github.com/PlayTazUO/TazUO/pull/503) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
 * Mouse wheel macros hijack scroll from shop gumps - [P.R 479](https://github.com/PlayTazUO/TazUO/pull/479) ([yuval-po](https://github.com/yuval-po))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.2.6</AssemblyVersion>
-    <FileVersion>5.2.6</FileVersion>
+    <AssemblyVersion>5.2.7</AssemblyVersion>
+    <FileVersion>5.2.7</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/AssistantWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/AssistantWindow.cs
@@ -1,4 +1,5 @@
 using ClassicUO.Game.Managers;
+using ClassicUO.Game.UI;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Game.UI.MyraWindows.Widgets;
 using ClassicUO.Game.UI.MyraWindows.Widgets.Assistant;
@@ -12,14 +13,24 @@ namespace ClassicUO.Game.UI.MyraWindows;
 
 public class AssistantWindow : MyraControl
 {
-    public static void Show() => UIManager.Add(new AssistantWindow());
+    public static void Show()
+    {
+        foreach (IGui g in UIManager.Gumps)
+        {
+            if (g is AssistantWindow w)
+            {
+                w.CenterInViewPort();
+                w.BringOnTop();
+                return;
+            }
+        }
+        UIManager.Add(new AssistantWindow());
+    }
 
     private SkillsTabContent _skillsTabContent;
 
     public AssistantWindow() : base("Legion Assistant")
     {
-        UIManager.ForEach<AssistantWindow>(w => { if(w != this) w.Dispose(); });
-
         CanBeSaved = true;
         Build();
         CenterInViewPort();

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/ScriptManagerWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/ScriptManagerWindow.cs
@@ -60,6 +60,7 @@ public class ScriptManagerWindow : MyraControl
         {
             if (g is ScriptManagerWindow w)
             {
+                w.CenterInViewPort();
                 w.BringOnTop();
                 return;
             }


### PR DESCRIPTION
Matches the assistant window behavior: clicking the button always recenters the window regardless of whether it was open, minimized, or moved off-screen.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Script Manager window now centers in the viewport when opened, improving visibility and positioning.
  * Assistant window now reuses an existing open instance (centers and brings it to front) instead of creating duplicates, resulting in more predictable window behavior and fewer duplicate windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->