### PR TITLE
Fix NullReferenceException in CampfirePortrait when character has no …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to TazUO will be recorded here.
 * Added an alternative character select screen - [P.R 513](https://github.com/PlayTazUO/TazUO/pull/513) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
+* Fix NullReferenceException in campfire character selection when a character has no appearance data - [P.R 515](https://github.com/PlayTazUO/TazUO/pull/515) ([bittiez](https://github.com/bittiez))
 * Mouse wheel macros hijack scroll from shop gumps - [P.R 479](https://github.com/PlayTazUO/TazUO/pull/479) ([yuval-po](https://github.com/yuval-po))
 * FindItems now properly returns the highest level container - [P.R 488](https://github.com/PlayTazUO/TazUO/pull/488) ([Jascen](https://github.com/Jascen))
 * Grid container label missing updates - [P.R 487](https://github.com/PlayTazUO/TazUO/pull/487) ([yuval-po](https://github.com/yuval-po))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.2.19</AssemblyVersion>
-    <FileVersion>5.2.19</FileVersion>
+    <AssemblyVersion>5.2.20</AssemblyVersion>
+    <FileVersion>5.2.20</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Gumps/Login/CampfireCharacterSelectionGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/Login/CampfireCharacterSelectionGump.cs
@@ -244,7 +244,7 @@ namespace ClassicUO.Game.UI.Gumps.Login
                 );
 
                 nameLabel.ForceSizeUpdate();
-                nameLabel.X = nameBg.X = (view.Width - nameLabel.Width) / 2;
+                nameLabel.X = nameBg.X = ((view?.Width ?? width) - nameLabel.Width) / 2;
                 nameBg.Width = nameLabel.Width;
                 nameBg.Height = nameLabel.Height;
 


### PR DESCRIPTION
…appearance data

When a character slot has no Lem value, view is null, causing a crash on view.Width. Fall back to the width parameter in that case.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed character name label positioning in the character selection screen to properly center based on display dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->