### PR TITLE
Make autoloot corpse retry delay configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to TazUO will be recorded here.
 * Opening an already open grid container will now unminimize it if minimized and bring it to the front - [P.R 502](https://github.com/PlayTazUO/TazUO/pull/502) ([bittiez](https://github.com/bittiez))
 * Script manager and assistant windows now re-center when reopened via toolbar button instead of closing/reopening - [P.R 503](https://github.com/PlayTazUO/TazUO/pull/503) ([bittiez](https://github.com/bittiez))
 * Swapped a few hard coded texts for their cliloc equivelent - [P.R 505](https://github.com/PlayTazUO/TazUO/pull/505) ([bittiez](https://github.com/bittiez))
-* Auto loot corpse retry delay is now configurable in the Auto Loot agent UI (range 1000–600000ms, default 5000ms)
+* Auto loot corpse retry delay is now configurable in the Auto Loot agent UI (range 1000–600000ms, default 5000ms) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
 * Mouse wheel macros hijack scroll from shop gumps - [P.R 479](https://github.com/PlayTazUO/TazUO/pull/479) ([yuval-po](https://github.com/yuval-po))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to TazUO will be recorded here.
 * Opening an already open grid container will now unminimize it if minimized and bring it to the front - [P.R 502](https://github.com/PlayTazUO/TazUO/pull/502) ([bittiez](https://github.com/bittiez))
 * Script manager and assistant windows now re-center when reopened via toolbar button instead of closing/reopening - [P.R 503](https://github.com/PlayTazUO/TazUO/pull/503) ([bittiez](https://github.com/bittiez))
 * Swapped a few hard coded texts for their cliloc equivelent - [P.R 505](https://github.com/PlayTazUO/TazUO/pull/505) ([bittiez](https://github.com/bittiez))
-* Auto loot corpse retry delay is now configurable in the Auto Loot agent UI (range 1000–600000ms, default 5000ms) ([bittiez](https://github.com/bittiez))
+* Auto loot corpse retry delay is now configurable in the Auto Loot agent UI (range 1000–600000ms, default 5000ms) - [P.R 508](https://github.com/PlayTazUO/TazUO/pull/508) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
 * Mouse wheel macros hijack scroll from shop gumps - [P.R 479](https://github.com/PlayTazUO/TazUO/pull/479) ([yuval-po](https://github.com/yuval-po))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to TazUO will be recorded here.
 * Opening an already open grid container will now unminimize it if minimized and bring it to the front - [P.R 502](https://github.com/PlayTazUO/TazUO/pull/502) ([bittiez](https://github.com/bittiez))
 * Script manager and assistant windows now re-center when reopened via toolbar button instead of closing/reopening - [P.R 503](https://github.com/PlayTazUO/TazUO/pull/503) ([bittiez](https://github.com/bittiez))
 * Swapped a few hard coded texts for their cliloc equivelent - [P.R 505](https://github.com/PlayTazUO/TazUO/pull/505) ([bittiez](https://github.com/bittiez))
+* Auto loot corpse retry delay is now configurable in the Auto Loot agent UI (range 1000–600000ms, default 5000ms)
 
 ### Fixes
 * Mouse wheel macros hijack scroll from shop gumps - [P.R 479](https://github.com/PlayTazUO/TazUO/pull/479) ([yuval-po](https://github.com/yuval-po))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.2.13</AssemblyVersion>
-    <FileVersion>5.2.13</FileVersion>
+    <AssemblyVersion>5.2.14</AssemblyVersion>
+    <FileVersion>5.2.14</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -780,6 +780,10 @@ namespace ClassicUO.Configuration
         public partial bool HueCorpseAfterAutoloot { get; set; }
 
         [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, Constants.SqlSettings.AUTOLOOT_RETRY_DELAY, 5000)]
+        public partial int AutoLootRetryDelay { get; set; }
+
+        [JsonIgnore]
         [SqlSetting(SettingsScope.Global, Constants.SqlSettings.PATH_Z_LEVEL, 10)]
         public partial int PathfindingZLevelDiff { get; set; }
 

--- a/src/ClassicUO.Client/Game/Constants.cs
+++ b/src/ClassicUO.Client/Game/Constants.cs
@@ -133,6 +133,7 @@ namespace ClassicUO.Game
             public const string IRC_AUTO_CONNECT = "irc_disable_auto_connect";
             public const string PATH_Z_LEVEL = "path_z_level";
             public const string SINGLE_CLICK_SET_LAST_TARG = "single_click_set_last_targ";
+            public const string AUTOLOOT_RETRY_DELAY = "autoloot_retry_delay";
             public const string OVERHEAD_MESSAGE_TYPES_HIDDEN = "overhead_message_types_shown";
             public const string SKIP_SERVER_SELECTION = "skip_server_selection";
         }

--- a/src/ClassicUO.Client/Game/Managers/AutoLootManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/AutoLootManager.cs
@@ -45,7 +45,7 @@ namespace ClassicUO.Game.Managers
         private bool _loaded = false;
         private readonly string _savePath;
         private long _nextLootTime = Time.Ticks;
-        private long _nextClearRecents = Time.Ticks + 5000;
+        private long _nextClearRecents = Time.Ticks + (ProfileManager.CurrentProfile?.AutoLootRetryDelay ?? 5000);
         private ProgressBarGump _progressBarGump;
         private int _currentLootTotalCount = 0;
         private bool IsEnabled => ProfileManager.CurrentProfile.EnableAutoLoot;
@@ -74,7 +74,7 @@ namespace ClassicUO.Game.Managers
                 priority = entry.Priority;
             _lootItems.Enqueue((item, entry), priority);
             _currentLootTotalCount++;
-            _nextClearRecents = Time.Ticks + 5000;
+            _nextClearRecents = Time.Ticks + (ProfileManager.CurrentProfile?.AutoLootRetryDelay ?? 5000);
         }
 
         public void ForceLootContainer(uint serial)
@@ -299,7 +299,7 @@ namespace ClassicUO.Game.Managers
                 if (Time.Ticks > _nextClearRecents)
                 {
                     _recentlyLooted.Clear();
-                    _nextClearRecents = Time.Ticks + 5000;
+                    _nextClearRecents = Time.Ticks + (ProfileManager.CurrentProfile?.AutoLootRetryDelay ?? 5000);
                 }
                 return;
             }

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/AutoLootAgentTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/AutoLootAgentTabContent.cs
@@ -69,7 +69,7 @@ public static class AutoLootAgentTabContent
         var optRow3 = new HorizontalStackPanel { Spacing = 8, VerticalAlignment = Myra.Graphics2D.UI.VerticalAlignment.Center };
         optRow3.Widgets.Add(new MyraLabel("Corpse retry delay (ms):", MyraLabel.TextStyle.P)
         {
-            Tooltip = "Milliseconds before a failed corpse is retried. Lower values retry sooner; 0 disables the reset.",
+            Tooltip = "Milliseconds before a failed corpse is retried. Minimum 1000ms.",
             VerticalAlignment = Myra.Graphics2D.UI.VerticalAlignment.Center
         });
         var retrySpinner = new SpinButton
@@ -79,7 +79,7 @@ public static class AutoLootAgentTabContent
             Minimum = 1000,
             Maximum = 600000,
             MinWidth = 100,
-            Tooltip = "Milliseconds before a failed corpse is retried. Lower values retry sooner; 0 disables the reset."
+            Tooltip = "Milliseconds before a failed corpse is retried. Minimum 1000ms."
         };
         retrySpinner.ValueChangedByUser += (_, _) =>
             profile.AutoLootRetryDelay = (int)Math.Clamp(retrySpinner.Value ?? 5000f, 1000f, 600000f);

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/AutoLootAgentTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/AutoLootAgentTabContent.cs
@@ -76,13 +76,13 @@ public static class AutoLootAgentTabContent
         {
             Integer = true,
             Value = profile.AutoLootRetryDelay,
-            Minimum = 0,
-            Maximum = 300000,
+            Minimum = 1000,
+            Maximum = 600000,
             MinWidth = 100,
             Tooltip = "Milliseconds before a failed corpse is retried. Lower values retry sooner; 0 disables the reset."
         };
         retrySpinner.ValueChangedByUser += (_, _) =>
-            profile.AutoLootRetryDelay = (int)Math.Clamp(retrySpinner.Value ?? 5000f, 0f, 300000f);
+            profile.AutoLootRetryDelay = (int)Math.Clamp(retrySpinner.Value ?? 5000f, 1000f, 600000f);
         optRow3.Widgets.Add(retrySpinner);
         root.Widgets.Add(optRow3);
 

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/AutoLootAgentTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/AutoLootAgentTabContent.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -64,6 +65,26 @@ public static class AutoLootAgentTabContent
             "Hue Corpse After Processing",
             "Hue corpses after processing to make it easier to see if autoloot has processed them."));
         root.Widgets.Add(optRow2);
+
+        var optRow3 = new HorizontalStackPanel { Spacing = 8, VerticalAlignment = Myra.Graphics2D.UI.VerticalAlignment.Center };
+        optRow3.Widgets.Add(new MyraLabel("Corpse retry delay (ms):", MyraLabel.TextStyle.P)
+        {
+            Tooltip = "Milliseconds before a failed corpse is retried. Lower values retry sooner; 0 disables the reset.",
+            VerticalAlignment = Myra.Graphics2D.UI.VerticalAlignment.Center
+        });
+        var retrySpinner = new SpinButton
+        {
+            Integer = true,
+            Value = profile.AutoLootRetryDelay,
+            Minimum = 0,
+            Maximum = 300000,
+            MinWidth = 100,
+            Tooltip = "Milliseconds before a failed corpse is retried. Lower values retry sooner; 0 disables the reset."
+        };
+        retrySpinner.ValueChangedByUser += (_, _) =>
+            profile.AutoLootRetryDelay = (int)Math.Clamp(retrySpinner.Value ?? 5000f, 0f, 300000f);
+        optRow3.Widgets.Add(retrySpinner);
+        root.Widgets.Add(optRow3);
 
         // Entries section
         root.Widgets.Add(new MyraSpacer(15, 5));


### PR DESCRIPTION
Replaces the hardcoded 5000ms reset interval for the recently-looted corpse HashSet with a profile setting (AutoLootRetryDelay), exposed in the Auto Loot agent UI as a spinner.


## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-loot corpse retry delay is now configurable through settings, allowing users to adjust the retry interval from 0 to 300,000 milliseconds instead of the previously fixed value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->