### PR TITLE
Add Gumps art browser tab to Tinkerer window

### DIFF
--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -5,7 +5,7 @@
 ; Missing keys are auto-appended with English defaults when
 ; this file's version is newer than the user's copy.
 ; -------------------------------------------------------
-_version=19
+_version=20
 accountname=Account Name
 accountcontextmenutooltip=Right click to select another account.
 music=Music

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -204,6 +204,7 @@ tinkerer_tab_clilocs=Clilocs
 tinkerer_tab_hues=Hues
 tinkerer_tab_art=Art
 tinkerer_tab_land=Land
+tinkerer_tab_gumps=Gumps
 
 ; Tinkerer - Art browser tab
 tinkerer_art_nodata=Art data not available
@@ -261,6 +262,26 @@ tinkerer_land_next=Next >
 tinkerer_land_page=Page {0} of {1}
 tinkerer_land_tooltip_named={0} ({1}) — {2}
 tinkerer_land_tooltip={0} ({1})
+
+; Tinkerer - Gump browser tab
+tinkerer_gump_nodata=Gump data not available
+tinkerer_gump_selectprompt=Select a gump graphic to view details.
+tinkerer_gump_noart=(No art at this graphic)
+tinkerer_gump_zoomout=-
+tinkerer_gump_zoomin=+
+tinkerer_gump_zoomlevel={0}px
+tinkerer_gump_reset=Reset
+tinkerer_gump_graphicid=Graphic ID: {0} ({1})
+tinkerer_gump_dimensions=Dimensions: {0} x {1}
+tinkerer_gump_dimensions_noart=Dimensions: No art
+tinkerer_gump_copyid=Copy ID
+tinkerer_gump_goto=Go to:
+tinkerer_gump_jumphint=Graphic # or 0x..
+tinkerer_gump_jump=Jump
+tinkerer_gump_prev=< Prev
+tinkerer_gump_next=Next >
+tinkerer_gump_page=Page {0} of {1}
+tinkerer_gump_tooltip={0} ({1})
 
 ; Boat control
 boatcontrol_notdriving=You need to be driving a boat to use this.

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Tinkerer/GumpBrowserTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Tinkerer/GumpBrowserTabContent.cs
@@ -1,0 +1,271 @@
+#nullable enable
+using System;
+using ClassicUO.Assets;
+using ClassicUO.Configuration;
+using ClassicUO.Renderer;
+using ClassicUO.Utility;
+using Microsoft.Xna.Framework;
+using Myra.Graphics2D;
+using Myra.Graphics2D.Brushes;
+using Myra.Graphics2D.UI;
+using SDL3;
+
+namespace ClassicUO.Game.UI.MyraWindows.Widgets.Assistant.Tinkerer;
+
+/// <summary>
+/// Tinkerer tab for browsing gump art. A paged square grid of gump graphics on
+/// the left; clicking a cell shows an enlarged preview with zoom controls and
+/// basic metadata on the right.
+/// </summary>
+public static class GumpBrowserTabContent
+{
+    private const int COLS = 8;
+    private const int ROWS = 8;
+    private const int PAGE_SIZE = COLS * ROWS;
+    private const int CELL = 44;
+
+    private const int ZOOM_MIN = 32;
+    private const int ZOOM_MAX = 512;
+    private const int ZOOM_STEP = 32;
+    private const int ZOOM_DEFAULT = 128;
+
+    private static readonly SolidBrush SelectedBorder = new SolidBrush(Color.Gold);
+
+    public static Widget Build()
+    {
+        if (Client.Game?.UO?.Gumps == null)
+            return new MyraLabel(TazLang.Get("tinkerer_gump_nodata", "Gump data not available"), MyraLabel.TextStyle.P);
+
+        // Upper bound on browsable gump graphics. Gump art is indexed by gump
+        // graphic id; cap to the available file entries / max range.
+        int maxGraphic = GumpsLoader.MAX_GUMP_DATA_INDEX_COUNT;
+        var gumpFile = Client.Game.UO.FileManager?.Gumps?.File;
+        if (gumpFile?.Entries != null && gumpFile.Entries.Length < maxGraphic)
+            maxGraphic = gumpFile.Entries.Length;
+
+        int totalPages = Math.Max(1, (maxGraphic + PAGE_SIZE - 1) / PAGE_SIZE);
+
+        int currentPage = 0;
+        int selectedGraphic = -1;
+        int zoomSize = ZOOM_DEFAULT;
+
+        // --- Left (grid) column -------------------------------------------------
+        var gridPanel = new VerticalStackPanel { Spacing = 1 };
+        var pageLabel = new MyraLabel("", MyraLabel.TextStyle.P);
+        MyraButton prevBtn = null!;
+        MyraButton nextBtn = null!;
+
+        // --- Right (detail) column ---------------------------------------------
+        var detailPanel = new VerticalStackPanel { Spacing = 4, Width = 280 };
+
+        void BuildDetail()
+        {
+            detailPanel.Widgets.Clear();
+
+            if (selectedGraphic < 0)
+            {
+                detailPanel.Widgets.Add(new MyraLabel(
+                    TazLang.Get("tinkerer_gump_selectprompt", "Select a gump graphic to view details."),
+                    MyraLabel.TextStyle.P));
+                return;
+            }
+
+            uint id = (uint)selectedGraphic;
+            ref readonly SpriteInfo gump = ref Client.Game.UO.Gumps.GetGump(id);
+            bool hasArt = gump.Texture != null;
+
+            // Preview, scaled to the requested zoom while preserving aspect ratio.
+            if (hasArt)
+            {
+                var preview = new MyraGumpTexture(id, zoomSize);
+                int natW = gump.UV.Width;
+                int natH = gump.UV.Height;
+                if (natW > 0 && natH > 0)
+                {
+                    float scale = (float)zoomSize / Math.Max(natW, natH);
+                    preview.Width = Math.Max(1, (int)Math.Round(natW * scale));
+                    preview.Height = Math.Max(1, (int)Math.Round(natH * scale));
+                    preview.MaxWidth = preview.Width;
+                    preview.MaxHeight = preview.Height;
+                }
+                detailPanel.Widgets.Add(new Panel
+                {
+                    Width = ZOOM_MAX,
+                    Height = zoomSize,
+                    Widgets = { Configure(preview) }
+                });
+            }
+            else
+            {
+                detailPanel.Widgets.Add(new MyraLabel(TazLang.Get("tinkerer_gump_noart", "(No art at this graphic)"), MyraLabel.TextStyle.P));
+            }
+
+            // Zoom controls
+            var zoomRow = new HorizontalStackPanel { Spacing = 4, VerticalAlignment = VerticalAlignment.Center };
+            zoomRow.Widgets.Add(new MyraButton(TazLang.Get("tinkerer_gump_zoomout", "-"), () =>
+            {
+                zoomSize = Math.Max(ZOOM_MIN, zoomSize - ZOOM_STEP);
+                BuildDetail();
+            }));
+            zoomRow.Widgets.Add(new MyraLabel(TazLang.Get("tinkerer_gump_zoomlevel", new[] { zoomSize.ToString() }), MyraLabel.TextStyle.P));
+            zoomRow.Widgets.Add(new MyraButton(TazLang.Get("tinkerer_gump_zoomin", "+"), () =>
+            {
+                zoomSize = Math.Min(ZOOM_MAX, zoomSize + ZOOM_STEP);
+                BuildDetail();
+            }));
+            zoomRow.Widgets.Add(new MyraButton(TazLang.Get("tinkerer_gump_reset", "Reset"), () =>
+            {
+                zoomSize = ZOOM_DEFAULT;
+                BuildDetail();
+            }));
+            detailPanel.Widgets.Add(zoomRow);
+
+            // Info
+            detailPanel.Widgets.Add(new MyraLabel(
+                TazLang.Get("tinkerer_gump_graphicid", new[] { id.ToString(), $"0x{id:X4}" }), MyraLabel.TextStyle.P));
+            detailPanel.Widgets.Add(new MyraLabel(
+                hasArt
+                    ? TazLang.Get("tinkerer_gump_dimensions", new[] { gump.UV.Width.ToString(), gump.UV.Height.ToString() })
+                    : TazLang.Get("tinkerer_gump_dimensions_noart", "Dimensions: No art"),
+                MyraLabel.TextStyle.P));
+
+            detailPanel.Widgets.Add(new MyraButton(TazLang.Get("tinkerer_gump_copyid", "Copy ID"), () => SDL.SDL_SetClipboardText(id.ToString())));
+        }
+
+        void BuildPage()
+        {
+            if (currentPage < 0) currentPage = 0;
+            if (currentPage >= totalPages) currentPage = totalPages - 1;
+
+            gridPanel.Widgets.Clear();
+            pageLabel.Text = TazLang.Get("tinkerer_gump_page", new[] { (currentPage + 1).ToString(), totalPages.ToString() });
+            prevBtn.Enabled = currentPage > 0;
+            nextBtn.Enabled = currentPage < totalPages - 1;
+
+            int start = currentPage * PAGE_SIZE;
+
+            for (int r = 0; r < ROWS; r++)
+            {
+                var rowPanel = new HorizontalStackPanel { Spacing = 1 };
+                for (int c = 0; c < COLS; c++)
+                {
+                    int id = start + r * COLS + c;
+                    if (id >= maxGraphic)
+                    {
+                        rowPanel.Widgets.Add(new Panel { Width = CELL, Height = CELL });
+                        continue;
+                    }
+
+                    rowPanel.Widgets.Add(BuildCell(id, selectedGraphic, gfx =>
+                    {
+                        selectedGraphic = gfx;
+                        BuildPage();
+                        BuildDetail();
+                    }));
+                }
+                gridPanel.Widgets.Add(rowPanel);
+            }
+        }
+
+        void JumpTo(int id)
+        {
+            if (id < 0 || id >= maxGraphic) return;
+            selectedGraphic = id;
+            currentPage = id / PAGE_SIZE;
+            BuildPage();
+            BuildDetail();
+        }
+
+        var leftColumn = new VerticalStackPanel { Spacing = 4 };
+
+        // Jump-to-graphic row
+        var jumpRow = new HorizontalStackPanel { Spacing = 4, VerticalAlignment = VerticalAlignment.Center };
+        var jumpBox = new MyraInputBox
+        {
+            HintText = TazLang.Get("tinkerer_gump_jumphint", "Graphic # or 0x.."),
+            Width = 120,
+            InputFilter = MyraInputBox.HueInputFilter
+        };
+        void DoJump()
+        {
+            if (TryParseGraphic(jumpBox.Text, out int gfx))
+                JumpTo(gfx);
+        }
+        jumpBox.TextChangedByUser += (_, _) => DoJump();
+        jumpRow.Widgets.Add(new MyraLabel(TazLang.Get("tinkerer_gump_goto", "Go to:"), MyraLabel.TextStyle.P));
+        jumpRow.Widgets.Add(jumpBox);
+        jumpRow.Widgets.Add(new MyraButton(TazLang.Get("tinkerer_gump_jump", "Jump"), DoJump));
+        leftColumn.Widgets.Add(jumpRow);
+
+        // Pagination controls
+        prevBtn = new MyraButton(TazLang.Get("tinkerer_gump_prev", "< Prev"), () => { currentPage--; BuildPage(); }) { Enabled = false };
+        nextBtn = new MyraButton(TazLang.Get("tinkerer_gump_next", "Next >"), () => { currentPage++; BuildPage(); }) { Enabled = false };
+        var pageRow = new HorizontalStackPanel { Spacing = 6, VerticalAlignment = VerticalAlignment.Center };
+        pageRow.Widgets.Add(prevBtn);
+        pageRow.Widgets.Add(pageLabel);
+        pageRow.Widgets.Add(nextBtn);
+        leftColumn.Widgets.Add(pageRow);
+
+        leftColumn.Widgets.Add(new ScrollViewer { MaxHeight = 450, Content = gridPanel });
+
+        var root = new HorizontalStackPanel { Spacing = 12 };
+        root.Widgets.Add(leftColumn);
+        root.Widgets.Add(detailPanel);
+
+        BuildPage();
+        BuildDetail();
+        return root;
+    }
+
+    private static Widget BuildCell(int id, int selectedGraphic, Action<int> onSelect)
+    {
+        var cell = new Panel
+        {
+            Width = CELL,
+            Height = CELL,
+            BorderThickness = new Thickness(1),
+            Tooltip = BuildCellTooltip(id)
+        };
+
+        if (id == selectedGraphic)
+            cell.Border = SelectedBorder;
+
+        var art = new MyraGumpTexture((uint)id, CELL - 4)
+        {
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center
+        };
+        cell.Widgets.Add(art);
+
+        cell.TouchDown += (_, _) => onSelect(id);
+        return cell;
+    }
+
+    private static string BuildCellTooltip(int id)
+    {
+        return TazLang.Get("tinkerer_gump_tooltip", new[] { id.ToString(), $"0x{id:X4}" });
+    }
+
+    private static bool TryParseGraphic(string? text, out int graphic)
+    {
+        graphic = 0;
+        if (string.IsNullOrWhiteSpace(text))
+            return false;
+
+        text = text.Trim();
+        if (text.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+        {
+            return int.TryParse(text.AsSpan(2), System.Globalization.NumberStyles.HexNumber,
+                System.Globalization.CultureInfo.InvariantCulture, out graphic);
+        }
+
+        return StringHelper.TryParseInt(text, out graphic);
+    }
+
+    private static Widget Configure(Widget w)
+    {
+        w.HorizontalAlignment = HorizontalAlignment.Center;
+        w.VerticalAlignment = VerticalAlignment.Center;
+        return w;
+    }
+}

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Tinkerer/GumpBrowserTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Tinkerer/GumpBrowserTabContent.cs
@@ -23,6 +23,7 @@ public static class GumpBrowserTabContent
     private const int ROWS = 8;
     private const int PAGE_SIZE = COLS * ROWS;
     private const int CELL = 44;
+    private const int CELL_ID_FONT = 10;
 
     private const int ZOOM_MIN = 32;
     private const int ZOOM_MAX = 512;
@@ -236,6 +237,16 @@ public static class GumpBrowserTabContent
             VerticalAlignment = VerticalAlignment.Center
         };
         cell.Widgets.Add(art);
+
+        // Overlay the graphic id at the bottom of the cell so it can be read
+        // at a glance without hovering for the tooltip.
+        var idLabel = new MyraLabel(id.ToString(), CELL_ID_FONT)
+        {
+            Wrap = false,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Bottom
+        };
+        cell.Widgets.Add(idLabel);
 
         cell.TouchDown += (_, _) => onSelect(id);
         return cell;

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Tinkerer/TinkererTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Tinkerer/TinkererTab.cs
@@ -12,6 +12,7 @@ public static class TinkererTab
         tabs.AddTab(TazLang.Get("tinkerer_tab_hues", "Hues"), HueViewTabContent.Build);
         tabs.AddTab(TazLang.Get("tinkerer_tab_art", "Art"), ArtBrowserTabContent.Build);
         tabs.AddTab(TazLang.Get("tinkerer_tab_land", "Land"), LandBrowserTabContent.Build);
+        tabs.AddTab(TazLang.Get("tinkerer_tab_gumps", "Gumps"), GumpBrowserTabContent.Build);
         tabs.SelectFirst();
         return tabs;
     }

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/MyraGumpTexture.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/MyraGumpTexture.cs
@@ -1,0 +1,32 @@
+#nullable enable
+using ClassicUO.Renderer;
+using Myra.Graphics2D.TextureAtlases;
+using Myra.Graphics2D.UI;
+
+namespace ClassicUO.Game.UI.MyraWindows.Widgets;
+
+/// <summary>
+/// A Myra Image widget that displays a UO gump graphic by graphic ID.
+/// Uses the correct UV sub-rectangle from the texture atlas so that only
+/// the target sprite is rendered. The atlas Texture2D is NOT owned here and
+/// must never be disposed — Myra's Image widget does not implement IDisposable,
+/// so there is no disposal risk.
+/// </summary>
+public class MyraGumpTexture : Image
+{
+    public MyraGumpTexture(uint graphic, int maxSize = 36)
+    {
+        SpriteInfo gumpInfo = Client.Game.UO.Gumps.GetGump(graphic);
+
+        if (gumpInfo.Texture != null)
+        {
+            // gumpInfo.UV is the sub-rectangle within the shared atlas texture.
+            // Passing just the Texture2D would render the entire atlas page;
+            // supplying gumpInfo.UV scopes it to only this sprite.
+            Renderable = new TextureRegion(gumpInfo.Texture, gumpInfo.UV);
+        }
+
+        MaxWidth = maxSize;
+        MaxHeight = maxSize;
+    }
+}


### PR DESCRIPTION
Adds a new "Gumps" tab to the Tinkerer window for browsing gump art, modeled after the existing Art and Land tabs. Includes a paged grid of gump graphics with zoom controls, jump-to-graphic search, and basic metadata (graphic ID and dimensions) in the detail panel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Gumps" tab to the Tinkerer tool featuring a browsable grid of gump graphics with thumbnails and pagination controls.
  * Included preview pane with zoom functionality, graphic ID metadata display, and clipboard copy feature for selected gump IDs.
  * Added direct search capability to jump to specific gumps via decimal or hexadecimal ID input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->