### PR TITLE
Fix back button with Skip Server Select & add -skipserverselect arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to TazUO will be recorded here.
 * Added maximum depth recursion to legion py scripting to prevent stack overflow - ([bittiez](https://github.com/bittiez))
 * Fixed tooltips going outside window bounds when scaled - ([bittiez](https://github.com/bittiez))
 * Fixed logout gump not being centered when scaled - ([bittiez](https://github.com/bittiez))
+* Back button now reaches the server select & username screens when 'Skip Server Select' is enabled, and added a `-skipserverselect` command-line arg - ([bittiez](https://github.com/bittiez))
 
 ### Misc
 * Remove tab completion and command history tracking - [P.R 489](https://github.com/PlayTazUO/TazUO/pull/489) ([Jascen](https://github.com/Jascen))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ All notable changes to TazUO will be recorded here.
 * Added maximum depth recursion to legion py scripting to prevent stack overflow - ([bittiez](https://github.com/bittiez))
 * Fixed tooltips going outside window bounds when scaled - ([bittiez](https://github.com/bittiez))
 * Fixed logout gump not being centered when scaled - ([bittiez](https://github.com/bittiez))
-* Back button now reaches the server select & username screens when 'Skip Server Select' is enabled, and added a `-skipserverselect` command-line arg - ([bittiez](https://github.com/bittiez))
+* Back button now reaches the server select & username screens when 'Skip Server Select' is enabled, and added a `-skipserverselect` command-line arg - [P.R 512](https://github.com/PlayTazUO/TazUO/pull/512) ([bittiez](https://github.com/bittiez))
 
 ### Misc
 * Remove tab completion and command history tracking - [P.R 489](https://github.com/PlayTazUO/TazUO/pull/489) ([Jascen](https://github.com/Jascen))

--- a/src/ClassicUO.Client/CUOEnviroment.cs
+++ b/src/ClassicUO.Client/CUOEnviroment.cs
@@ -18,6 +18,7 @@ namespace ClassicUO
         public static bool IsHighDPI;
         public static uint CurrentRefreshRate;
         public static bool SkipLoginScreen;
+        public static bool SkipServerSelect;
         public static bool NoServerPing;
         public static Assembly Assembly => Assembly.GetEntryAssembly();
 

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.2.16</AssemblyVersion>
-    <FileVersion>5.2.16</FileVersion>
+    <AssemblyVersion>5.2.17</AssemblyVersion>
+    <FileVersion>5.2.17</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Client.cs
+++ b/src/ClassicUO.Client/Client.cs
@@ -184,7 +184,7 @@ namespace ClassicUO
             }
 
             skipServerSelectTask.Wait();
-            Settings.GlobalSettings.SkipServerSelect = skipServerSelectTask.Result;
+            Settings.GlobalSettings.SkipServerSelect = skipServerSelectTask.Result || CUOEnviroment.SkipServerSelect;
 
             Log.Trace($"Client path: '{clientPath}'");
             Log.Trace($"Client version: {clientVersion}");

--- a/src/ClassicUO.Client/Game/Scenes/LoginScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/LoginScene.cs
@@ -474,6 +474,10 @@ namespace ClassicUO.Game.Scenes
                     break;
 
                 case LoginSteps.LoginInToServer:
+                    // Stepping back here reconnects and walks the flow back to server selection.
+                    // If 'Skip Server Select' is enabled the auto-skip would bounce us straight back to
+                    // character selection, so suppress it once to let the user reach the server screen.
+                    LoginHandshake.Instance.BypassServerSelectSkipOnce = true;
                     LoginHandshake.Instance.Disconnect();
                     Connect(Account, Password);
 

--- a/src/ClassicUO.Client/Main.cs
+++ b/src/ClassicUO.Client/Main.cs
@@ -442,6 +442,11 @@ namespace ClassicUO
 
                         break;
 
+                    case "skipserverselect":
+                        CUOEnviroment.SkipServerSelect = true;
+
+                        break;
+
                     case "plugins":
                         Settings.GlobalSettings.Plugins = string.IsNullOrEmpty(value) ? new string[0] : value.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
 

--- a/src/ClassicUO.Client/Network/LoginHandshake.cs
+++ b/src/ClassicUO.Client/Network/LoginHandshake.cs
@@ -43,6 +43,11 @@ namespace ClassicUO.Network
         public CityInfo[] Cities { get; set; }
         public string[] Characters { get; private set; }
         public byte ServerIndex { get; private set; }
+
+        // When the user steps back from character selection while 'Skip Server Select' is enabled,
+        // we need to suppress the auto-skip once so they actually land on the server selection screen
+        // instead of being bounced straight back to character selection.
+        public bool BypassServerSelectSkipOnce { get; set; }
         public static string Account { get; private set; }
         private static string Password { get; set; }
         public static string IP { get; set; }
@@ -174,8 +179,13 @@ namespace ClassicUO.Network
 
             SetLoginStep(LoginSteps.ServerSelection);
 
-            if (Settings.GlobalSettings.SkipServerSelect && Servers.Length == 1 && CurrentLoginStep == LoginSteps.ServerSelection) //Double check server selection, the previous call may initiate auto login and already select one
-            {      
+            if (BypassServerSelectSkipOnce)
+            {
+                // User explicitly navigated back to server selection, don't auto-skip this time.
+                BypassServerSelectSkipOnce = false;
+            }
+            else if (Settings.GlobalSettings.SkipServerSelect && Servers.Length == 1 && CurrentLoginStep == LoginSteps.ServerSelection) //Double check server selection, the previous call may initiate auto login and already select one
+            {
                 SelectServer((byte)Servers[0].Index, Servers[0].Name);
                 return;
             }


### PR DESCRIPTION
When 'Skip Server Select' is enabled, stepping back from character selection would reconnect and immediately auto-skip server selection, bouncing the user right back to character selection. They could never reach the server select (or username/password) screen without logging out. Suppress the auto-skip once when the user explicitly steps back so the server selection screen is shown.

Also add a -skipserverselect command-line argument that enables the feature at startup.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update