### PR TITLE
Fix UltimaLive chunk reload unlinking chunk from map tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable changes to TazUO will be recorded here.
 * Fixed SDL GPU assertion ("Command buffer already submitted!") on macOS caused by unnecessary GPU texture readback in the web map server - [P.R 538](https://github.com/PlayTazUO/TazUO/pull/538) ([bittiez](https://github.com/bittiez))
 * A few minor ui fixes where focus gained was not needed - ([bittiez](https://github.com/bittiez))
 * Fix: spell bar hotkeys not firing when Scroll Lock is on - [P.R 548](https://github.com/PlayTazUO/TazUO/pull/549) ([eddo87](https://github.com/eddo87))
+* Fixed UltimaLive block reloads leaving the reloaded map chunk untracked, so it could never be garbage collected and stayed loaded until relog - [P.R 556](https://github.com/PlayTazUO/TazUO/pull/556) ([bittiez](https://github.com/bittiez))
 
 ### Legion
 * Added ModernNineSliceGump.SetLegionTexture to go along with zip files and custom png's - Use your own png for a 9-slice texture - ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.2.45</AssemblyVersion>
-    <FileVersion>5.2.45</FileVersion>
+    <AssemblyVersion>5.2.46</AssemblyVersion>
+    <FileVersion>5.2.46</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/Map/Chunk.cs
+++ b/src/ClassicUO.Client/Game/Map/Chunk.cs
@@ -542,6 +542,51 @@ namespace ClassicUO.Game.Map
             IsDestroyed = true;
         }
 
+        /// <summary>
+        /// Clears the chunk's tile objects for an in-place reload (UltimaLive block
+        /// update) WITHOUT destroying or unlinking the chunk itself. The chunk stays
+        /// owned by the map: its <see cref="Map.Map._terrainChunks"/> slot and
+        /// <see cref="Node"/> are left intact and <see cref="IsDestroyed"/> stays false.
+        /// Using <see cref="Clear"/>/<see cref="Destroy"/> here would remove
+        /// <see cref="Node"/> from the map's used-indices list while the slot still
+        /// references this chunk; the reloaded chunk would then no longer be tracked
+        /// for cleanup (it could never be garbage collected by ClearUnusedBlocks and
+        /// would stay loaded until relog).
+        /// </summary>
+        public void ClearForReload()
+        {
+            for (int i = 0; i < 8; i++)
+            {
+                for (int j = 0; j < 8; j++)
+                {
+                    GameObject obj = Tiles[i, j];
+
+                    if (obj == null)
+                    {
+                        continue;
+                    }
+
+                    GameObject first = GetHeadObject(i, j);
+
+                    while (first != null)
+                    {
+                        GameObject next = first.TNext;
+
+                        if (!ReferenceEquals(first, _world.Player))
+                        {
+                            first.Destroy();
+                        }
+
+                        first.TPrevious = null;
+                        first.TNext = null;
+                        first = next;
+                    }
+
+                    Tiles[i, j] = null;
+                }
+            }
+        }
+
         public bool HasNoExternalData()
         {
             for (int i = 0; i < 8; i++)

--- a/src/ClassicUO.Client/Game/UltimaLive.cs
+++ b/src/ClassicUO.Client/Game/UltimaLive.cs
@@ -289,7 +289,7 @@ namespace ClassicUO.Game
                                 }
                             }
 
-                            mapChunk.Clear();
+                            mapChunk.ClearForReload();
                             _UL._ULMap.ReloadBlock(mapId, block);
                             mapChunk.Load(mapId, true);
 
@@ -541,7 +541,7 @@ namespace ClassicUO.Game
                             }
                         }
 
-                        mapChunk.Clear();
+                        mapChunk.ClearForReload();
                         mapChunk.Load(mapId, true);
 
                         foreach (GameObject obj in gameObjects)


### PR DESCRIPTION
Port of ClassicUO PR #1917. During an UltimaLive block reload, the code called Chunk.Clear() which removes the chunk's Node from the map's _usedIndices list and sets IsDestroyed = true, then immediately called Load() to repopulate the same chunk in place. Load() clears IsDestroyed but never re-adds the node, leaving a live chunk in _terrainChunks that is no longer tracked in _usedIndices. ClearUnusedBlocks() iterates _usedIndices, so the reloaded chunk could never be garbage collected and stayed loaded until relog.

Add Chunk.ClearForReload() which clears the tile objects in place without unlinking the chunk's Node or marking it destroyed, and use it at both UltimaLive reload sites.