### PR TITLE
Migrate scripting, UI commons, errors, map, and top bar strings to TazLang system

### DIFF
--- a/src/ClassicUO.Client/Configuration/Language.cs
+++ b/src/ClassicUO.Client/Configuration/Language.cs
@@ -13,12 +13,7 @@ namespace ClassicUO.Configuration
     public class Language
     {
         public ModernOptionsGumpLanguage GetModernOptionsGumpLanguage { get; set; } = new();
-        public ErrorsLanguage ErrorsLanguage { get; set; } = new();
-        public MapLanguage MapLanguage { get; set; } = new();
-        public TopBarGumpLanguage TopBarGump { get; set; } = new();
-        public ScriptingLanguage Scripting { get; set; } = new();
         public AssistantLanguage Assistant { get; set; } = new();
-        public UiCommonsLanguage UiCommons { get; set; } = new();
 
         public string TazuoVersionHistory { get; set; } = "TazUO Version History";
         public string CurrentVersion { get; set; } = "Current Version: ";
@@ -635,35 +630,6 @@ namespace ClassicUO.Configuration
             public string HiddenLayersEnabled { get; set; } = "Enable visible layer system";
             #endregion
         }
-    }
-
-    public class ScriptingLanguage
-    {
-        public string OpenLocation { get; set; } = "Open Location";
-        public string OpenLocationFailed { get; set; } = "Failed to open location '{0}'";
-    }
-
-    public class UiCommonsLanguage
-    {
-        public string DragToResize { get; set; } = "Drag to resize";
-        public string MinMaxWindowButtonTooltip { get; set; } = "Minimize or maximize this window";
-        public string ResetWindowSizeButtonTooltip { get; set; } = "Reset window size";
-    }
-
-    public class ErrorsLanguage
-    {
-        public string CommandNotFound { get; set; } = "Command was not found: {0}";
-    }
-
-    public class MapLanguage
-    {
-        public string Follow { get; set; } = "Follow";
-        public string Yourself { get; set; } = "Yourself";
-    }
-
-    public class TopBarGumpLanguage
-    {
-        public string CommandsEntry { get; set; } = "Client Commands";
     }
 
     public class AssistantLanguage

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -5,7 +5,7 @@
 ; Missing keys are auto-appended with English defaults when
 ; this file's version is newer than the user's copy.
 ; -------------------------------------------------------
-_version=16
+_version=17
 accountname=Account Name
 accountcontextmenutooltip=Right click to select another account.
 music=Music
@@ -429,3 +429,22 @@ autosell_clearall=Clear All
 autosell_clearall_tooltip=Remove all entries from the sell list.
 autosell_imported=Imported sell list!
 autosell_exported=Exported sell list to your clipboard!
+
+; Scripting
+scripting_openlocation=Open Location
+scripting_openlocationfailed=Failed to open location '{0}'
+
+; UI commons
+uicommons_dragtoresize=Drag to resize
+uicommons_minmaxwindow_tooltip=Minimize or maximize this window
+uicommons_resetwindowsize_tooltip=Reset window size
+
+; Errors
+errors_commandnotfound=Command was not found: {0}
+
+; World map
+map_follow=Follow
+map_yourself=Yourself
+
+; Top bar gump
+topbargump_commandsentry=Client Commands

--- a/src/ClassicUO.Client/Game/Managers/CommandManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/CommandManager.cs
@@ -320,7 +320,7 @@ namespace ClassicUO.Game.Managers
             }
             else
             {
-                GameActions.Print(_world, string.Format(Language.Instance.ErrorsLanguage.CommandNotFound, name));
+                GameActions.Print(_world, TazLang.Get("errors_commandnotfound", new[] { name }));
                 Log.Warn($"Command: '{name}' not exists");
             }
         }

--- a/src/ClassicUO.Client/Game/UI/Controls/ResizableComponents/ResizableWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ResizableComponents/ResizableWindow.cs
@@ -392,7 +392,7 @@ public class ResizableWindow : Window, IDisposable
         {
             Width = StyleConstantsDefaults.TOOLBAR_BUTTON_SIZE,
             Height = StyleConstantsDefaults.TOOLBAR_BUTTON_SIZE,
-            Tooltip = Language.Instance.UiCommons.MinMaxWindowButtonTooltip,
+            Tooltip = TazLang.Get("uicommons_minmaxwindow_tooltip"),
             Content = _minMaxButtonLabel,
             VerticalAlignment = VerticalAlignment.Center
         };
@@ -424,7 +424,7 @@ public class ResizableWindow : Window, IDisposable
         {
             Width = StyleConstantsDefaults.TOOLBAR_BUTTON_SIZE,
             Height = StyleConstantsDefaults.TOOLBAR_BUTTON_SIZE,
-            Tooltip = Language.Instance.UiCommons.ResetWindowSizeButtonTooltip,
+            Tooltip = TazLang.Get("uicommons_resetwindowsize_tooltip"),
             Content = label,
             VerticalAlignment = VerticalAlignment.Center
         };

--- a/src/ClassicUO.Client/Game/UI/Gumps/TopBarGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/TopBarGump.cs
@@ -201,7 +201,7 @@ namespace ClassicUO.Game.UI.Gumps
             moreMenu.ContextMenu = new ContextMenuControl(this);
             moreMenu.MouseUp += (s, e) => { moreMenu.ContextMenu?.Show(); };
             //moreMenu.ContextMenu.Add(new ContextMenuItemEntry("TazUO Chat", () => { MyraWindows.TazUOChatWindow.Show(); }));
-            moreMenu.ContextMenu.Add(new ContextMenuItemEntry(Language.Instance.TopBarGump.CommandsEntry, () =>
+            moreMenu.ContextMenu.Add(new ContextMenuItemEntry(TazLang.Get("topbargump_commandsentry"), () =>
             {
                 UIManager.Add(new CommandsGump(world));
             }));

--- a/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
@@ -517,8 +517,8 @@ public class WorldMapGump : ResizableGump
         ContextMenu?.Dispose();
         ContextMenu = new ContextMenuControl(this);
 
-        var follow = new ContextMenuItemEntry(Language.Instance.MapLanguage.Follow);
-        follow.Add(new ContextMenuItemEntry(Language.Instance.MapLanguage.Yourself, () => { following = World.Player; }, true));
+        var follow = new ContextMenuItemEntry(TazLang.Get("map_follow"));
+        follow.Add(new ContextMenuItemEntry(TazLang.Get("map_yourself"), () => { following = World.Player; }, true));
         if (World.Party != null && World.Party.Leader != 0)
         {
             foreach (PartyMember e in World.Party.Members)

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/ScriptManagerWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/ScriptManagerWindow.cs
@@ -318,19 +318,19 @@ public class ScriptManagerWindow : MyraControl
         {
             items.Add(("Rename",          () => ShowRenameScriptDialog(script)));
             items.Add(("Edit Externally", () => FileSystemHelper.OpenFileWithDefaultApp(script.FullPath)));
-            items.Add((Language.Instance.Scripting.OpenLocation, () =>
+            items.Add((TazLang.Get("scripting_openlocation"), () =>
             {
                 if (!FileSystemHelper.OpenLocation(script.FullPath))
-                    GameActions.PrintUserWarn(World.Instance, string.Format(Language.Instance.Scripting.OpenLocationFailed, script.FullPath));
+                    GameActions.PrintUserWarn(World.Instance, TazLang.Get("scripting_openlocationfailed", new[] { script.FullPath }));
             }));
         }
         else
         {
-            items.Add((Language.Instance.Scripting.OpenLocation, () =>
+            items.Add((TazLang.Get("scripting_openlocation"), () =>
             {
                 var zipScript = (ZipScriptFile)script;
                 if (!FileSystemHelper.OpenLocation(zipScript.ZipPath))
-                    GameActions.PrintUserWarn(World.Instance, string.Format(Language.Instance.Scripting.OpenLocationFailed, zipScript.ZipPath));
+                    GameActions.PrintUserWarn(World.Instance, TazLang.Get("scripting_openlocationfailed", new[] { zipScript.ZipPath }));
             }));
         }
 


### PR DESCRIPTION
Replace the JSON-based ScriptingLanguage, UiCommonsLanguage, ErrorsLanguage, MapLanguage, and TopBarGumpLanguage classes with keys in the TazLang language.ini system. Updates all usages to TazLang.Get and bumps the language file version.