### PR TITLE
Add reusable OptionsWindow and Edit settings option to login screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to TazUO will be recorded here.
 * Script manager and assistant windows now re-center when reopened via toolbar button instead of closing/reopening - [P.R 503](https://github.com/PlayTazUO/TazUO/pull/503) ([bittiez](https://github.com/bittiez))
 * Swapped a few hard coded texts for their cliloc equivelent - [P.R 505](https://github.com/PlayTazUO/TazUO/pull/505) ([bittiez](https://github.com/bittiez))
 * Auto loot corpse retry delay is now configurable in the Auto Loot agent UI (range 1000–600000ms, default 5000ms) - [P.R 508](https://github.com/PlayTazUO/TazUO/pull/508) ([bittiez](https://github.com/bittiez))
+* Added a quick settings.json editor on the login gump - [P.R 510](https://github.com/PlayTazUO/TazUO/pull/510) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
 * Mouse wheel macros hijack scroll from shop gumps - [P.R 479](https://github.com/PlayTazUO/TazUO/pull/479) ([yuval-po](https://github.com/yuval-po))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.2.15</AssemblyVersion>
-    <FileVersion>5.2.15</FileVersion>
+    <AssemblyVersion>5.2.16</AssemblyVersion>
+    <FileVersion>5.2.16</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Controls/MyraControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/MyraControl.cs
@@ -197,6 +197,20 @@ public class MyraControl : IGui
         return this;
     }
 
+    public MyraControl CenterInScreen()
+    {
+        Rectangle bounds = Client.Game.Window.ClientBounds;
+        X = (int)(((bounds.Width / Client.Game.RenderScale) - (Width * Client.Game.RenderScale)) / 2);
+        Y = (int)(((bounds.Height / Client.Game.RenderScale) - (Height * Client.Game.RenderScale)) / 2);
+
+        if (X < 0)
+            X = 0;
+
+        SetPosition(X, Y);
+
+        return this;
+    }
+
     public void SetPosition(int x, int y)
     {
         _rootWindow.Left = x;

--- a/src/ClassicUO.Client/Game/UI/Gumps/Login/LoginGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/Login/LoginGump.cs
@@ -497,7 +497,7 @@ namespace ClassicUO.Game.UI.Gumps.Login
 
             w.AddInput("Port:", s.Port.ToString(), v =>
             {
-                if (ushort.TryParse(v, out ushort port))
+                if (ushort.TryParse(v, out ushort port) && port >= 1)
                 {
                     s.Port = port;
                     s.Save();
@@ -512,7 +512,7 @@ namespace ClassicUO.Game.UI.Gumps.Login
 
             w.AddInput("Reconnect time (sec):", s.ReconnectTime.ToString(), v =>
             {
-                if (int.TryParse(v, out int time))
+                if (int.TryParse(v, out int time) && time >= 0)
                 {
                     s.ReconnectTime = time;
                     s.Save();

--- a/src/ClassicUO.Client/Game/UI/Gumps/Login/LoginGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/Login/LoginGump.cs
@@ -481,10 +481,10 @@ namespace ClassicUO.Game.UI.Gumps.Login
 
         private static void OpenEditSettings()
         {
-            OptionsWindow existing = OptionsWindow.GetExisting("Edit Settings");
+            var existing = OptionsWindow.GetExisting("Edit Settings");
             if (existing != null)
             {
-                existing.CenterInViewPort();
+                existing.CenterInScreen();
                 existing.BringOnTop();
                 return;
             }
@@ -529,6 +529,8 @@ namespace ClassicUO.Game.UI.Gumps.Login
             }, 80, "Graphics driver to force (0 = default). Change won't take effect until restart.");
 
             w.AddLabel("Note: Force driver change won't take effect until restart.");
+
+            w.CenterInScreen();
         }
 
         protected override void OnControllerButtonUp(SDL.SDL_GamepadButton button)

--- a/src/ClassicUO.Client/Game/UI/Gumps/Login/LoginGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/Login/LoginGump.cs
@@ -481,6 +481,14 @@ namespace ClassicUO.Game.UI.Gumps.Login
 
         private static void OpenEditSettings()
         {
+            OptionsWindow existing = OptionsWindow.GetExisting("Edit Settings");
+            if (existing != null)
+            {
+                existing.CenterInViewPort();
+                existing.BringOnTop();
+                return;
+            }
+
             Settings s = Settings.GlobalSettings;
 
             var w = new OptionsWindow("Edit Settings");

--- a/src/ClassicUO.Client/Game/UI/Gumps/Login/LoginGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/Login/LoginGump.cs
@@ -4,6 +4,7 @@ using ClassicUO.Configuration;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Controls;
+using ClassicUO.Game.UI.MyraWindows;
 using ClassicUO.Input;
 using ClassicUO.Assets;
 using ClassicUO.Renderer;
@@ -458,6 +459,8 @@ namespace ClassicUO.Game.UI.Gumps.Login
                 _ = Client.Settings.SetAsync(SettingsScope.Global, Constants.SqlSettings.SKIP_SERVER_SELECTION, Settings.GlobalSettings.SkipServerSelect);
             }, true, Settings.GlobalSettings.SkipServerSelect));
 
+            c.Add(new ContextMenuItemEntry("Edit settings", OpenEditSettings, true, false));
+
             c.Add(new ContextMenuItemEntry("TazUO Website", () =>
             {
                 PlatformHelper.LaunchBrowser("https://tazuo.org");
@@ -474,6 +477,50 @@ namespace ClassicUO.Game.UI.Gumps.Login
             }, true, false));
 
             return c;
+        }
+
+        private static void OpenEditSettings()
+        {
+            Settings s = Settings.GlobalSettings;
+
+            var w = new OptionsWindow("Edit Settings");
+
+            w.AddInput("IP:", s.IP, v => { s.IP = v; s.Save(); }, 200, "Server IP address or hostname.");
+
+            w.AddInput("Port:", s.Port.ToString(), v =>
+            {
+                if (ushort.TryParse(v, out ushort port))
+                {
+                    s.Port = port;
+                    s.Save();
+                }
+            }, 80, "Server port.");
+
+            w.AddCheckbox("Auto login", s.AutoLogin, v => { s.AutoLogin = v; s.Save(); },
+                "Automatically log in using the saved account.");
+
+            w.AddCheckbox("Reconnect", s.Reconnect, v => { s.Reconnect = v; s.Save(); },
+                "Automatically reconnect after a disconnect.");
+
+            w.AddInput("Reconnect time (sec):", s.ReconnectTime.ToString(), v =>
+            {
+                if (int.TryParse(v, out int time))
+                {
+                    s.ReconnectTime = time;
+                    s.Save();
+                }
+            }, 80, "Seconds to wait before reconnecting.");
+
+            w.AddInput("Force driver:", s.ForceDriver.ToString(), v =>
+            {
+                if (byte.TryParse(v, out byte driver))
+                {
+                    s.ForceDriver = driver;
+                    s.Save();
+                }
+            }, 80, "Graphics driver to force (0 = default). Change won't take effect until restart.");
+
+            w.AddLabel("Note: Force driver change won't take effect until restart.");
         }
 
         protected override void OnControllerButtonUp(SDL.SDL_GamepadButton button)

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/OptionsWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/OptionsWindow.cs
@@ -28,7 +28,7 @@ public class OptionsWindow : MyraControl
         _stack = new VerticalStackPanel { Spacing = MyraStyle.STANDARD_SPACING, Padding = new Thickness(8) };
 
         SetRootContent(_stack);
-        CenterInViewPort();
+        CenterInScreen();
         UIManager.Add(this);
         BringOnTop();
     }

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/OptionsWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/OptionsWindow.cs
@@ -18,15 +18,34 @@ public class OptionsWindow : MyraControl
 {
     private readonly VerticalStackPanel _stack;
 
+    /// <summary>The window title, also used to match existing instances in <see cref="GetExisting"/>.</summary>
+    public string Title { get; }
+
     /// <param name="title">The window title shown in the title bar.</param>
     public OptionsWindow(string title) : base(title)
     {
+        Title = title;
         _stack = new VerticalStackPanel { Spacing = MyraStyle.STANDARD_SPACING, Padding = new Thickness(8) };
 
         SetRootContent(_stack);
         CenterInViewPort();
         UIManager.Add(this);
         BringOnTop();
+    }
+
+    /// <summary>
+    /// Returns an existing, non-disposed <see cref="OptionsWindow"/> with the given <paramref name="title"/>,
+    /// or null if none is open. Useful to focus an existing window instead of opening a duplicate.
+    /// </summary>
+    public static OptionsWindow? GetExisting(string title)
+    {
+        foreach (IGui g in UIManager.Gumps)
+        {
+            if (g is OptionsWindow ow && !ow.IsDisposed && ow.Title == title)
+                return ow;
+        }
+
+        return null;
     }
 
     /// <summary>Appends a plain text label.</summary>

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/OptionsWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/OptionsWindow.cs
@@ -1,0 +1,75 @@
+#nullable enable
+using System;
+using ClassicUO.Game.Managers;
+using ClassicUO.Game.UI.Controls;
+using ClassicUO.Game.UI.MyraWindows.Widgets;
+using Myra.Graphics2D;
+using Myra.Graphics2D.UI;
+
+namespace ClassicUO.Game.UI.MyraWindows;
+
+/// <summary>
+/// A reusable, lightweight options window for quick settings that don't warrant a dedicated window.
+/// Build it up fluently with <see cref="AddLabel"/>, <see cref="AddCheckbox"/> and <see cref="AddInput"/>,
+/// each of which appends the appropriate control (wired to a callback) to a vertical stack.
+/// The window is shown automatically once constructed.
+/// </summary>
+public class OptionsWindow : MyraControl
+{
+    private readonly VerticalStackPanel _stack;
+
+    /// <param name="title">The window title shown in the title bar.</param>
+    public OptionsWindow(string title) : base(title)
+    {
+        _stack = new VerticalStackPanel { Spacing = MyraStyle.STANDARD_SPACING, Padding = new Thickness(8) };
+
+        SetRootContent(_stack);
+        CenterInViewPort();
+        UIManager.Add(this);
+        BringOnTop();
+    }
+
+    /// <summary>Appends a plain text label.</summary>
+    public OptionsWindow AddLabel(string text, MyraLabel.TextStyle style = MyraLabel.TextStyle.P)
+    {
+        _stack.Widgets.Add(new MyraLabel(text, style));
+        Refresh();
+        return this;
+    }
+
+    /// <summary>Appends a labeled checkbox that invokes <paramref name="onChange"/> when toggled.</summary>
+    public OptionsWindow AddCheckbox(string label, bool isChecked, Action<bool> onChange, string? tooltip = null)
+    {
+        _stack.Widgets.Add(MyraCheckButton.CreateWithCallback(isChecked, onChange, label, tooltip));
+        Refresh();
+        return this;
+    }
+
+    /// <summary>Appends a labeled text input that invokes <paramref name="onChange"/> as the user types.</summary>
+    public OptionsWindow AddInput(
+        string label,
+        string value,
+        Action<string> onChange,
+        int width = 200,
+        string? tooltip = null,
+        Func<char, bool>? inputFilter = null
+    )
+    {
+        var row = MyraInputBox.WithLabel(label, out MyraInputBox input, width, value, tooltip: tooltip);
+
+        if (inputFilter != null)
+            input.InputFilter = inputFilter;
+
+        input.TextChangedByUser += (_, _) => onChange(input.Text ?? string.Empty);
+
+        _stack.Widgets.Add(row);
+        Refresh();
+        return this;
+    }
+
+    private void Refresh()
+    {
+        ForceSizeUpdate();
+        CenterInViewPort();
+    }
+}


### PR DESCRIPTION
Add a lightweight, fluent OptionsWindow (MyraControl) with AddLabel, AddCheckbox and AddInput helpers that append callback-wired controls to a vertical stack. Wire up an 'Edit settings' entry in the LoginGump options context menu to edit IP, port, auto login, reconnect, reconnect time and force driver.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Edit Settings" to the login menu for quick, in-app editing of server address/port, auto-login, reconnect behavior, reconnect delay, and driver selection (note: driver change requires restart).
  * New reusable quick-options window with labeled inputs and toggles for editing settings.

* **Documentation**
  * Added an "In Development" changelog entry describing the quick settings editor.

* **Chores**
  * Application version incremented to 5.2.16.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->