### PR TITLE
Add handshake watchdog so stalled reconnects retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to TazUO will be recorded here.
 * Added a macro to set an organizer's source container via target - [P.R 516](https://github.com/PlayTazUO/TazUO/pull/516) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
+* Fixed reconnect getting stuck when the server is unavailable or restarting during a reconnect attempt - [P.R 517](https://github.com/PlayTazUO/TazUO/pull/517) ([bittiez](https://github.com/bittiez))
 * Fix NullReferenceException in campfire character selection when a character has no appearance data - [P.R 515](https://github.com/PlayTazUO/TazUO/pull/515) ([bittiez](https://github.com/bittiez))
 * Mouse wheel macros hijack scroll from shop gumps - [P.R 479](https://github.com/PlayTazUO/TazUO/pull/479) ([yuval-po](https://github.com/yuval-po))
 * FindItems now properly returns the highest level container - [P.R 488](https://github.com/PlayTazUO/TazUO/pull/488) ([Jascen](https://github.com/Jascen))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.2.21</AssemblyVersion>
-    <FileVersion>5.2.21</FileVersion>
+    <AssemblyVersion>5.2.22</AssemblyVersion>
+    <FileVersion>5.2.22</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/Scenes/LoginScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/LoginScene.cs
@@ -237,6 +237,7 @@ namespace ClassicUO.Game.Scenes
         {
             base.Update();
 
+            LoginHandshake.Instance.CheckHandshakeTimeout();
             LoginHandshake.Instance.HandleReconnect(Settings.GlobalSettings.ReconnectTime * 1000);
             LoginHandshake.Instance.SendPing();
         }

--- a/src/ClassicUO.Client/Network/AsyncNetClient.cs
+++ b/src/ClassicUO.Client/Network/AsyncNetClient.cs
@@ -107,10 +107,11 @@ namespace ClassicUO.Network
             {
                 while (!cancellationToken.IsCancellationRequested && IsConnected)
                 {
-                    int toRead = Math.Min(buffer.Length, _socket.Client.Available);
-                    int bytesRead = -1;
-                    if(toRead > 0)
-                        bytesRead = await _stream.ReadAsync(buffer, 0, toRead, cancellationToken);
+                    // Read directly instead of gating on Available. A blocking ReadAsync returns 0
+                    // when the remote closes the connection (FIN); gating on Available > 0 meant a
+                    // graceful/half-open close was never detected, leaving the socket "connected"
+                    // forever. ReadAsync also yields naturally, so no busy-wait delay is needed.
+                    int bytesRead = await _stream.ReadAsync(buffer, 0, buffer.Length, cancellationToken);
 
                     if (bytesRead == 0)
                     {
@@ -120,15 +121,13 @@ namespace ClassicUO.Network
                         break;
                     }
 
-                    if (bytesRead > 0 && !cancellationToken.IsCancellationRequested)
+                    if (!cancellationToken.IsCancellationRequested)
                     {
                         byte[] data = new byte[bytesRead];
                         Array.Copy(buffer, data, bytesRead);
                         _client.OnDataReceived(data);
                         //OnDataReceived?.Invoke(this, data);
                     }
-
-                    await Task.Delay(1, cancellationToken);
                 }
             }
             catch (IOException ioEx) when (ioEx.InnerException is SocketException socketEx)

--- a/src/ClassicUO.Client/Network/LoginHandshake.cs
+++ b/src/ClassicUO.Client/Network/LoginHandshake.cs
@@ -30,9 +30,16 @@ namespace ClassicUO.Network
             private set;
         }
 
+        // How long (ms) to wait on the server during a handshake stage before giving up.
+        // A reconnect that lands while the server is still starting up can complete the TCP
+        // connect but never receive a reply, leaving us pinned in VerifyingAccount with no way
+        // out. This watchdog forces a fallback so the reconnect loop can retry.
+        private const int HANDSHAKE_TIMEOUT_MS = 8000;
+
         private ushort _retries;
         private int _reconnectTryCounter = 1;
         private long _reconnectTime;
+        private long _handshakeTimeout;
         private bool _isDisposed;
         private uint _pingTime;
 
@@ -319,9 +326,36 @@ namespace ClassicUO.Network
         internal void SetLoginStep(LoginSteps step)
         {
             _pingTime = Time.Ticks + 60000;
+
+            // Arm the handshake watchdog while we're waiting on the server during the initial
+            // handshake, disarm it otherwise. Each step change re-arms the timer, so a stage only
+            // times out if it stalls with no progress. Scoped to Connecting/VerifyingAccount to
+            // avoid interfering with the relay/server-selection flow which has its own retry logic.
+            if (step is LoginSteps.Connecting or LoginSteps.VerifyingAccount)
+                _handshakeTimeout = (long)Time.Ticks + HANDSHAKE_TIMEOUT_MS;
+            else
+                _handshakeTimeout = 0;
+
             Log.TraceDebug($"[HandShake] Set login step to {step}.");
             CurrentLoginStep = step;
             LoginStepChanged?.Invoke(this, step);
+        }
+
+        /// <summary>
+        /// Call in Update() of the login scene. If a handshake stage stalls (e.g. a reconnect that
+        /// connects to a server which is still restarting and never replies), force a disconnect and
+        /// fall back to the popup so the reconnect loop can retry instead of getting stuck.
+        /// </summary>
+        public void CheckHandshakeTimeout()
+        {
+            if (_handshakeTimeout == 0 || Time.Ticks < _handshakeTimeout)
+                return;
+
+            _handshakeTimeout = 0;
+            Log.Warn($"[HandShake] Handshake timed out at step {CurrentLoginStep}, aborting connection attempt.");
+
+            Disconnect();
+            HandleConnectionFailure(SocketError.TimedOut);
         }
 
         private void OnNetClientConnected(object sender, EventArgs e)
@@ -366,6 +400,11 @@ namespace ClassicUO.Network
                 return;
             }
 
+            HandleConnectionFailure(e);
+        }
+
+        private void HandleConnectionFailure(SocketError e)
+        {
             Characters = null;
             DisposeAllServerEntries();
 

--- a/src/ClassicUO.Client/Network/LoginHandshake.cs
+++ b/src/ClassicUO.Client/Network/LoginHandshake.cs
@@ -146,7 +146,12 @@ namespace ClassicUO.Network
         /// <param name="reconnectTime">In ms</param>
         public void HandleReconnect(int reconnectTime)
         {
-            if (Reconnect && (CurrentLoginStep == LoginSteps.PopUpMessage || CurrentLoginStep == LoginSteps.Main) && !AsyncNetClient.Socket.IsConnected)
+            // Note: we intentionally don't gate on IsConnected here. On PopUpMessage/Main with
+            // Reconnect set we're not in a live session by definition, and Socket.Connected only
+            // reflects the last I/O so a timed-out/half-open socket can report a stale 'true' and
+            // wedge the retry loop forever. Connect() tears down and replaces the socket anyway,
+            // and _reconnectTime enforces the delay between attempts.
+            if (Reconnect && (CurrentLoginStep == LoginSteps.PopUpMessage || CurrentLoginStep == LoginSteps.Main))
             {
                 if (_reconnectTime >= Time.Ticks)
                     return;


### PR DESCRIPTION
A reconnect that lands while the server is still restarting can complete the TCP connect but never receive a reply, leaving the client pinned in VerifyingAccount with IsConnected true. HandleReconnect only retries from PopUpMessage/Main with !IsConnected, so the reconnect loop would get stuck with no way out.

Arm a watchdog when entering Connecting/VerifyingAccount; if the stage stalls past HANDSHAKE_TIMEOUT_MS with no progress, force a disconnect and fall back to the popup via the shared HandleConnectionFailure path so the reconnect loop re-engages.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update