### PR TITLE
Fix crash returning non-pooled buffer in ReadUOPAnimationFrames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to TazUO will be recorded here.
 * Added loops to in-game macros - [P.R 519](https://github.com/PlayTazUO/TazUO/pull/519) ([DavideRei](https://github.com/DavideRei))
 
 ### Fixes
+* Fixed crash reading BWT-compressed UOP animations caused by returning a non-pooled buffer to the array pool - [P.R 532](https://github.com/PlayTazUO/TazUO/pull/532) ([bittiez](https://github.com/bittiez))
 * Fixed WorldMap crash when a marker has a null/empty name - [P.R 530](https://github.com/PlayTazUO/TazUO/pull/530) ([bittiez](https://github.com/bittiez))
 * Fixed reconnect getting stuck when the server is unavailable or restarting during a reconnect attempt - [P.R 517](https://github.com/PlayTazUO/TazUO/pull/517) ([bittiez](https://github.com/bittiez))
 * Fix NullReferenceException in campfire character selection when a character has no appearance data - [P.R 515](https://github.com/PlayTazUO/TazUO/pull/515) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Assets/AnimationsLoader.cs
+++ b/src/ClassicUO.Assets/AnimationsLoader.cs
@@ -1249,20 +1249,28 @@ namespace ClassicUO.Assets
             var reader = new StackDataReader(buf);
 
             byte[] dbuf = null;
+            // dbufPooled tracks the array we actually rented from the pool. dbuf may be
+            // reassigned to a non-pooled array by BwtDecompress, so we must never return
+            // dbuf itself to the pool (that throws ArgumentException_BufferNotFromPool).
+            byte[] dbufPooled = null;
             if (index.CompressionType >= CompressionType.Zlib)
             {
-                dbuf = ArrayPool<byte>.Shared.Rent((int)index.UncompressedSize); //new byte[(int)index.UncompressedSize];
-                ZLib.ZLibError result = ZLib.Decompress(buf, dbuf);
+                dbufPooled = ArrayPool<byte>.Shared.Rent((int)index.UncompressedSize); //new byte[(int)index.UncompressedSize];
+                dbuf = dbufPooled;
+                ZLib.ZLibError result = ZLib.Decompress(buf, dbufPooled);
                 if (result != ZLib.ZLibError.Ok)
                 {
                     Log.Error($"error reading uop animation. AnimID: {animID} | Group: {animGroup} | Dir: {direction} | FileIndex: {fileIndex}");
+
+                    ArrayPool<byte>.Shared.Return(buf);
+                    ArrayPool<byte>.Shared.Return(dbufPooled);
 
                     return Span<FrameInfo>.Empty;
                 }
 
                 if (index.CompressionType == CompressionType.ZlibBwt)
                 {
-                    dbuf = BwtDecompress.Decompress(dbuf);
+                    dbuf = BwtDecompress.Decompress(dbufPooled);
                 }
 
                 reader = new StackDataReader(dbuf);
@@ -1390,8 +1398,8 @@ namespace ClassicUO.Assets
             {
                 ArrayPool<UOPFrameData>.Shared.Return(sharedBuffer);
                 ArrayPool<byte>.Shared.Return(buf);
-                if(dbuf != null)
-                    ArrayPool<byte>.Shared.Return(dbuf);
+                if(dbufPooled != null)
+                    ArrayPool<byte>.Shared.Return(dbufPooled);
             }
         }
 

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.2.31</AssemblyVersion>
-    <FileVersion>5.2.31</FileVersion>
+    <AssemblyVersion>5.2.32</AssemblyVersion>
+    <FileVersion>5.2.32</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
BWT-compressed UOP animations (e.g. UOAlive) reassign dbuf to a non-pooled array via BwtDecompress.Decompress, then the finally block returned that array to ArrayPool, throwing ArgumentException_BufferNotFromPool.

Track the rented array separately (dbufPooled) and always return that to the pool. Also free buf/dbuf on the zlib-error early-return path, which previously leaked them.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed memory buffer management in animation frame decompression to ensure proper resource cleanup and prevent potential memory leaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->