### PR TITLE
Localize raw user-facing strings in Gumps via TazLang

### DIFF
--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -5,7 +5,7 @@
 ; Missing keys are auto-appended with English defaults when
 ; this file's version is newer than the user's copy.
 ; -------------------------------------------------------
-_version=9
+_version=10
 accountname=Account Name
 accountcontextmenutooltip=Right click to select another account.
 music=Music
@@ -158,3 +158,110 @@ gridhighlight_rarityfilters=Item Rarity Filters
 gridhighlight_raritydesc=Only items with at least one of these rarities will match
 gridhighlight_addrarity=Add Rarity Filter
 gridhighlight_deleteproperty_tooltip=Delete this property
+
+; Anim browser
+animbrowser_next=>>
+animbrowser_prev=<<
+animbrowser_entergraphic=Enter Graphic
+animbrowser_tooltip=Animation: {0}\nDouble click to copy.
+
+; Art browser
+artbrowser_tooltip=Graphic: {0}\nDouble click to copy.
+
+; Boat control
+boatcontrol_notdriving=You need to be driving a boat to use this.
+boatcontrol_reg=Reg
+boatcontrol_slow=Slow
+boatcontrol_one=One
+
+; Dress agent config
+dressagent_selectconfig=Select Config:
+dressagent_createnew=Create New
+dressagent_configname=Config Name:
+dressagent_krpacket=Use Equip Packets (faster)
+dressagent_krpacket_tooltip=Not all servers support this.
+dressagent_additem=Add Item (Target)
+dressagent_addallequipped=Add All Equipped
+dressagent_clearitems=Clear All Items
+dressagent_setundressbag=Set Undress Bag
+dressagent_dress=Dress
+dressagent_undress=Undress
+dressagent_createdressmacro=Create Dress Macro
+dressagent_createundressmacro=Create Undress Macro
+dressagent_deleteconfig=Delete Config
+dressagent_deleteitem=X
+dressagent_noitems=No items configured.
+dressagent_additemshelp=Use the buttons on the left to add items.
+dressagent_defaultbag=Undress Bag: Player Backpack (default)
+dressagent_newconfigname=New Config
+dressagent_targetitem=Target item to add to dress config
+dressagent_targetcontainer=Target container for undress items
+
+; Durability gump
+durability_minimize_tooltip=Open Equipment Durability Tracker
+durability_title=Equipment Durability
+
+; File selector
+fileselector_close=Close
+fileselector_currentpath=Current Path:
+fileselector_filter=Filter:
+fileselector_filename=File Name:
+fileselector_ok=OK
+fileselector_cancel=Cancel
+fileselector_ready=Ready
+fileselector_currentdir=(Current Dir)
+fileselector_parentdir=(Parent Dir)
+fileselector_found=Found {0} directories and {1} files
+fileselector_invalidpath=Invalid directory path
+fileselector_errorloading=Error loading drives: {0}
+fileselector_error=Error: {0}
+
+; Grid container
+gridcontainer_search=Search...
+gridcontainer_clearsearch=X
+gridcontainer_clearsearch_tooltip=Clear search
+gridcontainer_controls_tooltip=/c[orange]Grid Container Controls:/cd\nCtrl + Click to lock an item in place\nAlt + Click to toggle selection for multi-move\nAlt + Double Click to select all similar items\nShift + Click to add an item to your auto loot list\nSort and single click looting can be enabled with the icons on the right side
+gridcontainer_openoriginal=Open Original View
+gridcontainer_defaultoriginal=Open New Containers in the Original View
+gridcontainer_stacksimilar=Stack Similar Items in the Original View
+gridcontainer_openhighlightsettings=Open Grid View Highlight Settings
+gridcontainer_autolootthis=Autoloot this container
+gridcontainer_refreshhighlights=Refresh item highlights
+gridcontainer_renamecontainer=Rename container
+gridcontainer_rename_title=Rename Container
+gridcontainer_rename_desc=Type in a custom name for this container.
+gridcontainer_save=Save
+gridcontainer_reset=Reset
+gridcontainer_sortbygraphichue=Sort by Graphic + Hue
+gridcontainer_sortbyname=Sort by Name
+gridcontainer_sortmode_graphichue=Graphic + Hue
+gridcontainer_sortmode_name=Name
+gridcontainer_setlootbag=Set loot bag
+gridcontainer_setlootbag_tooltip=For double click looting only
+gridcontainer_quickloot_corpse_tooltip=Drop an item here to send it to your backpack.<br><br>Click this icon to enable/disable single-click looting for corpses.<br>   Currently {0}
+gridcontainer_quickloot_container_tooltip=Drop an item here to send it to your backpack.<br><br>Click this icon to enable/disable single-click loot for this container while it remains open.<br>   Currently {0}
+gridcontainer_sort_tooltip=Sort this container.<br>Left click to show sort options<br>Alt + Click to enable auto sort<br>Current sort: {0}<br>Auto sort currently {1}
+
+; Inspector gump
+inspector_clipboard=To clipboard
+
+; Supporters gump
+supporters_title=TazUO supporters and honorable mentions<br>And a special thanks to all the ClassicUO devs that made this possible!
+
+; Tooltip config gump
+tooltipconfig_title=Tooltip Override Configuration
+tooltipconfig_wiki=Tooltip Overrides Wiki
+tooltipconfig_add=Add +
+tooltipconfig_export=Export
+tooltipconfig_import=Import
+tooltipconfig_deleteall=Delete All
+tooltipconfig_deleteall_tooltip=/c[red]This will remove ALL tooltip override settings.\nThis is not reversible.
+tooltipconfig_minmax=Min/Max
+tooltipconfig_searchtext_tooltip=This is the search text for matching tooltip lines.
+tooltipconfig_formattext_tooltip=This is what the matching tooltip line will be replaced with. See the wiki for more details!
+tooltipconfig_deleterow=Delete this override
+
+; Version history
+versionhistory_desc=Version history can now be found on our GitHub repo CHANGELOG.md file.
+versionhistory_main=Main branch changelog
+versionhistory_dev=Dev branch changelog

--- a/src/ClassicUO.Client/Game/UI/Gumps/AnimBrowser.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/AnimBrowser.cs
@@ -1,4 +1,5 @@
 using System;
+using ClassicUO.Configuration;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Input;
 using ClassicUO.Utility.Logging;
@@ -21,11 +22,11 @@ public class AnimBrowser : Gump
         Add(new AlphaBlendControl() { Width = Width, Height = Height });
         Add(dataBox);
 
-        var next = new NiceButton(Width - 100, Height - 20, 100, 20, ButtonAction.Default, ">>");
+        var next = new NiceButton(Width - 100, Height - 20, 100, 20, ButtonAction.Default, TazLang.Get("animbrowser_next", ">>"));
         next.MouseDown += (s, e) => { Page++; BuildPage(); };
         Add(next);
 
-        var prev = new NiceButton(0, Height - 20, 100, 20, ButtonAction.Default, "<<");
+        var prev = new NiceButton(0, Height - 20, 100, 20, ButtonAction.Default, TazLang.Get("animbrowser_prev", "<<"));
         prev.MouseDown += (s, e) => { Page--; BuildPage(); };
         Add(prev);
 
@@ -47,7 +48,7 @@ public class AnimBrowser : Gump
         };
         Add(pageInput);
 
-        StbTextBox graphicInput = new(0xFF, maxWidth: 100, hue: 52, align: Assets.TEXT_ALIGN_TYPE.TS_CENTER) { Width = 100, Height = 20, PlaceHolderText = "Enter Graphic" };
+        StbTextBox graphicInput = new(0xFF, maxWidth: 100, hue: 52, align: Assets.TEXT_ALIGN_TYPE.TS_CENTER) { Width = 100, Height = 20, PlaceHolderText = TazLang.Get("animbrowser_entergraphic", "Enter Graphic") };
         graphicInput.X = (Width - 100) >> 1;
         graphicInput.TextChanged += (s, e) =>
         {
@@ -116,7 +117,7 @@ public class AnimBrowser : Gump
             {
                 AnimationDisplay c = animationDisplays[count];
                 c.UpdateGraphic((ushort)index);
-                c.SetTooltip($"Animation: {index}\nDouble click to copy.");
+                c.SetTooltip(TazLang.Get("animbrowser_tooltip", new string[] { index.ToString() }));
                 count++;
             }
             index++;

--- a/src/ClassicUO.Client/Game/UI/Gumps/ArtBrowserGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ArtBrowserGump.cs
@@ -1,4 +1,5 @@
 using System;
+using ClassicUO.Configuration;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Input;
 using ClassicUO.Utility.Logging;
@@ -21,11 +22,11 @@ public class ArtBrowserGump : Gump
         Add(new AlphaBlendControl() { Width = Width, Height = Height });
         Add(dataBox);
 
-        var next = new NiceButton(Width - 100, Height - 20, 100, 20, ButtonAction.Default, ">>");
+        var next = new NiceButton(Width - 100, Height - 20, 100, 20, ButtonAction.Default, TazLang.Get("animbrowser_next", ">>"));
         next.MouseDown += (s, e) => { Page++; BuildPage(); };
         Add(next);
 
-        var prev = new NiceButton(0, Height - 20, 100, 20, ButtonAction.Default, "<<");
+        var prev = new NiceButton(0, Height - 20, 100, 20, ButtonAction.Default, TazLang.Get("animbrowser_prev", "<<"));
         prev.MouseDown += (s, e) => { Page--; BuildPage(); };
         Add(prev);
 
@@ -47,7 +48,7 @@ public class ArtBrowserGump : Gump
         };
         Add(pageInput);
 
-        StbTextBox graphicInput = new(0xFF, maxWidth: 100, hue: 52, align: Assets.TEXT_ALIGN_TYPE.TS_CENTER) { Width = 100, Height = 20, PlaceHolderText = "Enter Graphic" };
+        StbTextBox graphicInput = new(0xFF, maxWidth: 100, hue: 52, align: Assets.TEXT_ALIGN_TYPE.TS_CENTER) { Width = 100, Height = 20, PlaceHolderText = TazLang.Get("animbrowser_entergraphic", "Enter Graphic") };
         graphicInput.X = (Width - 100) >> 1;
         graphicInput.TextChanged += (s, e) =>
         {
@@ -116,7 +117,7 @@ public class ArtBrowserGump : Gump
             {
                 ResizableStaticPic c = resizableStaticPics[count];
                 c.Graphic = index;
-                c.SetTooltip($"Graphic: {index}\nDouble click to copy.");
+                c.SetTooltip(TazLang.Get("artbrowser_tooltip", new string[] { index.ToString() }));
                 count++;
             }
             index++;

--- a/src/ClassicUO.Client/Game/UI/Gumps/BoatControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/BoatControl.cs
@@ -1,6 +1,5 @@
+using ClassicUO.Configuration;
 using ClassicUO.Game.UI.Controls;
-using static System.Net.Mime.MediaTypeNames;
-using System.Drawing;
 using ClassicUO.Game.Managers;
 
 namespace ClassicUO.Game.UI.Gumps
@@ -70,7 +69,7 @@ namespace ClassicUO.Game.UI.Gumps
             (
                 0x00D2,
                 0x00D3,
-                "Reg",
+                TazLang.Get("boatcontrol_reg", "Reg"),
                 0xff,
                 0xffff
             )
@@ -85,7 +84,7 @@ namespace ClassicUO.Game.UI.Gumps
             (
                 0x00D2,
                 0x00D3,
-                "Slow",
+                TazLang.Get("boatcontrol_slow", "Slow"),
                 0xff,
                 0xffff
             )
@@ -100,7 +99,7 @@ namespace ClassicUO.Game.UI.Gumps
             (
                 0x00D2,
                 0x00D3,
-                "One",
+                TazLang.Get("boatcontrol_one", "One"),
                 0xff,
                 0xffff
             )
@@ -141,7 +140,7 @@ namespace ClassicUO.Game.UI.Gumps
                 return true;
             else
             {
-                GameActions.Print(World, "You need to be driving a boat to use this.");
+                GameActions.Print(World, TazLang.Get("boatcontrol_notdriving", "You need to be driving a boat to use this."));
                 return false;
             }
         }

--- a/src/ClassicUO.Client/Game/UI/Gumps/DressAgentConfigGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/DressAgentConfigGump.cs
@@ -43,7 +43,7 @@ namespace ClassicUO.Game.UI.Gumps
             _allConfigs.AddRange(DressAgentManager.Instance.OtherCharacterConfigs);
 
             // Config selection dropdown
-            Add(new Label("Select Config:", true, 0xFFFF, font: 1)
+            Add(new Label(TazLang.Get("dressagent_selectconfig", "Select Config:"), true, 0xFFFF, font: 1)
             {
                 X = 20,
                 Y = 20
@@ -67,7 +67,7 @@ namespace ClassicUO.Game.UI.Gumps
             Add(_configCombobox);
 
             // Create Config button
-            var createButton = new NiceButton(380, 20, 80, 25, ButtonAction.Default, "Create New") { IsSelectable = false, DisplayBorder = true };
+            var createButton = new NiceButton(380, 20, 80, 25, ButtonAction.Default, TazLang.Get("dressagent_createnew", "Create New")) { IsSelectable = false, DisplayBorder = true };
             createButton.MouseUp += (s, e) =>
             {
                 CreateNewConfig();
@@ -75,7 +75,7 @@ namespace ClassicUO.Game.UI.Gumps
             Add(createButton);
 
             // Title with rename functionality
-            Add(new Label("Config Name:", true, 0xFFFF, font: 1)
+            Add(new Label(TazLang.Get("dressagent_configname", "Config Name:"), true, 0xFFFF, font: 1)
             {
                 X = 20,
                 Y = 50
@@ -118,7 +118,7 @@ namespace ClassicUO.Game.UI.Gumps
             // KR Packet option
             if (!_readOnly)
             {
-                var krPacketCheckbox = new Checkbox(0x00D2, 0x00D3, "Use Equip Packets (faster)", 1, 0xFFFF, true)
+                var krPacketCheckbox = new Checkbox(0x00D2, 0x00D3, TazLang.Get("dressagent_krpacket", "Use Equip Packets (faster)"), 1, 0xFFFF, true)
                 {
                     X = 300,
                     Y = 75,
@@ -129,7 +129,7 @@ namespace ClassicUO.Game.UI.Gumps
                     _config.UseKREquipPacket = krPacketCheckbox.IsChecked;
                     DressAgentManager.Instance.Save();
                 };
-                krPacketCheckbox.SetTooltip("Not all servers support this.");
+                krPacketCheckbox.SetTooltip(TazLang.Get("dressagent_krpacket_tooltip", "Not all servers support this."));
                 Add(krPacketCheckbox);
             }
 
@@ -142,9 +142,9 @@ namespace ClassicUO.Game.UI.Gumps
 
             if (!_readOnly)
             {
-                AddButton("Add Item (Target)", () =>
+                AddButton(TazLang.Get("dressagent_additem", "Add Item (Target)"), () =>
                 {
-                    GameActions.Print(World, "Target item to add to dress config");
+                    GameActions.Print(World, TazLang.Get("dressagent_targetitem", "Target item to add to dress config"));
                     World.TargetManager.SetTargeting((obj) =>
                     {
                         if (obj != null && obj is Entity objEntity && SerialHelper.IsItem(objEntity.Serial))
@@ -155,21 +155,21 @@ namespace ClassicUO.Game.UI.Gumps
                     });
                 });
 
-                AddButton("Add All Equipped", () =>
+                AddButton(TazLang.Get("dressagent_addallequipped", "Add All Equipped"), () =>
                 {
                     DressAgentManager.Instance.AddCurrentlyEquippedItems(_config);
                     RefreshItemsList();
                 });
 
-                AddButton("Clear All Items", () =>
+                AddButton(TazLang.Get("dressagent_clearitems", "Clear All Items"), () =>
                 {
                     DressAgentManager.Instance.ClearConfig(_config);
                     RefreshItemsList();
                 });
 
-                AddButton("Set Undress Bag", () =>
+                AddButton(TazLang.Get("dressagent_setundressbag", "Set Undress Bag"), () =>
                 {
-                    GameActions.Print(World, "Target container for undress items");
+                    GameActions.Print(World, TazLang.Get("dressagent_targetcontainer", "Target container for undress items"));
                     World.TargetManager.SetTargeting((obj) =>
                     {
                         if (obj != null && obj is Entity objEntity && SerialHelper.IsItem(objEntity.Serial))
@@ -182,30 +182,30 @@ namespace ClassicUO.Game.UI.Gumps
                 });
             }
 
-            AddButton("Dress", 63, () =>
+            AddButton(TazLang.Get("dressagent_dress", "Dress"), 63, () =>
             {
                 DressAgentManager.Instance.DressFromConfig(_config);
             });
 
-            AddButton("Undress", 49, () =>
+            AddButton(TazLang.Get("dressagent_undress", "Undress"), 49, () =>
             {
                 DressAgentManager.Instance.UndressFromConfig(_config);
             });
 
             if(!_readOnly) {
-                AddButton("Create Dress Macro", () =>
+                AddButton(TazLang.Get("dressagent_createdressmacro", "Create Dress Macro"), () =>
                 {
                     DressAgentManager.Instance.CreateDressMacro(_config.Name);
                     GameActions.Print(World, $"Created dress macro: Dress: {_config.Name}");
                 });
 
-                AddButton("Create Undress Macro", () =>
+                AddButton(TazLang.Get("dressagent_createundressmacro", "Create Undress Macro"), () =>
                 {
                     DressAgentManager.Instance.CreateUndressMacro(_config.Name);
                     GameActions.Print(World, $"Created undress macro: Undress: {_config.Name}");
                 });
 
-                AddButton("Delete Config", 33, () =>
+                AddButton(TazLang.Get("dressagent_deleteconfig", "Delete Config"), 33, () =>
                 {
                     DeleteCurrentConfig();
                 });
@@ -263,7 +263,7 @@ namespace ClassicUO.Game.UI.Gumps
         private void CreateNewConfig()
         {
             // Generate a unique name for the new config
-            string baseName = "New Config";
+            string baseName = TazLang.Get("dressagent_newconfigname", "New Config");
             string newName = baseName;
             int counter = 1;
 
@@ -357,7 +357,7 @@ namespace ClassicUO.Game.UI.Gumps
                     // Delete button
                     if (!_readOnly)
                     {
-                        var deleteButton = new NiceButton(itemArea.Width - 25, 2, 20, 20, ButtonAction.Default, "X") { IsSelectable = false, DisplayBorder = true };
+                        var deleteButton = new NiceButton(itemArea.Width - 25, 2, 20, 20, ButtonAction.Default, TazLang.Get("dressagent_deleteitem", "X")) { IsSelectable = false, DisplayBorder = true };
                         deleteButton.MouseUp += (s, e) =>
                         {
                             DressAgentManager.Instance.RemoveItemFromConfig(_config, item.Serial);
@@ -371,10 +371,10 @@ namespace ClassicUO.Game.UI.Gumps
             }
             else
             {
-                _itemsList.Add(new Label("No items configured.", true, 0xFFFF, font: 1));
+                _itemsList.Add(new Label(TazLang.Get("dressagent_noitems", "No items configured."), true, 0xFFFF, font: 1));
                 if (!_readOnly)
                 {
-                    _itemsList.Add(new Label("Use the buttons on the left to add items.", true, 0xFFFF, font: 1));
+                    _itemsList.Add(new Label(TazLang.Get("dressagent_additemshelp", "Use the buttons on the left to add items."), true, 0xFFFF, font: 1));
                 }
             }
 
@@ -387,7 +387,7 @@ namespace ClassicUO.Game.UI.Gumps
             }
             else
             {
-                _itemsList.Add(new Label("Undress Bag: Player Backpack (default)", true, 0xFFFF, font: 1));
+                _itemsList.Add(new Label(TazLang.Get("dressagent_defaultbag", "Undress Bag: Player Backpack (default)"), true, 0xFFFF, font: 1));
             }
         }
     }

--- a/src/ClassicUO.Client/Game/UI/Gumps/DurabilityGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/DurabilityGump.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
 using ClassicUO.Assets;
+using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.Managers;
@@ -19,7 +20,7 @@ namespace ClassicUO.Game.UI.Gumps
 
         public DurabilityGumpMinimized(World world) : base(world, 0, 0)
         {
-            SetTooltip("Open Equipment Durability Tracker");
+            SetTooltip(TazLang.Get("durability_minimize_tooltip", "Open Equipment Durability Tracker"));
 
             WantUpdateSize = true;
             AcceptMouseInput = true;
@@ -112,7 +113,7 @@ namespace ClassicUO.Game.UI.Gumps
 
         private void BuildHeader()
         {
-            Label l = new ("Equipment Durability", true, 0xFF);
+            Label l = new (TazLang.Get("durability_title", "Equipment Durability"), true, 0xFF);
             l.X = (Width >> 1) - (l.Width >> 1);
             l.Y = (l.Height >> 1) >> 1;
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/FileSelector.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/FileSelector.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using ClassicUO.Assets;
+using ClassicUO.Configuration;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Renderer;
@@ -81,13 +82,13 @@ namespace ClassicUO.Game.UI.Gumps
             });
 
             // Close button
-            Add(new NiceButton(GUMP_WIDTH - 80, 5, 75, 20, ButtonAction.Activate, "Close")
+            Add(new NiceButton(GUMP_WIDTH - 80, 5, 75, 20, ButtonAction.Activate, TazLang.Get("fileselector_close", "Close"))
             {
                 ButtonParameter = 0
             });
 
             // Current path display
-            Add(new Label("Current Path:", true, 0x0386, font: 1)
+            Add(new Label(TazLang.Get("fileselector_currentpath", "Current Path:"), true, 0x0386, font: 1)
             {
                 X = 20,
                 Y = 35
@@ -99,7 +100,7 @@ namespace ClassicUO.Game.UI.Gumps
             Add(_pathTextBox);
 
             // File extension filter
-            Add(new Label("Filter:", true, 0x0386, font: 1)
+            Add(new Label(TazLang.Get("fileselector_filter", "Filter:"), true, 0x0386, font: 1)
             {
                 X = 20,
                 Y = 85
@@ -119,7 +120,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             // Selected file name
             Control c;
-            Add(c = new Label("File Name:", true, 0x0386, font: 1)
+            Add(c = new Label(TazLang.Get("fileselector_filename", "File Name:"), true, 0x0386, font: 1)
             {
                 X = 20,
                 Y = GUMP_HEIGHT - 40
@@ -131,19 +132,19 @@ namespace ClassicUO.Game.UI.Gumps
             Add(_fileNameTextBox);
 
             // OK button
-            Add(new NiceButton(GUMP_WIDTH - 180, 477, 75, 20, ButtonAction.Activate, "OK")
+            Add(new NiceButton(GUMP_WIDTH - 180, 477, 75, 20, ButtonAction.Activate, TazLang.Get("fileselector_ok", "OK"))
             {
                 ButtonParameter = 3
             });
 
             // Cancel button
-            Add(new NiceButton(GUMP_WIDTH - 90, 477, 75, 20, ButtonAction.Activate, "Cancel")
+            Add(new NiceButton(GUMP_WIDTH - 90, 477, 75, 20, ButtonAction.Activate, TazLang.Get("fileselector_cancel", "Cancel"))
             {
                 ButtonParameter = 4
             });
 
             // Status label
-            _statusLabel = new Label("Ready", true, 0x0386, font: 1)
+            _statusLabel = new Label(TazLang.Get("fileselector_ready", "Ready"), true, 0x0386, font: 1)
             {
                 X = 20,
                 Y = GUMP_HEIGHT - 20
@@ -159,7 +160,7 @@ namespace ClassicUO.Game.UI.Gumps
             try
             {
                 string dirc = _currentPath;
-                var dirButtonUp = new NiceButton(0, 0, BUTTON_WIDTH, 20, ButtonAction.Default, $"(Current Dir)", align: TEXT_ALIGN_TYPE.TS_LEFT, hue:693);
+                var dirButtonUp = new NiceButton(0, 0, BUTTON_WIDTH, 20, ButtonAction.Default, TazLang.Get("fileselector_currentdir", "(Current Dir)"), align: TEXT_ALIGN_TYPE.TS_LEFT, hue:693);
                 if (_type == FileSelectorType.Directory)
                     dirButtonUp.MouseUp += (sender, e) => SelectFile(dirc);
                 _scrollVBox.Add(dirButtonUp);
@@ -168,7 +169,7 @@ namespace ClassicUO.Game.UI.Gumps
                 if(parent != null)
                 {
                     string dirp = parent.FullName;
-                    dirButtonUp = new NiceButton(0, 0, BUTTON_WIDTH, 20, ButtonAction.Default, $"(Parent Dir)",
+                    dirButtonUp = new NiceButton(0, 0, BUTTON_WIDTH, 20, ButtonAction.Default, TazLang.Get("fileselector_parentdir", "(Parent Dir)"),
                         align: TEXT_ALIGN_TYPE.TS_LEFT, hue: 693);
                     if (_type == FileSelectorType.Directory)
                         dirButtonUp.MouseUp += (sender, e) => SelectFile(dirp);
@@ -195,13 +196,13 @@ namespace ClassicUO.Game.UI.Gumps
                     }
                     catch (Exception ex)
                     {
-                        _statusLabel.Text = $"Error loading drives: {ex.Message}";
+                        _statusLabel.Text = TazLang.Get("fileselector_errorloading", new string[] { ex.Message });
                     }
                 }
 
                 if (!Directory.Exists(_currentPath))
                 {
-                    _statusLabel.Text = "Invalid directory path";
+                    _statusLabel.Text = TazLang.Get("fileselector_invalidpath", "Invalid directory path");
                     return;
                 }
 
@@ -237,11 +238,11 @@ namespace ClassicUO.Game.UI.Gumps
                     _scrollVBox.Add(fileButton);
                 }
 
-                _statusLabel.Text = $"Found {directories.Length} directories and {files.Length} files";
+                _statusLabel.Text = TazLang.Get("fileselector_found", new string[] { directories.Length.ToString(), files.Length.ToString() });
             }
             catch (Exception ex)
             {
-                _statusLabel.Text = $"Error: {ex.Message}";
+                _statusLabel.Text = TazLang.Get("fileselector_error", new string[] { ex.Message });
             }
         }
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
@@ -112,8 +112,8 @@ namespace ClassicUO.Game.UI.Gumps
             get
             {
                 if (_isCorpse)
-                    return $"Drop an item here to send it to your backpack.<br><br>Click this icon to enable/disable single-click looting for corpses.<br>   Currently {QuickLootStatus}";
-                return $"Drop an item here to send it to your backpack.<br><br>Click this icon to enable/disable single-click loot for this container while it remains open.<br>   Currently {GetEnabledDisabledText(_quickLootThisContainer)}";
+                    return TazLang.Get("gridcontainer_quickloot_corpse_tooltip", new string[] { QuickLootStatus });
+                return TazLang.Get("gridcontainer_quickloot_container_tooltip", new string[] { GetEnabledDisabledText(_quickLootThisContainer) });
             }
 
         }
@@ -122,8 +122,8 @@ namespace ClassicUO.Game.UI.Gumps
             get
             {
                 string status = GetEnabledDisabledText(_autoSortContainer);
-                string sortModeText = _sortMode == GridSortMode.Name ? "Name" : "Graphic + Hue";
-                return $"Sort this container.<br>Left click to show sort options<br>Alt + Click to enable auto sort<br>Current sort: {sortModeText}<br>Auto sort currently {status}";
+                string sortModeText = _sortMode == GridSortMode.Name ? TazLang.Get("gridcontainer_sortmode_name", "Name") : TazLang.Get("gridcontainer_sortmode_graphichue", "Graphic + Hue");
+                return TazLang.Get("gridcontainer_sort_tooltip", new string[] { sortModeText, status });
             }
         }
 
@@ -335,10 +335,10 @@ namespace ClassicUO.Game.UI.Gumps
                 Width = _background.Width - 18,
                 Height = 20
             };
-            _searchBox.PlaceHolderText = "Search...";
+            _searchBox.PlaceHolderText = TazLang.Get("gridcontainer_search", "Search...");
             _searchBox.TextChanged += (sender, e) => { UpdateItems(); };
 
-            _searchClearButton = new NiceButton(_borderWidth + _background.Width - 16, _borderWidth + LABEL_HEIGHT, 16, _searchBox.Height, ButtonAction.Default, "X");
+            _searchClearButton = new NiceButton(_borderWidth + _background.Width - 16, _borderWidth + LABEL_HEIGHT, 16, _searchBox.Height, ButtonAction.Default, TazLang.Get("gridcontainer_clearsearch", "X"));
             _searchClearButton.MouseUp += (sender, e) =>
             {
                 if (e.Button == MouseButtonType.Left)
@@ -347,7 +347,7 @@ namespace ClassicUO.Game.UI.Gumps
                     UIManager.SystemChat?.SetFocus();
                 }
             };
-            _searchClearButton.SetTooltip("Clear search");
+            _searchClearButton.SetTooltip(TazLang.Get("gridcontainer_clearsearch_tooltip", "Clear search"));
 
             Texture2D regularGumpIcon = Client.Game.UO.Gumps.GetGump(5839).Texture;
             _openRegularGump = new GumpPic(_background.Width - 25 - _borderWidth, _borderWidth, regularGumpIcon == null ? (ushort)1209 : (ushort)5839, 0);
@@ -362,13 +362,13 @@ namespace ClassicUO.Game.UI.Gumps
             };
             _openRegularGump.MouseEnter += (sender, e) => { _openRegularGump.Graphic = regularGumpIcon == null ? (ushort)1210 : (ushort)5840; };
             _openRegularGump.MouseExit += (sender, e) => { _openRegularGump.Graphic = regularGumpIcon == null ? (ushort)1209 : (ushort)5839; };
-            _openRegularGump.SetTooltip(
+            _openRegularGump.SetTooltip(TazLang.Get("gridcontainer_controls_tooltip",
                 "/c[orange]Grid Container Controls:/cd\n" +
                 "Ctrl + Click to lock an item in place\n" +
                 "Alt + Click to toggle selection for multi-move\n" +
                 "Alt + Double Click to select all similar items\n" +
                 "Shift + Click to add an item to your auto loot list\n" +
-                "Sort and single click looting can be enabled with the icons on the right side");
+                "Sort and single click looting can be enabled with the icons on the right side"));
             _quickDropBackpack = new ResizableStaticPic(World.Player.Backpack.DisplayedGraphic, 20, 20)
             {
                 X = Width - _openRegularGump.Width - 20 - _borderWidth,
@@ -445,9 +445,9 @@ namespace ClassicUO.Game.UI.Gumps
             #endregion
 
             #region Set loot bag
-            _setLootBag = new NiceButton(0, Height - 20, 100, 20, ButtonAction.Default, "Set loot bag") { IsSelectable = false };
+            _setLootBag = new NiceButton(0, Height - 20, 100, 20, ButtonAction.Default, TazLang.Get("gridcontainer_setlootbag", "Set loot bag")) { IsSelectable = false };
             _setLootBag.IsVisible = _isCorpse;
-            _setLootBag.SetTooltip("For double click looting only");
+            _setLootBag.SetTooltip(TazLang.Get("gridcontainer_setlootbag_tooltip", "For double click looting only"));
             _setLootBag.MouseUp += (s, e) =>
             {
                 GameActions.Print(world, Resources.ResGumps.TargetContainerToGrabItemsInto);
@@ -600,7 +600,7 @@ namespace ClassicUO.Game.UI.Gumps
         private ContextMenuControl GenContextMenu()
         {
             var control = new ContextMenuControl(this);
-            control.Add(new ContextMenuItemEntry("Open Original View", () =>
+            control.Add(new ContextMenuItemEntry(TazLang.Get("gridcontainer_openoriginal", "Open Original View"), () =>
             {
                 UseOldContainerStyle = true;
                 OpenOldContainer(LocalSerial);
@@ -608,42 +608,42 @@ namespace ClassicUO.Game.UI.Gumps
 
             control.Add(new ContextMenuItemEntry
             (
-                "Open New Containers in the Original View", () =>
+                TazLang.Get("gridcontainer_defaultoriginal", "Open New Containers in the Original View"), () =>
                 {
                     ProfileManager.CurrentProfile.GridContainersDefaultToOldStyleView = !ProfileManager.CurrentProfile.GridContainersDefaultToOldStyleView;
                     _openRegularGump.ContextMenu = GenContextMenu();
                 }, true, ProfileManager.CurrentProfile.GridContainersDefaultToOldStyleView
             ));
 
-            control.Add(new ContextMenuItemEntry("Stack Similar Items in the Original View", () =>
+            control.Add(new ContextMenuItemEntry(TazLang.Get("gridcontainer_stacksimilar", "Stack Similar Items in the Original View"), () =>
             {
                 StackNonStackableItems = !StackNonStackableItems;
                 _openRegularGump.ContextMenu = GenContextMenu();
             }, true, StackNonStackableItems));
 
-            control.Add(new ContextMenuItemEntry("Open Grid View Highlight Settings", () =>
+            control.Add(new ContextMenuItemEntry(TazLang.Get("gridcontainer_openhighlightsettings", "Open Grid View Highlight Settings"), () =>
             {
                 GridHighlightMenu.Open(World);
             }));
 
             if (Container != World.Player.Backpack)
             {
-                control.Add(new ContextMenuItemEntry("Autoloot this container", () =>
+                control.Add(new ContextMenuItemEntry(TazLang.Get("gridcontainer_autolootthis", "Autoloot this container"), () =>
                 {
                     AutoLootManager.Instance.ForceLootContainer(LocalSerial);
                 }));
             }
 
             // Re-applies highlight rules and colors; useful if item highlights desync after SOS loot or container refresh.
-            control.Add(new ContextMenuItemEntry("Refresh item highlights", GridHighlightData.RecheckMatchStatus));
+            control.Add(new ContextMenuItemEntry(TazLang.Get("gridcontainer_refreshhighlights", "Refresh item highlights"), GridHighlightData.RecheckMatchStatus));
 
-            control.Add(new ContextMenuItemEntry("Rename container", () =>
+            control.Add(new ContextMenuItemEntry(TazLang.Get("gridcontainer_renamecontainer", "Rename container"), () =>
             {
-                new PromptPopupWindow("Rename Container", "Type in a custom name for this container.", s =>
+                new PromptPopupWindow(TazLang.Get("gridcontainer_rename_title", "Rename Container"), TazLang.Get("gridcontainer_rename_desc", "Type in a custom name for this container."), s =>
                 {
                     _gridContainerEntry?.CustomName = s;
                     UpdateContainerNameLabel();
-                }, "Save", "Reset", () =>
+                }, TazLang.Get("gridcontainer_save", "Save"), TazLang.Get("gridcontainer_reset", "Reset"), () =>
                 {
                     _gridContainerEntry?.CustomName = null;
                     UpdateContainerNameLabel();
@@ -657,7 +657,7 @@ namespace ClassicUO.Game.UI.Gumps
         {
             var control = new ContextMenuControl(this);
 
-            control.Add(new ContextMenuItemEntry("Sort by Graphic + Hue", () =>
+            control.Add(new ContextMenuItemEntry(TazLang.Get("gridcontainer_sortbygraphichue", "Sort by Graphic + Hue"), () =>
             {
                 _sortMode = GridSortMode.GraphicAndHue;
                 _sortContents.ContextMenu = GenSortContextMenu();
@@ -666,7 +666,7 @@ namespace ClassicUO.Game.UI.Gumps
                 _gridContainerEntry.UpdateSaveDataEntry(this);
             }, true, _sortMode == GridSortMode.GraphicAndHue));
 
-            control.Add(new ContextMenuItemEntry("Sort by Name", () =>
+            control.Add(new ContextMenuItemEntry(TazLang.Get("gridcontainer_sortbyname", "Sort by Name"), () =>
             {
                 _sortMode = GridSortMode.Name;
                 _sortContents.ContextMenu = GenSortContextMenu();

--- a/src/ClassicUO.Client/Game/UI/Gumps/InspectorGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/InspectorGump.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using ClassicUO.Assets;
+using ClassicUO.Configuration;
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Input;
@@ -97,7 +98,7 @@ namespace ClassicUO.Game.UI.Gumps
                     100,
                     25,
                     ButtonAction.Activate,
-                    "To clipboard"
+                    TazLang.Get("inspector_clipboard", "To clipboard")
                 )
                 {
                     ButtonParameter = 0

--- a/src/ClassicUO.Client/Game/UI/Gumps/Supporters.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/Supporters.cs
@@ -1,4 +1,5 @@
 ﻿using ClassicUO.Assets;
+using ClassicUO.Configuration;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Renderer;
 using Microsoft.Xna.Framework;
@@ -51,7 +52,7 @@ namespace ClassicUO.Game.UI.Gumps
             _background.Y = 1;
             Add(_background);
 
-            var title = new Label("TazUO supporters and honorable mentions<br>And a special thanks to all the ClassicUO devs that made this possible!", true, 0xffff, WIDTH, 255, FontStyle.BlackBorder, Assets.TEXT_ALIGN_TYPE.TS_CENTER, true);
+            var title = new Label(TazLang.Get("supporters_title", "TazUO supporters and honorable mentions<br>And a special thanks to all the ClassicUO devs that made this possible!"), true, 0xffff, WIDTH, 255, FontStyle.BlackBorder, Assets.TEXT_ALIGN_TYPE.TS_CENTER, true);
             title.Y = 1;
             Add(title);
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/TooltipConfigGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/TooltipConfigGump.cs
@@ -48,11 +48,11 @@ namespace ClassicUO.Game.UI.Gumps
 
         private void AddHeader()
         {
-            var titleLabel = TextBox.GetOne("Tooltip Override Configuration", TrueTypeLoader.EMBEDDED_FONT, 18, Color.OrangeRed, TextBox.RTLOptions.Default());
+            var titleLabel = TextBox.GetOne(TazLang.Get("tooltipconfig_title", "Tooltip Override Configuration"), TrueTypeLoader.EMBEDDED_FONT, 18, Color.OrangeRed, TextBox.RTLOptions.Default());
 
             mainContainer.Add(titleLabel);
 
-            var wikiLink = new HttpClickableLink("Tooltip Overrides Wiki", "https://github.com/PlayTazUO/TazUO/wiki/TazUO.Tooltip-Override", Color.White);
+            var wikiLink = new HttpClickableLink(TazLang.Get("tooltipconfig_wiki", "Tooltip Overrides Wiki"), "https://github.com/PlayTazUO/TazUO/wiki/TazUO.Tooltip-Override", Color.White);
 
             mainContainer.Add(wikiLink);
         }
@@ -61,7 +61,7 @@ namespace ClassicUO.Game.UI.Gumps
         {
             var buttonContainer = new Area(false);
 
-            var addButton = new NiceButton(0, 0, 60, 20, ButtonAction.Activate, "Add +")
+            var addButton = new NiceButton(0, 0, 60, 20, ButtonAction.Activate, TazLang.Get("tooltipconfig_add", "Add +"))
             {
                 IsSelectable = false,
                 DisplayBorder = true
@@ -77,7 +77,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             buttonContainer.Add(addButton);
 
-            var exportButton = new NiceButton(65, 0, 60, 20, ButtonAction.Activate, "Export")
+            var exportButton = new NiceButton(65, 0, 60, 20, ButtonAction.Activate, TazLang.Get("tooltipconfig_export", "Export"))
             {
                 IsSelectable = false,
                 DisplayBorder = true
@@ -93,7 +93,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             buttonContainer.Add(exportButton);
 
-            var importButton = new NiceButton(130, 0, 60, 20, ButtonAction.Activate, "Import")
+            var importButton = new NiceButton(130, 0, 60, 20, ButtonAction.Activate, TazLang.Get("tooltipconfig_import", "Import"))
             {
                 IsSelectable = false,
                 DisplayBorder = true
@@ -109,13 +109,13 @@ namespace ClassicUO.Game.UI.Gumps
 
             buttonContainer.Add(importButton);
 
-            var deleteAllButton = new NiceButton(195, 0, 100, 20, ButtonAction.Activate, "Delete All")
+            var deleteAllButton = new NiceButton(195, 0, 100, 20, ButtonAction.Activate, TazLang.Get("tooltipconfig_deleteall", "Delete All"))
             {
                 IsSelectable = false,
                 DisplayBorder = true
             };
 
-            deleteAllButton.SetTooltip("/c[red]This will remove ALL tooltip override settings.\nThis is not reversible.");
+            deleteAllButton.SetTooltip(TazLang.Get("tooltipconfig_deleteall_tooltip", "/c[red]This will remove ALL tooltip override settings.\nThis is not reversible."));
 
             deleteAllButton.MouseUp += (s, e) =>
             {
@@ -199,7 +199,7 @@ namespace ClassicUO.Game.UI.Gumps
                     ShowSavedMessage(searchTextInput);
                 }
             }, searchTextInput.Text);
-            searchTextInput.SetTooltip("This is the search text for matching tooltip lines.");
+            searchTextInput.SetTooltip(TazLang.Get("tooltipconfig_searchtext_tooltip", "This is the search text for matching tooltip lines."));
 
             rowContainer.Add(searchTextInput);
 
@@ -216,12 +216,12 @@ namespace ClassicUO.Game.UI.Gumps
                 data.Save();
                 ShowSavedMessage(formatTextInput);
             }, formatTextInput.Text);
-            formatTextInput.SetTooltip("This is what the matching tooltip line will be replaced with. See the wiki for more details!");
+            formatTextInput.SetTooltip(TazLang.Get("tooltipconfig_formattext_tooltip", "This is what the matching tooltip line will be replaced with. See the wiki for more details!"));
 
             rowContainer.Add(formatTextInput);
 
             // Row 2: Min/Max values and Layer
-            var minMaxLabel = new Label("Min/Max", true, 0xFFFF)
+            var minMaxLabel = new Label(TazLang.Get("tooltipconfig_minmax", "Min/Max"), true, 0xFFFF)
             {
                 X = 5,
                 Y = 25
@@ -252,7 +252,7 @@ namespace ClassicUO.Game.UI.Gumps
             }, max1Input.Text);
             rowContainer.Add(max1Input);
 
-            var minMaxLabel2 = new Label("Min/Max", true, 0xFFFF)
+            var minMaxLabel2 = new Label(TazLang.Get("tooltipconfig_minmax", "Min/Max"), true, 0xFFFF)
             {
                 X = max1Input.X + max1Input.Width + 15,
                 Y = 25
@@ -301,7 +301,7 @@ namespace ClassicUO.Game.UI.Gumps
             {
                 IsSelectable = false
             };
-            deleteButton.SetTooltip("Delete this override");
+            deleteButton.SetTooltip(TazLang.Get("tooltipconfig_deleterow", "Delete this override"));
             deleteButton.MouseUp += (s, e) =>
             {
                 if (e.Button == MouseButtonType.Left)

--- a/src/ClassicUO.Client/Game/UI/Gumps/VersionHistory.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/VersionHistory.cs
@@ -36,9 +36,9 @@ internal class VersionHistory : NineSliceGump
         _vBoxContainer = new VBoxContainer(_scrollArea.Width - _scrollArea.ScrollBarWidth());
         _scrollArea.Add(_vBoxContainer);
 
-        _vBoxContainer.Add(TextBox.GetOne("Version history can now be found on our GitHub repo CHANGELOG.md file.", TrueTypeLoader.EMBEDDED_FONT, 15, Color.Orange, TextBox.RTLOptions.Default(_scrollArea.Width - _scrollArea.ScrollBarWidth())));
-        _vBoxContainer.Add(pos.PositionExact(new HttpClickableLink("Main branch changelog", "https://github.com/PlayTazUO/TazUO/blob/main/CHANGELOG.md", Color.Orange, 15), 25, Height - 20));
-        _vBoxContainer.Add(pos.PositionExact(new HttpClickableLink("Dev branch changelog", "https://github.com/PlayTazUO/TazUO/blob/dev/CHANGELOG.md", Color.Orange, 15), 25, Height - 20));
+        _vBoxContainer.Add(TextBox.GetOne(TazLang.Get("versionhistory_desc", "Version history can now be found on our GitHub repo CHANGELOG.md file."), TrueTypeLoader.EMBEDDED_FONT, 15, Color.Orange, TextBox.RTLOptions.Default(_scrollArea.Width - _scrollArea.ScrollBarWidth())));
+        _vBoxContainer.Add(pos.PositionExact(new HttpClickableLink(TazLang.Get("versionhistory_main", "Main branch changelog"), "https://github.com/PlayTazUO/TazUO/blob/main/CHANGELOG.md", Color.Orange, 15), 25, Height - 20));
+        _vBoxContainer.Add(pos.PositionExact(new HttpClickableLink(TazLang.Get("versionhistory_dev", "Dev branch changelog"), "https://github.com/PlayTazUO/TazUO/blob/dev/CHANGELOG.md", Color.Orange, 15), 25, Height - 20));
 
         Add(pos.Position(_scrollArea));
 


### PR DESCRIPTION
Replace hardcoded strings in 11 gump files with TazLang.Get() calls and add the corresponding keys to language.ini (version bumped to 10).

Files updated:
- AnimBrowser.cs: next/prev buttons, placeholder, tooltip
- ArtBrowserGump.cs: next/prev buttons, placeholder, tooltip
- BoatControl.cs: speed labels, error message
- DressAgentConfigGump.cs: all labels, buttons, tooltips, messages
- DurabilityGump.cs: minimize tooltip, title label
- FileSelector.cs: all labels, buttons, status messages
- GridContainer.cs: search box, context menus, sort menus, tooltips
- InspectorGump.cs: "To clipboard" button
- Supporters.cs: title text
- TooltipConfigGump.cs: title, buttons, tooltips, field labels
- VersionHistory.cs: description and changelog link labels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced localization support across multiple UI windows, including animation browser, art browser, boat controls, dress agent configuration, durability tracking, file selector, grid container, inspector, supporters, tooltip configuration, and version history. UI text now supports multiple language translations through updated language configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->