### PR TITLE
Fix: spell bar hotkeys not firing when Scroll Lock is on

### DIFF
--- a/src/ClassicUO.Client/Game/Managers/SpellBarManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/SpellBarManager.cs
@@ -69,9 +69,11 @@ public class SpellBarManager
         if (!enabled || !spellBarSettings.Enabled || ProfileManager.CurrentProfile.DisableHotkeys)
             return;
 
-        // Remove NUM lock from modifier checks
+        // Remove lock keys from modifier checks (these shouldn't affect hotkey matching)
         mod &= ~SDL.SDL_Keymod.SDL_KMOD_NUM;
         mod &= ~SDL.SDL_Keymod.SDL_KMOD_CAPS;
+        mod &= ~SDL.SDL_Keymod.SDL_KMOD_SCROLL;
+        mod &= ~SDL.SDL_Keymod.SDL_KMOD_MODE;
 
         // Normalize left/right modifiers to generic modifiers
         if ((mod & (SDL.SDL_Keymod.SDL_KMOD_LCTRL | SDL.SDL_Keymod.SDL_KMOD_RCTRL)) != 0)


### PR DESCRIPTION
`SpellBarManager.KeyPress` strips NUM and CAPS lock from the modifier state before the no-modifier match check, but not SCROLL or MODE lock. With Scroll Lock active, a plain (no-modifier) hotkey's modifier state is `SDL_KMOD_SCROLL` instead of `SDL_KMOD_NONE`, so the `mod == NONE` check fails and the slot never casts — the hotkeys silently do nothing.

Fix: also strip `SDL_KMOD_SCROLL` and `SDL_KMOD_MODE`, matching how NUM/CAPS are already handled.

Tested: build clean; spell bar hotkeys fire with Scroll Lock on or off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)