### PR TITLE
Fix IndexOutOfRangeException on server selection arrow button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to TazUO will be recorded here.
 * Fixed logout gump not being centered when scaled - ([bittiez](https://github.com/bittiez))
 * Back button now reaches the server select & username screens when 'Skip Server Select' is enabled, and added a `-skipserverselect` command-line arg - [P.R 512](https://github.com/PlayTazUO/TazUO/pull/512) ([bittiez](https://github.com/bittiez))
 * Fixed an issue with Toggle Legion Script macro not reoping it - ([bittiez](https://github.com/bittiez))
+* Fixed IndexOutOfRangeException when pressing the arrow button on the server selection screen - [P.R 520](https://github.com/PlayTazUO/TazUO/pull/520) ([bittiez](https://github.com/bittiez))
 
 ### Misc
 * Remove tab completion and command history tracking - [P.R 489](https://github.com/PlayTazUO/TazUO/pull/489) ([Jascen](https://github.com/Jascen))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.2.23</AssemblyVersion>
-    <FileVersion>5.2.23</FileVersion>
+    <AssemblyVersion>5.2.24</AssemblyVersion>
+    <FileVersion>5.2.24</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Gumps/Login/ServerSelectionGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/Login/ServerSelectionGump.cs
@@ -229,23 +229,7 @@ namespace ClassicUO.Game.UI.Gumps.Login
                     case Buttons.Next:
                     case Buttons.Earth:
 
-                        if (loginScene.Servers.Length != 0)
-                        {
-                            int index = loginScene.GetServerIndexFromSettings();
-
-                            // 'index' is a server Index value (not an array position) and may not
-                            // exist in the list, so resolve it to a valid server before selecting.
-                            ServerListEntry target = null;
-                            foreach (ServerListEntry s in loginScene.Servers)
-                                if (s.Index == index)
-                                {
-                                    target = s;
-                                    break;
-                                }
-
-                            target ??= loginScene.Servers[0];
-                            loginScene.SelectServer((byte) target.Index);
-                        }
+                        SelectServerFromSettings(loginScene);
 
                         break;
 
@@ -264,23 +248,7 @@ namespace ClassicUO.Game.UI.Gumps.Login
             {
                 LoginScene loginScene = Client.Game.GetScene<LoginScene>();
 
-                if (loginScene.Servers?.Any(s => s != null) ?? false)
-                {
-                    int index = loginScene.GetServerIndexFromSettings();
-
-                    // 'index' is a server Index value (not an array position) and may not
-                    // exist in the list, so resolve it to a valid server before selecting.
-                    ServerListEntry target = null;
-                    foreach (ServerListEntry s in loginScene.Servers)
-                        if (s.Index == index)
-                        {
-                            target = s;
-                            break;
-                        }
-
-                    target ??= loginScene.Servers[0];
-                    loginScene.SelectServer((byte)target.Index);
-                }
+                SelectServerFromSettings(loginScene);
             }
         }
 
@@ -290,25 +258,29 @@ namespace ClassicUO.Game.UI.Gumps.Login
             {
                 LoginScene loginScene = Client.Game.GetScene<LoginScene>();
 
-                if (loginScene.Servers?.Any(s => s != null) ?? false)
-                {
-                    int index = loginScene.GetServerIndexFromSettings();
-                    bool serverSelected = false;
-
-                    foreach (ServerListEntry s in loginScene.Servers)
-                        if (s.Index == index)
-                        {
-                            loginScene.SelectServer((byte)index);
-                            serverSelected = true;
-                            break;
-                        }
-                    
-                    if (!serverSelected)
-                    {
-                        loginScene.SelectServer((byte)loginScene.Servers[0].Index);
-                    }
-                }
+                SelectServerFromSettings(loginScene);
             }
+        }
+
+        private static void SelectServerFromSettings(LoginScene loginScene)
+        {
+            if (loginScene.Servers == null || loginScene.Servers.Length == 0)
+                return;
+
+            int index = loginScene.GetServerIndexFromSettings();
+
+            // 'index' is a server Index value (not an array position) and may not
+            // exist in the list, so resolve it to a valid server before selecting.
+            ServerListEntry target = null;
+            foreach (ServerListEntry s in loginScene.Servers)
+                if (s.Index == index)
+                {
+                    target = s;
+                    break;
+                }
+
+            target ??= loginScene.Servers[0];
+            loginScene.SelectServer((byte)target.Index);
         }
 
         private enum Buttons

--- a/src/ClassicUO.Client/Game/UI/Gumps/Login/ServerSelectionGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/Login/ServerSelectionGump.cs
@@ -1,6 +1,5 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
-using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
 using ClassicUO.Configuration;

--- a/src/ClassicUO.Client/Game/UI/Gumps/Login/ServerSelectionGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/Login/ServerSelectionGump.cs
@@ -233,7 +233,18 @@ namespace ClassicUO.Game.UI.Gumps.Login
                         {
                             int index = loginScene.GetServerIndexFromSettings();
 
-                            loginScene.SelectServer((byte) loginScene.Servers[index].Index);
+                            // 'index' is a server Index value (not an array position) and may not
+                            // exist in the list, so resolve it to a valid server before selecting.
+                            ServerListEntry target = null;
+                            foreach (ServerListEntry s in loginScene.Servers)
+                                if (s.Index == index)
+                                {
+                                    target = s;
+                                    break;
+                                }
+
+                            target ??= loginScene.Servers[0];
+                            loginScene.SelectServer((byte) target.Index);
                         }
 
                         break;
@@ -257,7 +268,18 @@ namespace ClassicUO.Game.UI.Gumps.Login
                 {
                     int index = loginScene.GetServerIndexFromSettings();
 
-                    loginScene.SelectServer((byte)loginScene.Servers[index].Index);
+                    // 'index' is a server Index value (not an array position) and may not
+                    // exist in the list, so resolve it to a valid server before selecting.
+                    ServerListEntry target = null;
+                    foreach (ServerListEntry s in loginScene.Servers)
+                        if (s.Index == index)
+                        {
+                            target = s;
+                            break;
+                        }
+
+                    target ??= loginScene.Servers[0];
+                    loginScene.SelectServer((byte)target.Index);
                 }
             }
         }


### PR DESCRIPTION
GetServerIndexFromSettings() returns a server's Index property value (or LastServerNum), which does not correlate with the position in the Servers array. The Next button and controller handlers used this directly as an array index, throwing IndexOutOfRangeException when the stored value exceeded the list length. Resolve the value to a matching server entry (falling back to the first server) before selecting.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server selection reliability by ensuring your saved server preference is correctly loaded. If your previously selected server is unavailable, the client now gracefully defaults to the first available server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->