### PR TITLE
Create optional graphic override system using a zip in UO directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to TazUO will be recorded here.
 * UI language selection on the login screen now applies immediately instead of requiring a restart - [P.R 526](https://github.com/PlayTazUO/TazUO/pull/526) ([bittiez](https://github.com/bittiez))
 * Added loops to in-game macros - [P.R 519](https://github.com/PlayTazUO/TazUO/pull/519) ([DavideRei](https://github.com/DavideRei))
 * ZIP file support for Legion Scripting - script libraries with custom PNG artwork can now be distributed and loaded as a single .zip file; scripts in gumps can display zip textures via `API.Gumps.LegionTextureControl` - [P.R 533](https://github.com/PlayTazUO/TazUO/pull/533) ([bittiez](https://github.com/bittiez))
+* Added tuoassets.zip support to override embedded TUO graphics assets; a zip in the client directory overrides embedded assets and a zip in the UO directory takes highest priority for server-specific overrides; supports named embedded asset overrides and gump/art ID overrides matching the existing PNG system - [P.R 534](https://github.com/PlayTazUO/TazUO/pull/534) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
 * Fixed crash reading BWT-compressed UOP animations caused by returning a non-pooled buffer to the array pool - [P.R 532](https://github.com/PlayTazUO/TazUO/pull/532) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Assets/PNGLoader.cs
+++ b/src/ClassicUO.Assets/PNGLoader.cs
@@ -358,6 +358,13 @@ namespace ClassicUO.Assets
             }
         }
 
+        private static bool TryParseId(string value, out uint result)
+        {
+            if (value.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+                return uint.TryParse(value.AsSpan(2), System.Globalization.NumberStyles.HexNumber, null, out result);
+            return uint.TryParse(value, out result);
+        }
+
         private static bool ShouldSkipEntry(string fullName)
         {
             string normalized = fullName.Replace('\\', '/');
@@ -435,12 +442,12 @@ namespace ClassicUO.Assets
 
                         if (folder.Equals(GUMP_EXTERNAL_FOLDER, StringComparison.OrdinalIgnoreCase))
                         {
-                            if (uint.TryParse(baseName, out uint id))
+                            if (TryParseId(baseName, out uint id))
                                 RegisterGumpFromBytes(id, bytes);
                         }
                         else if (folder.Equals(ART_EXTERNAL_FOLDER, StringComparison.OrdinalIgnoreCase))
                         {
-                            if (uint.TryParse(baseName, out uint fileId))
+                            if (TryParseId(baseName, out uint fileId))
                                 RegisterArtFromBytes(fileId + 0x4000, bytes);
                         }
                     }

--- a/src/ClassicUO.Assets/PNGLoader.cs
+++ b/src/ClassicUO.Assets/PNGLoader.cs
@@ -14,6 +14,7 @@ namespace ClassicUO.Assets
         private const string IMAGES_FOLDER = "ExternalImages", GUMP_EXTERNAL_FOLDER = "gumps", ART_EXTERNAL_FOLDER = "art";
 
         private string exePath;
+        private string _uoDirectory;
 
         private Dictionary<string, Texture2D> EmbeddedArt = new Dictionary<string, Texture2D>();
         private Dictionary<string, Texture2D> _zipNamedTextures = new Dictionary<string, Texture2D>();
@@ -206,9 +207,10 @@ namespace ClassicUO.Assets
             return pixels;
         }
 
-        public void Load()
+        public void Load(string uoDirectory = null)
         {
             exePath = AppContext.BaseDirectory;
+            _uoDirectory = uoDirectory;
 
             string gumpPath = Path.Combine(exePath, IMAGES_FOLDER, GUMP_EXTERNAL_FOLDER);
 
@@ -294,6 +296,8 @@ namespace ClassicUO.Assets
                     }
                 }
             }
+
+            LoadTuoAssetsZips();
         }
 
         private static void FixPNGAlpha(ref Texture2D texture)
@@ -351,6 +355,100 @@ namespace ClassicUO.Assets
                         }
                     }
                 }
+            }
+        }
+
+        private static bool ShouldSkipEntry(string fullName)
+        {
+            string normalized = fullName.Replace('\\', '/');
+            foreach (string seg in normalized.Split('/', StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (seg[0] == '_' || seg[0] == '.') return true;
+            }
+            return false;
+        }
+
+        private void LoadTuoAssetsZips()
+        {
+            const string ZIP_NAME = "tuoassets.zip";
+
+            string exeZip = Path.Combine(exePath, ZIP_NAME);
+            LoadTuoAssetsZip(exeZip);
+
+            if (!string.IsNullOrEmpty(_uoDirectory))
+            {
+                string uoZip = Path.Combine(_uoDirectory, ZIP_NAME);
+                if (!string.Equals(uoZip, exeZip, StringComparison.OrdinalIgnoreCase))
+                    LoadTuoAssetsZip(uoZip);
+            }
+        }
+
+        private void LoadTuoAssetsZip(string zipPath)
+        {
+            if (GraphicsDevice == null || !File.Exists(zipPath)) return;
+
+            Log.Info($"Loading tuoassets.zip: {zipPath}");
+            try
+            {
+                using var archive = ZipFile.OpenRead(zipPath);
+                foreach (ZipArchiveEntry entry in archive.Entries)
+                {
+                    if (string.IsNullOrEmpty(entry.Name)) continue;
+                    if (!entry.Name.EndsWith(".png", StringComparison.OrdinalIgnoreCase)) continue;
+                    if (ShouldSkipEntry(entry.FullName)) continue;
+
+                    byte[] bytes;
+                    using (var ms = new MemoryStream())
+                    using (var es = entry.Open())
+                    {
+                        es.CopyTo(ms);
+                        bytes = ms.ToArray();
+                    }
+
+                    if (EmbeddedArt.ContainsKey(entry.Name))
+                    {
+                        try
+                        {
+                            using var ms = new MemoryStream(bytes);
+                            var tex = Texture2D.FromStream(GraphicsDevice, ms);
+                            if (tex == null) continue;
+                            FixPNGAlpha(ref tex);
+                            if (EmbeddedArt.TryGetValue(entry.Name, out Texture2D old)
+                                && old != null && !old.IsDisposed)
+                                old.Dispose();
+                            EmbeddedArt[entry.Name] = tex;
+                            Log.Debug($"tuoassets.zip overrode embedded asset: {entry.Name}");
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Error($"tuoassets.zip: error overriding embedded asset '{entry.Name}': {ex.Message}");
+                        }
+                        continue;
+                    }
+
+                    string entryPath = entry.FullName.Replace('\\', '/');
+                    string[] parts = entryPath.Split('/');
+                    if (parts.Length >= 2)
+                    {
+                        string folder = parts[parts.Length - 2];
+                        string baseName = Path.GetFileNameWithoutExtension(entry.Name);
+
+                        if (folder.Equals(GUMP_EXTERNAL_FOLDER, StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (uint.TryParse(baseName, out uint id))
+                                RegisterGumpFromBytes(id, bytes);
+                        }
+                        else if (folder.Equals(ART_EXTERNAL_FOLDER, StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (uint.TryParse(baseName, out uint fileId))
+                                RegisterArtFromBytes(fileId + 0x4000, bytes);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error($"tuoassets.zip: error loading '{zipPath}': {ex.Message}");
             }
         }
 

--- a/src/ClassicUO.Assets/UOFileManager.cs
+++ b/src/ClassicUO.Assets/UOFileManager.cs
@@ -167,7 +167,7 @@ namespace ClassicUO.Assets
             TileArt.Load();
             StringDictionary.Load();
 
-            PNGLoader.Instance.Load();
+            PNGLoader.Instance.Load(BasePath);
             //TrueTypeLoader.Instance.Load();
 
             ReadArtDefFile();

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.2.34</AssemblyVersion>
-    <FileVersion>5.2.34</FileVersion>
+    <AssemblyVersion>5.2.35</AssemblyVersion>
+    <FileVersion>5.2.35</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
## Description
Create optional graphic override system using a zip in UO directory

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Asset loading now supports loading PNG textures from alternate, user-configurable directories in addition to default embedded sources, enabling greater flexibility in managing custom graphics across installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->