### PR TITLE
Add Land tab to Tinkerer window

### DIFF
--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -203,6 +203,7 @@ artbrowser_tooltip=Graphic: {0}\nDouble click to copy.
 tinkerer_tab_clilocs=Clilocs
 tinkerer_tab_hues=Hues
 tinkerer_tab_art=Art
+tinkerer_tab_land=Land
 
 ; Tinkerer - Art browser tab
 tinkerer_art_nodata=Art data not available
@@ -234,6 +235,32 @@ tinkerer_art_next=Next >
 tinkerer_art_page=Page {0} of {1}
 tinkerer_art_tooltip_named={0} ({1}) — {2}
 tinkerer_art_tooltip={0} ({1})
+
+; Tinkerer - Land browser tab
+tinkerer_land_nodata=Land data not available
+tinkerer_land_selectprompt=Select a land graphic to view details.
+tinkerer_land_noart=(No art at this graphic)
+tinkerer_land_zoomout=-
+tinkerer_land_zoomin=+
+tinkerer_land_zoomlevel={0}px
+tinkerer_land_reset=Reset
+tinkerer_land_graphicid=Graphic ID: {0} ({1})
+tinkerer_land_dimensions=Dimensions: {0} x {1}
+tinkerer_land_dimensions_noart=Dimensions: No art
+tinkerer_land_name=Name: {0}
+tinkerer_land_unnamed=(unnamed)
+tinkerer_land_flags=Flags: {0}
+tinkerer_land_texid=TexID: {0} ({1})
+tinkerer_land_tiledata_nodata=TileData: No data
+tinkerer_land_copyid=Copy ID
+tinkerer_land_goto=Go to:
+tinkerer_land_jumphint=Graphic # or 0x..
+tinkerer_land_jump=Jump
+tinkerer_land_prev=< Prev
+tinkerer_land_next=Next >
+tinkerer_land_page=Page {0} of {1}
+tinkerer_land_tooltip_named={0} ({1}) — {2}
+tinkerer_land_tooltip={0} ({1})
 
 ; Boat control
 boatcontrol_notdriving=You need to be driving a boat to use this.

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -5,7 +5,7 @@
 ; Missing keys are auto-appended with English defaults when
 ; this file's version is newer than the user's copy.
 ; -------------------------------------------------------
-_version=18
+_version=19
 accountname=Account Name
 accountcontextmenutooltip=Right click to select another account.
 music=Music

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Tinkerer/LandBrowserTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Tinkerer/LandBrowserTabContent.cs
@@ -1,0 +1,289 @@
+#nullable enable
+using System;
+using ClassicUO.Assets;
+using ClassicUO.Configuration;
+using ClassicUO.Renderer;
+using ClassicUO.Utility;
+using Microsoft.Xna.Framework;
+using Myra.Graphics2D;
+using Myra.Graphics2D.Brushes;
+using Myra.Graphics2D.UI;
+using SDL3;
+
+namespace ClassicUO.Game.UI.MyraWindows.Widgets.Assistant.Tinkerer;
+
+/// <summary>
+/// Tinkerer tab for browsing land (terrain) art. A paged square grid of land
+/// graphics on the left; clicking a cell shows an enlarged preview with zoom
+/// controls and TileData metadata on the right.
+/// </summary>
+public static class LandBrowserTabContent
+{
+    private const int COLS = 8;
+    private const int ROWS = 8;
+    private const int PAGE_SIZE = COLS * ROWS;
+    private const int CELL = 44;
+
+    private const int ZOOM_MIN = 32;
+    private const int ZOOM_MAX = 512;
+    private const int ZOOM_STEP = 32;
+    private const int ZOOM_DEFAULT = 128;
+
+    private static readonly SolidBrush SelectedBorder = new SolidBrush(Color.Gold);
+
+    public static Widget Build()
+    {
+        if (Client.Game?.UO?.Arts == null)
+            return new MyraLabel(TazLang.Get("tinkerer_land_nodata", "Land data not available"), MyraLabel.TextStyle.P);
+
+        // Upper bound on browsable land graphics. Land art is indexed by land
+        // graphic id; cap to the available LandData range.
+        int maxGraphic = ArtLoader.MAX_LAND_DATA_INDEX_COUNT;
+        var tileData = Client.Game.UO.FileManager?.TileData;
+        if (tileData?.LandData != null && tileData.LandData.Length < maxGraphic)
+            maxGraphic = tileData.LandData.Length;
+
+        int totalPages = Math.Max(1, (maxGraphic + PAGE_SIZE - 1) / PAGE_SIZE);
+
+        int currentPage = 0;
+        int selectedGraphic = -1;
+        int zoomSize = ZOOM_DEFAULT;
+
+        // --- Left (grid) column -------------------------------------------------
+        var gridPanel = new VerticalStackPanel { Spacing = 1 };
+        var pageLabel = new MyraLabel("", MyraLabel.TextStyle.P);
+        MyraButton prevBtn = null!;
+        MyraButton nextBtn = null!;
+
+        // --- Right (detail) column ---------------------------------------------
+        var detailPanel = new VerticalStackPanel { Spacing = 4, Width = 280 };
+
+        void BuildDetail()
+        {
+            detailPanel.Widgets.Clear();
+
+            if (selectedGraphic < 0)
+            {
+                detailPanel.Widgets.Add(new MyraLabel(
+                    TazLang.Get("tinkerer_land_selectprompt", "Select a land graphic to view details."),
+                    MyraLabel.TextStyle.P));
+                return;
+            }
+
+            uint id = (uint)selectedGraphic;
+            ref readonly SpriteInfo land = ref Client.Game.UO.Arts.GetLand(id);
+            bool hasArt = land.Texture != null;
+
+            // Preview, scaled to the requested zoom while preserving aspect ratio.
+            if (hasArt)
+            {
+                var preview = new MyraLandTexture(id, zoomSize);
+                int natW = land.UV.Width;
+                int natH = land.UV.Height;
+                if (natW > 0 && natH > 0)
+                {
+                    float scale = (float)zoomSize / Math.Max(natW, natH);
+                    preview.Width = Math.Max(1, (int)Math.Round(natW * scale));
+                    preview.Height = Math.Max(1, (int)Math.Round(natH * scale));
+                    preview.MaxWidth = preview.Width;
+                    preview.MaxHeight = preview.Height;
+                }
+                detailPanel.Widgets.Add(new Panel
+                {
+                    Width = ZOOM_MAX,
+                    Height = zoomSize,
+                    Widgets = { Configure(preview) }
+                });
+            }
+            else
+            {
+                detailPanel.Widgets.Add(new MyraLabel(TazLang.Get("tinkerer_land_noart", "(No art at this graphic)"), MyraLabel.TextStyle.P));
+            }
+
+            // Zoom controls
+            var zoomRow = new HorizontalStackPanel { Spacing = 4, VerticalAlignment = VerticalAlignment.Center };
+            zoomRow.Widgets.Add(new MyraButton(TazLang.Get("tinkerer_land_zoomout", "-"), () =>
+            {
+                zoomSize = Math.Max(ZOOM_MIN, zoomSize - ZOOM_STEP);
+                BuildDetail();
+            }));
+            zoomRow.Widgets.Add(new MyraLabel(TazLang.Get("tinkerer_land_zoomlevel", new[] { zoomSize.ToString() }), MyraLabel.TextStyle.P));
+            zoomRow.Widgets.Add(new MyraButton(TazLang.Get("tinkerer_land_zoomin", "+"), () =>
+            {
+                zoomSize = Math.Min(ZOOM_MAX, zoomSize + ZOOM_STEP);
+                BuildDetail();
+            }));
+            zoomRow.Widgets.Add(new MyraButton(TazLang.Get("tinkerer_land_reset", "Reset"), () =>
+            {
+                zoomSize = ZOOM_DEFAULT;
+                BuildDetail();
+            }));
+            detailPanel.Widgets.Add(zoomRow);
+
+            // Info
+            detailPanel.Widgets.Add(new MyraLabel(
+                TazLang.Get("tinkerer_land_graphicid", new[] { id.ToString(), $"0x{id:X4}" }), MyraLabel.TextStyle.P));
+            detailPanel.Widgets.Add(new MyraLabel(
+                hasArt
+                    ? TazLang.Get("tinkerer_land_dimensions", new[] { land.UV.Width.ToString(), land.UV.Height.ToString() })
+                    : TazLang.Get("tinkerer_land_dimensions_noart", "Dimensions: No art"),
+                MyraLabel.TextStyle.P));
+
+            var ld = Client.Game.UO.FileManager?.TileData?.LandData;
+            if (ld != null && id < ld.Length)
+            {
+                LandTiles lt = ld[id];
+                string name = string.IsNullOrEmpty(lt.Name) ? TazLang.Get("tinkerer_land_unnamed", "(unnamed)") : lt.Name;
+                detailPanel.Widgets.Add(new MyraLabel(TazLang.Get("tinkerer_land_name", new[] { name }), MyraLabel.TextStyle.P));
+                detailPanel.Widgets.Add(new MyraLabel(TazLang.Get("tinkerer_land_flags", new[] { lt.Flags.ToString() }), MyraLabel.TextStyle.P));
+                detailPanel.Widgets.Add(new MyraLabel(
+                    TazLang.Get("tinkerer_land_texid", new[] { lt.TexID.ToString(), $"0x{lt.TexID:X4}" }), MyraLabel.TextStyle.P));
+            }
+            else
+            {
+                detailPanel.Widgets.Add(new MyraLabel(TazLang.Get("tinkerer_land_tiledata_nodata", "TileData: No data"), MyraLabel.TextStyle.P));
+            }
+
+            detailPanel.Widgets.Add(new MyraButton(TazLang.Get("tinkerer_land_copyid", "Copy ID"), () => SDL.SDL_SetClipboardText(id.ToString())));
+        }
+
+        void BuildPage()
+        {
+            if (currentPage < 0) currentPage = 0;
+            if (currentPage >= totalPages) currentPage = totalPages - 1;
+
+            gridPanel.Widgets.Clear();
+            pageLabel.Text = TazLang.Get("tinkerer_land_page", new[] { (currentPage + 1).ToString(), totalPages.ToString() });
+            prevBtn.Enabled = currentPage > 0;
+            nextBtn.Enabled = currentPage < totalPages - 1;
+
+            int start = currentPage * PAGE_SIZE;
+
+            for (int r = 0; r < ROWS; r++)
+            {
+                var rowPanel = new HorizontalStackPanel { Spacing = 1 };
+                for (int c = 0; c < COLS; c++)
+                {
+                    int id = start + r * COLS + c;
+                    if (id >= maxGraphic)
+                    {
+                        rowPanel.Widgets.Add(new Panel { Width = CELL, Height = CELL });
+                        continue;
+                    }
+
+                    rowPanel.Widgets.Add(BuildCell(id, selectedGraphic, gfx =>
+                    {
+                        selectedGraphic = gfx;
+                        BuildPage();
+                        BuildDetail();
+                    }));
+                }
+                gridPanel.Widgets.Add(rowPanel);
+            }
+        }
+
+        void JumpTo(int id)
+        {
+            if (id < 0 || id >= maxGraphic) return;
+            selectedGraphic = id;
+            currentPage = id / PAGE_SIZE;
+            BuildPage();
+            BuildDetail();
+        }
+
+        var leftColumn = new VerticalStackPanel { Spacing = 4 };
+
+        // Jump-to-graphic row
+        var jumpRow = new HorizontalStackPanel { Spacing = 4, VerticalAlignment = VerticalAlignment.Center };
+        var jumpBox = new MyraInputBox
+        {
+            HintText = TazLang.Get("tinkerer_land_jumphint", "Graphic # or 0x.."),
+            Width = 120,
+            InputFilter = MyraInputBox.HueInputFilter
+        };
+        void DoJump()
+        {
+            if (TryParseGraphic(jumpBox.Text, out int gfx))
+                JumpTo(gfx);
+        }
+        jumpBox.TextChangedByUser += (_, _) => DoJump();
+        jumpRow.Widgets.Add(new MyraLabel(TazLang.Get("tinkerer_land_goto", "Go to:"), MyraLabel.TextStyle.P));
+        jumpRow.Widgets.Add(jumpBox);
+        jumpRow.Widgets.Add(new MyraButton(TazLang.Get("tinkerer_land_jump", "Jump"), DoJump));
+        leftColumn.Widgets.Add(jumpRow);
+
+        // Pagination controls
+        prevBtn = new MyraButton(TazLang.Get("tinkerer_land_prev", "< Prev"), () => { currentPage--; BuildPage(); }) { Enabled = false };
+        nextBtn = new MyraButton(TazLang.Get("tinkerer_land_next", "Next >"), () => { currentPage++; BuildPage(); }) { Enabled = false };
+        var pageRow = new HorizontalStackPanel { Spacing = 6, VerticalAlignment = VerticalAlignment.Center };
+        pageRow.Widgets.Add(prevBtn);
+        pageRow.Widgets.Add(pageLabel);
+        pageRow.Widgets.Add(nextBtn);
+        leftColumn.Widgets.Add(pageRow);
+
+        leftColumn.Widgets.Add(new ScrollViewer { MaxHeight = 450, Content = gridPanel });
+
+        var root = new HorizontalStackPanel { Spacing = 12 };
+        root.Widgets.Add(leftColumn);
+        root.Widgets.Add(detailPanel);
+
+        BuildPage();
+        BuildDetail();
+        return root;
+    }
+
+    private static Widget BuildCell(int id, int selectedGraphic, Action<int> onSelect)
+    {
+        var cell = new Panel
+        {
+            Width = CELL,
+            Height = CELL,
+            BorderThickness = new Thickness(1),
+            Tooltip = BuildCellTooltip(id)
+        };
+
+        if (id == selectedGraphic)
+            cell.Border = SelectedBorder;
+
+        var art = new MyraLandTexture((uint)id, CELL - 4)
+        {
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center
+        };
+        cell.Widgets.Add(art);
+
+        cell.TouchDown += (_, _) => onSelect(id);
+        return cell;
+    }
+
+    private static string BuildCellTooltip(int id)
+    {
+        var ld = Client.Game.UO.FileManager?.TileData?.LandData;
+        if (ld != null && id < ld.Length && !string.IsNullOrEmpty(ld[id].Name))
+            return TazLang.Get("tinkerer_land_tooltip_named", new[] { id.ToString(), $"0x{id:X4}", ld[id].Name });
+        return TazLang.Get("tinkerer_land_tooltip", new[] { id.ToString(), $"0x{id:X4}" });
+    }
+
+    private static bool TryParseGraphic(string? text, out int graphic)
+    {
+        graphic = 0;
+        if (string.IsNullOrWhiteSpace(text))
+            return false;
+
+        text = text.Trim();
+        if (text.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+        {
+            return int.TryParse(text.AsSpan(2), System.Globalization.NumberStyles.HexNumber,
+                System.Globalization.CultureInfo.InvariantCulture, out graphic);
+        }
+
+        return StringHelper.TryParseInt(text, out graphic);
+    }
+
+    private static Widget Configure(Widget w)
+    {
+        w.HorizontalAlignment = HorizontalAlignment.Center;
+        w.VerticalAlignment = VerticalAlignment.Center;
+        return w;
+    }
+}

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Tinkerer/TinkererTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Tinkerer/TinkererTab.cs
@@ -11,6 +11,7 @@ public static class TinkererTab
         tabs.AddTab(TazLang.Get("tinkerer_tab_clilocs", "Clilocs"), CililocsTabContent.Build);
         tabs.AddTab(TazLang.Get("tinkerer_tab_hues", "Hues"), HueViewTabContent.Build);
         tabs.AddTab(TazLang.Get("tinkerer_tab_art", "Art"), ArtBrowserTabContent.Build);
+        tabs.AddTab(TazLang.Get("tinkerer_tab_land", "Land"), LandBrowserTabContent.Build);
         tabs.SelectFirst();
         return tabs;
     }

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/MyraLandTexture.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/MyraLandTexture.cs
@@ -1,0 +1,32 @@
+#nullable enable
+using ClassicUO.Renderer;
+using Myra.Graphics2D.TextureAtlases;
+using Myra.Graphics2D.UI;
+
+namespace ClassicUO.Game.UI.MyraWindows.Widgets;
+
+/// <summary>
+/// A Myra Image widget that displays a UO land (terrain) graphic by graphic ID.
+/// Uses the correct UV sub-rectangle from the texture atlas so that only
+/// the target sprite is rendered. The atlas Texture2D is NOT owned here and
+/// must never be disposed — Myra's Image widget does not implement IDisposable,
+/// so there is no disposal risk.
+/// </summary>
+public class MyraLandTexture : Image
+{
+    public MyraLandTexture(uint graphic, int maxSize = 36)
+    {
+        SpriteInfo landInfo = Client.Game.UO.Arts.GetLand(graphic);
+
+        if (landInfo.Texture != null)
+        {
+            // landInfo.UV is the sub-rectangle within the shared atlas texture.
+            // Passing just the Texture2D would render the entire atlas page;
+            // supplying landInfo.UV scopes it to only this sprite.
+            Renderable = new TextureRegion(landInfo.Texture, landInfo.UV);
+        }
+
+        MaxWidth = maxSize;
+        MaxHeight = maxSize;
+    }
+}


### PR DESCRIPTION
Adds a Land (terrain) browser tab to the Tinkerer window, mirroring the existing Art tab. Includes a paged grid of land graphics with a zoomable preview and LandData/TileData metadata (name, flags, TexID).