### PR TITLE
Fix ZIP script context menu missing Open Location, and stale content …

### DIFF
--- a/src/ClassicUO.Client/Game/UI/MyraWindows/ScriptManagerWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/ScriptManagerWindow.cs
@@ -324,6 +324,15 @@ public class ScriptManagerWindow : MyraControl
                     GameActions.PrintUserWarn(World.Instance, string.Format(Language.Instance.Scripting.OpenLocationFailed, script.FullPath));
             }));
         }
+        else
+        {
+            items.Add((Language.Instance.Scripting.OpenLocation, () =>
+            {
+                var zipScript = (ZipScriptFile)script;
+                if (!FileSystemHelper.OpenLocation(zipScript.ZipPath))
+                    GameActions.PrintUserWarn(World.Instance, string.Format(Language.Instance.Scripting.OpenLocationFailed, zipScript.ZipPath));
+            }));
+        }
 
         items.Add((ContextMenuLabelToggle(globalAuto, "Autostart on all chars"), () =>
         {

--- a/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
@@ -200,6 +200,9 @@ namespace ClassicUO.LegionScripting
 
             foreach (string file in subgroups)
                 HandleScriptsInDirectory(file); //No third level supported, ignore directories
+
+            foreach (ScriptFile sf in LoadedScripts)
+                sf.ReadFromFile();
         }
 
         private static void AddScriptFromFile(string path)


### PR DESCRIPTION
…on Refresh

- Add "Open Location" to the context menu for ZipScriptFile scripts so users can navigate to the folder containing the ZIP for external editing. Previously the ZIP commit (b68f6c5) put Rename/Edit Externally/Open Location inside if (!isZip), leaving ZIP-sourced grouped scripts with no way to locate them.

- Call ReadFromFile() on all loaded scripts at the end of LoadScriptsFromFile() so that clicking Refresh picks up externally-made changes without requiring a game restart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed opening script file locations when working with zip-based scripts.

* **Performance Improvements**
  * Scripts now load their contents during the initial startup phase for improved responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->