### PR TITLE
Reload UI language live on selection in login settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to TazUO will be recorded here.
 * Added a macro to set an organizer's source container via target - [P.R 516](https://github.com/PlayTazUO/TazUO/pull/516) ([bittiez](https://github.com/bittiez))
 * Added new language system for easier futute translations - [P.R 519](https://github.com/PlayTazUO/TazUO/pull/519) ([bittiez](https://github.com/bittiez))
 * Added an auto stat lock agent - [P.R 524](https://github.com/PlayTazUO/TazUO/pull/524) ([bittiez](https://github.com/bittiez))
+* UI language selection on the login screen now applies immediately instead of requiring a restart - [P.R 526](https://github.com/PlayTazUO/TazUO/pull/526) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
 * Fixed reconnect getting stuck when the server is unavailable or restarting during a reconnect attempt - [P.R 517](https://github.com/PlayTazUO/TazUO/pull/517) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.2.28</AssemblyVersion>
-    <FileVersion>5.2.28</FileVersion>
+    <AssemblyVersion>5.2.29</AssemblyVersion>
+    <FileVersion>5.2.29</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -31,7 +31,7 @@ forcedriver=Force driver:
 forcedrivertooltip=Graphics driver to force (0 = default). Change won't take effect until restart.
 forcedriverwarning=Note: Force driver change won't take effect until restart.
 uilangentry=UI Language:
-uilangtooltip=TazUO UI language. Change takes effect on restart.
+uilangtooltip=TazUO UI language. Changes apply immediately.
 langwarning=Note: Language change takes effect on restart.
 
 ; Auto Stat Lock

--- a/src/ClassicUO.Client/Game/Scenes/LoginScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/LoginScene.cs
@@ -553,6 +553,23 @@ namespace ClassicUO.Game.Scenes
             UIManager.Add(_currentGump = CreateCharacterSelectionGump());
         }
 
+        /// <summary>
+        /// Disposes the active login screen and rebuilds it. Used by the live UI language
+        /// switch so the freshly loaded strings show immediately and <see cref="_currentGump"/>
+        /// stays consistent.
+        /// </summary>
+        public void RebuildLoginGump()
+        {
+            if (CurrentLoginStep != LoginSteps.Main)
+                return;
+
+            UIManager.GetGump<LoginGump>()?.Dispose();
+
+            _currentGump?.Dispose();
+
+            UIManager.Add(_currentGump = new LoginGump(_world, this));
+        }
+
         private void UpdateCharacterList()
         {
             UIManager.GetGump<CharacterSelectionGumpBase>()?.Dispose();

--- a/src/ClassicUO.Client/Game/UI/Gumps/Login/LoginGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/Login/LoginGump.cs
@@ -479,7 +479,7 @@ namespace ClassicUO.Game.UI.Gumps.Login
             return c;
         }
 
-        private static void OpenEditSettings()
+        private void OpenEditSettings()
         {
             var existing = OptionsWindow.GetExisting(TazLang.Get("editsettings"));
             if (existing != null)
@@ -536,10 +536,18 @@ namespace ClassicUO.Game.UI.Gumps.Login
                 TazLang.Get("uilangentry"),
                 langs,
                 langIdx >= 0 ? langIdx : 0,
-                i => { s.UILanguage = langs[i]; s.Save(); },
+                i =>
+                {
+                    s.UILanguage = langs[i];
+                    s.Save();
+
+                    // Reload the language strings and rebuild the login screen so the
+                    // selection takes effect live without requiring a restart.
+                    TazLang.Load(langs[i]);
+                    Client.Game.GetScene<LoginScene>()?.RebuildLoginGump();
+                },
                 TazLang.Get("uilangtooltip")
             );
-            w.AddLabel(TazLang.Get("langwarning"));
 
             w.CenterInScreen();
         }


### PR DESCRIPTION
When changing the UI language file from the login screen's settings page, reload the language strings and rebuild the login gump so the selection takes effect immediately instead of requiring a restart.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * UI language changes now apply immediately without requiring an application restart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->