### PR TITLE
Fix server selection gump lingering behind login screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to TazUO will be recorded here.
 * Back button now reaches the server select & username screens when 'Skip Server Select' is enabled, and added a `-skipserverselect` command-line arg - [P.R 512](https://github.com/PlayTazUO/TazUO/pull/512) ([bittiez](https://github.com/bittiez))
 * Fixed an issue with Toggle Legion Script macro not reoping it - ([bittiez](https://github.com/bittiez))
 * Fixed IndexOutOfRangeException when pressing the arrow button on the server selection screen - [P.R 520](https://github.com/PlayTazUO/TazUO/pull/520) ([bittiez](https://github.com/bittiez))
+* Fixed server selection gump lingering behind the login screen when stepping back - [P.R 521](https://github.com/PlayTazUO/TazUO/pull/521) ([bittiez](https://github.com/bittiez))
 
 ### Misc
 * Remove tab completion and command history tracking - [P.R 489](https://github.com/PlayTazUO/TazUO/pull/489) ([Jascen](https://github.com/Jascen))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.2.24</AssemblyVersion>
-    <FileVersion>5.2.24</FileVersion>
+    <AssemblyVersion>5.2.25</AssemblyVersion>
+    <FileVersion>5.2.25</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/Scenes/LoginScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/LoginScene.cs
@@ -226,7 +226,17 @@ namespace ClassicUO.Game.Scenes
                     return;
 
                 Client.Game.UO.GameCursor.IsLoading = false;
-                UIManager.Add(_currentGump = GetGumpForStep());
+
+                Gump next = GetGumpForStep();
+
+                // Dispose any login screens left over from a previous step before showing the next one.
+                // Step changes can be dispatched from the network thread, so a racing transition may
+                // capture a stale '_currentGump' and orphan the screen an earlier deferred callback
+                // created (most visibly the server selection gump lingering behind the login screen).
+                // Only one of these interactive screens should ever be visible, so clear the rest.
+                DisposeStaleLoginScreens(next);
+
+                UIManager.Add(_currentGump = next);
                 g?.Dispose();
             });
 
@@ -240,6 +250,29 @@ namespace ClassicUO.Game.Scenes
             LoginHandshake.Instance.CheckHandshakeTimeout();
             LoginHandshake.Instance.HandleReconnect(Settings.GlobalSettings.ReconnectTime * 1000);
             LoginHandshake.Instance.SendPing();
+        }
+
+        /// <summary>
+        /// Disposes any lingering login-flow screens that aren't the one we're about to show.
+        /// These screens are mutually exclusive, so anything orphaned by a racing step change
+        /// (e.g. a server selection gump stuck behind the login screen) gets cleared here.
+        /// </summary>
+        private static void DisposeStaleLoginScreens(Gump keep)
+        {
+            DisposeStaleGumpsOfType<LoginGump>(keep);
+            DisposeStaleGumpsOfType<ServerSelectionGump>(keep);
+            DisposeStaleGumpsOfType<CharacterSelectionGumpBase>(keep);
+            DisposeStaleGumpsOfType<CharCreationGump>(keep);
+        }
+
+        private static void DisposeStaleGumpsOfType<T>(Gump keep) where T : Gump
+        {
+            // 'keep' has not been added to the UIManager yet, so GetGump never returns it; the
+            // reference check is just a safety net to avoid disposing the incoming screen.
+            for (T g = UIManager.GetGump<T>(); g != null && !ReferenceEquals(g, keep); g = UIManager.GetGump<T>())
+            {
+                g.Dispose();
+            }
         }
 
         private Gump GetGumpForStep()


### PR DESCRIPTION
When stepping back from server selection to the login screen, the server selection gump could remain open behind the login gump. Login step changes are dispatched from the network thread, so a racing transition can capture a stale _currentGump and orphan the screen created by an earlier deferred callback, leaving it in the UIManager but never disposed.

Defensively dispose any leftover login-flow screens (login, server selection, character selection, character creation) before showing the next one, since only one of these interactive screens should ever be visible at a time.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated visual flicker during login screen transitions for a smoother experience
  * Resolved issues with login screens persisting or appearing unexpectedly
  * Improved login flow stability and responsiveness with enhanced screen transition management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->