### PR TITLE
Add auto stat lock system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to TazUO will be recorded here.
 * Added an alternative character select screen - [P.R 513](https://github.com/PlayTazUO/TazUO/pull/513) ([bittiez](https://github.com/bittiez))
 * Added a macro to set an organizer's source container via target - [P.R 516](https://github.com/PlayTazUO/TazUO/pull/516) ([bittiez](https://github.com/bittiez))
 * Added new language system for easier futute translations - [P.R 519](https://github.com/PlayTazUO/TazUO/pull/519) ([bittiez](https://github.com/bittiez))
+* Added an auto stat lock agent - [P.R 524](https://github.com/PlayTazUO/TazUO/pull/524) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
 * Fixed reconnect getting stuck when the server is unavailable or restarting during a reconnect attempt - [P.R 517](https://github.com/PlayTazUO/TazUO/pull/517) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.2.26</AssemblyVersion>
-    <FileVersion>5.2.26</FileVersion>
+    <AssemblyVersion>5.2.27</AssemblyVersion>
+    <FileVersion>5.2.27</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -5,7 +5,7 @@
 ; Missing keys are auto-appended with English defaults when
 ; this file's version is newer than the user's copy.
 ; -------------------------------------------------------
-_version=3
+_version=4
 accountname=Account Name
 accountcontextmenutooltip=Right click to select another account.
 music=Music
@@ -35,7 +35,7 @@ uilangtooltip=TazUO UI language. Change takes effect on restart.
 langwarning=Note: Language change takes effect on restart.
 
 ; Auto Stat Lock
-autostatlock_description=Automatically adjusts stat locks to reach desired stat values.
+autostatlock_desc=Automatically adjusts stat locks to reach desired stat values.\nNote: Equipement bonuses may also trigger this.
 autostatlock_enable=Enable auto stat lock
 autostatlock_strength=Strength
 autostatlock_dexterity=Dexterity

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -5,7 +5,7 @@
 ; Missing keys are auto-appended with English defaults when
 ; this file's version is newer than the user's copy.
 ; -------------------------------------------------------
-_version=2
+_version=3
 accountname=Account Name
 accountcontextmenutooltip=Right click to select another account.
 music=Music
@@ -33,3 +33,13 @@ forcedriverwarning=Note: Force driver change won't take effect until restart.
 uilangentry=UI Language:
 uilangtooltip=TazUO UI language. Change takes effect on restart.
 langwarning=Note: Language change takes effect on restart.
+
+; Auto Stat Lock
+autostatlock_description=Automatically adjusts stat locks to reach desired stat values.
+autostatlock_enable=Enable auto stat lock
+autostatlock_strength=Strength
+autostatlock_dexterity=Dexterity
+autostatlock_intelligence=Intelligence
+autostatlock_autolock=Auto lock
+autostatlock_desired=Desired:
+autostatlock_profilenotloaded=Profile not loaded

--- a/src/ClassicUO.Client/Game/Constants.cs
+++ b/src/ClassicUO.Client/Game/Constants.cs
@@ -138,6 +138,7 @@ namespace ClassicUO.Game
             public const string SKIP_SERVER_SELECTION = "skip_server_selection";
             public const string CAMPFIRE_CHAR_SELECT = "campfire_char_select";
             public const string UI_LANGUAGE = "ui_language";
+            public const string AUTO_STAT_LOCK = "auto_stat_lock";
         }
     }
 }

--- a/src/ClassicUO.Client/Game/Managers/AutoStatLockManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/AutoStatLockManager.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ClassicUO.Game.Data;
+using ClassicUO.Utility.Logging;
+using ClassicUO.Game;
+using ClassicUO;
+
+namespace ClassicUO.Game.Managers;
+
+public class AutoStatLockState
+{
+    public bool Enabled { get; set; } = false;
+    public bool StrEnabled { get; set; } = false;
+    public ushort DesiredStr { get; set; } = 0;
+    public bool DexEnabled { get; set; } = false;
+    public ushort DesiredDex { get; set; } = 0;
+    public bool IntEnabled { get; set; } = false;
+    public ushort DesiredInt { get; set; } = 0;
+}
+
+[JsonSerializable(typeof(AutoStatLockState))]
+public partial class AutoStatLockStateContext : JsonSerializerContext { }
+
+public class AutoStatLockManager
+{
+    private AutoStatLockState _state = new();
+    private bool _isLoaded;
+    private uint _lastLoadedSerial;
+
+    public static AutoStatLockManager Instance { get; } = new();
+
+    private AutoStatLockManager() { }
+
+    public AutoStatLockState State
+    {
+        get
+        {
+            EnsureLoaded();
+            return _state;
+        }
+    }
+
+    private void EnsureLoaded()
+    {
+        uint playerSerial = World.Instance?.Player?.Serial ?? 0;
+        if (playerSerial == 0) return;
+
+        if (!_isLoaded || _lastLoadedSerial != playerSerial)
+        {
+            _lastLoadedSerial = playerSerial;
+            Load();
+        }
+    }
+
+    private void Load()
+    {
+        if (Client.Settings == null)
+        {
+            Log.Warn("SQLSettings not available for AutoStatLockManager");
+            _isLoaded = true;
+            return;
+        }
+
+        try
+        {
+            string json = Client.Settings.Get(SettingsScope.Char, Constants.SqlSettings.AUTO_STAT_LOCK, "");
+            _state = !string.IsNullOrWhiteSpace(json)
+                ? JsonSerializer.Deserialize(json, AutoStatLockStateContext.Default.AutoStatLockState) ?? new()
+                : new();
+        }
+        catch (Exception ex)
+        {
+            Log.Error($"Failed to load auto stat lock state: {ex.Message}");
+            _state = new();
+        }
+
+        _isLoaded = true;
+    }
+
+    public void Save()
+    {
+        if (Client.Settings == null) return;
+
+        try
+        {
+            string json = JsonSerializer.Serialize(_state, AutoStatLockStateContext.Default.AutoStatLockState);
+            _ = Client.Settings.SetAsync(SettingsScope.Char, Constants.SqlSettings.AUTO_STAT_LOCK, json);
+        }
+        catch (Exception ex)
+        {
+            Log.Error($"Failed to save auto stat lock state: {ex.Message}");
+        }
+    }
+
+    public void OnStatsUpdated(World world)
+    {
+        EnsureLoaded();
+
+        if (!_state.Enabled || world.Player == null) return;
+
+        CheckAndApplyStatLock(0, world.Player.Strength, _state.DesiredStr, _state.StrEnabled, ref world.Player.StrLock);
+        CheckAndApplyStatLock(1, world.Player.Dexterity, _state.DesiredDex, _state.DexEnabled, ref world.Player.DexLock);
+        CheckAndApplyStatLock(2, world.Player.Intelligence, _state.DesiredInt, _state.IntEnabled, ref world.Player.IntLock);
+    }
+
+    private static void CheckAndApplyStatLock(byte statIndex, ushort currentValue, ushort desiredValue, bool enabled, ref Lock lockState)
+    {
+        if (!enabled || desiredValue == 0 || currentValue == 0) return;
+
+        Lock newLock;
+        if (currentValue < desiredValue)
+            newLock = Lock.Up;
+        else if (currentValue > desiredValue)
+            newLock = Lock.Down;
+        else
+            newLock = Lock.Locked;
+
+        if (lockState == newLock) return;
+
+        lockState = newLock;
+        GameActions.ChangeStatLock(statIndex, newLock);
+    }
+}

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/AgentTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/AgentTab.cs
@@ -13,6 +13,7 @@ public static class AgentTab
         tabs.AddTab("Auto Sell", AutoSellAgentTabContent.Build);
         tabs.AddTab("Bandage", BandageAgentTabContent.Build);
         tabs.AddTab("Organizer", OrganizerAgentTabContent.Build);
+        tabs.AddTab("Stat Lock", AutoStatLockAgentTabContent.Build);
         tabs.SelectFirst();
         return tabs;
     }

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/AutoStatLockAgentTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/AutoStatLockAgentTabContent.cs
@@ -1,0 +1,87 @@
+using System;
+using ClassicUO.Configuration;
+using ClassicUO.Game;
+using ClassicUO.Game.Managers;
+using Myra.Graphics2D.UI;
+
+namespace ClassicUO.Game.UI.MyraWindows.Widgets.Assistant.Agents;
+
+public static class AutoStatLockAgentTabContent
+{
+    public static Widget Build()
+    {
+        if (World.Instance?.Player == null)
+            return new MyraLabel(TazLang.Get("autostatlock_profilenotloaded", "Profile not loaded"), MyraLabel.TextStyle.P);
+
+        AutoStatLockManager manager = AutoStatLockManager.Instance;
+        AutoStatLockState state = manager.State;
+
+        var root = new VerticalStackPanel { Spacing = MyraStyle.STANDARD_SPACING };
+
+        root.Widgets.Add(new MyraLabel(TazLang.Get("autostatlock_description", "Automatically adjusts stat locks to reach desired stat values."), MyraLabel.TextStyle.P));
+
+        root.Widgets.Add(MyraCheckButton.CreateWithCallback(
+            state.Enabled,
+            b => { state.Enabled = b; manager.Save(); },
+            TazLang.Get("autostatlock_enable", "Enable auto stat lock")
+        ));
+
+        root.Widgets.Add(new MyraSpacer(10, 10));
+
+        root.Widgets.Add(BuildStatRow(
+            TazLang.Get("autostatlock_strength", "Strength"),
+            state.StrEnabled,
+            state.DesiredStr,
+            b => { state.StrEnabled = b; manager.Save(); },
+            v => { state.DesiredStr = v; manager.Save(); }
+        ));
+
+        root.Widgets.Add(BuildStatRow(
+            TazLang.Get("autostatlock_dexterity", "Dexterity"),
+            state.DexEnabled,
+            state.DesiredDex,
+            b => { state.DexEnabled = b; manager.Save(); },
+            v => { state.DesiredDex = v; manager.Save(); }
+        ));
+
+        root.Widgets.Add(BuildStatRow(
+            TazLang.Get("autostatlock_intelligence", "Intelligence"),
+            state.IntEnabled,
+            state.DesiredInt,
+            b => { state.IntEnabled = b; manager.Save(); },
+            v => { state.DesiredInt = v; manager.Save(); }
+        ));
+
+        return root;
+    }
+
+    private static Widget BuildStatRow(
+        string statName,
+        bool enabled,
+        ushort desired,
+        Action<bool> onEnabledChanged,
+        Action<ushort> onDesiredChanged)
+    {
+        var row = new HorizontalStackPanel { Spacing = MyraStyle.STANDARD_SPACING, VerticalAlignment = Myra.Graphics2D.UI.VerticalAlignment.Center };
+
+        row.Widgets.Add(new MyraLabel(statName, MyraLabel.TextStyle.P) { Width = 90 });
+
+        row.Widgets.Add(MyraCheckButton.CreateWithCallback(enabled, onEnabledChanged, TazLang.Get("autostatlock_autolock", "Auto lock")));
+
+        row.Widgets.Add(new MyraLabel(TazLang.Get("autostatlock_desired", "Desired:"), MyraLabel.TextStyle.P));
+
+        var input = new MyraInputBox
+        {
+            Text = desired.ToString(),
+            Width = 60,
+        };
+        input.TextChangedByUser += (_, _) =>
+        {
+            if (ushort.TryParse(input.Text, out ushort v))
+                onDesiredChanged(v);
+        };
+        row.Widgets.Add(input);
+
+        return row;
+    }
+}

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/AutoStatLockAgentTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/AutoStatLockAgentTabContent.cs
@@ -11,25 +11,25 @@ public static class AutoStatLockAgentTabContent
     public static Widget Build()
     {
         if (World.Instance?.Player == null)
-            return new MyraLabel(TazLang.Get("autostatlock_profilenotloaded", "Profile not loaded"), MyraLabel.TextStyle.P);
+            return new MyraLabel(TazLang.Get("autostatlock_profilenotloaded"), MyraLabel.TextStyle.P);
 
         AutoStatLockManager manager = AutoStatLockManager.Instance;
         AutoStatLockState state = manager.State;
 
         var root = new VerticalStackPanel { Spacing = MyraStyle.STANDARD_SPACING };
 
-        root.Widgets.Add(new MyraLabel(TazLang.Get("autostatlock_description", "Automatically adjusts stat locks to reach desired stat values."), MyraLabel.TextStyle.P));
+        root.Widgets.Add(new MyraLabel(TazLang.Get("autostatlock_desc"), MyraLabel.TextStyle.P));
 
         root.Widgets.Add(MyraCheckButton.CreateWithCallback(
             state.Enabled,
             b => { state.Enabled = b; manager.Save(); },
-            TazLang.Get("autostatlock_enable", "Enable auto stat lock")
+            TazLang.Get("autostatlock_enable")
         ));
 
         root.Widgets.Add(new MyraSpacer(10, 10));
 
         root.Widgets.Add(BuildStatRow(
-            TazLang.Get("autostatlock_strength", "Strength"),
+            TazLang.Get("autostatlock_strength"),
             state.StrEnabled,
             state.DesiredStr,
             b => { state.StrEnabled = b; manager.Save(); },
@@ -37,7 +37,7 @@ public static class AutoStatLockAgentTabContent
         ));
 
         root.Widgets.Add(BuildStatRow(
-            TazLang.Get("autostatlock_dexterity", "Dexterity"),
+            TazLang.Get("autostatlock_dexterity"),
             state.DexEnabled,
             state.DesiredDex,
             b => { state.DexEnabled = b; manager.Save(); },
@@ -45,7 +45,7 @@ public static class AutoStatLockAgentTabContent
         ));
 
         root.Widgets.Add(BuildStatRow(
-            TazLang.Get("autostatlock_intelligence", "Intelligence"),
+            TazLang.Get("autostatlock_intelligence"),
             state.IntEnabled,
             state.DesiredInt,
             b => { state.IntEnabled = b; manager.Save(); },
@@ -66,9 +66,9 @@ public static class AutoStatLockAgentTabContent
 
         row.Widgets.Add(new MyraLabel(statName, MyraLabel.TextStyle.P) { Width = 90 });
 
-        row.Widgets.Add(MyraCheckButton.CreateWithCallback(enabled, onEnabledChanged, TazLang.Get("autostatlock_autolock", "Auto lock")));
+        row.Widgets.Add(MyraCheckButton.CreateWithCallback(enabled, onEnabledChanged, TazLang.Get("autostatlock_autolock")));
 
-        row.Widgets.Add(new MyraLabel(TazLang.Get("autostatlock_desired", "Desired:"), MyraLabel.TextStyle.P));
+        row.Widgets.Add(new MyraLabel(TazLang.Get("autostatlock_desired"), MyraLabel.TextStyle.P));
 
         var input = new MyraInputBox
         {

--- a/src/ClassicUO.Client/Network/PacketHandlers/CharacterStatus.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers/CharacterStatus.cs
@@ -130,6 +130,8 @@ internal static class CharacterStatus
                     world.Player.Dexterity = dex;
                     world.Player.Intelligence = intell;
 
+                    AutoStatLockManager.Instance.OnStatsUpdated(world);
+
                     if (type >= 5) //ML
                     {
                         world.Player.WeightMax = p.ReadUInt16BE();


### PR DESCRIPTION
Adds an AutoStatLockManager that automatically adjusts the server-side stat lock (Up/Down/Locked) for STR/DEX/INT based on desired target values configured per character. State is saved as JSON to the SQL settings DB at character scope, loaded lazily on first stat update per character session.

UI: new "Stat Lock" agent tab in the Assistant window using TazLang strings. Logic: each time the character status packet updates stats, the manager checks if each stat is above/below/at the desired value and sends a ChangeStatLock request only when the current lock differs.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Auto Stat Lock agent tab to the assistant with per-character configuration of automatic stat lock management
  * Configure and toggle desired values for Strength, Dexterity, and Intelligence
  * Settings persist automatically per character
  * Version updated to 5.2.27

<!-- end of auto-generated comment: release notes by coderabbit.ai -->