### PR TITLE
Add pre/post loot actions to auto loot system

### DIFF
--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -818,6 +818,34 @@ namespace ClassicUO.Configuration
         [SqlSetting(SettingsScope.Global, Constants.SqlSettings.OVERHEAD_MESSAGE_TYPES_HIDDEN, (uint)0)]
         public partial uint DisabledOverheadMessageTypes { get; set; }
 
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, Constants.SqlSettings.AUTOLOOT_PRE_ACTION_TYPE, 0)]
+        public partial int AutoLootPreActionType { get; set; }
+
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, Constants.SqlSettings.AUTOLOOT_PRE_ACTION_TEXT, "")]
+        public partial string AutoLootPreActionText { get; set; }
+
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, Constants.SqlSettings.AUTOLOOT_PRE_ACTION_TARGET_CORPSE, false)]
+        public partial bool AutoLootPreActionTargetCorpse { get; set; }
+
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, Constants.SqlSettings.AUTOLOOT_PRE_ACTION_DELAY_MS, 0)]
+        public partial int AutoLootPreActionDelayMs { get; set; }
+
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, Constants.SqlSettings.AUTOLOOT_POST_ACTION_TYPE, 0)]
+        public partial int AutoLootPostActionType { get; set; }
+
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, Constants.SqlSettings.AUTOLOOT_POST_ACTION_TEXT, "")]
+        public partial string AutoLootPostActionText { get; set; }
+
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, Constants.SqlSettings.AUTOLOOT_POST_ACTION_TARGET_CORPSE, false)]
+        public partial bool AutoLootPostActionTargetCorpse { get; set; }
+
         private long lastSave;
 
         internal void AfterLoad()

--- a/src/ClassicUO.Client/Game/Constants.cs
+++ b/src/ClassicUO.Client/Game/Constants.cs
@@ -135,6 +135,13 @@ namespace ClassicUO.Game
             public const string SINGLE_CLICK_SET_LAST_TARG = "single_click_set_last_targ";
             public const string OVERHEAD_MESSAGE_TYPES_HIDDEN = "overhead_message_types_shown";
             public const string SKIP_SERVER_SELECTION = "skip_server_selection";
+            public const string AUTOLOOT_PRE_ACTION_TYPE = "autoloot_pre_action_type";
+            public const string AUTOLOOT_PRE_ACTION_TEXT = "autoloot_pre_action_text";
+            public const string AUTOLOOT_PRE_ACTION_TARGET_CORPSE = "autoloot_pre_action_target_corpse";
+            public const string AUTOLOOT_PRE_ACTION_DELAY_MS = "autoloot_pre_action_delay_ms";
+            public const string AUTOLOOT_POST_ACTION_TYPE = "autoloot_post_action_type";
+            public const string AUTOLOOT_POST_ACTION_TEXT = "autoloot_post_action_text";
+            public const string AUTOLOOT_POST_ACTION_TARGET_CORPSE = "autoloot_post_action_target_corpse";
         }
     }
 }

--- a/src/ClassicUO.Client/Game/Managers/AutoLootManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/AutoLootManager.cs
@@ -53,8 +53,8 @@ namespace ClassicUO.Game.Managers
         private readonly HashSet<uint> _preActionTriggeredCorpses = new();
         private readonly Dictionary<uint, long> _corpsesPendingTarget = new();
         private readonly Dictionary<uint, long> _corpsesPendingLoot = new();
-        private bool _loopingHasLooted = false;
-        private uint _lastLootedCorpseSerial = 0;
+        private readonly Dictionary<uint, int> _pendingLootByCorpse = new();   // corpse serial → items still in queue
+        private readonly Dictionary<uint, uint> _itemToCorpseSerial = new();   // item serial → corpse serial
         private const long TARGET_WAIT_TIMEOUT_MS = 5000;
 
         private readonly World _world;
@@ -81,8 +81,15 @@ namespace ClassicUO.Game.Managers
                 priority = entry.Priority;
             _lootItems.Enqueue((item, entry), priority);
             _currentLootTotalCount++;
-            _loopingHasLooted = true;
             _nextClearRecents = Time.Ticks + 5000;
+
+            // Track which corpse this item belongs to (skip if it's a distance-retry re-queue)
+            if (!_itemToCorpseSerial.ContainsKey(item.Serial) && _world.Items.Get(item.RootContainer) is { IsCorpse: true } root)
+            {
+                _pendingLootByCorpse.TryGetValue(root.Serial, out int c);
+                _pendingLootByCorpse[root.Serial] = c + 1;
+                _itemToCorpseSerial[item.Serial] = root.Serial;
+            }
         }
 
         public void ForceLootContainer(uint serial)
@@ -206,6 +213,35 @@ namespace ClassicUO.Game.Managers
 
             if (ProfileManager.CurrentProfile.HueCorpseAfterAutoloot)
                 corpse.Hue = 73;
+
+            // If nothing was queued for this corpse, fire the post-action immediately
+            if (!_pendingLootByCorpse.ContainsKey(corpse.Serial))
+                FirePostActionForCorpse(corpse.Serial);
+        }
+
+        private void FirePostActionForCorpse(uint corpseSerial)
+        {
+            Profile p = ProfileManager.CurrentProfile;
+            LootActionType postType = (LootActionType)p.AutoLootPostActionType;
+            if (postType == LootActionType.None) return;
+            if (p.AutoLootPostActionTargetCorpse && corpseSerial != 0)
+                TargetManager.SetAutoTarget(corpseSerial, TargetType.Neutral);
+            ExecuteLootAction(postType, p.AutoLootPostActionText);
+        }
+
+        private void OnItemLootCompleted(uint itemSerial)
+        {
+            if (!_itemToCorpseSerial.TryGetValue(itemSerial, out uint corpseSerial)) return;
+            _itemToCorpseSerial.Remove(itemSerial);
+            if (!_pendingLootByCorpse.TryGetValue(corpseSerial, out int remaining)) return;
+            remaining--;
+            if (remaining <= 0)
+            {
+                _pendingLootByCorpse.Remove(corpseSerial);
+                FirePostActionForCorpse(corpseSerial);
+            }
+            else
+                _pendingLootByCorpse[corpseSerial] = remaining;
         }
 
         private void ExecuteLootAction(LootActionType type, string text)
@@ -383,18 +419,6 @@ namespace ClassicUO.Game.Managers
             if (_lootItems.Count == 0)
             {
                 _progressBarGump?.Dispose();
-                if (_loopingHasLooted && _corpsesPendingTarget.Count == 0 && _corpsesPendingLoot.Count == 0)
-                {
-                    _loopingHasLooted = false;
-                    Profile p = ProfileManager.CurrentProfile;
-                    LootActionType postType = (LootActionType)p.AutoLootPostActionType;
-                    if (postType != LootActionType.None)
-                    {
-                        if (p.AutoLootPostActionTargetCorpse && _lastLootedCorpseSerial != 0)
-                            TargetManager.SetAutoTarget(_lastLootedCorpseSerial, TargetType.Neutral);
-                        ExecuteLootAction(postType, p.AutoLootPostActionText);
-                    }
-                }
                 if (Time.Ticks > _nextClearRecents)
                 {
                     _recentlyLooted.Clear();
@@ -415,7 +439,10 @@ namespace ClassicUO.Game.Managers
             Item moveItem = _world.Items.Get(item);
 
             if (moveItem == null)
+            {
+                OnItemLootCompleted(item);
                 return;
+            }
 
             CreateProgressBar();
 
@@ -456,10 +483,6 @@ namespace ClassicUO.Game.Managers
 
             if (destinationSerial != 0)
             {
-                Item rootContainer = _world.Items.Get(moveItem.RootContainer);
-                if (rootContainer?.IsCorpse == true)
-                    _lastLootedCorpseSerial = rootContainer.Serial;
-
                 ActionPriority lootPriority = entry?.Priority switch
                 {
                     AutoLootPriority.High => ActionPriority.LootItemHigh,
@@ -471,6 +494,7 @@ namespace ClassicUO.Game.Managers
             else
                 GameActions.Print("Could not find a container to loot into. Try setting a grab bag.");
 
+            OnItemLootCompleted(item);
             _nextLootTime = Time.Ticks + ProfileManager.CurrentProfile.MoveMultiObjectDelay;
         }
 
@@ -549,8 +573,8 @@ namespace ClassicUO.Game.Managers
             _corpsesPendingTarget.Clear();
             _corpsesPendingLoot.Clear();
             _preActionTriggeredCorpses.Clear();
-            _loopingHasLooted = false;
-            _lastLootedCorpseSerial = 0;
+            _pendingLootByCorpse.Clear();
+            _itemToCorpseSerial.Clear();
         }
 
         public void ImportFromOtherCharacter(string characterName, List<AutoLootConfigEntry> entries)

--- a/src/ClassicUO.Client/Game/Managers/AutoLootManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/AutoLootManager.cs
@@ -50,6 +50,13 @@ namespace ClassicUO.Game.Managers
         private int _currentLootTotalCount = 0;
         private bool IsEnabled => ProfileManager.CurrentProfile.EnableAutoLoot;
 
+        private readonly HashSet<uint> _preActionTriggeredCorpses = new();
+        private readonly Dictionary<uint, long> _corpsesPendingTarget = new();
+        private readonly Dictionary<uint, long> _corpsesPendingLoot = new();
+        private bool _loopingHasLooted = false;
+        private uint _lastLootedCorpseSerial = 0;
+        private const long TARGET_WAIT_TIMEOUT_MS = 5000;
+
         private readonly World _world;
 
         private AutoLootManager()
@@ -74,6 +81,7 @@ namespace ClassicUO.Game.Managers
                 priority = entry.Priority;
             _lootItems.Enqueue((item, entry), priority);
             _currentLootTotalCount++;
+            _loopingHasLooted = true;
             _nextClearRecents = Time.Ticks + 5000;
         }
 
@@ -166,11 +174,54 @@ namespace ClassicUO.Game.Managers
 
             if (corpse.IsHumanCorpse && !ProfileManager.CurrentProfile.AutoLootHumanCorpses) return;
 
+            Profile p = ProfileManager.CurrentProfile;
+            LootActionType preType = (LootActionType)p.AutoLootPreActionType;
+
+            if (preType != LootActionType.None)
+            {
+                if (!_preActionTriggeredCorpses.Add(corpse.Serial)) return;
+
+                // Register auto-target BEFORE executing the action so the target info is
+                // set before the server's target cursor packet can arrive.
+                if (p.AutoLootPreActionTargetCorpse)
+                    TargetManager.SetAutoTarget(corpse.Serial, TargetType.Neutral);
+
+                ExecuteLootAction(preType, p.AutoLootPreActionText);
+
+                if (p.AutoLootPreActionTargetCorpse)
+                    _corpsesPendingTarget[corpse.Serial] = Time.Ticks;
+                else
+                    _corpsesPendingLoot[corpse.Serial] = Time.Ticks + p.AutoLootPreActionDelayMs;
+
+                return;
+            }
+
+            LootCorpseItems(corpse);
+        }
+
+        private void LootCorpseItems(Item corpse)
+        {
             for (LinkedObject i = corpse.Items; i != null; i = i.Next)
                 CheckAndLoot((Item)i);
 
-            if(ProfileManager.CurrentProfile.HueCorpseAfterAutoloot)
+            if (ProfileManager.CurrentProfile.HueCorpseAfterAutoloot)
                 corpse.Hue = 73;
+        }
+
+        private void ExecuteLootAction(LootActionType type, string text)
+        {
+            if (type == LootActionType.None || string.IsNullOrWhiteSpace(text)) return;
+            switch (type)
+            {
+                case LootActionType.Say:
+                    GameActions.Say(text);
+                    break;
+                case LootActionType.Macro:
+                    Macro macro = _world.Macros.FindMacro(text);
+                    if (macro?.Items is MacroObject macroObj)
+                        _world.Macros.SetMacroToExecute(macroObj);
+                    break;
+            }
         }
 
         public void TryRemoveAutoLootEntry(string uid)
@@ -293,12 +344,61 @@ namespace ClassicUO.Game.Managers
             if (Client.Game.UO.GameCursor.ItemHold.Enabled)
                 return; //Prevent moving stuff while holding an item.
 
+            // Advance corpses from "waiting for target" → "delay countdown"
+            if (_corpsesPendingTarget.Count > 0)
+            {
+                List<uint> targetReady = null;
+                long now = Time.Ticks;
+                foreach (KeyValuePair<uint, long> kv in _corpsesPendingTarget)
+                {
+                    bool consumed = !TargetManager.NextAutoTarget.IsSet;
+                    bool timedOut = now - kv.Value >= TARGET_WAIT_TIMEOUT_MS;
+                    if (consumed || timedOut)
+                        (targetReady ??= new List<uint>()).Add(kv.Key);
+                }
+                if (targetReady != null)
+                    foreach (uint serial in targetReady)
+                    {
+                        _corpsesPendingTarget.Remove(serial);
+                        _corpsesPendingLoot[serial] = Time.Ticks + ProfileManager.CurrentProfile.AutoLootPreActionDelayMs;
+                    }
+            }
+
+            // Loot corpses whose pre-action delay has expired
+            if (_corpsesPendingLoot.Count > 0)
+            {
+                List<uint> lootReady = null;
+                foreach (KeyValuePair<uint, long> kv in _corpsesPendingLoot)
+                    if (Time.Ticks >= kv.Value)
+                        (lootReady ??= new List<uint>()).Add(kv.Key);
+                if (lootReady != null)
+                    foreach (uint serial in lootReady)
+                    {
+                        _corpsesPendingLoot.Remove(serial);
+                        Item corpse = _world.Items.Get(serial);
+                        if (corpse != null) LootCorpseItems(corpse);
+                    }
+            }
+
             if (_lootItems.Count == 0)
             {
                 _progressBarGump?.Dispose();
+                if (_loopingHasLooted)
+                {
+                    _loopingHasLooted = false;
+                    Profile p = ProfileManager.CurrentProfile;
+                    LootActionType postType = (LootActionType)p.AutoLootPostActionType;
+                    if (postType != LootActionType.None)
+                    {
+                        if (p.AutoLootPostActionTargetCorpse && _lastLootedCorpseSerial != 0)
+                            TargetManager.SetAutoTarget(_lastLootedCorpseSerial, TargetType.Neutral);
+                        ExecuteLootAction(postType, p.AutoLootPostActionText);
+                    }
+                }
                 if (Time.Ticks > _nextClearRecents)
                 {
                     _recentlyLooted.Clear();
+                    _preActionTriggeredCorpses.Clear();
                     _nextClearRecents = Time.Ticks + 5000;
                 }
                 return;
@@ -356,6 +456,10 @@ namespace ClassicUO.Game.Managers
 
             if (destinationSerial != 0)
             {
+                Item rootContainer = _world.Items.Get(moveItem.RootContainer);
+                if (rootContainer?.IsCorpse == true)
+                    _lastLootedCorpseSerial = rootContainer.Serial;
+
                 ActionPriority lootPriority = entry?.Priority switch
                 {
                     AutoLootPriority.High => ActionPriority.LootItemHigh,
@@ -442,6 +546,10 @@ namespace ClassicUO.Game.Managers
             _quickContainsLookup.Clear();
             _progressBarGump?.Dispose();
             _progressBarGump = null;
+            _corpsesPendingTarget.Clear();
+            _corpsesPendingLoot.Clear();
+            _preActionTriggeredCorpses.Clear();
+            _loopingHasLooted = false;
         }
 
         public void ImportFromOtherCharacter(string characterName, List<AutoLootConfigEntry> entries)
@@ -573,6 +681,7 @@ namespace ClassicUO.Game.Managers
         }
 
         public enum AutoLootPriority { Low = 0, Normal = 1, High = 2 }
+        public enum LootActionType { None = 0, Say = 1, Macro = 2 }
 
         public class AutoLootConfigEntry
         {

--- a/src/ClassicUO.Client/Game/Managers/AutoLootManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/AutoLootManager.cs
@@ -50,12 +50,17 @@ namespace ClassicUO.Game.Managers
         private int _currentLootTotalCount = 0;
         private bool IsEnabled => ProfileManager.CurrentProfile.EnableAutoLoot;
 
-        private readonly HashSet<uint> _preActionTriggeredCorpses = new();
-        private readonly HashSet<uint> _postActionFiredCorpses = new();
-        private readonly Dictionary<uint, long> _corpsesPendingTarget = new();
-        private readonly Dictionary<uint, long> _corpsesPendingLoot = new();
-        private readonly Dictionary<uint, int> _pendingLootByCorpse = new();   // corpse serial → items still in queue
-        private readonly Dictionary<uint, uint> _itemToCorpseSerial = new();   // item serial → corpse serial
+        // Pre/post loot action state, all keyed by corpse serial. Per-corpse lifecycle:
+        //   pre-action fires → [wait for target] → [delay] → loot items → post-action.
+        // The two "fired" sets gate one-shot actions and are cleared on the periodic
+        // cleanup (see Update) or by ClearActiveLootQueue. The pending/count maps drain
+        // themselves as corpses advance through the stages.
+        private readonly HashSet<uint> _preActionTriggeredCorpses = new();    // pre-action already fired
+        private readonly HashSet<uint> _postActionFiredCorpses = new();       // post-action already fired
+        private readonly Dictionary<uint, long> _corpsesPendingTarget = new();// corpse → tick action fired, awaiting target consumption
+        private readonly Dictionary<uint, long> _corpsesPendingLoot = new();  // corpse → tick when looting may begin
+        private readonly Dictionary<uint, int> _pendingLootByCorpse = new();  // corpse → items still queued
+        private readonly Dictionary<uint, uint> _itemToCorpseSerial = new();  // queued item → its corpse
         private const long TARGET_WAIT_TIMEOUT_MS = 5000;
 
         private readonly World _world;
@@ -382,33 +387,35 @@ namespace ClassicUO.Game.Managers
             if (Client.Game.UO.GameCursor.ItemHold.Enabled)
                 return; //Prevent moving stuff while holding an item.
 
-            // Advance corpses from "waiting for target" → "delay countdown"
+            // Advance corpses from "waiting for target" → "delay countdown".
+            // NextAutoTarget is a single global slot, so once it clears every
+            // corpse waiting on a target advances together.
             if (_corpsesPendingTarget.Count > 0)
             {
-                List<uint> targetReady = null;
                 long now = Time.Ticks;
+                bool targetConsumed = !TargetManager.NextAutoTarget.IsSet;
+                List<uint> targetReady = null;
                 foreach (KeyValuePair<uint, long> kv in _corpsesPendingTarget)
-                {
-                    bool consumed = !TargetManager.NextAutoTarget.IsSet;
-                    bool timedOut = now - kv.Value >= TARGET_WAIT_TIMEOUT_MS;
-                    if (consumed || timedOut)
+                    if (targetConsumed || now - kv.Value >= TARGET_WAIT_TIMEOUT_MS)
                         (targetReady ??= new List<uint>()).Add(kv.Key);
-                }
+
                 if (targetReady != null)
                     foreach (uint serial in targetReady)
                     {
                         _corpsesPendingTarget.Remove(serial);
-                        _corpsesPendingLoot[serial] = Time.Ticks + ProfileManager.CurrentProfile.AutoLootPreActionDelayMs;
+                        _corpsesPendingLoot[serial] = now + ProfileManager.CurrentProfile.AutoLootPreActionDelayMs;
                     }
             }
 
             // Loot corpses whose pre-action delay has expired
             if (_corpsesPendingLoot.Count > 0)
             {
+                long now = Time.Ticks;
                 List<uint> lootReady = null;
                 foreach (KeyValuePair<uint, long> kv in _corpsesPendingLoot)
-                    if (Time.Ticks >= kv.Value)
+                    if (now >= kv.Value)
                         (lootReady ??= new List<uint>()).Add(kv.Key);
+
                 if (lootReady != null)
                     foreach (uint serial in lootReady)
                     {

--- a/src/ClassicUO.Client/Game/Managers/AutoLootManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/AutoLootManager.cs
@@ -51,6 +51,7 @@ namespace ClassicUO.Game.Managers
         private bool IsEnabled => ProfileManager.CurrentProfile.EnableAutoLoot;
 
         private readonly HashSet<uint> _preActionTriggeredCorpses = new();
+        private readonly HashSet<uint> _postActionFiredCorpses = new();
         private readonly Dictionary<uint, long> _corpsesPendingTarget = new();
         private readonly Dictionary<uint, long> _corpsesPendingLoot = new();
         private readonly Dictionary<uint, int> _pendingLootByCorpse = new();   // corpse serial → items still in queue
@@ -221,6 +222,7 @@ namespace ClassicUO.Game.Managers
 
         private void FirePostActionForCorpse(uint corpseSerial)
         {
+            if (!_postActionFiredCorpses.Add(corpseSerial)) return;
             Profile p = ProfileManager.CurrentProfile;
             LootActionType postType = (LootActionType)p.AutoLootPostActionType;
             if (postType == LootActionType.None) return;
@@ -423,6 +425,7 @@ namespace ClassicUO.Game.Managers
                 {
                     _recentlyLooted.Clear();
                     _preActionTriggeredCorpses.Clear();
+                    _postActionFiredCorpses.Clear();
                     _nextClearRecents = Time.Ticks + 5000;
                 }
                 return;
@@ -573,6 +576,7 @@ namespace ClassicUO.Game.Managers
             _corpsesPendingTarget.Clear();
             _corpsesPendingLoot.Clear();
             _preActionTriggeredCorpses.Clear();
+            _postActionFiredCorpses.Clear();
             _pendingLootByCorpse.Clear();
             _itemToCorpseSerial.Clear();
         }

--- a/src/ClassicUO.Client/Game/Managers/AutoLootManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/AutoLootManager.cs
@@ -383,7 +383,7 @@ namespace ClassicUO.Game.Managers
             if (_lootItems.Count == 0)
             {
                 _progressBarGump?.Dispose();
-                if (_loopingHasLooted)
+                if (_loopingHasLooted && _corpsesPendingTarget.Count == 0 && _corpsesPendingLoot.Count == 0)
                 {
                     _loopingHasLooted = false;
                     Profile p = ProfileManager.CurrentProfile;
@@ -550,6 +550,7 @@ namespace ClassicUO.Game.Managers
             _corpsesPendingLoot.Clear();
             _preActionTriggeredCorpses.Clear();
             _loopingHasLooted = false;
+            _lastLootedCorpseSerial = 0;
         }
 
         public void ImportFromOtherCharacter(string characterName, List<AutoLootConfigEntry> entries)

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/AutoLootAgentTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/AutoLootAgentTabContent.cs
@@ -81,12 +81,12 @@ public static class AutoLootAgentTabContent
             var section = new VerticalStackPanel { Spacing = 4 };
             section.Widgets.Add(new MyraLabel(sectionTitle, MyraLabel.TextStyle.H3));
 
-            var typeLabel = new MyraLabel(typeLabels[Math.Clamp(getType(), 0, 2)], MyraLabel.TextStyle.P) { MinWidth = 50 };
             var textInput = new MyraInputBox { Text = getText() ?? "", HintText = "Text/command", Width = 180, Visible = getType() == 1 };
             textInput.TextChangedByUser += (_, _) => setText(textInput.Text);
 
 #pragma warning disable CS0612, CS0618
             var macroCombo = new ComboBox { Width = 180, Visible = getType() == 2 };
+            var typeDropdown = new ComboBox { Width = 100 };
 #pragma warning restore CS0612, CS0618
 
             List<Macro> macros = Client.Game.UO.World?.Macros.GetAllMacros() ?? new();
@@ -100,25 +100,19 @@ public static class AutoLootAgentTabContent
                     setText(li.Text);
             };
 
-            void UpdateInputVisibility()
+            foreach (string label in typeLabels)
+                typeDropdown.Items.Add(new ListItem(label));
+            typeDropdown.SelectedIndex = Math.Clamp(getType(), 0, 2);
+            typeDropdown.SelectedIndexChanged += (_, _) =>
             {
-                int t = getType();
+                int t = typeDropdown.SelectedIndex ?? 0;
+                setType(t);
                 textInput.Visible = t == 1;
                 macroCombo.Visible = t == 2;
-            }
+            };
 
             var typeRow = new HorizontalStackPanel { Spacing = 4, VerticalAlignment = VerticalAlignment.Center };
-            typeRow.Widgets.Add(new MyraButton("<", () =>
-            {
-                int t = ((getType() - 1) + typeLabels.Length) % typeLabels.Length;
-                setType(t); typeLabel.Text = typeLabels[t]; UpdateInputVisibility();
-            }));
-            typeRow.Widgets.Add(typeLabel);
-            typeRow.Widgets.Add(new MyraButton(">", () =>
-            {
-                int t = (getType() + 1) % typeLabels.Length;
-                setType(t); typeLabel.Text = typeLabels[t]; UpdateInputVisibility();
-            }));
+            typeRow.Widgets.Add(typeDropdown);
             typeRow.Widgets.Add(textInput);
             typeRow.Widgets.Add(macroCombo);
             typeRow.Widgets.Add(MyraCheckButton.CreateWithCallback(

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/AutoLootAgentTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/AutoLootAgentTabContent.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -64,6 +65,91 @@ public static class AutoLootAgentTabContent
             "Hue Corpse After Processing",
             "Hue corpses after processing to make it easier to see if autoloot has processed them."));
         root.Widgets.Add(optRow2);
+
+        // Loot Actions section
+        root.Widgets.Add(new MyraSpacer(15, 5));
+        root.Widgets.Add(new MyraLabel("Loot Actions:", MyraLabel.TextStyle.H2));
+
+        VerticalStackPanel BuildLootActionSection(
+            string sectionTitle,
+            Func<int> getType, Action<int> setType,
+            Func<string?> getText, Action<string?> setText,
+            Func<bool> getTarget, Action<bool> setTarget,
+            Func<int>? getDelay = null, Action<int>? setDelay = null)
+        {
+            string[] typeLabels = { "None", "Say", "Macro" };
+            var section = new VerticalStackPanel { Spacing = 4 };
+            section.Widgets.Add(new MyraLabel(sectionTitle, MyraLabel.TextStyle.H3));
+
+            var typeLabel = new MyraLabel(typeLabels[Math.Clamp(getType(), 0, 2)], MyraLabel.TextStyle.P) { MinWidth = 50 };
+            var textInput = new MyraInputBox { Text = getText() ?? "", HintText = "Text/command", Width = 180, Visible = getType() == 1 };
+            textInput.TextChangedByUser += (_, _) => setText(textInput.Text);
+
+#pragma warning disable CS0612, CS0618
+            var macroCombo = new ComboBox { Width = 180, Visible = getType() == 2 };
+#pragma warning restore CS0612, CS0618
+
+            List<Macro> macros = Client.Game.UO.World?.Macros.GetAllMacros() ?? new();
+            foreach (Macro m in macros)
+                macroCombo.Items.Add(new ListItem(m.Name));
+            int selIdx = macros.FindIndex(m => m.Name == getText());
+            if (selIdx >= 0) macroCombo.SelectedIndex = selIdx;
+            macroCombo.SelectedIndexChanged += (_, _) =>
+            {
+                if (macroCombo.SelectedItem is ListItem li)
+                    setText(li.Text);
+            };
+
+            void UpdateInputVisibility()
+            {
+                int t = getType();
+                textInput.Visible = t == 1;
+                macroCombo.Visible = t == 2;
+            }
+
+            var typeRow = new HorizontalStackPanel { Spacing = 4, VerticalAlignment = VerticalAlignment.Center };
+            typeRow.Widgets.Add(new MyraButton("<", () =>
+            {
+                int t = ((getType() - 1) + typeLabels.Length) % typeLabels.Length;
+                setType(t); typeLabel.Text = typeLabels[t]; UpdateInputVisibility();
+            }));
+            typeRow.Widgets.Add(typeLabel);
+            typeRow.Widgets.Add(new MyraButton(">", () =>
+            {
+                int t = (getType() + 1) % typeLabels.Length;
+                setType(t); typeLabel.Text = typeLabels[t]; UpdateInputVisibility();
+            }));
+            typeRow.Widgets.Add(textInput);
+            typeRow.Widgets.Add(macroCombo);
+            typeRow.Widgets.Add(MyraCheckButton.CreateWithCallback(
+                getTarget(), b => setTarget(b),
+                "Target Corpse", "Automatically target the corpse when the server requests a target cursor."));
+            section.Widgets.Add(typeRow);
+
+            if (getDelay != null && setDelay != null)
+            {
+                section.Widgets.Add(MyraHSlider.SliderWithLabel(
+                    "Delay (s)", out _,
+                    v => setDelay((int)(v * 1000)),
+                    0f, 30f,
+                    getDelay() / 1000f));
+            }
+
+            return section;
+        }
+
+        root.Widgets.Add(BuildLootActionSection(
+            "Pre-Loot Action:",
+            () => profile.AutoLootPreActionType, v => profile.AutoLootPreActionType = v,
+            () => profile.AutoLootPreActionText, v => profile.AutoLootPreActionText = v ?? "",
+            () => profile.AutoLootPreActionTargetCorpse, v => profile.AutoLootPreActionTargetCorpse = v,
+            () => profile.AutoLootPreActionDelayMs, v => profile.AutoLootPreActionDelayMs = v));
+
+        root.Widgets.Add(BuildLootActionSection(
+            "Post-Loot Action:",
+            () => profile.AutoLootPostActionType, v => profile.AutoLootPostActionType = v,
+            () => profile.AutoLootPostActionText, v => profile.AutoLootPostActionText = v ?? "",
+            () => profile.AutoLootPostActionTargetCorpse, v => profile.AutoLootPostActionTargetCorpse = v));
 
         // Entries section
         root.Widgets.Add(new MyraSpacer(15, 5));


### PR DESCRIPTION
Adds configurable pre-action and post-action support to the auto loot manager. A pre-action (say text or execute a macro) fires before looting a corpse; if targeting is expected, looting waits until the auto-target is consumed before starting the configurable delay. A post-action fires once after the loot queue drains. Both actions support targeting the corpse automatically. UI exposed in the Auto Loot agent tab.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable pre-loot and post-loot actions for autoloot: None / Say / Macro, with text or macro selection and an optional "Target Corpse" toggle.
  * Pre-action can include a configurable delay before looting.
  * Post-action runs after a corpse is fully processed (after the last queued item).
  * UI: new "Loot Actions" section with per-action controls and a delay slider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->