### PR TITLE
Fix WorldMap crash when a marker has a null Name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to TazUO will be recorded here.
 * Added loops to in-game macros - [P.R 519](https://github.com/PlayTazUO/TazUO/pull/519) ([DavideRei](https://github.com/DavideRei))
 
 ### Fixes
+* Fixed WorldMap crash when a marker has a null/empty name - [P.R 530](https://github.com/PlayTazUO/TazUO/pull/530) ([bittiez](https://github.com/bittiez))
 * Fixed reconnect getting stuck when the server is unavailable or restarting during a reconnect attempt - [P.R 517](https://github.com/PlayTazUO/TazUO/pull/517) ([bittiez](https://github.com/bittiez))
 * Fix NullReferenceException in campfire character selection when a character has no appearance data - [P.R 515](https://github.com/PlayTazUO/TazUO/pull/515) ([bittiez](https://github.com/bittiez))
 * Mouse wheel macros hijack scroll from shop gumps - [P.R 479](https://github.com/PlayTazUO/TazUO/pull/479) ([yuval-po](https://github.com/yuval-po))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.2.30</AssemblyVersion>
-    <FileVersion>5.2.30</FileVersion>
+    <AssemblyVersion>5.2.31</AssemblyVersion>
+    <FileVersion>5.2.31</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
@@ -2741,6 +2741,9 @@ public class WorldMapGump : ResizableGump
 
     private void DrawMarkerString(UltimaBatcher2D batcher, WMapMarker marker, int x, int y, int width, int height)
     {
+        if (string.IsNullOrEmpty(marker.Name))
+            return;
+
         int sx = marker.X - _center.X;
         int sy = marker.Y - _center.Y;
 

--- a/src/ClassicUO.Renderer/SpriteFont.cs
+++ b/src/ClassicUO.Renderer/SpriteFont.cs
@@ -53,11 +53,6 @@ namespace ClassicUO.Renderer
         {
             if (text.IsEmpty)
             {
-                throw new ArgumentNullException(nameof(text));
-            }
-
-            if (text.Length == 0)
-            {
                 return Vector2.Zero;
             }
 


### PR DESCRIPTION
SpriteFont.MeasureString was throwing ArgumentNullException for any empty or null string because the IsEmpty guard threw instead of returning zero (making the Length == 0 early-return dead code). Fixed by returning Vector2.Zero for empty spans. Also added an early-exit guard in DrawMarkerString so markers with no name are silently skipped rather than attempting to measure/draw an empty string.

Fixes #529

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update