### PR TITLE
Add option to disable system chat while Resizable Journal is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to TazUO will be recorded here.
 * ZIP file support for Legion Scripting - script libraries with custom PNG artwork can now be distributed and loaded as a single .zip file; scripts in gumps can display zip textures via `API.Gumps.LegionTextureControl` - [P.R 533](https://github.com/PlayTazUO/TazUO/pull/533) ([bittiez](https://github.com/bittiez))
 * Added tuoassets.zip support to override embedded TUO graphics assets; a zip in the client directory overrides embedded assets and a zip in the UO directory takes highest priority for server-specific overrides; supports named embedded asset overrides and gump/art ID overrides matching the existing PNG system - [P.R 534](https://github.com/PlayTazUO/TazUO/pull/534) ([bittiez](https://github.com/bittiez))
 * Add option to disable door opening while player is hidden - [P.R 535](https://github.com/PlayTazUO/TazUO/pull/535) ([bittiez](https://github.com/bittiez))
+* Add option to disable system chat while the Resizable Journal is open - [P.R 541](https://github.com/PlayTazUO/TazUO/pull/541) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
 * Fixed crash reading BWT-compressed UOP animations caused by returning a non-pooled buffer to the array pool - [P.R 532](https://github.com/PlayTazUO/TazUO/pull/532) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.2.38</AssemblyVersion>
-    <FileVersion>5.2.38</FileVersion>
+    <AssemblyVersion>5.2.39</AssemblyVersion>
+    <FileVersion>5.2.39</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Configuration/Language.cs
+++ b/src/ClassicUO.Client/Configuration/Language.cs
@@ -514,7 +514,6 @@ namespace ClassicUO.Configuration
             #region Misc
             public string Misc { get; set; } = "Misc";
             public string DisableSystemChat { get; set; } = "Disable system chat";
-            public string DisableSystemChatWhileJournalOpen { get; set; } = "Disable system chat while Resizable Journal is open";
             public string EnableImprovedBuffGump { get; set; } = "Enable improved buff gump";
             public string BuffGumpHue { get; set; } = "Buff gump hue";
             public string MainGameWindowBackground { get; set; } = "Main game window background";

--- a/src/ClassicUO.Client/Configuration/Language.cs
+++ b/src/ClassicUO.Client/Configuration/Language.cs
@@ -514,6 +514,7 @@ namespace ClassicUO.Configuration
             #region Misc
             public string Misc { get; set; } = "Misc";
             public string DisableSystemChat { get; set; } = "Disable system chat";
+            public string DisableSystemChatWhileJournalOpen { get; set; } = "Disable system chat while Resizable Journal is open";
             public string EnableImprovedBuffGump { get; set; } = "Enable improved buff gump";
             public string BuffGumpHue { get; set; } = "Buff gump hue";
             public string MainGameWindowBackground { get; set; } = "Main game window background";

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -433,6 +433,8 @@ namespace ClassicUO.Configuration
 
         public bool DisableSystemChat { get; set => SetProperty(ref field, value); }
 
+        public bool DisableSystemChatWhileJournalOpen { get; set => SetProperty(ref field, value); }
+
         public bool UsePromptPopup { get; set => SetProperty(ref field, value); } = true;
 
         public uint SetFavoriteMoveBagSerial { get; set => SetProperty(ref field, value); }

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -5,7 +5,7 @@
 ; Missing keys are auto-appended with English defaults when
 ; this file's version is newer than the user's copy.
 ; -------------------------------------------------------
-_version=11
+_version=12
 accountname=Account Name
 accountcontextmenutooltip=Right click to select another account.
 music=Music
@@ -299,3 +299,6 @@ nameoverhead_invulnerable=Invulnerable (yellow)
 
 ; Macro control
 macrocontrol_hotkey=HotKey:
+
+; Misc
+disablesystemchat_journalopen=Disable system chat while Resizable Journal is open

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
@@ -3706,7 +3706,7 @@ namespace ClassicUO.Game.UI.Gumps
             content.BlankLine();
 
             content.AddToRight(
-                new CheckboxWithLabel(lang.GetTazUO.DisableSystemChatWhileJournalOpen, 0, profile.DisableSystemChatWhileJournalOpen,
+                new CheckboxWithLabel(TazLang.Get("disablesystemchat_journalopen", "Disable system chat while Resizable Journal is open"), 0, profile.DisableSystemChatWhileJournalOpen,
                     (b) => { profile.DisableSystemChatWhileJournalOpen = b; }), true, page);
             content.BlankLine();
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
@@ -3705,6 +3705,11 @@ namespace ClassicUO.Game.UI.Gumps
                     (b) => { profile.DisableSystemChat = b; }), true, page);
             content.BlankLine();
 
+            content.AddToRight(
+                new CheckboxWithLabel(lang.GetTazUO.DisableSystemChatWhileJournalOpen, 0, profile.DisableSystemChatWhileJournalOpen,
+                    (b) => { profile.DisableSystemChatWhileJournalOpen = b; }), true, page);
+            content.BlankLine();
+
             content.AddToRight
             (
                 new CheckboxWithLabel(lang.GetGeneral.AutoAvoidObstacules, isChecked: profile.AutoAvoidObstacules,

--- a/src/ClassicUO.Client/Game/UI/Gumps/SystemChatControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/SystemChatControl.cs
@@ -234,6 +234,9 @@ namespace ClassicUO.Game.UI.Gumps
             if (ProfileManager.CurrentProfile.DisableSystemChat)
                 return;
 
+            if (ProfileManager.CurrentProfile.DisableSystemChatWhileJournalOpen && UIManager.GetGump<ResizableJournal>() != null)
+                return;
+
             switch (e.Type)
             {
                 case MessageType.Regular when e.Parent == null || !SerialHelper.IsValid(e.Parent.Serial):

--- a/src/ClassicUO.Client/Game/UI/Gumps/SystemChatControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/SystemChatControl.cs
@@ -234,17 +234,14 @@ namespace ClassicUO.Game.UI.Gumps
             if (ProfileManager.CurrentProfile.DisableSystemChat)
                 return;
 
-            bool suppressSystemChat = ProfileManager.CurrentProfile.DisableSystemChatWhileJournalOpen
-                && UIManager.GetGump<ResizableJournal>() != null;
+            if (ProfileManager.CurrentProfile.DisableSystemChatWhileJournalOpen && UIManager.GetGump<ResizableJournal>() != null)
+                return;
 
             switch (e.Type)
             {
                 case MessageType.Regular when e.Parent == null || !SerialHelper.IsValid(e.Parent.Serial):
                 case MessageType.Discord:
                 case MessageType.System:
-                    if (suppressSystemChat)
-                        break;
-
                     if (!string.IsNullOrEmpty(e.Name) && !e.Name.Equals("system", StringComparison.InvariantCultureIgnoreCase))
                     {
                         AddLine($"{e.Name}: {e.Text}", e.Font, e.Hue, e.IsUnicode);
@@ -280,7 +277,7 @@ namespace ClassicUO.Game.UI.Gumps
                     break;
                 default:
 
-                    if (!suppressSystemChat && (e.Parent == null || !SerialHelper.IsValid(e.Parent.Serial)))
+                    if (e.Parent == null || !SerialHelper.IsValid(e.Parent.Serial))
                     {
                         if (string.IsNullOrEmpty(e.Name) || e.Name.Equals("system", StringComparison.InvariantCultureIgnoreCase))
                         {

--- a/src/ClassicUO.Client/Game/UI/Gumps/SystemChatControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/SystemChatControl.cs
@@ -234,14 +234,17 @@ namespace ClassicUO.Game.UI.Gumps
             if (ProfileManager.CurrentProfile.DisableSystemChat)
                 return;
 
-            if (ProfileManager.CurrentProfile.DisableSystemChatWhileJournalOpen && UIManager.GetGump<ResizableJournal>() != null)
-                return;
+            bool suppressSystemChat = ProfileManager.CurrentProfile.DisableSystemChatWhileJournalOpen
+                && UIManager.GetGump<ResizableJournal>() != null;
 
             switch (e.Type)
             {
                 case MessageType.Regular when e.Parent == null || !SerialHelper.IsValid(e.Parent.Serial):
                 case MessageType.Discord:
                 case MessageType.System:
+                    if (suppressSystemChat)
+                        break;
+
                     if (!string.IsNullOrEmpty(e.Name) && !e.Name.Equals("system", StringComparison.InvariantCultureIgnoreCase))
                     {
                         AddLine($"{e.Name}: {e.Text}", e.Font, e.Hue, e.IsUnicode);
@@ -277,7 +280,7 @@ namespace ClassicUO.Game.UI.Gumps
                     break;
                 default:
 
-                    if (e.Parent == null || !SerialHelper.IsValid(e.Parent.Serial))
+                    if (!suppressSystemChat && (e.Parent == null || !SerialHelper.IsValid(e.Parent.Serial)))
                     {
                         if (string.IsNullOrEmpty(e.Name) || e.Name.Equals("system", StringComparison.InvariantCultureIgnoreCase))
                         {


### PR DESCRIPTION
Adds a new Misc option that suppresses incoming system chat messages whenever a Resizable Journal gump is open, separate from the existing DisableSystemChat toggle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new option to disable system chat messages while the Resizable Journal window is open. The setting can be toggled in the options menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->