### PR TITLE
Make managed zlib a platform-aware global SQL setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to TazUO will be recorded here.
 * Remove tab completion and command history tracking - [P.R 489](https://github.com/PlayTazUO/TazUO/pull/489) ([Jascen](https://github.com/Jascen))
 * Add option to toggle bandage agent from macros - [P.R 491](https://github.com/PlayTazUO/TazUO/pull/491) ([bittiez](https://github.com/bittiez))
 * Refactored PromptPopupWindow into a reusable text prompt and replaced InputRequest with it - [P.R 509](https://github.com/PlayTazUO/TazUO/pull/509) ([bittiez](https://github.com/bittiez))
+* Managed zlib is now a global setting, defaults to enabled on Linux and disabled on Windows/Mac, and the `-zlib` arg now persists the setting - [P.R 514](https://github.com/PlayTazUO/TazUO/pull/514) ([bittiez](https://github.com/bittiez))
 
 ---
 

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.2.17</AssemblyVersion>
-    <FileVersion>5.2.17</FileVersion>
+    <AssemblyVersion>5.2.18</AssemblyVersion>
+    <FileVersion>5.2.18</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/GameController.cs
+++ b/src/ClassicUO.Client/GameController.cs
@@ -15,6 +15,7 @@ using ClassicUO.Network.Encryption;
 using ClassicUO.Renderer;
 using ClassicUO.Resources;
 using ClassicUO.Utility;
+using ClassicUO.Utility.Platforms;
 using ClassicUO.Utility.Logging;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
@@ -143,8 +144,17 @@ namespace ClassicUO
             base.Initialize();
         }
 
-        private void PreloadSettings() => _ = Client.Settings.GetAsyncOnMainThread(SettingsScope.Global, Constants.SqlSettings.MANAGED_ZLIB, false,
-                (b) => { if (b) ZLib.SetForceManagedZlib(b); });
+        private void PreloadSettings()
+        {
+            bool platformDefault = PlatformHelper.IsLinux;
+            _ = Client.Settings.GetAsyncOnMainThread(SettingsScope.Global, Constants.SqlSettings.MANAGED_ZLIB, platformDefault, (b) =>
+            {
+                if (ZLib.CommandLineOverride)
+                    _ = Client.Settings.SetAsync(SettingsScope.Global, Constants.SqlSettings.MANAGED_ZLIB, true);
+                else
+                    ZLib.SetForceManagedZlib(b);
+            });
+        }
 
         private const int MAX_PACKETS_PER_FRAME = 25;
 

--- a/src/ClassicUO.Client/Main.cs
+++ b/src/ClassicUO.Client/Main.cs
@@ -547,7 +547,7 @@ namespace ClassicUO
                         break;
 
                     case "zlib":
-                        ZLib.SetForceManagedZlib(true);
+                        ZLib.SetCommandLineOverride();
 
                         break;
                 }

--- a/src/ClassicUO.Utility/ZLib.cs
+++ b/src/ClassicUO.Utility/ZLib.cs
@@ -12,12 +12,9 @@ namespace ClassicUO.Utility
 
         private static ICompressor _compressor;
 
-        public static bool ManagedZlibForced { get; private set; } =
-#if DEBUG
-            true;
-#else
-            false;
-#endif
+        public static bool ManagedZlibForced { get; private set; } = PlatformHelper.IsLinux;
+
+        public static bool CommandLineOverride { get; private set; } = false;
 
         static ZLib()
         {
@@ -47,6 +44,12 @@ namespace ClassicUO.Utility
         {
             ManagedZlibForced = enabled;
             SetupCompressor();
+        }
+
+        public static void SetCommandLineOverride()
+        {
+            CommandLineOverride = true;
+            SetForceManagedZlib(true);
         }
 
         public static ZLibError Decompress(byte[] source, int offset, byte[] dest, int length) => _compressor.Decompress(dest, ref length, source, source.Length - offset);


### PR DESCRIPTION
- Default ManagedZlibForced to true on Linux, false on Windows/Mac
- Add ZLib.CommandLineOverride flag and SetCommandLineOverride() method
- -zlib command line arg now calls SetCommandLineOverride() to both enable managed zlib and persist the choice to SQL global settings
- PreloadSettings() uses platform-specific default and saves command line override to SQL when applicable

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added command-line override support for compression library settings.
  * Enhanced platform-specific optimization for Linux systems with improved compression configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->