### PR TITLE
Fix overhead damage filter not applying to damage packets

### DIFF
--- a/src/ClassicUO.Client/Network/PacketHandlers/Damage.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers/Damage.cs
@@ -1,4 +1,6 @@
+using ClassicUO.Configuration;
 using ClassicUO.Game;
+using ClassicUO.Game.Data;
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.Managers;
 using ClassicUO.IO;
@@ -20,7 +22,9 @@ internal static class Damage
 
             if (damage > 0)
             {
-                world.WorldTextManager.AddDamage(entity, damage);
+                if (!MessageTypeFilter.IsEnabled(ProfileManager.CurrentProfile.DisabledOverheadMessageTypes, MessageType.Damage))
+                    world.WorldTextManager.AddDamage(entity, damage);
+
                 EventSink.InvokeOnEntityDamage(entity, damage);
             }
         }


### PR DESCRIPTION
Damage numbers bypass MessageManager entirely — they flow through WorldTextManager.AddDamage() directly from the Damage packet handler. Added the DisabledOverheadMessageTypes filter check at the packet handler level so disabling MessageType.Damage in settings suppresses overhead damage numbers as expected.