### PR TITLE
Add macro to set an organizer's source container via target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to TazUO will be recorded here.
 * Auto loot corpse retry delay is now configurable in the Auto Loot agent UI (range 1000–600000ms, default 5000ms) - [P.R 508](https://github.com/PlayTazUO/TazUO/pull/508) ([bittiez](https://github.com/bittiez))
 * Added a quick settings.json editor on the login gump - [P.R 510](https://github.com/PlayTazUO/TazUO/pull/510) ([bittiez](https://github.com/bittiez))
 * Added an alternative character select screen - [P.R 513](https://github.com/PlayTazUO/TazUO/pull/513) ([bittiez](https://github.com/bittiez))
+* Added a macro to set an organizer's source container via target - [P.R 516](https://github.com/PlayTazUO/TazUO/pull/516) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
 * Fix NullReferenceException in campfire character selection when a character has no appearance data - [P.R 515](https://github.com/PlayTazUO/TazUO/pull/515) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.2.20</AssemblyVersion>
-    <FileVersion>5.2.20</FileVersion>
+    <AssemblyVersion>5.2.21</AssemblyVersion>
+    <FileVersion>5.2.21</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Common/Enums/MacroType.cs
+++ b/src/ClassicUO.Client/Common/Enums/MacroType.cs
@@ -112,4 +112,5 @@ public enum MacroType
     SetLastTarget,
     ToggleAutoWalk,
     ToggleBandageAgent,
+    SetOrganizerSource,
 }

--- a/src/ClassicUO.Client/Game/Managers/MacroManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/MacroManager.cs
@@ -2439,6 +2439,17 @@ namespace ClassicUO.Game.Managers
                     ProfileManager.CurrentProfile.EnableBandageAgent = newStatus;
                     GameActions.Print($"Bandage agent {(newStatus ? "enabled" : "disabled")}.", newStatus ? Constants.HUE_SUCCESS : Constants.HUE_ERROR);
                     break;
+
+                case MacroType.SetOrganizerSource:
+                    if (macro is MacroObjectString { Text: { } organizerName } && !string.IsNullOrWhiteSpace(organizerName))
+                    {
+                        OrganizerAgent.Instance.SetSourceContainerViaTarget(organizerName);
+                    }
+                    else
+                    {
+                        GameActions.Print(_world, "Set the organizer name (or index) in the macro to target a source container for it.", Constants.HUE_ERROR);
+                    }
+                    break;
             }
 
             return result;
@@ -2756,6 +2767,7 @@ namespace ClassicUO.Game.Managers
                 case MacroType.SetSpellBarRow:
                 case MacroType.ClientCommand:
                 case MacroType.UseType:
+                case MacroType.SetOrganizerSource:
                     obj = new MacroObjectString(code, MacroSubType.MSC_NONE);
 
                     break;
@@ -2942,6 +2954,7 @@ namespace ClassicUO.Game.Managers
                 case MacroType.SetSpellBarRow:
                 case MacroType.ClientCommand:
                 case MacroType.UseType:
+                case MacroType.SetOrganizerSource:
                     SubMenuType = 2;
 
                     break;

--- a/src/ClassicUO.Client/Game/Managers/OrganizerAgent.cs
+++ b/src/ClassicUO.Client/Game/Managers/OrganizerAgent.cs
@@ -73,6 +73,49 @@ namespace ClassicUO.Game.Managers
 
         public void Save() => JsonHelper.SaveAndBackup(OrganizerConfigs, Path.Combine(GetDataPath(), "OrganizerConfig.json"), OrganizerAgentContext.Default.ListOrganizerConfig);
 
+        public OrganizerConfig FindConfig(string nameOrIndex)
+        {
+            if (string.IsNullOrWhiteSpace(nameOrIndex))
+                return null;
+
+            nameOrIndex = nameOrIndex.Trim();
+
+            if (int.TryParse(nameOrIndex, out int index))
+            {
+                if (index >= 0 && index < OrganizerConfigs.Count)
+                    return OrganizerConfigs[index];
+
+                return null;
+            }
+
+            return OrganizerConfigs.FirstOrDefault(c => c.Name.Equals(nameOrIndex, StringComparison.OrdinalIgnoreCase));
+        }
+
+        public void SetSourceContainerViaTarget(string nameOrIndex)
+        {
+            OrganizerConfig config = FindConfig(nameOrIndex);
+            if (config == null)
+            {
+                GameActions.Print(World.Instance, $"Organizer '{nameOrIndex}' not found.", Constants.HUE_ERROR);
+                return;
+            }
+
+            GameActions.Print(World.Instance, $"Target the source container for organizer '{config.Name}'.");
+            World.Instance.TargetManager.SetTargeting((o) =>
+            {
+                if (o is Item item && item.ItemData.IsContainer)
+                {
+                    config.SourceContSerial = item.Serial;
+                    Save();
+                    GameActions.Print(World.Instance, $"Source container for organizer '{config.Name}' set.", Constants.HUE_SUCCESS);
+                }
+                else
+                {
+                    GameActions.Print(World.Instance, "That doesn't appear to be a valid container.", Constants.HUE_ERROR);
+                }
+            });
+        }
+
         public static void Unload()
         {
             Instance?.Save();


### PR DESCRIPTION
## Description
Add macro to set an organizer's source container via target

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Additional Notes
Addresses #511 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "SetOrganizerSource" macro type enabling users to dynamically assign source containers to organizers through macro commands with target-based selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->