### PR TITLE
Add support for journal tracking to trigger bandage agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to TazUO will be recorded here.
 * Add option to disable door opening while player is hidden - [P.R 535](https://github.com/PlayTazUO/TazUO/pull/535) ([bittiez](https://github.com/bittiez))
 * Add option to disable system chat while the Resizable Journal is open - [P.R 541](https://github.com/PlayTazUO/TazUO/pull/541) ([bittiez](https://github.com/bittiez))
 * Expanded the spell bar so slots can hold macros and weapon abilities in addition to spells - [P.R 543](https://github.com/PlayTazUO/TazUO/pull/543) ([bittiez](https://github.com/bittiez))
+* Bandage agent now supports journal message triggers — configure messages (separated by `;`) that immediately allow re-bandaging when matched - [P.R 550](https://github.com/PlayTazUO/TazUO/pull/550) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
 * Fixed crash reading BWT-compressed UOP animations caused by returning a non-pooled buffer to the array pool - [P.R 532](https://github.com/PlayTazUO/TazUO/pull/532) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.2.42</AssemblyVersion>
-    <FileVersion>5.2.42</FileVersion>
+    <AssemblyVersion>5.2.43</AssemblyVersion>
+    <FileVersion>5.2.43</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Configuration/Language.cs
+++ b/src/ClassicUO.Client/Configuration/Language.cs
@@ -753,5 +753,10 @@ namespace ClassicUO.Configuration
         public string SkipIfYellowHits { get; set; } = "Skip bandage if yellow hits";
         public string BandageGraphicIdTooltip { get; set; } = "Graphic ID of bandages to use (default: 0x0E21). Accepts hex (0x0E21) or decimal (3617)";
         public string BandageGraphicIdLabel { get; set; } = "Bandage graphic ID:";
+
+        public string UseJournalTriggerCheckbox { get; set; } = "Use journal trigger";
+        public string UseJournalTriggerTooltip { get; set; } = "Re-apply bandage when a matching journal message is received";
+        public string JournalMessagesLabel { get; set; } = "Journal message triggers (separate multiple with ;):";
+        public string JournalMessagesTooltip { get; set; } = "Journal message text that triggers re-bandaging. Separate multiple messages with ;. Matching is case-insensitive and checks if the message contains the trigger text.";
     }
 }

--- a/src/ClassicUO.Client/Configuration/Language.cs
+++ b/src/ClassicUO.Client/Configuration/Language.cs
@@ -753,10 +753,5 @@ namespace ClassicUO.Configuration
         public string SkipIfYellowHits { get; set; } = "Skip bandage if yellow hits";
         public string BandageGraphicIdTooltip { get; set; } = "Graphic ID of bandages to use (default: 0x0E21). Accepts hex (0x0E21) or decimal (3617)";
         public string BandageGraphicIdLabel { get; set; } = "Bandage graphic ID:";
-
-        public string UseJournalTriggerCheckbox { get; set; } = "Use journal trigger";
-        public string UseJournalTriggerTooltip { get; set; } = "Re-apply bandage when a matching journal message is received";
-        public string JournalMessagesLabel { get; set; } = "Journal message triggers (separate multiple with ;):";
-        public string JournalMessagesTooltip { get; set; } = "Journal message text that triggers re-bandaging. Separate multiple messages with ;. Matching is case-insensitive and checks if the message contains the trigger text.";
     }
 }

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -182,8 +182,8 @@ namespace ClassicUO.Configuration
         public bool BandageAgentCheckForBuff { get; set => SetProperty(ref field, value); } = false;
         public ushort BandageAgentGraphic { get; set => SetProperty(ref field, value); } = 0x0E21;
         public bool BandageAgentUseNewPacket { get; set => SetProperty(ref field, value); } = true;
-        public bool BandageAgentCheckHidden { get; set => SetProperty(ref field, value); } = false;
-        public bool BandageAgentCheckPoisoned { get; set => SetProperty(ref field, value); } = false;
+        public bool BandageAgentCheckHidden { get; set => SetProperty(ref field, value); } = true;
+        public bool BandageAgentCheckPoisoned { get; set => SetProperty(ref field, value); } = true;
         public int BandageAgentHPPercentage { get; set => SetProperty(ref field, value); } = 80;
         public bool BandageAgentCheckInvul { get; set => SetProperty(ref field, value); } = true;
         public bool BandageAgentBandageFriends { get; set => SetProperty(ref field, value); } = false;

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -191,6 +191,8 @@ namespace ClassicUO.Configuration
         public bool BandageAgentBandagePets { get; set => SetProperty(ref field, value); } = false;
         public bool BandageAgentUseDexFormula { get; set => SetProperty(ref field, value); } = false;
         public bool BandageAgentDisableSelfHeal { get; set => SetProperty(ref field, value); } = false;
+        public bool BandageAgentUseJournalTrigger { get; set => SetProperty(ref field, value); } = false;
+        public string BandageAgentJournalMessages { get; set => SetProperty(ref field, value); } = "";
 
         public bool EnableDeathScreen { get; set => SetProperty(ref field, value); } = true;
         public bool EnableBlackWhiteEffect { get; set => SetProperty(ref field, value); } = true;

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -191,8 +191,14 @@ namespace ClassicUO.Configuration
         public bool BandageAgentBandagePets { get; set => SetProperty(ref field, value); } = false;
         public bool BandageAgentUseDexFormula { get; set => SetProperty(ref field, value); } = false;
         public bool BandageAgentDisableSelfHeal { get; set => SetProperty(ref field, value); } = false;
-        public bool BandageAgentUseJournalTrigger { get; set => SetProperty(ref field, value); } = false;
-        public string BandageAgentJournalMessages { get; set => SetProperty(ref field, value); } = "";
+
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Char, Constants.SqlSettings.BANDAGE_JOURNAL_TRIGGER, false)]
+        public partial bool BandageAgentUseJournalTrigger { get; set; }
+
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Char, Constants.SqlSettings.BANDAGE_JOURNAL_MESSAGES, "")]
+        public partial string BandageAgentJournalMessages { get; set; }
 
         public bool EnableDeathScreen { get; set => SetProperty(ref field, value); } = true;
         public bool EnableBlackWhiteEffect { get; set => SetProperty(ref field, value); } = true;

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -5,7 +5,7 @@
 ; Missing keys are auto-appended with English defaults when
 ; this file's version is newer than the user's copy.
 ; -------------------------------------------------------
-_version=14
+_version=15
 accountname=Account Name
 accountcontextmenutooltip=Right click to select another account.
 music=Music
@@ -333,3 +333,9 @@ macrocontrol_hotkey=HotKey:
 
 ; Misc
 disablesystemchat_journalopen=Disable system chat while Resizable Journal is open
+
+; Bandage agent - journal trigger
+bandageagent_journaltrigger=Use journal trigger
+bandageagent_journaltrigger_tooltip=Re-apply bandage when a matching journal message is received
+bandageagent_journalmessages_label=Journal message triggers (separate multiple with ;):
+bandageagent_journalmessages_tooltip=Journal message text that triggers re-bandaging. Separate multiple with ;. Matching is case-insensitive contains check.

--- a/src/ClassicUO.Client/Game/Constants.cs
+++ b/src/ClassicUO.Client/Game/Constants.cs
@@ -139,6 +139,8 @@ public const string SCALE_PETS_ENABLED = "scale_pets_enabled";
             public const string AUTO_STAT_LOCK = "auto_stat_lock";
             public const string DISABLE_AUTOLOOT_RETRY_CORPSE = "disable_authloot_retry";
             public const string AUTO_OPEN_DOORS_HIDDEN = "auto_open_doors_hidden";
+            public const string BANDAGE_JOURNAL_TRIGGER = "bandage_journal_trigger";
+            public const string BANDAGE_JOURNAL_MESSAGES = "bandage_journal_messages";
         }
     }
 }

--- a/src/ClassicUO.Client/Game/Managers/BandageManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/BandageManager.cs
@@ -48,11 +48,14 @@ namespace ClassicUO.Game.Managers
         private bool HasBandagingBuff { get; set; } = false;
         private bool UseDexFormula => ProfileManager.CurrentProfile?.BandageAgentUseDexFormula ?? false;
         private bool DisableSelfHeal => ProfileManager.CurrentProfile?.BandageAgentDisableSelfHeal ?? false;
+        private bool UseJournalTrigger => ProfileManager.CurrentProfile?.BandageAgentUseJournalTrigger ?? false;
+        private string JournalMessages => ProfileManager.CurrentProfile?.BandageAgentJournalMessages ?? "";
 
         private BandageManager()
         {
             EventSink.OnBuffAddedInternal += OnBuffAdded;
             EventSink.OnBuffRemovedInternal += OnBuffRemoved;
+            EventSink.JournalEntryAdded += OnJournalEntryAdded;
         }
 
         public void SetPoisoned(uint serial, bool status)
@@ -68,6 +71,26 @@ namespace ClassicUO.Game.Managers
         {
             if (e.Buff.Type == BuffIconType.Healing) HasBandagingBuff = true;
             if (e.Buff.Type == BuffIconType.Veterinary) HasBandagingBuff = true;
+        }
+
+        private void OnJournalEntryAdded(object sender, JournalEntry e)
+        {
+            if (!IsEnabled || !UseJournalTrigger || e == null) return;
+
+            string messages = JournalMessages;
+            if (string.IsNullOrWhiteSpace(messages)) return;
+
+            string[] triggers = messages.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            foreach (string trigger in triggers)
+            {
+                if (!string.IsNullOrEmpty(trigger) && e.Text.Contains(trigger, StringComparison.OrdinalIgnoreCase))
+                {
+                    _nextBandageTime = 0;
+                    HasBandagingBuff = false;
+                    VerifyTimer();
+                    return;
+                }
+            }
         }
 
         private void OnBuffRemoved(object sender, BuffEventArgs e)
@@ -353,6 +376,7 @@ namespace ClassicUO.Game.Managers
             ClearAllPendingHeals();
             EventSink.OnBuffAddedInternal -= OnBuffAdded;
             EventSink.OnBuffRemovedInternal -= OnBuffRemoved;
+            EventSink.JournalEntryAdded -= OnJournalEntryAdded;
             Instance = null;
         }
     }

--- a/src/ClassicUO.Client/Game/Managers/BandageManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/BandageManager.cs
@@ -76,6 +76,7 @@ namespace ClassicUO.Game.Managers
         private void OnJournalEntryAdded(object sender, JournalEntry e)
         {
             if (!IsEnabled || !UseJournalTrigger || e == null) return;
+            if (string.IsNullOrEmpty(e.Text)) return;
 
             string messages = JournalMessages;
             if (string.IsNullOrWhiteSpace(messages)) return;

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/BandageAgentTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/BandageAgentTabContent.cs
@@ -60,7 +60,7 @@ public static class BandageAgentTabContent
 
         root.Widgets.Add(enableRow);
 
-        // Delay
+        // Delay + HP threshold on the same row
         var delayBox = new MyraInputBox
         {
             Text = profile.BandageAgentDelay.ToString(),
@@ -78,30 +78,52 @@ public static class BandageAgentTabContent
         var delayRow = new HorizontalStackPanel { Spacing = MyraStyle.STANDARD_SPACING };
         delayRow.Widgets.Add(delayBox);
         delayRow.Widgets.Add(new MyraLabel(bandLang.BandageDelayMsLabel, MyraLabel.TextStyle.P));
-        root.Widgets.Add(new MyraSpacer(15, 1));
-        root.Widgets.Add(delayRow);
-
-        root.Widgets.Add(MyraCheckButton.CreateWithCallback(
-            profile.BandageAgentUseDexFormula,
-            b => profile.BandageAgentUseDexFormula = b,
-            bandLang.UseDexFormulaCheckbox,
-            bandLang.UseDexFormulaTooltip
-        ));
-
-        root.Widgets.Add(MyraCheckButton.CreateWithCallback(
-            profile.BandageAgentCheckForBuff,
-            b => profile.BandageAgentCheckForBuff = b,
-            bandLang.UseBandageBuffCheckbox,
-            bandLang.UseBandageBuffTooltip
-        ));
-
-        root.Widgets.Add(MyraHSlider.SliderWithLabel(
+        delayRow.Widgets.Add(new MyraSpacer(15, 1));
+        delayRow.Widgets.Add(MyraHSlider.SliderWithLabel(
             bandLang.HealthThresholdSliderLabel,
             out _,
             v => profile.BandageAgentHPPercentage = (int)v,
             1, 99,
             profile.BandageAgentHPPercentage
         ));
+        root.Widgets.Add(new MyraSpacer(15, 1));
+        root.Widgets.Add(delayRow);
+
+        // Journal messages below delay/HP
+        root.Widgets.Add(new MyraLabel(TazLang.Get("bandageagent_journalmessages_label"), MyraLabel.TextStyle.P));
+        var journalMessageBox = new MyraInputBox
+        {
+            Text = profile.BandageAgentJournalMessages,
+            Tooltip = TazLang.Get("bandageagent_journalmessages_tooltip"),
+            Width = 300,
+        };
+        journalMessageBox.TextChangedByUser += (_, _) =>
+        {
+            profile.BandageAgentJournalMessages = journalMessageBox.Text ?? "";
+        };
+        root.Widgets.Add(journalMessageBox);
+
+        // Timing mode checkboxes in one row
+        var timingRow = new HorizontalStackPanel { Spacing = MyraStyle.STANDARD_SPACING };
+        timingRow.Widgets.Add(MyraCheckButton.CreateWithCallback(
+            profile.BandageAgentUseDexFormula,
+            b => profile.BandageAgentUseDexFormula = b,
+            bandLang.UseDexFormulaCheckbox,
+            bandLang.UseDexFormulaTooltip
+        ));
+        timingRow.Widgets.Add(MyraCheckButton.CreateWithCallback(
+            profile.BandageAgentCheckForBuff,
+            b => profile.BandageAgentCheckForBuff = b,
+            bandLang.UseBandageBuffCheckbox,
+            bandLang.UseBandageBuffTooltip
+        ));
+        timingRow.Widgets.Add(MyraCheckButton.CreateWithCallback(
+            profile.BandageAgentUseJournalTrigger,
+            b => profile.BandageAgentUseJournalTrigger = b,
+            TazLang.Get("bandageagent_journaltrigger"),
+            TazLang.Get("bandageagent_journaltrigger_tooltip")
+        ));
+        root.Widgets.Add(timingRow);
 
         root.Widgets.Add(new MyraSpacer(15, 1));
         root.Widgets.Add(MyraCheckButton.CreateWithCallback(
@@ -127,27 +149,6 @@ public static class BandageAgentTabContent
             b => profile.BandageAgentCheckInvul = b,
             bandLang.SkipIfYellowHits
         ));
-
-        root.Widgets.Add(new MyraSpacer(15, 1));
-        root.Widgets.Add(MyraCheckButton.CreateWithCallback(
-            profile.BandageAgentUseJournalTrigger,
-            b => profile.BandageAgentUseJournalTrigger = b,
-            TazLang.Get("bandageagent_journaltrigger"),
-            TazLang.Get("bandageagent_journaltrigger_tooltip")
-        ));
-
-        var journalMessageBox = new MyraInputBox
-        {
-            Text = profile.BandageAgentJournalMessages,
-            Tooltip = TazLang.Get("bandageagent_journalmessages_tooltip"),
-            Width = 300,
-        };
-        journalMessageBox.TextChangedByUser += (_, _) =>
-        {
-            profile.BandageAgentJournalMessages = journalMessageBox.Text ?? "";
-        };
-        root.Widgets.Add(new MyraLabel(TazLang.Get("bandageagent_journalmessages_label"), MyraLabel.TextStyle.P));
-        root.Widgets.Add(journalMessageBox);
 
         // Bandage graphic
         var graphicBox = new MyraInputBox

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/BandageAgentTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/BandageAgentTabContent.cs
@@ -132,21 +132,21 @@ public static class BandageAgentTabContent
         root.Widgets.Add(MyraCheckButton.CreateWithCallback(
             profile.BandageAgentUseJournalTrigger,
             b => profile.BandageAgentUseJournalTrigger = b,
-            bandLang.UseJournalTriggerCheckbox,
-            bandLang.UseJournalTriggerTooltip
+            TazLang.Get("bandageagent_journaltrigger"),
+            TazLang.Get("bandageagent_journaltrigger_tooltip")
         ));
 
         var journalMessageBox = new MyraInputBox
         {
             Text = profile.BandageAgentJournalMessages,
-            Tooltip = bandLang.JournalMessagesTooltip,
+            Tooltip = TazLang.Get("bandageagent_journalmessages_tooltip"),
             Width = 300,
         };
         journalMessageBox.TextChangedByUser += (_, _) =>
         {
             profile.BandageAgentJournalMessages = journalMessageBox.Text ?? "";
         };
-        root.Widgets.Add(new MyraLabel(bandLang.JournalMessagesLabel, MyraLabel.TextStyle.P));
+        root.Widgets.Add(new MyraLabel(TazLang.Get("bandageagent_journalmessages_label"), MyraLabel.TextStyle.P));
         root.Widgets.Add(journalMessageBox);
 
         // Bandage graphic

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/BandageAgentTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/BandageAgentTabContent.cs
@@ -128,6 +128,27 @@ public static class BandageAgentTabContent
             bandLang.SkipIfYellowHits
         ));
 
+        root.Widgets.Add(new MyraSpacer(15, 1));
+        root.Widgets.Add(MyraCheckButton.CreateWithCallback(
+            profile.BandageAgentUseJournalTrigger,
+            b => profile.BandageAgentUseJournalTrigger = b,
+            bandLang.UseJournalTriggerCheckbox,
+            bandLang.UseJournalTriggerTooltip
+        ));
+
+        var journalMessageBox = new MyraInputBox
+        {
+            Text = profile.BandageAgentJournalMessages,
+            Tooltip = bandLang.JournalMessagesTooltip,
+            Width = 300,
+        };
+        journalMessageBox.TextChangedByUser += (_, _) =>
+        {
+            profile.BandageAgentJournalMessages = journalMessageBox.Text ?? "";
+        };
+        root.Widgets.Add(new MyraLabel(bandLang.JournalMessagesLabel, MyraLabel.TextStyle.P));
+        root.Widgets.Add(journalMessageBox);
+
         // Bandage graphic
         var graphicBox = new MyraInputBox
         {


### PR DESCRIPTION
Allows setting journal messages that will reset the bandage timer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bandage Agent now supports journal message triggers, enabling players to configure automatic bandage application when specified journal messages are detected in-game. New configuration options allow customization of trigger messages with flexible matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->