### PR TITLE
Add toggle buy and sell agent macros

### DIFF
--- a/src/ClassicUO.Client/Common/Enums/MacroType.cs
+++ b/src/ClassicUO.Client/Common/Enums/MacroType.cs
@@ -113,5 +113,7 @@ public enum MacroType
     ToggleAutoWalk,
     ToggleBandageAgent,
     SetOrganizerSource,
-    LoopContainer
+    LoopContainer,
+    ToggleBuyAgent,
+    ToggleSellAgent
 }

--- a/src/ClassicUO.Client/Game/Managers/MacroManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/MacroManager.cs
@@ -2459,6 +2459,18 @@ namespace ClassicUO.Game.Managers
                     GameActions.Print($"Bandage agent {(newStatus ? "enabled" : "disabled")}.", newStatus ? Constants.HUE_SUCCESS : Constants.HUE_ERROR);
                     break;
 
+                case MacroType.ToggleBuyAgent:
+                    bool newBuyStatus = !ProfileManager.CurrentProfile.BuyAgentEnabled;
+                    ProfileManager.CurrentProfile.BuyAgentEnabled = newBuyStatus;
+                    GameActions.Print($"Buy agent {(newBuyStatus ? "enabled" : "disabled")}.", newBuyStatus ? Constants.HUE_SUCCESS : Constants.HUE_ERROR);
+                    break;
+
+                case MacroType.ToggleSellAgent:
+                    bool newSellStatus = !ProfileManager.CurrentProfile.SellAgentEnabled;
+                    ProfileManager.CurrentProfile.SellAgentEnabled = newSellStatus;
+                    GameActions.Print($"Sell agent {(newSellStatus ? "enabled" : "disabled")}.", newSellStatus ? Constants.HUE_SUCCESS : Constants.HUE_ERROR);
+                    break;
+
                 case MacroType.SetOrganizerSource:
                     if (macro is MacroObjectString { Text: { } organizerName } && !string.IsNullOrWhiteSpace(organizerName))
                     {


### PR DESCRIPTION
Adds ToggleBuyAgent and ToggleSellAgent macro types that flip the buy/sell agent enabled state and print whether each was toggled on or off.