### PR TITLE
Fix IsFlying flag reference and add missing CantWalkOrRun speed mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable changes to TazUO will be recorded here.
 * A few minor ui fixes where focus gained was not needed - ([bittiez](https://github.com/bittiez))
 * Fix: spell bar hotkeys not firing when Scroll Lock is on - [P.R 548](https://github.com/PlayTazUO/TazUO/pull/549) ([eddo87](https://github.com/eddo87))
 * Fixed UltimaLive block reloads leaving the reloaded map chunk untracked, so it could never be garbage collected and stayed loaded until relog - [P.R 556](https://github.com/PlayTazUO/TazUO/pull/556) ([bittiez](https://github.com/bittiez))
+* Fix IsFlying flag reference and add missing CantWalkOrRun speed mode - [P.R 560](https://github.com/PlayTazUO/TazUO/pull/560) ([bittiez](https://github.com/bittiez))
 
 ### Legion
 * Added ModernNineSliceGump.SetLegionTexture to go along with zip files and custom png's - Use your own png for a 9-slice texture - ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.2.47</AssemblyVersion>
-    <FileVersion>5.2.47</FileVersion>
+    <AssemblyVersion>5.2.48</AssemblyVersion>
+    <FileVersion>5.2.48</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/Data/CharacterSpeedType.cs
+++ b/src/ClassicUO.Client/Game/Data/CharacterSpeedType.cs
@@ -7,6 +7,7 @@ namespace ClassicUO.Game.Data
         Normal,
         FastUnmount,
         CantRun,
-        FastUnmountAndCantRun
+        FastUnmountAndCantRun,
+        CantWalkOrRun
     }
 }

--- a/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
@@ -175,7 +175,7 @@ namespace ClassicUO.Game.GameObjects
         }
 
         public bool IsFlying =>
-            Client.Game.UO.Version >= ClientVersion.CV_7000 && (Flags & Flags.Poisoned) != 0;
+            Client.Game.UO.Version >= ClientVersion.CV_7000 && (Flags & Flags.Flying) != 0;
 
         public virtual bool InWarMode
         {

--- a/src/ClassicUO.Client/Game/GameObjects/PlayerMobile.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/PlayerMobile.cs
@@ -631,7 +631,7 @@ namespace ClassicUO.Game.GameObjects
             }
             else
             {
-                if (Walker.WalkingFailed || Walker.LastStepRequestTime > Time.Ticks || Walker.StepsCount >= Constants.MAX_STEP_COUNT || Client.Game.UO.Version >= ClientVersion.CV_60142 && IsParalyzed)
+                if (Walker.WalkingFailed || Walker.LastStepRequestTime > Time.Ticks || Walker.StepsCount >= Constants.MAX_STEP_COUNT || Client.Game.UO.Version >= ClientVersion.CV_60142 && IsParalyzed || SpeedMode == CharacterSpeedType.CantWalkOrRun)
                 {
                     return false;
                 }
@@ -838,7 +838,7 @@ namespace ClassicUO.Game.GameObjects
 
         public bool WalkNotAvoid(Direction direction, bool run)
         {
-            if (Walker.WalkingFailed || Walker.LastStepRequestTime > Time.Ticks || Walker.StepsCount >= Constants.MAX_STEP_COUNT || Client.Game.UO.Version >= ClientVersion.CV_60142 && IsParalyzed)
+            if (Walker.WalkingFailed || Walker.LastStepRequestTime > Time.Ticks || Walker.StepsCount >= Constants.MAX_STEP_COUNT || Client.Game.UO.Version >= ClientVersion.CV_60142 && IsParalyzed || SpeedMode == CharacterSpeedType.CantWalkOrRun)
             {
                 return false;
             }


### PR DESCRIPTION
IsFlying was checking Flags.Poisoned instead of Flags.Flying (both are 0x04 so functionally identical, but the wrong name was used). Fix it to use the semantically correct Flags.Flying.

Add CharacterSpeedType.CantWalkOrRun (value 4) which the Sphere server protocol supports but was previously missing, causing the packet handler to clamp it to Normal instead of immobilising the player. Both Walk() and WalkNotAvoid() now return false when this mode is active.