### PR TITLE
Convert raw user-facing strings in UI Controls to TazLang

### DIFF
--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -5,7 +5,7 @@
 ; Missing keys are auto-appended with English defaults when
 ; this file's version is newer than the user's copy.
 ; -------------------------------------------------------
-_version=10
+_version=11
 accountname=Account Name
 accountcontextmenutooltip=Right click to select another account.
 music=Music
@@ -266,3 +266,36 @@ versionhistory_desc=Version history can now be found on our GitHub repo CHANGELO
 versionhistory_main=Main branch changelog
 versionhistory_dev=Dev branch changelog
 auto_open_doors_hidden=Open doors while hidden
+
+; Name overhead assign control
+nameoverhead_sethotkey=Set hotkey:
+nameoverhead_uncheckall=Uncheck all
+nameoverhead_checkall=Check all
+nameoverhead_items=Items
+nameoverhead_containers=Containers
+nameoverhead_gold=Gold
+nameoverhead_stackable=Stackable
+nameoverhead_lockeddown=Locked down
+nameoverhead_moveable=Moveable
+nameoverhead_immoveable=Immoveable
+nameoverhead_otheritems=Other items
+nameoverhead_corpses=Corpses
+nameoverhead_monstercorpses=Monster corpses
+nameoverhead_humanoidcorpses=Humanoid corpses
+nameoverhead_mobilesbytype=Mobiles by type
+nameoverhead_humanoid=Humanoid
+nameoverhead_monster=Monster
+nameoverhead_yourfollowers=Your Followers
+nameoverhead_yourself=Yourself
+nameoverhead_excludeyourself=Exclude yourself
+nameoverhead_mobilesbynotoriety=Mobiles by notoriety
+nameoverhead_innocent=Innocent (blue)
+nameoverhead_allied=Allied (green)
+nameoverhead_attackable=Attackable (gray)
+nameoverhead_criminal=Criminal (gray)
+nameoverhead_enemy=Enemy (orange)
+nameoverhead_murderer=Murderer (red)
+nameoverhead_invulnerable=Invulnerable (yellow)
+
+; Macro control
+macrocontrol_hotkey=HotKey:

--- a/src/ClassicUO.Client/Game/UI/Controls/MacroControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/MacroControl.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Linq;
+using ClassicUO.Configuration;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.UI.Gumps;
 using ClassicUO.Input;
@@ -37,7 +38,7 @@ namespace ClassicUO.Game.UI.Controls
             Label _keyBinding;
             Add(_keyBinding = new Label
                 (
-                    "HotKey:",
+                    TazLang.Get("macrocontrol_hotkey", "HotKey:"),
                     true,
                     0xFFFF,
                     60,

--- a/src/ClassicUO.Client/Game/UI/Controls/NameOverheadAssignControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/NameOverheadAssignControl.cs
@@ -33,6 +33,7 @@
 using System;
 using System.Collections.Generic;
 using ClassicUO.Assets;
+using ClassicUO.Configuration;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.UI.Gumps;
 using ClassicUO.Resources;
@@ -61,7 +62,7 @@ namespace ClassicUO.Game.UI.Controls
 
             CanMove = true;
 
-            AddLabel("Set hotkey:", 0, 0);
+            AddLabel(TazLang.Get("nameoverhead_sethotkey", "Set hotkey:"), 0, 0);
 
             _hotkeyBox = new HotkeyBox
             {
@@ -78,7 +79,7 @@ namespace ClassicUO.Game.UI.Controls
                 new NiceButton
                 (
                     0, _hotkeyBox.Height + 3, 100, 25,
-                    ButtonAction.Activate, "Uncheck all", 0, TEXT_ALIGN_TYPE.TS_LEFT
+                    ButtonAction.Activate, TazLang.Get("nameoverhead_uncheckall", "Uncheck all"), 0, TEXT_ALIGN_TYPE.TS_LEFT
                 ) { ButtonParameter = (int)ButtonType.UncheckAll, IsSelectable = false }
             );
 
@@ -87,7 +88,7 @@ namespace ClassicUO.Game.UI.Controls
                 new NiceButton
                 (
                     120, _hotkeyBox.Height + 3, 100, 25,
-                    ButtonAction.Activate, "Check all", 0, TEXT_ALIGN_TYPE.TS_LEFT
+                    ButtonAction.Activate, TazLang.Get("nameoverhead_checkall", "Check all"), 0, TEXT_ALIGN_TYPE.TS_LEFT
                 ) { ButtonParameter = (int)ButtonType.CheckAll, IsSelectable = false }
             );
 
@@ -102,55 +103,55 @@ namespace ClassicUO.Game.UI.Controls
         private void SetupOptionCheckboxes()
         {
             int y = 0;
-            AddLabel("Items", 75, y, true);
+            AddLabel(TazLang.Get("nameoverhead_items", "Items"), 75, y, true);
             y += 28;
 
-            AddCheckbox("Containers", NameOverheadOptions.Containers, 0, y);
-            AddCheckbox("Gold", NameOverheadOptions.Gold, 150, y);
+            AddCheckbox(TazLang.Get("nameoverhead_containers", "Containers"), NameOverheadOptions.Containers, 0, y);
+            AddCheckbox(TazLang.Get("nameoverhead_gold", "Gold"), NameOverheadOptions.Gold, 150, y);
             y += 22;
-            AddCheckbox("Stackable", NameOverheadOptions.Stackable, 0, y);
-            AddCheckbox("Locked down", NameOverheadOptions.LockedDown, 150, y);
+            AddCheckbox(TazLang.Get("nameoverhead_stackable", "Stackable"), NameOverheadOptions.Stackable, 0, y);
+            AddCheckbox(TazLang.Get("nameoverhead_lockeddown", "Locked down"), NameOverheadOptions.LockedDown, 150, y);
             y += 22;
-            AddCheckbox("Moveable", NameOverheadOptions.Moveable, 0, y);
-            AddCheckbox("Immoveable", NameOverheadOptions.Immoveable, 150, y);
+            AddCheckbox(TazLang.Get("nameoverhead_moveable", "Moveable"), NameOverheadOptions.Moveable, 0, y);
+            AddCheckbox(TazLang.Get("nameoverhead_immoveable", "Immoveable"), NameOverheadOptions.Immoveable, 150, y);
             y += 22;
-            AddCheckbox("Other items", NameOverheadOptions.Other, 0, y);
+            AddCheckbox(TazLang.Get("nameoverhead_otheritems", "Other items"), NameOverheadOptions.Other, 0, y);
             y += 28;
 
-            AddLabel("Corpses", 75, y, true);
+            AddLabel(TazLang.Get("nameoverhead_corpses", "Corpses"), 75, y, true);
             y += 28;
 
-            AddCheckbox("Monster corpses", NameOverheadOptions.MonsterCorpses, 0, y);
-            AddCheckbox("Humanoid corpses", NameOverheadOptions.HumanoidCorpses, 150, y);
+            AddCheckbox(TazLang.Get("nameoverhead_monstercorpses", "Monster corpses"), NameOverheadOptions.MonsterCorpses, 0, y);
+            AddCheckbox(TazLang.Get("nameoverhead_humanoidcorpses", "Humanoid corpses"), NameOverheadOptions.HumanoidCorpses, 150, y);
             //y += 22;
             //AddCheckbox("Own corpses", NameOverheadOptions.OwnCorpses, 0, y);
             y += 28;
 
-            AddLabel("Mobiles by type", 75, y, true);
+            AddLabel(TazLang.Get("nameoverhead_mobilesbytype", "Mobiles by type"), 75, y, true);
             y += 28;
 
-            AddCheckbox("Humanoid", NameOverheadOptions.Humanoid, 0, y);
-            AddCheckbox("Monster", NameOverheadOptions.Monster, 150, y);
+            AddCheckbox(TazLang.Get("nameoverhead_humanoid", "Humanoid"), NameOverheadOptions.Humanoid, 0, y);
+            AddCheckbox(TazLang.Get("nameoverhead_monster", "Monster"), NameOverheadOptions.Monster, 150, y);
             y += 22;
-            AddCheckbox("Your Followers", NameOverheadOptions.OwnFollowers, 0, y);
-            AddCheckbox("Yourself", NameOverheadOptions.Self, 150, y);
+            AddCheckbox(TazLang.Get("nameoverhead_yourfollowers", "Your Followers"), NameOverheadOptions.OwnFollowers, 0, y);
+            AddCheckbox(TazLang.Get("nameoverhead_yourself", "Yourself"), NameOverheadOptions.Self, 150, y);
             y += 22;
-            AddCheckbox("Exclude yourself", NameOverheadOptions.ExcludeSelf, 0, y);
+            AddCheckbox(TazLang.Get("nameoverhead_excludeyourself", "Exclude yourself"), NameOverheadOptions.ExcludeSelf, 0, y);
             y += 28;
 
-            AddLabel("Mobiles by notoriety", 75, y, true);
+            AddLabel(TazLang.Get("nameoverhead_mobilesbynotoriety", "Mobiles by notoriety"), 75, y, true);
             y += 28;
 
-            AddCheckbox("Innocent (blue)", NameOverheadOptions.Innocent, 0, y);
-            AddCheckbox("Allied (green)", NameOverheadOptions.Ally, 150, y);
+            AddCheckbox(TazLang.Get("nameoverhead_innocent", "Innocent (blue)"), NameOverheadOptions.Innocent, 0, y);
+            AddCheckbox(TazLang.Get("nameoverhead_allied", "Allied (green)"), NameOverheadOptions.Ally, 150, y);
             y += 22;
-            AddCheckbox("Attackable (gray)", NameOverheadOptions.Gray, 0, y);
-            AddCheckbox("Criminal (gray)", NameOverheadOptions.Criminal, 150, y);
+            AddCheckbox(TazLang.Get("nameoverhead_attackable", "Attackable (gray)"), NameOverheadOptions.Gray, 0, y);
+            AddCheckbox(TazLang.Get("nameoverhead_criminal", "Criminal (gray)"), NameOverheadOptions.Criminal, 150, y);
             y += 22;
-            AddCheckbox("Enemy (orange)", NameOverheadOptions.Enemy, 0, y);
-            AddCheckbox("Murderer (red)", NameOverheadOptions.Murderer, 150, y);
+            AddCheckbox(TazLang.Get("nameoverhead_enemy", "Enemy (orange)"), NameOverheadOptions.Enemy, 0, y);
+            AddCheckbox(TazLang.Get("nameoverhead_murderer", "Murderer (red)"), NameOverheadOptions.Murderer, 150, y);
             y += 22;
-            AddCheckbox("Invulnerable (yellow)", NameOverheadOptions.Invulnerable, 0, y);
+            AddCheckbox(TazLang.Get("nameoverhead_invulnerable", "Invulnerable (yellow)"), NameOverheadOptions.Invulnerable, 0, y);
         }
 
         private void AddLabel(string name, int x, int y, bool scrollArea = false)


### PR DESCRIPTION
Move hardcoded UI text in NameOverheadAssignControl and MacroControl into the language.ini system via TazLang.Get with English fallbacks, and add the corresponding keys (bumping the language file version so existing copies auto-merge the new entries).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced localization support for UI controls, including Name overhead assign control and Macro control elements.
  * Updated hotkey labels and button captions to support multiple languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->