### PR TITLE
Add ZIP file support to Legion Scripting system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to TazUO will be recorded here.
 * Added an auto stat lock agent - [P.R 524](https://github.com/PlayTazUO/TazUO/pull/524) ([bittiez](https://github.com/bittiez))
 * UI language selection on the login screen now applies immediately instead of requiring a restart - [P.R 526](https://github.com/PlayTazUO/TazUO/pull/526) ([bittiez](https://github.com/bittiez))
 * Added loops to in-game macros - [P.R 519](https://github.com/PlayTazUO/TazUO/pull/519) ([DavideRei](https://github.com/DavideRei))
+* ZIP file support for Legion Scripting - script libraries with custom PNG artwork can now be distributed and loaded as a single .zip file; scripts in gumps can display zip textures via `API.Gumps.LegionTextureControl` - [P.R 533](https://github.com/PlayTazUO/TazUO/pull/533) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
 * Fixed crash reading BWT-compressed UOP animations caused by returning a non-pooled buffer to the array pool - [P.R 532](https://github.com/PlayTazUO/TazUO/pull/532) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Assets/PNGLoader.cs
+++ b/src/ClassicUO.Assets/PNGLoader.cs
@@ -48,7 +48,14 @@ namespace ClassicUO.Assets
         }
 
         public bool TryGetNamedZipTexture(string name, out Texture2D texture)
-            => _zipNamedTextures.TryGetValue(name, out texture);
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                texture = null;
+                return false;
+            }
+            return _zipNamedTextures.TryGetValue(name, out texture);
+        }
 
         public Texture2D GetImageTexture(string fullImagePath)
         {
@@ -356,6 +363,8 @@ namespace ClassicUO.Assets
                 var tex = Texture2D.FromStream(GraphicsDevice, ms);
                 if (tex == null) return;
                 FixPNGAlpha(ref tex);
+                if (_zipNamedTextures.TryGetValue(name, out Texture2D existing) && existing != null && !existing.IsDisposed)
+                    existing.Dispose();
                 _zipNamedTextures[name] = tex;
             }
             catch (Exception ex) { Log.Error($"Error registering named zip texture '{name}': {ex.Message}"); }

--- a/src/ClassicUO.Assets/PNGLoader.cs
+++ b/src/ClassicUO.Assets/PNGLoader.cs
@@ -3,6 +3,7 @@ using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Threading.Tasks;
 using ClassicUO.Utility.Logging;
 
@@ -293,6 +294,103 @@ namespace ClassicUO.Assets
                 buffer[i] = Color.FromNonPremultiplied(buffer[i].R, buffer[i].G, buffer[i].B, buffer[i].A);
 
             texture.SetData(buffer);
+        }
+
+        public void RegisterZipPNGs(ZipArchive archive)
+        {
+            if (GraphicsDevice == null) return;
+
+            foreach (ZipArchiveEntry entry in archive.Entries)
+            {
+                if (!entry.Name.EndsWith(".png", StringComparison.OrdinalIgnoreCase)) continue;
+
+                string normalized = entry.FullName.Replace('\\', '/');
+                string[] parts = normalized.Split('/');
+                if (parts.Length < 2) continue;
+
+                string folder = parts[parts.Length - 2];
+                string baseName = entry.Name.Substring(0, entry.Name.Length - 4);
+
+                if (folder.Equals(GUMP_EXTERNAL_FOLDER, StringComparison.OrdinalIgnoreCase))
+                {
+                    if (!uint.TryParse(baseName, out uint id)) continue;
+                    if (gump_textureCache.ContainsKey(id)) continue;
+
+                    byte[] bytes;
+                    using (var ms = new MemoryStream())
+                    {
+                        entry.Open().CopyTo(ms);
+                        bytes = ms.ToArray();
+                    }
+
+                    RegisterGumpFromBytes(id, bytes);
+                }
+                else if (folder.Equals(ART_EXTERNAL_FOLDER, StringComparison.OrdinalIgnoreCase))
+                {
+                    if (!uint.TryParse(baseName, out uint fileId)) continue;
+                    uint graphicId = fileId + 0x4000;
+                    if (art_textureCache.ContainsKey(graphicId)) continue;
+
+                    byte[] bytes;
+                    using (var ms = new MemoryStream())
+                    {
+                        entry.Open().CopyTo(ms);
+                        bytes = ms.ToArray();
+                    }
+
+                    RegisterArtFromBytes(graphicId, bytes);
+                }
+            }
+        }
+
+        private void RegisterGumpFromBytes(uint id, byte[] bytes)
+        {
+            if (GraphicsDevice == null) return;
+            try
+            {
+                using var ms = new MemoryStream(bytes);
+                var tex = Texture2D.FromStream(GraphicsDevice, ms);
+                if (tex == null) return;
+                FixPNGAlpha(ref tex);
+                uint[] pixels = GetPixels(tex);
+                int width = tex.Width, height = tex.Height;
+                gump_textureCache[id] = (pixels, width, height);
+                tex.Dispose();
+
+                AppendToAvailableIDs(ref gump_availableIDs, id);
+            }
+            catch (Exception ex) { Log.Error($"Error registering zip gump PNG {id}: {ex.Message}"); }
+        }
+
+        private void RegisterArtFromBytes(uint id, byte[] bytes)
+        {
+            if (GraphicsDevice == null) return;
+            try
+            {
+                using var ms = new MemoryStream(bytes);
+                var tex = Texture2D.FromStream(GraphicsDevice, ms);
+                if (tex == null) return;
+                FixPNGAlpha(ref tex);
+                uint[] pixels = GetPixels(tex);
+                int width = tex.Width, height = tex.Height;
+                art_textureCache[id] = (pixels, width, height);
+                tex.Dispose();
+
+                AppendToAvailableIDs(ref art_availableIDs, id);
+            }
+            catch (Exception ex) { Log.Error($"Error registering zip art PNG {id}: {ex.Message}"); }
+        }
+
+        private static void AppendToAvailableIDs(ref uint[] arr, uint id)
+        {
+            if (arr == null)
+            {
+                arr = [id];
+                return;
+            }
+            if (Array.IndexOf(arr, id) >= 0) return;
+            Array.Resize(ref arr, arr.Length + 1);
+            arr[arr.Length - 1] = id;
         }
 
         public void ClearArtPixelCache(uint graphic) => art_textureCache.Remove(graphic);

--- a/src/ClassicUO.Assets/PNGLoader.cs
+++ b/src/ClassicUO.Assets/PNGLoader.cs
@@ -16,6 +16,7 @@ namespace ClassicUO.Assets
         private string exePath;
 
         private Dictionary<string, Texture2D> EmbeddedArt = new Dictionary<string, Texture2D>();
+        private Dictionary<string, Texture2D> _zipNamedTextures = new Dictionary<string, Texture2D>();
         private Texture2D _emptyTexture;
 
         private uint[] gump_availableIDs;
@@ -45,6 +46,9 @@ namespace ClassicUO.Assets
             texture = _emptyTexture;
             return false;
         }
+
+        public bool TryGetNamedZipTexture(string name, out Texture2D texture)
+            => _zipNamedTextures.TryGetValue(name, out texture);
 
         public Texture2D GetImageTexture(string fullImagePath)
         {
@@ -304,45 +308,57 @@ namespace ClassicUO.Assets
             {
                 if (!entry.Name.EndsWith(".png", StringComparison.OrdinalIgnoreCase)) continue;
 
-                string normalized = entry.FullName.Replace('\\', '/');
-                string[] parts = normalized.Split('/');
-                if (parts.Length < 2) continue;
-
-                string folder = parts[parts.Length - 2];
-                string baseName = entry.Name.Substring(0, entry.Name.Length - 4);
-
-                if (folder.Equals(GUMP_EXTERNAL_FOLDER, StringComparison.OrdinalIgnoreCase))
+                byte[] bytes;
+                using (var ms = new MemoryStream())
+                using (var es = entry.Open())
                 {
-                    if (!uint.TryParse(baseName, out uint id)) continue;
-                    if (gump_textureCache.ContainsKey(id)) continue;
-
-                    byte[] bytes;
-                    using (var ms = new MemoryStream())
-                    using (var es = entry.Open())
-                    {
-                        es.CopyTo(ms);
-                        bytes = ms.ToArray();
-                    }
-
-                    RegisterGumpFromBytes(id, bytes);
+                    es.CopyTo(ms);
+                    bytes = ms.ToArray();
                 }
-                else if (folder.Equals(ART_EXTERNAL_FOLDER, StringComparison.OrdinalIgnoreCase))
+
+                // Register as a named texture (full path and filename shortcut)
+                string entryPath = entry.FullName.Replace('\\', '/');
+                RegisterNamedZipTexture(entryPath, bytes);
+                if (!_zipNamedTextures.ContainsKey(entry.Name))
+                    RegisterNamedZipTexture(entry.Name, bytes);
+
+                // Also handle gumps/ and art/ ID-based overrides
+                string[] parts = entryPath.Split('/');
+                if (parts.Length >= 2)
                 {
-                    if (!uint.TryParse(baseName, out uint fileId)) continue;
-                    uint graphicId = fileId + 0x4000;
-                    if (art_textureCache.ContainsKey(graphicId)) continue;
+                    string folder = parts[parts.Length - 2];
+                    string baseName = entry.Name.Substring(0, entry.Name.Length - 4);
 
-                    byte[] bytes;
-                    using (var ms = new MemoryStream())
-                    using (var es = entry.Open())
+                    if (folder.Equals(GUMP_EXTERNAL_FOLDER, StringComparison.OrdinalIgnoreCase))
                     {
-                        es.CopyTo(ms);
-                        bytes = ms.ToArray();
+                        if (uint.TryParse(baseName, out uint id) && !gump_textureCache.ContainsKey(id))
+                            RegisterGumpFromBytes(id, bytes);
                     }
-
-                    RegisterArtFromBytes(graphicId, bytes);
+                    else if (folder.Equals(ART_EXTERNAL_FOLDER, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (uint.TryParse(baseName, out uint fileId))
+                        {
+                            uint graphicId = fileId + 0x4000;
+                            if (!art_textureCache.ContainsKey(graphicId))
+                                RegisterArtFromBytes(graphicId, bytes);
+                        }
+                    }
                 }
             }
+        }
+
+        private void RegisterNamedZipTexture(string name, byte[] bytes)
+        {
+            if (GraphicsDevice == null) return;
+            try
+            {
+                using var ms = new MemoryStream(bytes);
+                var tex = Texture2D.FromStream(GraphicsDevice, ms);
+                if (tex == null) return;
+                FixPNGAlpha(ref tex);
+                _zipNamedTextures[name] = tex;
+            }
+            catch (Exception ex) { Log.Error($"Error registering named zip texture '{name}': {ex.Message}"); }
         }
 
         private void RegisterGumpFromBytes(uint id, byte[] bytes)

--- a/src/ClassicUO.Assets/PNGLoader.cs
+++ b/src/ClassicUO.Assets/PNGLoader.cs
@@ -318,8 +318,9 @@ namespace ClassicUO.Assets
 
                     byte[] bytes;
                     using (var ms = new MemoryStream())
+                    using (var es = entry.Open())
                     {
-                        entry.Open().CopyTo(ms);
+                        es.CopyTo(ms);
                         bytes = ms.ToArray();
                     }
 
@@ -333,8 +334,9 @@ namespace ClassicUO.Assets
 
                     byte[] bytes;
                     using (var ms = new MemoryStream())
+                    using (var es = entry.Open())
                     {
-                        entry.Open().CopyTo(ms);
+                        es.CopyTo(ms);
                         bytes = ms.ToArray();
                     }
 

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.2.32</AssemblyVersion>
-    <FileVersion>5.2.32</FileVersion>
+    <AssemblyVersion>5.2.33</AssemblyVersion>
+    <FileVersion>5.2.33</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Controls/LegionTexturePic.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/LegionTexturePic.cs
@@ -1,0 +1,56 @@
+using ClassicUO.Assets;
+using ClassicUO.Renderer;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace ClassicUO.Game.UI.Controls;
+
+public class LegionTexturePic : Control
+{
+    private string _textureName;
+
+    public string TextureName
+    {
+        get => _textureName;
+        set
+        {
+            _textureName = value;
+            TryApplyNaturalSize();
+        }
+    }
+
+    public LegionTexturePic(string textureName, int width = 0, int height = 0)
+    {
+        _textureName = textureName;
+        CanMove = true;
+        AcceptMouseInput = false;
+
+        if (width > 0) Width = width;
+        if (height > 0) Height = height;
+
+        if (width <= 0 || height <= 0)
+            TryApplyNaturalSize();
+    }
+
+    private void TryApplyNaturalSize()
+    {
+        if (PNGLoader.Instance.TryGetNamedZipTexture(_textureName, out Texture2D tex) && tex != null && !tex.IsDisposed)
+        {
+            if (Width <= 0)  Width  = tex.Width;
+            if (Height <= 0) Height = tex.Height;
+        }
+    }
+
+    public override bool Draw(UltimaBatcher2D batcher, int x, int y)
+    {
+        if (IsDisposed) return false;
+
+        if (!PNGLoader.Instance.TryGetNamedZipTexture(_textureName, out Texture2D tex) || tex == null || tex.IsDisposed)
+            return false;
+
+        Vector3 hueVector = ShaderHueTranslator.GetHueVector(0, false, Alpha, true);
+        batcher.Draw(tex, new Rectangle(x, y, Width, Height), tex.Bounds, hueVector);
+
+        return base.Draw(batcher, x, y);
+    }
+}

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/ScriptConstantsEditorWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/ScriptConstantsEditorWindow.cs
@@ -246,8 +246,8 @@ public class ScriptConstantsEditorWindow : MyraControl
 
     private void RefreshConstants()
     {
-        if (!File.Exists(_script.FullPath)) return;
-        _script.FileContents = File.ReadAllLines(_script.FullPath);
+        if (!_script.FileExists()) return;
+        _script.FileContents = _script.ReadFromFile();
         _script.FileContentsJoined = string.Join("\n", _script.FileContents);
         ParseConstants();
         _hasUnsavedChanges = false;
@@ -272,7 +272,7 @@ public class ScriptConstantsEditorWindow : MyraControl
             foreach (ConstantEntry c in _constants.Values.Where(c => c.OriginalValue != c.EditValue))
                 updatedLines[c.LineNumber] = $"{c.Name} = {c.EditValue}";
 
-            File.WriteAllLines(_script.FullPath, updatedLines);
+            _script.OverrideFileContents(string.Join("\n", updatedLines));
 
             _script.FileContents = updatedLines;
             _script.FileContentsJoined = string.Join("\n", updatedLines);

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/ScriptManagerWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/ScriptManagerWindow.cs
@@ -675,8 +675,8 @@ public class ScriptManagerWindow : MyraControl
         try
         {
             string zipPath = script.ZipPath;
-            LegionScripting.LegionScripting.LoadedScripts.RemoveAll(s => s is ZipScriptFile z && z.ZipPath == zipPath);
             File.Delete(zipPath);
+            LegionScripting.LegionScripting.LoadedScripts.RemoveAll(s => s is ZipScriptFile z && z.ZipPath == zipPath);
             _pendingReload = true;
             GameActions.Print(World.Instance, $"Deleted zip '{Path.GetFileName(zipPath)}'.", 66);
         }

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/ScriptManagerWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/ScriptManagerWindow.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Xml;
 using ClassicUO.Common.Enums;
 using ClassicUO.Configuration;
@@ -305,44 +306,59 @@ public class ScriptManagerWindow : MyraControl
     {
         bool globalAuto = LegionScripting.LegionScripting.AutoLoadEnabled(script, true);
         bool charAuto   = LegionScripting.LegionScripting.AutoLoadEnabled(script, false);
+        bool isZip      = script is ZipScriptFile;
 
-        ShowContextMenu(
-            ("Edit Constants",       () => new ScriptConstantsEditorWindow(script)),
-            ("Rename",               () => ShowRenameScriptDialog(script)),
-            ("Edit",                 () => new ScriptEditorWindow(script)),
-            ("Edit Externally",      () => FileSystemHelper.OpenFileWithDefaultApp(script.FullPath)),
-            (Language.Instance.Scripting.OpenLocation, () =>
+        var items = new List<(string, Action)>
+        {
+            ("Edit Constants", () => new ScriptConstantsEditorWindow(script)),
+            ("Edit",           () => new ScriptEditorWindow(script))
+        };
+
+        if (!isZip)
+        {
+            items.Add(("Rename",          () => ShowRenameScriptDialog(script)));
+            items.Add(("Edit Externally", () => FileSystemHelper.OpenFileWithDefaultApp(script.FullPath)));
+            items.Add((Language.Instance.Scripting.OpenLocation, () =>
             {
                 if (!FileSystemHelper.OpenLocation(script.FullPath))
                     GameActions.PrintUserWarn(World.Instance, string.Format(Language.Instance.Scripting.OpenLocationFailed, script.FullPath));
-            }),
-            (ContextMenuLabelToggle(globalAuto, "Autostart on all chars"), () =>
-            {
-                LegionScripting.LegionScripting.SetAutoPlay(script, true, !globalAuto);
-                RebuildScriptList();
-            }),
-            (ContextMenuLabelToggle(charAuto, "Autostart for this char"), () =>
-            {
-                LegionScripting.LegionScripting.SetAutoPlay(script, false, !charAuto);
-                RebuildScriptList();
-            }),
-            ("Create Macro Button", () =>
-            {
-                var mm = MacroManager.TryGetMacroManager(World.Instance);
-                if (mm == null) return;
-                var mac = new Macro(script.FileName);
-                mac.Items = new MacroObjectString(MacroType.ClientCommand, MacroSubType.MSC_NONE, "togglelscript " + script.FileName);
-                mm.PushToBack(mac);
-                var bg = new MacroButtonGump(World.Instance, mac, 0, 0);
-                bg.CenterXInViewPort();
-                bg.CenterYInViewPort();
-                UIManager.Add(bg);
-            }),
-            ("Delete", () => ShowDeleteConfirm(
-                "Delete Script",
-                $"Are you sure you want to delete '{script.FileName}'?\nThis action cannot be undone.",
-                () => PerformDeleteScript(script)))
-        );
+            }));
+        }
+
+        items.Add((ContextMenuLabelToggle(globalAuto, "Autostart on all chars"), () =>
+        {
+            LegionScripting.LegionScripting.SetAutoPlay(script, true, !globalAuto);
+            RebuildScriptList();
+        }));
+        items.Add((ContextMenuLabelToggle(charAuto, "Autostart for this char"), () =>
+        {
+            LegionScripting.LegionScripting.SetAutoPlay(script, false, !charAuto);
+            RebuildScriptList();
+        }));
+        items.Add(("Create Macro Button", () =>
+        {
+            var mm = MacroManager.TryGetMacroManager(World.Instance);
+            if (mm == null) return;
+            var mac = new Macro(script.FileName);
+            mac.Items = new MacroObjectString(MacroType.ClientCommand, MacroSubType.MSC_NONE, "togglelscript " + script.FileName);
+            mm.PushToBack(mac);
+            var bg = new MacroButtonGump(World.Instance, mac, 0, 0);
+            bg.CenterXInViewPort();
+            bg.CenterYInViewPort();
+            UIManager.Add(bg);
+        }));
+        items.Add(("Delete", () =>
+        {
+            if (script is ZipScriptFile zs)
+                ShowZipDeleteConfirm(zs);
+            else
+                ShowDeleteConfirm(
+                    "Delete Script",
+                    $"Are you sure you want to delete '{script.FileName}'?\nThis action cannot be undone.",
+                    () => PerformDeleteScript(script));
+        }));
+
+        ShowContextMenu(items.ToArray());
     }
 
     private void ShowGroupContextMenu(string parentGroup, string groupName)
@@ -632,6 +648,41 @@ public class ScriptManagerWindow : MyraControl
         catch (Exception ex) { GameActions.Print(World.Instance, $"Error renaming group: {ex.Message}", 32); Log.Error(ex.ToString()); }
     }
 
+    private void ShowZipDeleteConfirm(ZipScriptFile script)
+    {
+        new ZipDeleteDialog(
+            script.FileName,
+            Path.GetFileName(script.ZipPath),
+            onDeleteScript: () => PerformDeleteZipScript(script),
+            onDeleteZip:    () => PerformDeleteEntireZip(script));
+    }
+
+    private void PerformDeleteZipScript(ZipScriptFile script)
+    {
+        try
+        {
+            using var archive = ZipFile.Open(script.ZipPath, ZipArchiveMode.Update);
+            archive.GetEntry(script.EntryPath)?.Delete();
+            LegionScripting.LegionScripting.LoadedScripts.Remove(script);
+            _pendingReload = true;
+            GameActions.Print(World.Instance, $"Deleted '{script.FileName}' from zip.", 66);
+        }
+        catch (Exception ex) { GameActions.Print(World.Instance, $"Error deleting zip entry: {ex.Message}", 32); Log.Error(ex.ToString()); }
+    }
+
+    private void PerformDeleteEntireZip(ZipScriptFile script)
+    {
+        try
+        {
+            string zipPath = script.ZipPath;
+            LegionScripting.LegionScripting.LoadedScripts.RemoveAll(s => s is ZipScriptFile z && z.ZipPath == zipPath);
+            File.Delete(zipPath);
+            _pendingReload = true;
+            GameActions.Print(World.Instance, $"Deleted zip '{Path.GetFileName(zipPath)}'.", 66);
+        }
+        catch (Exception ex) { GameActions.Print(World.Instance, $"Error deleting zip: {ex.Message}", 32); Log.Error(ex.ToString()); }
+    }
+
     private void PerformDeleteScript(ScriptFile script)
     {
         try
@@ -664,5 +715,42 @@ public class ScriptManagerWindow : MyraControl
         catch (UnauthorizedAccessException) { GameActions.Print(World.Instance, "Access denied.", 32); }
         catch (IOException ioEx) { GameActions.Print(World.Instance, $"Delete operation failed: {ioEx.Message}", 32); }
         catch (Exception ex) { GameActions.Print(World.Instance, $"Error deleting group: {ex.Message}", 32); Log.Error(ex.ToString()); }
+    }
+
+    private sealed class ZipDeleteDialog : MyraControl
+    {
+        public ZipDeleteDialog(string scriptName, string zipName, Action onDeleteScript, Action onDeleteZip)
+            : base("Delete Zip Script")
+        {
+            var layout = new VerticalStackPanel { Spacing = 8, Padding = new Thickness(8) };
+
+            layout.Widgets.Add(new MyraLabel(
+                $"'{scriptName}' is inside zip '{zipName}'.\nWhat would you like to do?",
+                MyraLabel.TextStyle.P) { TextColor = Color.OrangeRed });
+
+            var btnRow = new HorizontalStackPanel
+            {
+                Spacing = 8,
+                HorizontalAlignment = HorizontalAlignment.Right
+            };
+
+            btnRow.Widgets.Add(new MyraButton("Delete Script Only", () =>
+            {
+                _disposeRequested = true;
+                onDeleteScript();
+            }));
+            btnRow.Widgets.Add(new MyraButton("Delete Entire Zip", () =>
+            {
+                _disposeRequested = true;
+                onDeleteZip();
+            }));
+            btnRow.Widgets.Add(new MyraButton("Cancel", () => _disposeRequested = true));
+
+            layout.Widgets.Add(btnRow);
+            SetRootContent(layout);
+            CenterInViewPort();
+            UIManager.Add(this);
+            BringOnTop();
+        }
     }
 }

--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiGump.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiGump.cs
@@ -170,6 +170,24 @@ public class ApiUiGump(LegionAPI api)
     }
 
     /// <summary>
+    /// Create an image control that displays a named PNG texture loaded from a ZIP archive.
+    /// Place the PNG anywhere inside the ZIP (outside gumps/ and art/ folders) and reference it by its path within the archive.
+    /// Example:
+    /// ```py
+    /// # In your zip: icons/sword.png
+    /// img = API.Gumps.LegionTextureControl("icons/sword.png")
+    /// img.SetPos(10, 10)
+    /// g.Add(img)
+    /// ```
+    /// </summary>
+    /// <param name="textureName">The PNG path within the ZIP, e.g. "icons/sword.png" or just "sword.png" if at the root</param>
+    /// <param name="width">Display width in pixels; 0 uses the image's natural width</param>
+    /// <param name="height">Display height in pixels; 0 uses the image's natural height</param>
+    /// <returns>A LegionTexture control</returns>
+    public ApiUiLegionTexture LegionTextureControl(string textureName, int width = 0, int height = 0) =>
+        new ApiUiLegionTexture(new LegionTexturePic(textureName, width, height));
+
+    /// <summary>
     /// Create a button for gumps.
     /// Example:
     /// ```py

--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiLegionTexture.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiLegionTexture.cs
@@ -1,0 +1,24 @@
+using ClassicUO.Game.Managers;
+using ClassicUO.Game.UI.Controls;
+
+namespace ClassicUO.LegionScripting.ApiClasses;
+
+public class ApiUiLegionTexture(LegionTexturePic control) : ApiUiBaseControl(control)
+{
+    /// <summary>
+    /// The name of the texture being displayed, as it appears in the ZIP archive.
+    /// </summary>
+    public string TextureName
+    {
+        get
+        {
+            if (!VerifyIntegrity()) return string.Empty;
+            return MainThreadQueue.InvokeOnMainThread(() => control.TextureName);
+        }
+        set
+        {
+            if (!VerifyIntegrity()) return;
+            MainThreadQueue.EnqueueAction(() => control.TextureName = value);
+        }
+    }
+}

--- a/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
@@ -272,6 +272,9 @@ namespace ClassicUO.LegionScripting
                         if (seg.StartsWith("_") || seg.StartsWith(".")) { hasHiddenSegment = true; break; }
                     if (hasHiddenSegment || entry.Name == "API.py") continue;
 
+                    string group    = segments.Length >= 2 ? segments[0] : string.Empty;
+                    string subGroup = segments.Length == 3 ? segments[1] : string.Empty;
+
                     string syntheticKey = $"{zipPath}::{entryName}";
                     if (loadedScripts.Contains(syntheticKey)) continue;
 

--- a/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
@@ -260,7 +260,8 @@ namespace ClassicUO.LegionScripting
                     string entryName = entry.FullName.Replace('\\', '/');
                     string ext = Path.GetExtension(entry.Name);
 
-                    if (ext != ".py" && ext != ".cs") continue;
+                    if (!ext.Equals(".py", StringComparison.OrdinalIgnoreCase) &&
+                        !ext.Equals(".cs", StringComparison.OrdinalIgnoreCase)) continue;
                     if (entry.Name == "API.py" || entry.Name.StartsWith("_")) continue;
 
                     string[] segments = entryName.Split('/', StringSplitOptions.RemoveEmptyEntries);

--- a/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
@@ -262,13 +262,15 @@ namespace ClassicUO.LegionScripting
 
                     if (!ext.Equals(".py", StringComparison.OrdinalIgnoreCase) &&
                         !ext.Equals(".cs", StringComparison.OrdinalIgnoreCase)) continue;
-                    if (entry.Name == "API.py" || entry.Name.StartsWith("_")) continue;
 
                     string[] segments = entryName.Split('/', StringSplitOptions.RemoveEmptyEntries);
                     if (segments.Length == 0 || segments.Length > 3) continue;
 
-                    string group    = segments.Length >= 2 ? segments[0] : string.Empty;
-                    string subGroup = segments.Length == 3 ? segments[1] : string.Empty;
+                    // Skip if any path segment (dir or file) starts with _ or .
+                    bool hasHiddenSegment = false;
+                    foreach (string seg in segments)
+                        if (seg.StartsWith("_") || seg.StartsWith(".")) { hasHiddenSegment = true; break; }
+                    if (hasHiddenSegment || entry.Name == "API.py") continue;
 
                     string syntheticKey = $"{zipPath}::{entryName}";
                     if (loadedScripts.Contains(syntheticKey)) continue;

--- a/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Text.Json;
 using System.Threading;
@@ -238,10 +239,49 @@ namespace ClassicUO.LegionScripting
                     AddScriptFromFile(file);
                     loadedScripts.Add(file);
                 }
+                else if (file.EndsWith(".zip", StringComparison.OrdinalIgnoreCase) && File.Exists(file))
+                    HandleScriptsInZip(file, loadedScripts);
                 else if (Directory.Exists(file)) groups.Add(file);
             }
 
             return groups;
+        }
+
+        private static void HandleScriptsInZip(string zipPath, HashSet<string> loadedScripts)
+        {
+            try
+            {
+                using var archive = ZipFile.OpenRead(zipPath);
+
+                foreach (ZipArchiveEntry entry in archive.Entries)
+                {
+                    if (string.IsNullOrEmpty(entry.Name)) continue; // directory entry
+
+                    string entryName = entry.FullName.Replace('\\', '/');
+                    string ext = Path.GetExtension(entry.Name);
+
+                    if (ext != ".py" && ext != ".cs") continue;
+                    if (entry.Name == "API.py" || entry.Name.StartsWith("_")) continue;
+
+                    string[] segments = entryName.Split('/', StringSplitOptions.RemoveEmptyEntries);
+                    if (segments.Length == 0 || segments.Length > 3) continue;
+
+                    string group    = segments.Length >= 2 ? segments[0] : string.Empty;
+                    string subGroup = segments.Length == 3 ? segments[1] : string.Empty;
+
+                    string syntheticKey = $"{zipPath}::{entryName}";
+                    if (loadedScripts.Contains(syntheticKey)) continue;
+
+                    LoadedScripts.Add(new ZipScriptFile(_world, zipPath, entryName, group, subGroup));
+                    loadedScripts.Add(syntheticKey);
+                }
+
+                ClassicUO.Assets.PNGLoader.Instance.RegisterZipPNGs(archive);
+            }
+            catch (Exception ex)
+            {
+                Log.Error($"Error loading scripts from zip '{zipPath}': {ex}");
+            }
         }
 
         public static void SetAutoPlay(ScriptFile script, bool global, bool enabled)

--- a/src/ClassicUO.Client/LegionScripting/ScriptFile.cs
+++ b/src/ClassicUO.Client/LegionScripting/ScriptFile.cs
@@ -71,7 +71,7 @@ public partial class ScriptFile : IDisposable
             Type = ScriptType.Python;
     }
 
-    public void OverrideFileContents(string contents)
+    public virtual void OverrideFileContents(string contents)
     {
         string temp = System.IO.Path.GetTempFileName();
 
@@ -88,7 +88,7 @@ public partial class ScriptFile : IDisposable
         }
     }
 
-    public string[] ReadFromFile()
+    public virtual string[] ReadFromFile()
     {
         try
         {
@@ -115,9 +115,9 @@ public partial class ScriptFile : IDisposable
         }
     }
 
-    public bool FileExists() => File.Exists(FullPath);
+    public virtual bool FileExists() => File.Exists(FullPath);
 
-    public void SetupPythonEngine()
+    public virtual void SetupPythonEngine()
     {
         if (PythonEngine != null && !LegionScripting.LScriptSettings.DisableModuleCache)
             return;

--- a/src/ClassicUO.Client/LegionScripting/ScriptFile.cs
+++ b/src/ClassicUO.Client/LegionScripting/ScriptFile.cs
@@ -39,7 +39,7 @@ public partial class ScriptFile : IDisposable
         CSharp
     }
 
-    private World World;
+    protected World World;
     private bool _disposed;
 
     public ScriptFile(World world, string path, string fileName)

--- a/src/ClassicUO.Client/LegionScripting/ZipScriptFile.cs
+++ b/src/ClassicUO.Client/LegionScripting/ZipScriptFile.cs
@@ -16,7 +16,7 @@ public class ZipScriptFile : ScriptFile
     public string EntryPath;
 
     public ZipScriptFile(World world, string zipPath, string entryPath, string group, string subGroup)
-        : base(world, LegionScripting.ScriptPath, Path.GetFileName(entryPath))
+        : base(world, LegionScripting.ScriptPath, System.IO.Path.GetFileName(entryPath))
     {
         ZipPath = zipPath;
         EntryPath = entryPath;
@@ -29,8 +29,12 @@ public class ZipScriptFile : ScriptFile
     public override bool FileExists()
     {
         if (!File.Exists(ZipPath)) return false;
-        using var archive = ZipFile.OpenRead(ZipPath);
-        return archive.GetEntry(EntryPath) != null;
+        try
+        {
+            using var archive = ZipFile.OpenRead(ZipPath);
+            return archive.GetEntry(EntryPath) != null;
+        }
+        catch { return false; }
     }
 
     public override string[] ReadFromFile()
@@ -88,9 +92,10 @@ public class ZipScriptFile : ScriptFile
         PythonEngine = Python.CreateEngine(new Dictionary<string, object>() { { "RecursionLimit", 100 } });
 
         ICollection<string> paths = PythonEngine.GetSearchPaths();
-        paths.Add(Path.Combine(CUOEnviroment.ExecutablePath, "iplib"));
-        paths.Add(Path.Combine(CUOEnviroment.ExecutablePath, "LegionScripts"));
-        paths.Add(Path.GetDirectoryName(ZipPath) ?? Environment.CurrentDirectory);
+        paths.Add(System.IO.Path.Combine(CUOEnviroment.ExecutablePath, "iplib"));
+        paths.Add(System.IO.Path.Combine(CUOEnviroment.ExecutablePath, "LegionScripts"));
+        paths.Add(ZipPath);
+        paths.Add(System.IO.Path.GetDirectoryName(ZipPath) ?? Environment.CurrentDirectory);
 
         PythonEngine.SetSearchPaths(paths);
     }

--- a/src/ClassicUO.Client/LegionScripting/ZipScriptFile.cs
+++ b/src/ClassicUO.Client/LegionScripting/ZipScriptFile.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using System.Text.RegularExpressions;
+using ClassicUO.Game;
+using ClassicUO.Utility.Logging;
+using IronPython.Hosting;
+
+namespace ClassicUO.LegionScripting;
+
+public class ZipScriptFile : ScriptFile
+{
+    public string ZipPath;
+    public string EntryPath;
+
+    public ZipScriptFile(World world, string zipPath, string entryPath, string group, string subGroup)
+        : base(world, LegionScripting.ScriptPath, Path.GetFileName(entryPath))
+    {
+        ZipPath = zipPath;
+        EntryPath = entryPath;
+        Group = group;
+        SubGroup = subGroup;
+        FullPath = $"{zipPath}::{entryPath}";
+        FileContents = ReadFromFile();
+    }
+
+    public override bool FileExists()
+    {
+        if (!File.Exists(ZipPath)) return false;
+        using var archive = ZipFile.OpenRead(ZipPath);
+        return archive.GetEntry(EntryPath) != null;
+    }
+
+    public override string[] ReadFromFile()
+    {
+        if (ZipPath == null) return [];
+
+        try
+        {
+            using var archive = ZipFile.OpenRead(ZipPath);
+            ZipArchiveEntry entry = archive.GetEntry(EntryPath);
+            if (entry == null) return [];
+
+            using var reader = new StreamReader(entry.Open(), Encoding.UTF8);
+            string text = reader.ReadToEnd();
+
+            string pattern = @"^\s*(?:from\s+[\w.]+\s+import\s+API|import\s+API)\s*$";
+            string stripped = Regex.Replace(text, pattern, string.Empty, RegexOptions.Multiline);
+
+            if (Type == ScriptType.CSharp && FileContentsJoined != stripped)
+                CSharpCompiledScript = null;
+
+            FileContentsJoined = stripped;
+            return text.Split('\n');
+        }
+        catch (Exception e)
+        {
+            Log.Error($"Error reading zip script entry '{EntryPath}' in '{ZipPath}': {e}");
+            return [];
+        }
+    }
+
+    public override void OverrideFileContents(string contents)
+    {
+        try
+        {
+            using var archive = ZipFile.Open(ZipPath, ZipArchiveMode.Update);
+            archive.GetEntry(EntryPath)?.Delete();
+            ZipArchiveEntry newEntry = archive.CreateEntry(EntryPath);
+            using var writer = new StreamWriter(newEntry.Open(), Encoding.UTF8);
+            writer.Write(contents);
+
+            GameActions.Print(World, $"Saved {FileName}.");
+        }
+        catch (Exception ex)
+        {
+            GameActions.Print(World, ex.ToString());
+        }
+    }
+
+    public override void SetupPythonEngine()
+    {
+        if (PythonEngine != null && !LegionScripting.LScriptSettings.DisableModuleCache)
+            return;
+
+        PythonEngine = Python.CreateEngine(new Dictionary<string, object>() { { "RecursionLimit", 100 } });
+
+        ICollection<string> paths = PythonEngine.GetSearchPaths();
+        paths.Add(Path.Combine(CUOEnviroment.ExecutablePath, "iplib"));
+        paths.Add(Path.Combine(CUOEnviroment.ExecutablePath, "LegionScripts"));
+        paths.Add(Path.GetDirectoryName(ZipPath) ?? Environment.CurrentDirectory);
+
+        PythonEngine.SetSearchPaths(paths);
+    }
+}

--- a/src/ClassicUO.Client/LegionScripting/docs/API.py
+++ b/src/ClassicUO.Client/LegionScripting/docs/API.py
@@ -647,6 +647,21 @@ class ApiUiGump:
         """
         pass
 
+    def LegionTextureControl(self, textureName: "str", width: "int" = 0, height: "int" = 0) -> "Any":
+        """
+         Create an image control that displays a named PNG texture loaded from a ZIP archive.
+         Place the PNG anywhere inside the ZIP (outside gumps/ and art/ folders) and reference it by its path within the archive.
+         Example:
+         ```py
+         # In your zip: icons/sword.png
+         img = API.Gumps.LegionTextureControl("icons/sword.png")
+         img.SetPos(10, 10)
+         g.Add(img)
+         ```
+        
+        """
+        pass
+
     def CreateGumpButton(self, text: "str" = "", hue: "int" = 996, normal: "int" = 0x00EF, pressed: "int" = 0x00F0, hover: "int" = 0x00EE) -> "ApiUiButton":
         """
          Create a button for gumps.
@@ -866,6 +881,10 @@ class ApiUiLabel(ApiUiBaseControl):
     ""
     Text: str = None
     Hue: int = None
+
+class ApiUiLegionTexture(ApiUiBaseControl):
+    ""
+    TextureName: str = None
 
 class ApiUiMenuItem:
     ""

--- a/src/ClassicUO.Client/LegionScripting/docs/ApiUiGump.md
+++ b/src/ClassicUO.Client/LegionScripting/docs/ApiUiGump.md
@@ -181,6 +181,31 @@ description: ApiUiGump class documentation
 
 ---
 
+### LegionTextureControl
+`(textureName, width, height)`
+ Create an image control that displays a named PNG texture loaded from a ZIP archive.
+ Place the PNG anywhere inside the ZIP (outside gumps/ and art/ folders) and reference it by its path within the archive.
+ Example:
+ ```py
+ # In your zip: icons/sword.png
+ img = API.Gumps.LegionTextureControl("icons/sword.png")
+ img.SetPos(10, 10)
+ g.Add(img)
+ ```
+
+
+**Parameters:**
+
+| Name | Type | Optional | Description |
+| --- | --- | --- | --- |
+| `textureName` | `string` | ❌ No | The PNG path within the ZIP, e.g. "icons/sword.png" or just "sword.png" if at the root |
+| `width` | `int` | ✅ Yes | Display width in pixels; 0 uses the image's natural width |
+| `height` | `int` | ✅ Yes | Display height in pixels; 0 uses the image's natural height |
+
+**Return Type:** `ApiUiLegionTexture`
+
+---
+
 ### CreateGumpButton
 `(text, hue, normal, pressed, hover)`
  Create a button for gumps.

--- a/src/ClassicUO.Client/LegionScripting/docs/ApiUiLegionTexture.md
+++ b/src/ClassicUO.Client/LegionScripting/docs/ApiUiLegionTexture.md
@@ -1,0 +1,21 @@
+---
+title: ApiUiLegionTexture
+description: ApiUiLegionTexture class documentation
+---
+
+## Properties
+### `TextureName`
+
+**Type:** `string`
+
+ The name of the texture being displayed, as it appears in the ZIP archive.
+
+
+
+*No fields found.*
+
+## Enums
+*No enums found.*
+
+## Methods
+*No methods found.*


### PR DESCRIPTION
- Scripts (.py/.cs) inside .zip files in LegionScripts/ are discovered and loaded without extracting the archive; group/subgroup structure follows the zip's directory layout (up to 2 levels deep)
- PNG textures inside zips (gumps/{id}.png, art/{id}.png) are registered in PNGLoader at script-load time, allowing full library+artwork distribution as a single zip
- ZipScriptFile subclass overrides FileExists, ReadFromFile, OverrideFileContents, and SetupPythonEngine to read/write directly from the archive; the script editor works transparently with zip entries
- Deleting a zip-sourced script shows a 3-button dialog: "Delete Script Only" (removes entry from zip), "Delete Entire Zip" (deletes the file), or "Cancel"
- Context menu items that require a real file path (Rename, Edit Externally, Open Location) are hidden for zip scripts
- ScriptConstantsEditorWindow now uses virtual FileExists/ReadFromFile/OverrideFileContents instead of direct File.* calls so zip scripts work with the constants editor

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * ZIP file support for Legion Scripting: script libraries with custom PNG artwork can be distributed and loaded as a single `.zip` file.
  * New texture control in gump API for displaying custom artwork from ZIP-embedded scripts.
  * Enhanced script manager with support for deleting ZIP-based scripts.

* **Chores**
  * Version updated to 5.2.33.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->