### PR TITLE
Add option to disable door opening while player is hidden

### DIFF
--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -781,6 +781,10 @@ namespace ClassicUO.Configuration
         public partial bool QueueManualItemMoves { get; set; }
 
         [JsonIgnore]
+        [SqlSetting(SettingsScope.Char, Constants.SqlSettings.AUTO_OPEN_DOORS_HIDDEN, true)]
+        public partial bool AutoOpenDoorsIfHidden { get; set; }
+
+        [JsonIgnore]
         [SqlSetting(SettingsScope.Global, Constants.SqlSettings.QUEUE_MANUAL_ITEM_USES, false)]
         public partial bool QueueManualItemUses { get; set; }
 

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -5,7 +5,7 @@
 ; Missing keys are auto-appended with English defaults when
 ; this file's version is newer than the user's copy.
 ; -------------------------------------------------------
-_version=9
+_version=10
 accountname=Account Name
 accountcontextmenutooltip=Right click to select another account.
 music=Music
@@ -158,3 +158,4 @@ gridhighlight_rarityfilters=Item Rarity Filters
 gridhighlight_raritydesc=Only items with at least one of these rarities will match
 gridhighlight_addrarity=Add Rarity Filter
 gridhighlight_deleteproperty_tooltip=Delete this property
+auto_open_doors_hidden=Open doors while hidden

--- a/src/ClassicUO.Client/Game/Constants.cs
+++ b/src/ClassicUO.Client/Game/Constants.cs
@@ -140,6 +140,7 @@ namespace ClassicUO.Game
             public const string UI_LANGUAGE = "ui_language";
             public const string AUTO_STAT_LOCK = "auto_stat_lock";
             public const string DISABLE_AUTOLOOT_RETRY_CORPSE = "disable_authloot_retry";
+            public const string AUTO_OPEN_DOORS_HIDDEN = "auto_open_doors_hidden";
         }
     }
 }

--- a/src/ClassicUO.Client/Game/GameObjects/PlayerMobile.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/PlayerMobile.cs
@@ -417,7 +417,8 @@ namespace ClassicUO.Game.GameObjects
 
         private void TryOpenDoors()
         {
-            if (!World.Player.IsDead && ProfileManager.CurrentProfile.AutoOpenDoors)
+            if (!World.Player.IsDead && ProfileManager.CurrentProfile.AutoOpenDoors
+                && (ProfileManager.CurrentProfile.AutoOpenDoorsIfHidden || !IsHidden))
             {
                 int x = X, y = Y, z = Z;
                 Pathfinder.GetNewXY((byte)Direction, ref x, ref y);

--- a/src/ClassicUO.Client/Game/Pathfinder.cs
+++ b/src/ClassicUO.Client/Game/Pathfinder.cs
@@ -251,7 +251,8 @@ namespace ClassicUO.Game
                                 {
                                     dropFlags = true;
                                 }
-                                else if (ProfileManager.CurrentProfile.SmoothDoors && item2.ItemData.IsDoor)
+                                else if (ProfileManager.CurrentProfile.SmoothDoors && item2.ItemData.IsDoor
+                                    && (ProfileManager.CurrentProfile.AutoOpenDoorsIfHidden || !_world.Player.IsHidden))
                                 {
                                     dropFlags = true;
                                 }

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
@@ -168,6 +168,10 @@ namespace ClassicUO.Game.UI.Gumps
             (new CheckboxWithLabel(lang.GetGeneral.AutoOpenPathfinding, isChecked: profile.SmoothDoors, valueChanged: (b) => { profile.SmoothDoors = b; }),
                 true, page);
 
+            content.AddToRight
+            (new CheckboxWithLabel(TazLang.Get("auto_open_doors_hidden"), isChecked: profile.AutoOpenDoorsIfHidden, valueChanged: (b) => { profile.AutoOpenDoorsIfHidden = b; }),
+                true, page);
+
             content.RemoveIndent();
 
             content.BlankLine();


### PR DESCRIPTION
Adds a new per-character SQL setting (AutoOpenDoorsIfHidden, default true) that suppresses both auto door opening and pathfinder door passthrough when the player is hidden. The option appears as an indented checkbox under the existing door options in Modern Options, labelled via TazLang.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

- Added "Open doors while hidden" setting in General options. Players can now enable or disable automatic door opening while in hidden mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->