### PR TITLE
Migrate bandage, auto buy, and auto sell agent UI strings to TazLang …

### DIFF
--- a/src/ClassicUO.Client/Configuration/Language.cs
+++ b/src/ClassicUO.Client/Configuration/Language.cs
@@ -611,15 +611,6 @@ namespace ClassicUO.Configuration
             public string AutoLootProgessBarEnable { get; set; } = "Show progress bar while looting";
             public string AutoLootHumanCorpses { get; set; } = "Loot human corpses? (Potentially player corpses)";
 
-            public string AutoSellMenu { get; set; } = "Auto Sell";
-            public string AutoSellEnable { get; set; } = "Enable auto sell feature";
-            public string AutoSellMaxUniques { get; set; } = "Maximum unique items per transaction";
-            public string AutoSellMaxUniquesTooltip { get; set; } = "This is the maximum number of unique items that will be sold at once. A value of 0 means unlimited. A stack of items counts as one towards this limit. Some servers block transactions that sell too many unique items.";
-            public string AutoSellMaxItems { get; set; } = "Maximum total items per transaction";
-            public string AutoSellMaxItemsTooltip { get; set; } = "This is the maximum number of items that will be sold at once. A value of 0 means unlimited. Some servers block transactions that sell too many items.";
-
-            public string AutoBuyMenu { get; set; } = "Auto Buy";
-            public string AutoBuyEnable { get; set; } = "Enable auto buy feature";
             public string GraphicChangeFilter { get; set; } = "Graphic Filter";
             public string Hotkeys { get; set; } = "Hotkeys";
 
@@ -709,49 +700,5 @@ namespace ClassicUO.Configuration
         public string SetQuickCureSpell { get; set; } = "Set cure spell";
         public string QuickSpellTooltip { get; set; } = "These are used on health-bars for party members/pets.";
         public string SingleClickLastTarg { get; set; } = "Single clicking a mobile will set it as last target.";
-
-        public AgentsLanguage Agents { get; set; } = new();
-    }
-
-    public class AgentsLanguage
-    {
-        public BandageAgentLanguage Bandage { get; set; } = new();
-    }
-
-    public class BandageAgentLanguage
-    {
-        public string ProfileNotLoaded { get; set; } = "Profile not loaded";
-        public string AutoHealWhenHpBelowThreshold { get; set; } = "Automatically use bandages to heal when HP drops below threshold.";
-        public string EnableBandageAgent { get; set; } = "Enable bandage agent";
-
-        public string BandageFriendsCheckbox { get; set; } = "Bandage friends";
-        public string BandageFriendsTooltip { get; set; } = "Bandage mobiles in Friends list";
-
-        public string BandageAlliesCheckbox { get; set; } = "Bandage allies";
-        public string BandageAlliesTooltip { get; set; } = "Bandage nearby guild/alliance members (notoriety: ally)";
-
-        public string BandagePetsCheckbox { get; set; } = "Bandage pets";
-        public string BandagePetsTooltip { get; set; } = "Bandage nearby owned pets";
-
-        public string DisableSelfHealCheckbox { get; set; } = "Disable self heal";
-        public string DisableSelfHealTooltip { get; set; } = "When enabled, bandage agent will only heal friends and not yourself";
-
-        public string BandageDelayTooltip { get; set; } = "Delay between bandage attempts in milliseconds (50-30000)";
-
-        public string BandageDelayMsLabel { get; set; } = "Delay (ms)";
-
-        public string UseDexFormulaCheckbox { get; set; } = "Use dex formula";
-        public string UseDexFormulaTooltip { get; set; } = "Use the dex formula instead of a set delay";
-
-        public string UseBandageBuffCheckbox { get; set; } = "Use bandaging buff";
-        public string UseBandageBuffTooltip { get; set; } = "Use bandaging buff instead of delay";
-
-        public string HealthThresholdSliderLabel { get; set; } = "HP percentage threshold";
-        public string UseNewPacketCheckbox { get; set; } = "Use new bandage packet";
-        public string BandageIfPoisonedCheckbox { get; set; } = "Bandage if poisoned";
-        public string SkipIfHidden { get; set; } = "Skip bandage if hidden";
-        public string SkipIfYellowHits { get; set; } = "Skip bandage if yellow hits";
-        public string BandageGraphicIdTooltip { get; set; } = "Graphic ID of bandages to use (default: 0x0E21). Accepts hex (0x0E21) or decimal (3617)";
-        public string BandageGraphicIdLabel { get; set; } = "Bandage graphic ID:";
     }
 }

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -5,7 +5,7 @@
 ; Missing keys are auto-appended with English defaults when
 ; this file's version is newer than the user's copy.
 ; -------------------------------------------------------
-_version=15
+_version=16
 accountname=Account Name
 accountcontextmenutooltip=Right click to select another account.
 music=Music
@@ -334,8 +334,98 @@ macrocontrol_hotkey=HotKey:
 ; Misc
 disablesystemchat_journalopen=Disable system chat while Resizable Journal is open
 
-; Bandage agent - journal trigger
+; Bandage agent
+bandageagent_profilenotloaded=Profile not loaded
+bandageagent_autohealwhenhpbelowthreshold=Automatically use bandages to heal when HP drops below threshold.
+bandageagent_enable=Enable bandage agent
+bandageagent_bandagefriends=Bandage friends
+bandageagent_bandagefriends_tooltip=Bandage mobiles in Friends list
+bandageagent_bandageallies=Bandage allies
+bandageagent_bandageallies_tooltip=Bandage nearby guild/alliance members (notoriety: ally)
+bandageagent_bandagepets=Bandage pets
+bandageagent_bandagepets_tooltip=Bandage nearby owned pets
+bandageagent_disableselfheal=Disable self heal
+bandageagent_disableselfheal_tooltip=When enabled, bandage agent will only heal friends and not yourself
+bandageagent_delay_tooltip=Delay between bandage attempts in milliseconds (50-30000)
+bandageagent_delay_label=Delay (ms)
+bandageagent_usedexformula=Use dex formula
+bandageagent_usedexformula_tooltip=Use the dex formula instead of a set delay
+bandageagent_usebandagebuff=Use bandaging buff
+bandageagent_usebandagebuff_tooltip=Use bandaging buff instead of delay
+bandageagent_hpthreshold=HP percentage threshold
+bandageagent_usenewpacket=Use new bandage packet
+bandageagent_bandageifpoisoned=Bandage if poisoned
+bandageagent_skipifhidden=Skip bandage if hidden
+bandageagent_skipifyellowhits=Skip bandage if yellow hits
+bandageagent_graphicid_tooltip=Graphic ID of bandages to use (default: 0x0E21). Accepts hex (0x0E21) or decimal (3617)
+bandageagent_graphicid_label=Bandage graphic ID:
 bandageagent_journaltrigger=Use journal trigger
 bandageagent_journaltrigger_tooltip=Re-apply bandage when a matching journal message is received
 bandageagent_journalmessages_label=Journal message triggers (separate multiple with ;):
 bandageagent_journalmessages_tooltip=Journal message text that triggers re-bandaging. Separate multiple with ;. Matching is case-insensitive contains check.
+
+; Agent shared strings (used by Auto Buy and Auto Sell)
+agent_col_art=Art
+agent_col_graphic=Graphic
+agent_col_hue=Hue
+agent_col_maxamount=Max Amount
+agent_col_enabled=Enabled
+agent_col_actions=Actions
+agent_maxamount_tooltip=Set to 0 for unlimited.
+agent_delete=Delete
+agent_addnewentry=Add New Entry:
+agent_graphic_label=Graphic:
+agent_hue_label=Hue:
+agent_maxamount_label=Max Amount:
+agent_add=Add
+agent_cancel=Cancel
+agent_addmanualentry=Add Manual Entry
+agent_addfromtarget=Add from Target
+agent_import=Import
+agent_export=Export
+agent_import_tooltip=Import from clipboard (must have a valid export copied).
+agent_export_tooltip=Export your list to clipboard.
+agent_invalidimport=Your clipboard does not have a valid export copied.
+
+; Auto Buy agent
+autobuy_profilenotloaded=Profile not loaded
+autobuy_enable=Enable Auto Buy
+autobuy_subcontainers=Include sub containers?
+autobuy_subcontainers_tooltip=This will also count items inside containers in your backpack (Containers that have not been opened yet may not have an accurate count of contents).
+autobuy_options=Options:
+autobuy_maxitems=Max total items
+autobuy_maxuniques=Max unique items
+autobuy_entries=Entries:
+autobuy_noentries=No entries configured.
+autobuy_col_restockupto=Restock Up To
+autobuy_col_maxprice=Max Price
+autobuy_restockupto_tooltip=Amount to restock up to when buying (0 = disabled).
+autobuy_maxprice_tooltip=Maximum price per item (0 = no limit).
+autobuy_restockupto_label=Restock Up To:
+autobuy_maxprice_label=Max Price:
+autobuy_targetprompt=Target item to add
+autobuy_addfromtarget_tooltip=Target an item to add it to the buy list.
+autobuy_imported=Imported buy list!
+autobuy_exported=Exported buy list to your clipboard!
+
+; Auto Sell agent
+autosell_profilenotloaded=Profile not loaded
+autosell_enable=Enable Auto Sell
+autosell_options=Options:
+autosell_maxitems=Max total items
+autosell_maxuniques=Max unique items
+autosell_entries=Entries:
+autosell_noentries=No entries configured.
+autosell_col_minonhand=Min on Hand
+autosell_minonhand_tooltip=Minimum amount to keep on hand (0 = disabled).
+autosell_minonhand_label=Min on Hand:
+autosell_targetprompt=Target item to add
+autosell_addfromtarget_tooltip=Target an item to add it to the sell list.
+autosell_addfromcontainer=Add from Container
+autosell_addfromcontainer_prompt=Target a container to add all its items
+autosell_addfromcontainer_tooltip=Target a container to add all its items to the sell list.
+autosell_addedfromcontainer=Added {0} item(s) from container.
+autosell_clearall=Clear All
+autosell_clearall_tooltip=Remove all entries from the sell list.
+autosell_imported=Imported sell list!
+autosell_exported=Exported sell list to your clipboard!

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/AutoBuyAgentTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/AutoBuyAgentTabContent.cs
@@ -14,32 +14,33 @@ public static class AutoBuyAgentTabContent
     {
         Profile? profile = ProfileManager.CurrentProfile;
         if (profile == null)
-            return new MyraLabel("Profile not loaded", MyraLabel.TextStyle.P);
+            return new MyraLabel(TazLang.Get("autobuy_profilenotloaded"), MyraLabel.TextStyle.P);
 
         var root = new VerticalStackPanel { Spacing = 6 };
 
         root.Widgets.Add(MyraCheckButton.CreateWithCallback(
-            profile.BuyAgentEnabled, b => profile.BuyAgentEnabled = b, "Enable Auto Buy"));
+            profile.BuyAgentEnabled, b => profile.BuyAgentEnabled = b, TazLang.Get("autobuy_enable")));
 
         root.Widgets.Add(MyraCheckButton.CreateWithCallback(
-            profile.BuyAgentSubContainers, b => profile.BuyAgentSubContainers = b, "Include sub containers?",
-            "This will also count items inside containers in your backpack (Containers that have not been opened yet may not have an accurate count of contents)."));
+            profile.BuyAgentSubContainers, b => profile.BuyAgentSubContainers = b,
+            TazLang.Get("autobuy_subcontainers"),
+            TazLang.Get("autobuy_subcontainers_tooltip")));
 
-        root.Widgets.Add(new MyraLabel("Options:", MyraLabel.TextStyle.H3));
+        root.Widgets.Add(new MyraLabel(TazLang.Get("autobuy_options"), MyraLabel.TextStyle.H3));
         root.Widgets.Add(MyraHSlider.SliderWithLabel(
-            "Max total items",
+            TazLang.Get("autobuy_maxitems"),
             out _,
             v => profile.BuyAgentMaxItems = (int)v,
             0, 1000,
             profile.BuyAgentMaxItems));
         root.Widgets.Add(MyraHSlider.SliderWithLabel(
-            "Max unique items",
+            TazLang.Get("autobuy_maxuniques"),
             out _,
             v => profile.BuyAgentMaxUniques = (int)v,
             0, 100,
             profile.BuyAgentMaxUniques));
 
-        root.Widgets.Add(new MyraLabel("Entries:", MyraLabel.TextStyle.H3));
+        root.Widgets.Add(new MyraLabel(TazLang.Get("autobuy_entries"), MyraLabel.TextStyle.H3));
 
         var entriesPanel = new VerticalStackPanel { Spacing = 4 };
 
@@ -50,20 +51,20 @@ public static class AutoBuyAgentTabContent
 
             if (entries.Count == 0)
             {
-                entriesPanel.Widgets.Add(new MyraLabel("No entries configured.", MyraLabel.TextStyle.H3));
+                entriesPanel.Widgets.Add(new MyraLabel(TazLang.Get("autobuy_noentries"), MyraLabel.TextStyle.H3));
                 return;
             }
 
             var grid = new MyraGrid();
             grid.SetupWithHeaders(
-                GridColumnInfo.Auto("Art"),
-                GridColumnInfo.Fill("Graphic"),
-                GridColumnInfo.Fill("Hue"),
-                GridColumnInfo.Fill("Max Amount"),
-                GridColumnInfo.Fill("Restock Up To"),
-                GridColumnInfo.Fill("Max Price"),
-                GridColumnInfo.Auto("Enabled"),
-                GridColumnInfo.Auto("Actions")
+                GridColumnInfo.Auto(TazLang.Get("agent_col_art")),
+                GridColumnInfo.Fill(TazLang.Get("agent_col_graphic")),
+                GridColumnInfo.Fill(TazLang.Get("agent_col_hue")),
+                GridColumnInfo.Fill(TazLang.Get("agent_col_maxamount")),
+                GridColumnInfo.Fill(TazLang.Get("autobuy_col_restockupto")),
+                GridColumnInfo.Fill(TazLang.Get("autobuy_col_maxprice")),
+                GridColumnInfo.Auto(TazLang.Get("agent_col_enabled")),
+                GridColumnInfo.Auto(TazLang.Get("agent_col_actions"))
             );
 
             int dataRow = 1;
@@ -94,7 +95,7 @@ public static class AutoBuyAgentTabContent
                 var maxAmountBox = new MyraInputBox
                 {
                     Text = entry.MaxAmount == ushort.MaxValue ? "0" : entry.MaxAmount.ToString(),
-                    Tooltip = "Set to 0 for unlimited.",
+                    Tooltip = TazLang.Get("agent_maxamount_tooltip"),
                 };
                 maxAmountBox.TextChangedByUser += (_, _) =>
                 {
@@ -106,7 +107,7 @@ public static class AutoBuyAgentTabContent
                 var restockBox = new MyraInputBox
                 {
                     Text = entry.RestockUpTo.ToString(),
-                    Tooltip = "Amount to restock up to when buying (0 = disabled).",
+                    Tooltip = TazLang.Get("autobuy_restockupto_tooltip"),
                 };
                 restockBox.TextChangedByUser += (_, _) =>
                 {
@@ -117,7 +118,7 @@ public static class AutoBuyAgentTabContent
                 var maxPriceBox = new MyraInputBox
                 {
                     Text = entry.MaxPrice.ToString(),
-                    Tooltip = "Maximum price per item (0 = no limit).",
+                    Tooltip = TazLang.Get("autobuy_maxprice_tooltip"),
                 };
                 maxPriceBox.TextChangedByUser += (_, _) =>
                 {
@@ -129,7 +130,7 @@ public static class AutoBuyAgentTabContent
                 cb.HorizontalAlignment = HorizontalAlignment.Center;
                 grid.AddWidget(cb, dataRow, 6);
 
-                grid.AddWidget(MyraStyle.ApplyButtonDangerStyle(new MyraButton("Delete", () =>
+                grid.AddWidget(MyraStyle.ApplyButtonDangerStyle(new MyraButton(TazLang.Get("agent_delete"), () =>
                 {
                     BuySellAgent.Instance?.DeleteConfig(entry);
                     BuildEntriesList();
@@ -152,17 +153,17 @@ public static class AutoBuyAgentTabContent
         var newMaxPriceBox = new MyraInputBox { HintText = "Max Price (0=no limit)", Width = 110 };
 
         var addFieldsRow1 = new HorizontalStackPanel { Spacing = 4 };
-        addFieldsRow1.Widgets.Add(new MyraLabel("Graphic:", MyraLabel.TextStyle.P));
+        addFieldsRow1.Widgets.Add(new MyraLabel(TazLang.Get("agent_graphic_label"), MyraLabel.TextStyle.P));
         addFieldsRow1.Widgets.Add(newGraphicBox);
-        addFieldsRow1.Widgets.Add(new MyraLabel("Hue:", MyraLabel.TextStyle.P));
+        addFieldsRow1.Widgets.Add(new MyraLabel(TazLang.Get("agent_hue_label"), MyraLabel.TextStyle.P));
         addFieldsRow1.Widgets.Add(newHueBox);
 
         var addFieldsRow2 = new HorizontalStackPanel { Spacing = 4 };
-        addFieldsRow2.Widgets.Add(new MyraLabel("Max Amount:", MyraLabel.TextStyle.P));
+        addFieldsRow2.Widgets.Add(new MyraLabel(TazLang.Get("agent_maxamount_label"), MyraLabel.TextStyle.P));
         addFieldsRow2.Widgets.Add(newMaxAmountBox);
-        addFieldsRow2.Widgets.Add(new MyraLabel("Restock Up To:", MyraLabel.TextStyle.P));
+        addFieldsRow2.Widgets.Add(new MyraLabel(TazLang.Get("autobuy_restockupto_label"), MyraLabel.TextStyle.P));
         addFieldsRow2.Widgets.Add(newRestockBox);
-        addFieldsRow2.Widgets.Add(new MyraLabel("Max Price:", MyraLabel.TextStyle.P));
+        addFieldsRow2.Widgets.Add(new MyraLabel(TazLang.Get("autobuy_maxprice_label"), MyraLabel.TextStyle.P));
         addFieldsRow2.Widgets.Add(newMaxPriceBox);
 
         void ClearAddFields()
@@ -175,7 +176,7 @@ public static class AutoBuyAgentTabContent
         }
 
         var addConfirmRow = new HorizontalStackPanel { Spacing = 4 };
-        addConfirmRow.Widgets.Add(new MyraButton("Add", () =>
+        addConfirmRow.Widgets.Add(new MyraButton(TazLang.Get("agent_add"), () =>
         {
             if (StringHelper.TryParseInt(newGraphicBox.Text, out int graphic))
             {
@@ -201,23 +202,23 @@ public static class AutoBuyAgentTabContent
                 BuildEntriesList();
             }
         }));
-        addConfirmRow.Widgets.Add(new MyraButton("Cancel", () =>
+        addConfirmRow.Widgets.Add(new MyraButton(TazLang.Get("agent_cancel"), () =>
         {
             addEntryPanel.Visible = false;
             ClearAddFields();
         }));
 
-        addEntryPanel.Widgets.Add(new MyraLabel("Add New Entry:", MyraLabel.TextStyle.H3));
+        addEntryPanel.Widgets.Add(new MyraLabel(TazLang.Get("agent_addnewentry"), MyraLabel.TextStyle.H3));
         addEntryPanel.Widgets.Add(addFieldsRow1);
         addEntryPanel.Widgets.Add(addFieldsRow2);
         addEntryPanel.Widgets.Add(addConfirmRow);
 
         // Action buttons
         var actionRow = new HorizontalStackPanel { Spacing = 6 };
-        actionRow.Widgets.Add(new MyraButton("Add Manual Entry", () => addEntryPanel.Visible = !addEntryPanel.Visible));
-        actionRow.Widgets.Add(new MyraButton("Add from Target", () =>
+        actionRow.Widgets.Add(new MyraButton(TazLang.Get("agent_addmanualentry"), () => addEntryPanel.Visible = !addEntryPanel.Visible));
+        actionRow.Widgets.Add(new MyraButton(TazLang.Get("agent_addfromtarget"), () =>
         {
-            GameActions.Print(Client.Game.UO.World, "Target item to add");
+            GameActions.Print(Client.Game.UO.World, TazLang.Get("autobuy_targetprompt"));
             World.Instance.TargetManager.SetTargeting(targeted =>
             {
                 if (targeted is Entity entity && SerialHelper.IsItem(entity))
@@ -228,23 +229,23 @@ public static class AutoBuyAgentTabContent
                     BuildEntriesList();
                 }
             });
-        }) { Tooltip = "Target an item to add it to the buy list." });
-        actionRow.Widgets.Add(new MyraButton("Import", () =>
+        }) { Tooltip = TazLang.Get("autobuy_addfromtarget_tooltip") });
+        actionRow.Widgets.Add(new MyraButton(TazLang.Get("agent_import"), () =>
         {
             string? json = Clipboard.GetClipboardText();
             if (json.NotNullNotEmpty() && BuySellAgent.ImportFromJson(json, AgentType.Buy))
             {
-                GameActions.Print("Imported buy list!", Constants.HUE_SUCCESS);
+                GameActions.Print(TazLang.Get("autobuy_imported"), Constants.HUE_SUCCESS);
                 BuildEntriesList();
                 return;
             }
-            GameActions.Print("Your clipboard does not have a valid export copied.", Constants.HUE_ERROR);
-        }) { Tooltip = "Import from clipboard (must have a valid export copied)." });
-        actionRow.Widgets.Add(new MyraButton("Export", () =>
+            GameActions.Print(TazLang.Get("agent_invalidimport"), Constants.HUE_ERROR);
+        }) { Tooltip = TazLang.Get("agent_import_tooltip") });
+        actionRow.Widgets.Add(new MyraButton(TazLang.Get("agent_export"), () =>
         {
             BuySellAgent.GetJsonExport(AgentType.Buy)?.CopyToClipboard();
-            GameActions.Print("Exported buy list to your clipboard!", Constants.HUE_SUCCESS);
-        }) { Tooltip = "Export your list to clipboard." });
+            GameActions.Print(TazLang.Get("autobuy_exported"), Constants.HUE_SUCCESS);
+        }) { Tooltip = TazLang.Get("agent_export_tooltip") });
 
         root.Widgets.Add(actionRow);
         root.Widgets.Add(addEntryPanel);

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/AutoSellAgentTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/AutoSellAgentTabContent.cs
@@ -14,28 +14,28 @@ public static class AutoSellAgentTabContent
     {
         Profile? profile = ProfileManager.CurrentProfile;
         if (profile == null)
-            return new MyraLabel("Profile not loaded", MyraLabel.TextStyle.P);
+            return new MyraLabel(TazLang.Get("autosell_profilenotloaded"), MyraLabel.TextStyle.P);
 
         var root = new VerticalStackPanel { Spacing = 6 };
 
         root.Widgets.Add(MyraCheckButton.CreateWithCallback(
-            profile.SellAgentEnabled, b => profile.SellAgentEnabled = b, "Enable Auto Sell"));
+            profile.SellAgentEnabled, b => profile.SellAgentEnabled = b, TazLang.Get("autosell_enable")));
 
-        root.Widgets.Add(new MyraLabel("Options:", MyraLabel.TextStyle.H3));
+        root.Widgets.Add(new MyraLabel(TazLang.Get("autosell_options"), MyraLabel.TextStyle.H3));
         root.Widgets.Add(MyraHSlider.SliderWithLabel(
-            "Max total items",
+            TazLang.Get("autosell_maxitems"),
             out _,
             v => profile.SellAgentMaxItems = (int)v,
             0, 1000,
             profile.SellAgentMaxItems));
         root.Widgets.Add(MyraHSlider.SliderWithLabel(
-            "Max unique items",
+            TazLang.Get("autosell_maxuniques"),
             out _,
             v => profile.SellAgentMaxUniques = (int)v,
             0, 100,
             profile.SellAgentMaxUniques));
 
-        root.Widgets.Add(new MyraLabel("Entries:", MyraLabel.TextStyle.H3));
+        root.Widgets.Add(new MyraLabel(TazLang.Get("autosell_entries"), MyraLabel.TextStyle.H3));
 
         var entriesPanel = new VerticalStackPanel { Spacing = 4 };
 
@@ -46,19 +46,19 @@ public static class AutoSellAgentTabContent
 
             if (entries.Count == 0)
             {
-                entriesPanel.Widgets.Add(new MyraLabel("No entries configured.", MyraLabel.TextStyle.H3));
+                entriesPanel.Widgets.Add(new MyraLabel(TazLang.Get("autosell_noentries"), MyraLabel.TextStyle.H3));
                 return;
             }
 
             var grid = new MyraGrid();
             grid.SetupWithHeaders(
-                GridColumnInfo.Auto("Art"),
-                GridColumnInfo.Fill("Graphic"),
-                GridColumnInfo.Fill("Hue"),
-                GridColumnInfo.Fill("Max Amount"),
-                GridColumnInfo.Fill("Min on Hand"),
-                GridColumnInfo.Auto("Enabled"),
-                GridColumnInfo.Auto("Actions")
+                GridColumnInfo.Auto(TazLang.Get("agent_col_art")),
+                GridColumnInfo.Fill(TazLang.Get("agent_col_graphic")),
+                GridColumnInfo.Fill(TazLang.Get("agent_col_hue")),
+                GridColumnInfo.Fill(TazLang.Get("agent_col_maxamount")),
+                GridColumnInfo.Fill(TazLang.Get("autosell_col_minonhand")),
+                GridColumnInfo.Auto(TazLang.Get("agent_col_enabled")),
+                GridColumnInfo.Auto(TazLang.Get("agent_col_actions"))
             );
 
             int dataRow = 1;
@@ -89,7 +89,7 @@ public static class AutoSellAgentTabContent
                 var maxAmountBox = new MyraInputBox
                 {
                     Text = entry.MaxAmount == ushort.MaxValue ? "0" : entry.MaxAmount.ToString(),
-                    Tooltip = "Set to 0 for unlimited.",
+                    Tooltip = TazLang.Get("agent_maxamount_tooltip"),
                 };
                 maxAmountBox.TextChangedByUser += (_, _) =>
                 {
@@ -101,7 +101,7 @@ public static class AutoSellAgentTabContent
                 var restockBox = new MyraInputBox
                 {
                     Text = entry.RestockUpTo.ToString(),
-                    Tooltip = "Minimum amount to keep on hand (0 = disabled).",
+                    Tooltip = TazLang.Get("autosell_minonhand_tooltip"),
                 };
                 restockBox.TextChangedByUser += (_, _) =>
                 {
@@ -113,7 +113,7 @@ public static class AutoSellAgentTabContent
                 cb.HorizontalAlignment = HorizontalAlignment.Center;
                 grid.AddWidget(cb, dataRow, 5);
 
-                grid.AddWidget(MyraStyle.ApplyButtonDangerStyle(new MyraButton("Delete", () =>
+                grid.AddWidget(MyraStyle.ApplyButtonDangerStyle(new MyraButton(TazLang.Get("agent_delete"), () =>
                 {
                     BuySellAgent.Instance?.DeleteConfig(entry);
                     BuildEntriesList();
@@ -135,15 +135,15 @@ public static class AutoSellAgentTabContent
         var newRestockBox = new MyraInputBox { HintText = "Min on Hand (0=disabled)", Width = 130 };
 
         var addFieldsRow1 = new HorizontalStackPanel { Spacing = 4 };
-        addFieldsRow1.Widgets.Add(new MyraLabel("Graphic:", MyraLabel.TextStyle.P));
+        addFieldsRow1.Widgets.Add(new MyraLabel(TazLang.Get("agent_graphic_label"), MyraLabel.TextStyle.P));
         addFieldsRow1.Widgets.Add(newGraphicBox);
-        addFieldsRow1.Widgets.Add(new MyraLabel("Hue:", MyraLabel.TextStyle.P));
+        addFieldsRow1.Widgets.Add(new MyraLabel(TazLang.Get("agent_hue_label"), MyraLabel.TextStyle.P));
         addFieldsRow1.Widgets.Add(newHueBox);
 
         var addFieldsRow2 = new HorizontalStackPanel { Spacing = 4 };
-        addFieldsRow2.Widgets.Add(new MyraLabel("Max Amount:", MyraLabel.TextStyle.P));
+        addFieldsRow2.Widgets.Add(new MyraLabel(TazLang.Get("agent_maxamount_label"), MyraLabel.TextStyle.P));
         addFieldsRow2.Widgets.Add(newMaxAmountBox);
-        addFieldsRow2.Widgets.Add(new MyraLabel("Min on Hand:", MyraLabel.TextStyle.P));
+        addFieldsRow2.Widgets.Add(new MyraLabel(TazLang.Get("autosell_minonhand_label"), MyraLabel.TextStyle.P));
         addFieldsRow2.Widgets.Add(newRestockBox);
 
         void ClearAddFields()
@@ -155,7 +155,7 @@ public static class AutoSellAgentTabContent
         }
 
         var addConfirmRow = new HorizontalStackPanel { Spacing = 4 };
-        addConfirmRow.Widgets.Add(new MyraButton("Add", () =>
+        addConfirmRow.Widgets.Add(new MyraButton(TazLang.Get("agent_add"), () =>
         {
             if (StringHelper.TryParseInt(newGraphicBox.Text, out int graphic))
             {
@@ -178,23 +178,23 @@ public static class AutoSellAgentTabContent
                 BuildEntriesList();
             }
         }));
-        addConfirmRow.Widgets.Add(new MyraButton("Cancel", () =>
+        addConfirmRow.Widgets.Add(new MyraButton(TazLang.Get("agent_cancel"), () =>
         {
             addEntryPanel.Visible = false;
             ClearAddFields();
         }));
 
-        addEntryPanel.Widgets.Add(new MyraLabel("Add New Entry:", MyraLabel.TextStyle.H3));
+        addEntryPanel.Widgets.Add(new MyraLabel(TazLang.Get("agent_addnewentry"), MyraLabel.TextStyle.H3));
         addEntryPanel.Widgets.Add(addFieldsRow1);
         addEntryPanel.Widgets.Add(addFieldsRow2);
         addEntryPanel.Widgets.Add(addConfirmRow);
 
         // Action buttons
         var actionRow = new HorizontalStackPanel { Spacing = 6 };
-        actionRow.Widgets.Add(new MyraButton("Add Manual Entry", () => addEntryPanel.Visible = !addEntryPanel.Visible));
-        actionRow.Widgets.Add(new MyraButton("Add from Target", () =>
+        actionRow.Widgets.Add(new MyraButton(TazLang.Get("agent_addmanualentry"), () => addEntryPanel.Visible = !addEntryPanel.Visible));
+        actionRow.Widgets.Add(new MyraButton(TazLang.Get("agent_addfromtarget"), () =>
         {
-            GameActions.Print(Client.Game.UO.World, "Target item to add");
+            GameActions.Print(Client.Game.UO.World, TazLang.Get("autosell_targetprompt"));
             World.Instance.TargetManager.SetTargeting(targeted =>
             {
                 if (targeted is Entity entity && SerialHelper.IsItem(entity))
@@ -207,10 +207,10 @@ public static class AutoSellAgentTabContent
                     BuildEntriesList();
                 }
             });
-        }) { Tooltip = "Target an item to add it to the sell list." });
-        actionRow.Widgets.Add(new MyraButton("Add from Container", () =>
+        }) { Tooltip = TazLang.Get("autosell_addfromtarget_tooltip") });
+        actionRow.Widgets.Add(new MyraButton(TazLang.Get("autosell_addfromcontainer"), () =>
         {
-            GameActions.Print(Client.Game.UO.World, "Target a container to add all its items");
+            GameActions.Print(Client.Game.UO.World, TazLang.Get("autosell_addfromcontainer_prompt"));
             World.Instance.TargetManager.SetTargeting(targeted =>
             {
                 if (targeted is Item container)
@@ -228,32 +228,32 @@ public static class AutoSellAgentTabContent
                             added++;
                         }
                     }
-                    GameActions.Print(Client.Game.UO.World, $"Added {added} item(s) from container.");
+                    GameActions.Print(Client.Game.UO.World, TazLang.Get("autosell_addedfromcontainer", new string[] { added.ToString() }));
                     BuildEntriesList();
                 }
             });
-        }) { Tooltip = "Target a container to add all its items to the sell list." });
-        actionRow.Widgets.Add(MyraStyle.ApplyButtonDangerStyle(new MyraButton("Clear All", () =>
+        }) { Tooltip = TazLang.Get("autosell_addfromcontainer_tooltip") });
+        actionRow.Widgets.Add(MyraStyle.ApplyButtonDangerStyle(new MyraButton(TazLang.Get("autosell_clearall"), () =>
         {
             BuySellAgent.Instance.SellConfigs?.Clear();
             BuildEntriesList();
-        }) { Tooltip = "Remove all entries from the sell list." }));
-        actionRow.Widgets.Add(new MyraButton("Import", () =>
+        }) { Tooltip = TazLang.Get("autosell_clearall_tooltip") }));
+        actionRow.Widgets.Add(new MyraButton(TazLang.Get("agent_import"), () =>
         {
             string? json = Clipboard.GetClipboardText();
             if (json.NotNullNotEmpty() && BuySellAgent.ImportFromJson(json, AgentType.Sell))
             {
-                GameActions.Print("Imported sell list!", Constants.HUE_SUCCESS);
+                GameActions.Print(TazLang.Get("autosell_imported"), Constants.HUE_SUCCESS);
                 BuildEntriesList();
                 return;
             }
-            GameActions.Print("Your clipboard does not have a valid export copied.", Constants.HUE_ERROR);
-        }) { Tooltip = "Import from clipboard (must have a valid export copied)." });
-        actionRow.Widgets.Add(new MyraButton("Export", () =>
+            GameActions.Print(TazLang.Get("agent_invalidimport"), Constants.HUE_ERROR);
+        }) { Tooltip = TazLang.Get("agent_import_tooltip") });
+        actionRow.Widgets.Add(new MyraButton(TazLang.Get("agent_export"), () =>
         {
             BuySellAgent.GetJsonExport(AgentType.Sell)?.CopyToClipboard();
-            GameActions.Print("Exported sell list to your clipboard!", Constants.HUE_SUCCESS);
-        }) { Tooltip = "Export your list to clipboard." });
+            GameActions.Print(TazLang.Get("autosell_exported"), Constants.HUE_SUCCESS);
+        }) { Tooltip = TazLang.Get("agent_export_tooltip") });
 
         root.Widgets.Add(actionRow);
         root.Widgets.Add(addEntryPanel);

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/BandageAgentTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/BandageAgentTabContent.cs
@@ -11,15 +11,14 @@ public static class BandageAgentTabContent
     public static Widget Build()
     {
         Profile? profile = ProfileManager.CurrentProfile;
-        BandageAgentLanguage bandLang = Language.Instance.Assistant.Agents.Bandage;
 
         if (profile == null)
-            return new MyraLabel(bandLang.ProfileNotLoaded, MyraLabel.TextStyle.P);
+            return new MyraLabel(TazLang.Get("bandageagent_profilenotloaded"), MyraLabel.TextStyle.P);
 
         var root = new VerticalStackPanel { Spacing = MyraStyle.STANDARD_SPACING };
 
         root.Widgets.Add(new MyraLabel(
-            bandLang.AutoHealWhenHpBelowThreshold,
+            TazLang.Get("bandageagent_autohealwhenhpbelowthreshold"),
             MyraLabel.TextStyle.H3
         ));
 
@@ -27,35 +26,35 @@ public static class BandageAgentTabContent
         enableRow.Widgets.Add(MyraCheckButton.CreateWithCallback(
             profile.EnableBandageAgent,
             b => profile.EnableBandageAgent = b,
-            bandLang.EnableBandageAgent
+            TazLang.Get("bandageagent_enable")
         ));
 
         enableRow.Widgets.Add(MyraCheckButton.CreateWithCallback(
             profile.BandageAgentBandageFriends,
             b => profile.BandageAgentBandageFriends = b,
-            bandLang.BandageFriendsCheckbox,
-            bandLang.BandageFriendsTooltip
+            TazLang.Get("bandageagent_bandagefriends"),
+            TazLang.Get("bandageagent_bandagefriends_tooltip")
         ));
 
         enableRow.Widgets.Add(MyraCheckButton.CreateWithCallback(
             profile.BandageAgentBandageAllies,
             b => profile.BandageAgentBandageAllies = b,
-            bandLang.BandageAlliesCheckbox,
-            bandLang.BandageAlliesTooltip
+            TazLang.Get("bandageagent_bandageallies"),
+            TazLang.Get("bandageagent_bandageallies_tooltip")
         ));
 
         enableRow.Widgets.Add(MyraCheckButton.CreateWithCallback(
             profile.BandageAgentBandagePets,
             b => profile.BandageAgentBandagePets = b,
-            bandLang.BandagePetsCheckbox,
-            bandLang.BandagePetsTooltip
+            TazLang.Get("bandageagent_bandagepets"),
+            TazLang.Get("bandageagent_bandagepets_tooltip")
         ));
 
         enableRow.Widgets.Add(MyraCheckButton.CreateWithCallback(
             profile.BandageAgentDisableSelfHeal,
             b => profile.BandageAgentDisableSelfHeal = b,
-            bandLang.DisableSelfHealCheckbox,
-            bandLang.DisableSelfHealTooltip
+            TazLang.Get("bandageagent_disableselfheal"),
+            TazLang.Get("bandageagent_disableselfheal_tooltip")
         ));
 
         root.Widgets.Add(enableRow);
@@ -64,7 +63,7 @@ public static class BandageAgentTabContent
         var delayBox = new MyraInputBox
         {
             Text = profile.BandageAgentDelay.ToString(),
-            Tooltip = "Delay between bandage attempts in milliseconds (50-30000)",
+            Tooltip = TazLang.Get("bandageagent_delay_tooltip"),
             Width = 80,
         };
         delayBox.TextChangedByUser += (_, _) =>
@@ -77,10 +76,10 @@ public static class BandageAgentTabContent
         };
         var delayRow = new HorizontalStackPanel { Spacing = MyraStyle.STANDARD_SPACING };
         delayRow.Widgets.Add(delayBox);
-        delayRow.Widgets.Add(new MyraLabel(bandLang.BandageDelayMsLabel, MyraLabel.TextStyle.P));
+        delayRow.Widgets.Add(new MyraLabel(TazLang.Get("bandageagent_delay_label"), MyraLabel.TextStyle.P));
         delayRow.Widgets.Add(new MyraSpacer(15, 1));
         delayRow.Widgets.Add(MyraHSlider.SliderWithLabel(
-            bandLang.HealthThresholdSliderLabel,
+            TazLang.Get("bandageagent_hpthreshold"),
             out _,
             v => profile.BandageAgentHPPercentage = (int)v,
             1, 99,
@@ -108,14 +107,14 @@ public static class BandageAgentTabContent
         timingRow.Widgets.Add(MyraCheckButton.CreateWithCallback(
             profile.BandageAgentUseDexFormula,
             b => profile.BandageAgentUseDexFormula = b,
-            bandLang.UseDexFormulaCheckbox,
-            bandLang.UseDexFormulaTooltip
+            TazLang.Get("bandageagent_usedexformula"),
+            TazLang.Get("bandageagent_usedexformula_tooltip")
         ));
         timingRow.Widgets.Add(MyraCheckButton.CreateWithCallback(
             profile.BandageAgentCheckForBuff,
             b => profile.BandageAgentCheckForBuff = b,
-            bandLang.UseBandageBuffCheckbox,
-            bandLang.UseBandageBuffTooltip
+            TazLang.Get("bandageagent_usebandagebuff"),
+            TazLang.Get("bandageagent_usebandagebuff_tooltip")
         ));
         timingRow.Widgets.Add(MyraCheckButton.CreateWithCallback(
             profile.BandageAgentUseJournalTrigger,
@@ -129,32 +128,32 @@ public static class BandageAgentTabContent
         root.Widgets.Add(MyraCheckButton.CreateWithCallback(
             profile.BandageAgentUseNewPacket,
             b => profile.BandageAgentUseNewPacket = b,
-            bandLang.UseNewPacketCheckbox
+            TazLang.Get("bandageagent_usenewpacket")
         ));
 
         root.Widgets.Add(MyraCheckButton.CreateWithCallback(
             profile.BandageAgentCheckPoisoned,
             b => profile.BandageAgentCheckPoisoned = b,
-            bandLang.BandageIfPoisonedCheckbox
+            TazLang.Get("bandageagent_bandageifpoisoned")
         ));
 
         root.Widgets.Add(MyraCheckButton.CreateWithCallback(
             profile.BandageAgentCheckHidden,
             b => profile.BandageAgentCheckHidden = b,
-            bandLang.SkipIfHidden
+            TazLang.Get("bandageagent_skipifhidden")
         ));
 
         root.Widgets.Add(MyraCheckButton.CreateWithCallback(
             profile.BandageAgentCheckInvul,
             b => profile.BandageAgentCheckInvul = b,
-            bandLang.SkipIfYellowHits
+            TazLang.Get("bandageagent_skipifyellowhits")
         ));
 
         // Bandage graphic
         var graphicBox = new MyraInputBox
         {
             Text = $"0x{profile.BandageAgentGraphic:X4}",
-            Tooltip = bandLang.BandageGraphicIdTooltip,
+            Tooltip = TazLang.Get("bandageagent_graphicid_tooltip"),
             Width = 80,
         };
         graphicBox.TextChangedByUser += (_, _) =>
@@ -163,7 +162,7 @@ public static class BandageAgentTabContent
                 profile.BandageAgentGraphic = (ushort)graphic;
         };
         var graphicRow = new HorizontalStackPanel { Spacing = MyraStyle.STANDARD_SPACING };
-        graphicRow.Widgets.Add(new MyraLabel(bandLang.BandageGraphicIdLabel, MyraLabel.TextStyle.P));
+        graphicRow.Widgets.Add(new MyraLabel(TazLang.Get("bandageagent_graphicid_label"), MyraLabel.TextStyle.P));
         graphicRow.Widgets.Add(graphicBox);
         root.Widgets.Add(graphicRow);
 


### PR DESCRIPTION
…INI system

Replace all Language.cs JSON-based string references and hardcoded literals in BandageAgentTabContent, AutoBuyAgentTabContent, and AutoSellAgentTabContent with TazLang.Get() calls. Add corresponding keys to language.ini (version bumped to 16) using bandageagent_, autobuy_, autosell_, and agent_ (shared) prefixes. Remove the now-unused BandageAgentLanguage, AgentsLanguage classes and AutoBuy/AutoSell dead properties from Language.cs.