### PR TITLE
Add Self Heal hotkey (hold-to-heal, Magery + Chivalry)

### DIFF
--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -223,6 +223,7 @@ namespace ClassicUO.Configuration
         public bool BandageAgentUseDexFormula { get; set => SetProperty(ref field, value); } = false;
         public bool BandageAgentDisableSelfHeal { get; set => SetProperty(ref field, value); } = false;
         public bool SelfHeal_Enabled { get; set => SetProperty(ref field, value); } = false;
+        public bool SelfHeal_UseChivalry { get; set => SetProperty(ref field, value); } = false; // false = Magery (Heal/Cure), true = Chivalry (Close Wounds/Cleanse by Fire)
         public int SelfHeal_Key { get; set => SetProperty(ref field, value); } = 0;   // (int)SDL.SDL_Keycode, 0 = unbound
         public int SelfHeal_Mod { get; set => SetProperty(ref field, value); } = 0;   // (int)SDL.SDL_Keymod
         public int SelfHeal_RecastDelayMs { get; set => SetProperty(ref field, value); } = 50;  // pad after a successful heal before the next cast

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -222,6 +222,11 @@ namespace ClassicUO.Configuration
         public bool BandageAgentBandagePets { get; set => SetProperty(ref field, value); } = false;
         public bool BandageAgentUseDexFormula { get; set => SetProperty(ref field, value); } = false;
         public bool BandageAgentDisableSelfHeal { get; set => SetProperty(ref field, value); } = false;
+        public bool SelfHeal_Enabled { get; set => SetProperty(ref field, value); } = false;
+        public int SelfHeal_Key { get; set => SetProperty(ref field, value); } = 0;   // (int)SDL.SDL_Keycode, 0 = unbound
+        public int SelfHeal_Mod { get; set => SetProperty(ref field, value); } = 0;   // (int)SDL.SDL_Keymod
+        public int SelfHeal_CureVerifyMs { get; set => SetProperty(ref field, value); } = 600; // wait for poison to clear before recasting Cure
+        public int SelfHeal_InterruptRetryMs { get; set => SetProperty(ref field, value); } = 100; // delay before recasting after an interrupted cast
 
         [JsonIgnore]
         [SqlSetting(SettingsScope.Char, Constants.SqlSettings.BANDAGE_JOURNAL_TRIGGER, false)]

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -225,6 +225,8 @@ namespace ClassicUO.Configuration
         public bool SelfHeal_Enabled { get; set => SetProperty(ref field, value); } = false;
         public int SelfHeal_Key { get; set => SetProperty(ref field, value); } = 0;   // (int)SDL.SDL_Keycode, 0 = unbound
         public int SelfHeal_Mod { get; set => SetProperty(ref field, value); } = 0;   // (int)SDL.SDL_Keymod
+        public int SelfHeal_RecastDelayMs { get; set => SetProperty(ref field, value); } = 50;  // pad after a successful heal before the next cast
+        public int SelfHeal_CastStartGraceMs { get; set => SetProperty(ref field, value); } = 800; // max wait for a cast to register / produce a cursor
         public int SelfHeal_CureVerifyMs { get; set => SetProperty(ref field, value); } = 600; // wait for poison to clear before recasting Cure
         public int SelfHeal_InterruptRetryMs { get; set => SetProperty(ref field, value); } = 100; // delay before recasting after an interrupted cast
 

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -224,6 +224,8 @@ namespace ClassicUO.Configuration
         public bool BandageAgentDisableSelfHeal { get; set => SetProperty(ref field, value); } = false;
         public bool SelfHeal_Enabled { get; set => SetProperty(ref field, value); } = false;
         public bool SelfHeal_UseChivalry { get; set => SetProperty(ref field, value); } = false; // false = Magery (Heal/Cure), true = Chivalry (Close Wounds/Cleanse by Fire)
+        public int SelfHeal_FC { get; set => SetProperty(ref field, value); } = 2;   // Faster Casting (used to auto-compute timings)
+        public int SelfHeal_FCR { get; set => SetProperty(ref field, value); } = 6;  // Faster Cast Recovery (used to auto-compute timings)
         public int SelfHeal_Key { get; set => SetProperty(ref field, value); } = 0;   // (int)SDL.SDL_Keycode, 0 = unbound
         public int SelfHeal_Mod { get; set => SetProperty(ref field, value); } = 0;   // (int)SDL.SDL_Keymod
         public int SelfHeal_RecastDelayMs { get; set => SetProperty(ref field, value); } = 50;  // pad after a successful heal before the next cast

--- a/src/ClassicUO.Client/Game/Managers/SelfHealManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/SelfHealManager.cs
@@ -141,6 +141,14 @@ namespace ClassicUO.Game.Managers
 
             public bool IsCasting => Client.Game?.UO?.World?.Player?.IsCasting ?? false;
 
+            private static bool UseChivalry => ProfileManager.CurrentProfile?.SelfHeal_UseChivalry ?? false;
+
+            public int HealSpellId =>
+                UseChivalry ? SelfHealStateMachine.ChivalryHealSpellId : SelfHealStateMachine.MageryHealSpellId;
+
+            public int CureSpellId =>
+                UseChivalry ? SelfHealStateMachine.ChivalryCureSpellId : SelfHealStateMachine.MageryCureSpellId;
+
             public bool IsTargetingAfterCast
             {
                 get

--- a/src/ClassicUO.Client/Game/Managers/SelfHealManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/SelfHealManager.cs
@@ -2,6 +2,7 @@ using System;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Managers.SpellVisualRange;
 using ClassicUO.Input;
+using ClassicUO.Network;
 using SDL3;
 
 namespace ClassicUO.Game.Managers
@@ -127,19 +128,42 @@ namespace ClassicUO.Game.Managers
 
             public bool IsPoisoned => Client.Game?.UO?.World?.Player?.IsPoisoned ?? false;
 
-            public long RecastDelayMs =>
-                ProfileManager.CurrentProfile?.SelfHeal_RecastDelayMs ?? SelfHealStateMachine.DefaultRecastDelayMs;
+            // Recast (recovery) and cast-start grace are physical consequences of the spell school
+            // + FC/FCR, not free-form preferences, so we derive them from SelfHealTimings at runtime
+            // rather than a stored default. A stale stored grace (e.g. 800ms) can be shorter than the
+            // actual Cure cast (~0.75s + latency), which let the loop time out mid-cast and recast on
+            // top of the in-flight Cure (auto-fizzle). The formula always yields cast + a latency margin.
+            public long RecastDelayMs => Timings.recastDelayMs;
 
-            public long CastStartGraceMs =>
-                ProfileManager.CurrentProfile?.SelfHeal_CastStartGraceMs ?? SelfHealStateMachine.DefaultCastStartGraceMs;
+            public long CastStartGraceMs => Timings.castStartGraceMs;
 
-            public long CureVerifyMs =>
-                ProfileManager.CurrentProfile?.SelfHeal_CureVerifyMs ?? SelfHealStateMachine.DefaultCureVerifyMs;
+            private static (int recastDelayMs, int castStartGraceMs) Timings
+            {
+                get
+                {
+                    Profile p = ProfileManager.CurrentProfile;
+                    if (p == null)
+                        return ((int)SelfHealStateMachine.DefaultRecastDelayMs, (int)SelfHealStateMachine.DefaultCastStartGraceMs);
+                    return SelfHealTimings.Compute(p.SelfHeal_UseChivalry, p.SelfHeal_FC, p.SelfHeal_FCR);
+                }
+            }
+
+            public long CureVerifyMs
+            {
+                get
+                {
+                    int configured = (int)(ProfileManager.CurrentProfile?.SelfHeal_CureVerifyMs ?? SelfHealStateMachine.DefaultCureVerifyMs);
+                    int ping = (int)(AsyncNetClient.Socket?.Statistics?.Ping ?? 0);
+                    return SelfHealTimings.CureVerifyWindow(configured, ping);
+                }
+            }
 
             public long InterruptRetryMs =>
                 ProfileManager.CurrentProfile?.SelfHeal_InterruptRetryMs ?? SelfHealStateMachine.DefaultInterruptRetryMs;
 
             public bool IsCasting => Client.Game?.UO?.World?.Player?.IsCasting ?? false;
+
+            public long LastCastFailedAt => SpellVisualRangeManager.Instance?.LastCastFailedTick ?? 0;
 
             private static bool UseChivalry => ProfileManager.CurrentProfile?.SelfHeal_UseChivalry ?? false;
 

--- a/src/ClassicUO.Client/Game/Managers/SelfHealManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/SelfHealManager.cs
@@ -127,6 +127,12 @@ namespace ClassicUO.Game.Managers
 
             public bool IsPoisoned => Client.Game?.UO?.World?.Player?.IsPoisoned ?? false;
 
+            public long RecastDelayMs =>
+                ProfileManager.CurrentProfile?.SelfHeal_RecastDelayMs ?? SelfHealStateMachine.DefaultRecastDelayMs;
+
+            public long CastStartGraceMs =>
+                ProfileManager.CurrentProfile?.SelfHeal_CastStartGraceMs ?? SelfHealStateMachine.DefaultCastStartGraceMs;
+
             public long CureVerifyMs =>
                 ProfileManager.CurrentProfile?.SelfHeal_CureVerifyMs ?? SelfHealStateMachine.DefaultCureVerifyMs;
 

--- a/src/ClassicUO.Client/Game/Managers/SelfHealManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/SelfHealManager.cs
@@ -1,0 +1,162 @@
+using System;
+using ClassicUO.Configuration;
+using ClassicUO.Game.Managers.SpellVisualRange;
+using ClassicUO.Input;
+using SDL3;
+
+namespace ClassicUO.Game.Managers
+{
+    /// <summary>
+    /// Native hold-to-heal hotkey. While the bound key is held, spams Heal on self
+    /// (Cure when poisoned). Release stops after the in-flight cast.
+    /// </summary>
+    public static class SelfHealManager
+    {
+        private static readonly SelfHealStateMachine _machine = new();
+        private static readonly LiveEnv _env = new();
+        private static bool _held;
+        private static bool _loaded;
+
+        public static void Load()
+        {
+            if (_loaded) return;
+            Keyboard.KeyUpEvent += OnKeyUp;
+            _loaded = true;
+        }
+
+        public static void Unload()
+        {
+            if (!_loaded) return;
+            Keyboard.KeyUpEvent -= OnKeyUp;
+            _held = false;
+            _loaded = false;
+        }
+
+        public static void Update() => _machine.Tick(_env, _held);
+
+        /// <summary>Called from GameSceneInputHandler.OnKeyDown (already focus-gated).</summary>
+        public static void HandleKeyDown(SDL.SDL_Keycode key, SDL.SDL_Keymod mod, bool repeat)
+        {
+            if (repeat) return;
+
+            Profile p = ProfileManager.CurrentProfile;
+            if (p == null || !p.SelfHeal_Enabled || p.SelfHeal_Key == 0 || p.DisableHotkeys)
+                return;
+
+            if ((int)key != p.SelfHeal_Key)
+                return;
+
+            if (NormalizeMods(mod) != (SDL.SDL_Keymod)p.SelfHeal_Mod)
+                return;
+
+            _held = true;
+        }
+
+        // Key-up via the raw keyboard event so release is caught even if focus changed.
+        private static void OnKeyUp(string hotkey)
+        {
+            Profile p = ProfileManager.CurrentProfile;
+            if (p == null || p.SelfHeal_Key == 0)
+                return;
+
+            if (TryParseKeycode(hotkey, out SDL.SDL_Keycode key) && (int)key == p.SelfHeal_Key)
+                _held = false;
+        }
+
+        // Strip lock keys and normalize left/right modifiers, matching SpellBarManager.
+        private static SDL.SDL_Keymod NormalizeMods(SDL.SDL_Keymod mod)
+        {
+            mod &= ~SDL.SDL_Keymod.SDL_KMOD_NUM;
+            mod &= ~SDL.SDL_Keymod.SDL_KMOD_CAPS;
+            mod &= ~SDL.SDL_Keymod.SDL_KMOD_SCROLL;
+            mod &= ~SDL.SDL_Keymod.SDL_KMOD_MODE;
+
+            if ((mod & (SDL.SDL_Keymod.SDL_KMOD_LCTRL | SDL.SDL_Keymod.SDL_KMOD_RCTRL)) != 0)
+            {
+                mod &= ~(SDL.SDL_Keymod.SDL_KMOD_LCTRL | SDL.SDL_Keymod.SDL_KMOD_RCTRL);
+                mod |= SDL.SDL_Keymod.SDL_KMOD_CTRL;
+            }
+            if ((mod & (SDL.SDL_Keymod.SDL_KMOD_LSHIFT | SDL.SDL_Keymod.SDL_KMOD_RSHIFT)) != 0)
+            {
+                mod &= ~(SDL.SDL_Keymod.SDL_KMOD_LSHIFT | SDL.SDL_Keymod.SDL_KMOD_RSHIFT);
+                mod |= SDL.SDL_Keymod.SDL_KMOD_SHIFT;
+            }
+            if ((mod & (SDL.SDL_Keymod.SDL_KMOD_LALT | SDL.SDL_Keymod.SDL_KMOD_RALT)) != 0)
+            {
+                mod &= ~(SDL.SDL_Keymod.SDL_KMOD_LALT | SDL.SDL_Keymod.SDL_KMOD_RALT);
+                mod |= SDL.SDL_Keymod.SDL_KMOD_ALT;
+            }
+            return mod;
+        }
+
+        // Keyboard event strings look like "CTRL+SHIFT+SDLK_F1". Extract the SDLK_ token.
+        private static bool TryParseKeycode(string hotkey, out SDL.SDL_Keycode key)
+        {
+            key = SDL.SDL_Keycode.SDLK_UNKNOWN;
+            if (string.IsNullOrEmpty(hotkey))
+                return false;
+
+            foreach (string part in hotkey.Split('+'))
+            {
+                if (part.StartsWith("SDLK_", StringComparison.OrdinalIgnoreCase) &&
+                    Enum.TryParse(part, true, out SDL.SDL_Keycode parsed))
+                {
+                    key = parsed;
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private sealed class LiveEnv : ISelfHealEnv
+        {
+            public long Now => ClassicUO.Time.Ticks;
+
+            public bool CanAct
+            {
+                get
+                {
+                    Profile p = ProfileManager.CurrentProfile;
+                    if (p == null || !p.SelfHeal_Enabled || p.DisableHotkeys)
+                        return false;
+
+                    var player = Client.Game?.UO?.World?.Player;
+                    return player != null && !player.IsDead;
+                }
+            }
+
+            public bool IsPoisoned => Client.Game?.UO?.World?.Player?.IsPoisoned ?? false;
+
+            public long CureVerifyMs =>
+                ProfileManager.CurrentProfile?.SelfHeal_CureVerifyMs ?? SelfHealStateMachine.DefaultCureVerifyMs;
+
+            public long InterruptRetryMs =>
+                ProfileManager.CurrentProfile?.SelfHeal_InterruptRetryMs ?? SelfHealStateMachine.DefaultInterruptRetryMs;
+
+            public bool IsCasting => Client.Game?.UO?.World?.Player?.IsCasting ?? false;
+
+            public bool IsTargetingAfterCast
+            {
+                get
+                {
+                    // Prefer the spell-visual detector (it respects cast timing), but fall back to
+                    // the raw target-cursor flag so self-heal also works when Spell Indicators are
+                    // disabled. Only consulted right after our own cast, so the raw flag is safe.
+                    if (SpellVisualRangeManager.Instance?.IsTargetingAfterCasting() ?? false)
+                        return true;
+
+                    return Client.Game?.UO?.World?.TargetManager?.IsTargeting ?? false;
+                }
+            }
+
+            public void Cast(int spellId) => GameActions.CastSpell(spellId);
+
+            public void TargetSelf()
+            {
+                var world = Client.Game?.UO?.World;
+                if (world?.Player != null)
+                    world.TargetManager.Target(world.Player.Serial);
+            }
+        }
+    }
+}

--- a/src/ClassicUO.Client/Game/Managers/SelfHealStateMachine.cs
+++ b/src/ClassicUO.Client/Game/Managers/SelfHealStateMachine.cs
@@ -8,6 +8,8 @@ namespace ClassicUO.Game.Managers
         bool IsPoisoned { get; }
         bool IsTargetingAfterCast { get; }   // a post-cast target cursor is up
         bool IsCasting { get; }              // a spell cast is currently in progress
+        long RecastDelayMs { get; }          // pad after a successful heal before the next cast ("recuperation")
+        long CastStartGraceMs { get; }       // how long a cast may take to register before we treat it as failed
         long CureVerifyMs { get; }           // how long to wait for poison to clear before recasting Cure
         long InterruptRetryMs { get; }       // delay before recasting after an interrupted cast
         void Cast(int spellId);
@@ -17,23 +19,29 @@ namespace ClassicUO.Game.Managers
     /// <summary>
     /// Drives the hold-to-heal loop: while held, cast Heal (Cure if poisoned), wait for the
     /// post-cast cursor, target self, then repeat. Heal is spammed freely. After a Cure, it
-    /// verifies the poison actually cleared (waiting up to <see cref="CureVerifyMs"/>) before
-    /// re-casting Cure, so a single cure isn't double-cast while the status update is in flight.
+    /// verifies the poison actually cleared before re-casting Cure.
+    ///
+    /// The wait for the cursor is <b>cast-aware</b>: while <see cref="ISelfHealEnv.IsCasting"/> is
+    /// true the loop never times out (so a slow cast is never double-cast); the moment casting
+    /// stops without a cursor — or a cast never registers within <see cref="ISelfHealEnv.CastStartGraceMs"/>
+    /// — it recasts after a short <see cref="ISelfHealEnv.InterruptRetryMs"/> delay instead of stalling.
     /// Releasing only prevents the next cast.
     /// </summary>
     public sealed class SelfHealStateMachine
     {
         public const int HealSpellId = 4;     // Magery: Heal
         public const int CureSpellId = 11;    // Magery: Cure
-        public const long CastWaitMs = 3000;  // max wait for the target cursor before retrying
-        public const long SettleMs = 50;      // brief pad after targeting (Heal)
-        public const long DefaultCureVerifyMs = 600;     // default for the configurable cure-verify window
-        public const long DefaultInterruptRetryMs = 100; // default for the configurable interrupt-retry delay
+
+        // Defaults for the configurable timings (all overridable via ISelfHealEnv).
+        public const long DefaultRecastDelayMs = 50;       // pad after a successful heal
+        public const long DefaultCastStartGraceMs = 800;   // max wait for a cast to register / produce a cursor
+        public const long DefaultCureVerifyMs = 600;       // wait for poison to clear before recasting Cure
+        public const long DefaultInterruptRetryMs = 100;   // recast delay after an interrupted cast
 
         private enum State { Idle, WaitingForCursor, Settle, VerifyingCure, InterruptRetry }
 
         private State _state = State.Idle;
-        private long _deadline;
+        private long _stallUntil;
         private long _settleUntil;
         private long _verifyUntil;
         private long _interruptUntil;
@@ -57,7 +65,7 @@ namespace ClassicUO.Game.Managers
                         _lastCastWasCure = env.IsPoisoned;
                         _castStarted = false;
                         env.Cast(_lastCastWasCure ? CureSpellId : HealSpellId);
-                        _deadline = env.Now + CastWaitMs;
+                        _stallUntil = env.Now + env.CastStartGraceMs;
                         _state = State.WaitingForCursor;
                     }
                     break;
@@ -74,26 +82,24 @@ namespace ClassicUO.Game.Managers
                         }
                         else
                         {
-                            _settleUntil = env.Now + SettleMs;
+                            _settleUntil = env.Now + env.RecastDelayMs;
                             _state = State.Settle;
                         }
                     }
                     else if (env.IsCasting)
                     {
-                        _castStarted = true;            // cast is in progress; keep waiting for the cursor
+                        // Cast is genuinely in progress — keep waiting and push the grace forward so a
+                        // slow cast is never prematurely treated as failed (no double-cast).
+                        _castStarted = true;
+                        _stallUntil = env.Now + env.CastStartGraceMs;
                     }
-                    else if (_castStarted)
+                    else if (_castStarted || env.Now > _stallUntil)
                     {
-                        // The cast began and then stopped without ever producing a target cursor
-                        // (e.g. damage disrupted it). Recast quickly instead of waiting the full timeout.
+                        // Either the cast began and then died with no cursor (e.g. damage disrupted it),
+                        // or it never registered within the grace window. Recast quickly rather than stall.
                         _castStarted = false;
                         _interruptUntil = env.Now + env.InterruptRetryMs;
                         _state = State.InterruptRetry;
-                    }
-                    else if (env.Now > _deadline)   // strictly after deadline; == stays in window one more tick
-                    {
-                        _deadline = 0;
-                        _state = State.Idle;
                     }
                     break;
 

--- a/src/ClassicUO.Client/Game/Managers/SelfHealStateMachine.cs
+++ b/src/ClassicUO.Client/Game/Managers/SelfHealStateMachine.cs
@@ -8,6 +8,8 @@ namespace ClassicUO.Game.Managers
         bool IsPoisoned { get; }
         bool IsTargetingAfterCast { get; }   // a post-cast target cursor is up
         bool IsCasting { get; }              // a spell cast is currently in progress
+        int HealSpellId { get; }             // spell to cast for healing (Magery Heal / Chivalry Close Wounds)
+        int CureSpellId { get; }             // spell to cast to cure poison (Magery Cure / Chivalry Cleanse by Fire)
         long RecastDelayMs { get; }          // pad after a successful heal before the next cast ("recuperation")
         long CastStartGraceMs { get; }       // how long a cast may take to register before we treat it as failed
         long CureVerifyMs { get; }           // how long to wait for poison to clear before recasting Cure
@@ -29,8 +31,11 @@ namespace ClassicUO.Game.Managers
     /// </summary>
     public sealed class SelfHealStateMachine
     {
-        public const int HealSpellId = 4;     // Magery: Heal
-        public const int CureSpellId = 11;    // Magery: Cure
+        // Spell ids (the global cast ids GameActions.CastSpell expects).
+        public const int MageryHealSpellId = 4;       // Magery: Heal
+        public const int MageryCureSpellId = 11;      // Magery: Cure
+        public const int ChivalryHealSpellId = 202;   // Chivalry: Close Wounds
+        public const int ChivalryCureSpellId = 201;   // Chivalry: Cleanse by Fire
 
         // Defaults for the configurable timings (all overridable via ISelfHealEnv).
         public const long DefaultRecastDelayMs = 50;       // pad after a successful heal
@@ -64,7 +69,7 @@ namespace ClassicUO.Game.Managers
                     {
                         _lastCastWasCure = env.IsPoisoned;
                         _castStarted = false;
-                        env.Cast(_lastCastWasCure ? CureSpellId : HealSpellId);
+                        env.Cast(_lastCastWasCure ? env.CureSpellId : env.HealSpellId);
                         _stallUntil = env.Now + env.CastStartGraceMs;
                         _state = State.WaitingForCursor;
                     }

--- a/src/ClassicUO.Client/Game/Managers/SelfHealStateMachine.cs
+++ b/src/ClassicUO.Client/Game/Managers/SelfHealStateMachine.cs
@@ -14,6 +14,7 @@ namespace ClassicUO.Game.Managers
         long CastStartGraceMs { get; }       // how long a cast may take to register before we treat it as failed
         long CureVerifyMs { get; }           // how long to wait for poison to clear before recasting Cure
         long InterruptRetryMs { get; }       // delay before recasting after an interrupted cast
+        long LastCastFailedAt { get; }       // monotonic tick the server last reported a cast failure (disrupt/mana/etc.)
         void Cast(int spellId);
         void TargetSelf();
     }
@@ -54,6 +55,7 @@ namespace ClassicUO.Game.Managers
         private long _settleUntil;
         private long _verifyUntil;
         private long _interruptUntil;
+        private long _castIssuedAt;    // env.Now when we issued the in-flight cast (to detect failures since)
         private bool _lastCastWasCure;
 
         public void Tick(ISelfHealEnv env, bool held)
@@ -70,6 +72,7 @@ namespace ClassicUO.Game.Managers
                     if (held)
                     {
                         _lastCastWasCure = env.IsPoisoned;
+                        _castIssuedAt = env.Now;
                         env.Cast(_lastCastWasCure ? env.CureSpellId : env.HealSpellId);
                         _stallUntil = env.Now + env.CastStartGraceMs;
                         _state = State.WaitingForCursor;
@@ -91,6 +94,14 @@ namespace ClassicUO.Game.Managers
                             _settleUntil = env.Now + env.RecastDelayMs;
                             _state = State.Settle;
                         }
+                    }
+                    else if (env.LastCastFailedAt > _castIssuedAt)
+                    {
+                        // The server reported THIS cast failed (concentration disturbed, out of mana/
+                        // reagents, frozen, ...). It's a real failure, not a benign HP-driven casting-flag
+                        // flap, so retry immediately instead of waiting out the full cast grace.
+                        _interruptUntil = env.Now + env.InterruptRetryMs;
+                        _state = State.InterruptRetry;
                     }
                     else if (env.IsCasting)
                     {

--- a/src/ClassicUO.Client/Game/Managers/SelfHealStateMachine.cs
+++ b/src/ClassicUO.Client/Game/Managers/SelfHealStateMachine.cs
@@ -1,0 +1,128 @@
+namespace ClassicUO.Game.Managers
+{
+    /// <summary>Environment the self-heal loop acts against. Abstracted for testability.</summary>
+    public interface ISelfHealEnv
+    {
+        long Now { get; }                    // monotonic milliseconds
+        bool CanAct { get; }                 // player alive/in-world, feature enabled, hotkeys not disabled
+        bool IsPoisoned { get; }
+        bool IsTargetingAfterCast { get; }   // a post-cast target cursor is up
+        bool IsCasting { get; }              // a spell cast is currently in progress
+        long CureVerifyMs { get; }           // how long to wait for poison to clear before recasting Cure
+        long InterruptRetryMs { get; }       // delay before recasting after an interrupted cast
+        void Cast(int spellId);
+        void TargetSelf();
+    }
+
+    /// <summary>
+    /// Drives the hold-to-heal loop: while held, cast Heal (Cure if poisoned), wait for the
+    /// post-cast cursor, target self, then repeat. Heal is spammed freely. After a Cure, it
+    /// verifies the poison actually cleared (waiting up to <see cref="CureVerifyMs"/>) before
+    /// re-casting Cure, so a single cure isn't double-cast while the status update is in flight.
+    /// Releasing only prevents the next cast.
+    /// </summary>
+    public sealed class SelfHealStateMachine
+    {
+        public const int HealSpellId = 4;     // Magery: Heal
+        public const int CureSpellId = 11;    // Magery: Cure
+        public const long CastWaitMs = 3000;  // max wait for the target cursor before retrying
+        public const long SettleMs = 50;      // brief pad after targeting (Heal)
+        public const long DefaultCureVerifyMs = 600;     // default for the configurable cure-verify window
+        public const long DefaultInterruptRetryMs = 100; // default for the configurable interrupt-retry delay
+
+        private enum State { Idle, WaitingForCursor, Settle, VerifyingCure, InterruptRetry }
+
+        private State _state = State.Idle;
+        private long _deadline;
+        private long _settleUntil;
+        private long _verifyUntil;
+        private long _interruptUntil;
+        private bool _lastCastWasCure;
+        private bool _castStarted;     // have we observed the in-flight cast actually begin?
+
+        public void Tick(ISelfHealEnv env, bool held)
+        {
+            if (!env.CanAct)
+            {
+                _state = State.Idle;
+                _castStarted = false;
+                return;
+            }
+
+            switch (_state)
+            {
+                case State.Idle:
+                    if (held)
+                    {
+                        _lastCastWasCure = env.IsPoisoned;
+                        _castStarted = false;
+                        env.Cast(_lastCastWasCure ? CureSpellId : HealSpellId);
+                        _deadline = env.Now + CastWaitMs;
+                        _state = State.WaitingForCursor;
+                    }
+                    break;
+
+                case State.WaitingForCursor:
+                    if (env.IsTargetingAfterCast)
+                    {
+                        env.TargetSelf();
+
+                        if (_lastCastWasCure)
+                        {
+                            _verifyUntil = env.Now + env.CureVerifyMs;
+                            _state = State.VerifyingCure;
+                        }
+                        else
+                        {
+                            _settleUntil = env.Now + SettleMs;
+                            _state = State.Settle;
+                        }
+                    }
+                    else if (env.IsCasting)
+                    {
+                        _castStarted = true;            // cast is in progress; keep waiting for the cursor
+                    }
+                    else if (_castStarted)
+                    {
+                        // The cast began and then stopped without ever producing a target cursor
+                        // (e.g. damage disrupted it). Recast quickly instead of waiting the full timeout.
+                        _castStarted = false;
+                        _interruptUntil = env.Now + env.InterruptRetryMs;
+                        _state = State.InterruptRetry;
+                    }
+                    else if (env.Now > _deadline)   // strictly after deadline; == stays in window one more tick
+                    {
+                        _deadline = 0;
+                        _state = State.Idle;
+                    }
+                    break;
+
+                case State.InterruptRetry:
+                    if (env.Now > _interruptUntil)
+                    {
+                        _interruptUntil = 0;
+                        _state = State.Idle;
+                    }
+                    break;
+
+                case State.Settle:
+                    if (env.Now > _settleUntil)     // strictly after settle window
+                    {
+                        _settleUntil = 0;
+                        _state = State.Idle;
+                    }
+                    break;
+
+                case State.VerifyingCure:
+                    // Don't recast Cure until we confirm the poison cleared, or we've waited long
+                    // enough that it clearly didn't take (then allow another Cure).
+                    if (!env.IsPoisoned || env.Now > _verifyUntil)
+                    {
+                        _verifyUntil = 0;
+                        _state = State.Idle;
+                    }
+                    break;
+            }
+        }
+    }
+}

--- a/src/ClassicUO.Client/Game/Managers/SelfHealStateMachine.cs
+++ b/src/ClassicUO.Client/Game/Managers/SelfHealStateMachine.cs
@@ -24,9 +24,13 @@ namespace ClassicUO.Game.Managers
     /// verifies the poison actually cleared before re-casting Cure.
     ///
     /// The wait for the cursor is <b>cast-aware</b>: while <see cref="ISelfHealEnv.IsCasting"/> is
-    /// true the loop never times out (so a slow cast is never double-cast); the moment casting
-    /// stops without a cursor — or a cast never registers within <see cref="ISelfHealEnv.CastStartGraceMs"/>
-    /// — it recasts after a short <see cref="ISelfHealEnv.InterruptRetryMs"/> delay instead of stalling.
+    /// true the deadline is pushed forward so a slow cast is never treated as failed. Crucially, a
+    /// cast going <i>quiet</i> (IsCasting dropping to false) is NOT treated as an interrupt on its own:
+    /// the client clears its casting flag on any HP change (UpdateHitpoints → ClearCasting), so taking
+    /// a hit mid-cast flaps IsCasting off constantly while healing under fire — even though the cast is
+    /// still in flight. We therefore keep waiting for the cursor until <see cref="ISelfHealEnv.CastStartGraceMs"/>
+    /// elapses, and only then recast after a short <see cref="ISelfHealEnv.InterruptRetryMs"/> delay.
+    /// This avoids cancelling a real in-flight heal (and thus never landing one) under sustained damage.
     /// Releasing only prevents the next cast.
     /// </summary>
     public sealed class SelfHealStateMachine
@@ -51,14 +55,12 @@ namespace ClassicUO.Game.Managers
         private long _verifyUntil;
         private long _interruptUntil;
         private bool _lastCastWasCure;
-        private bool _castStarted;     // have we observed the in-flight cast actually begin?
 
         public void Tick(ISelfHealEnv env, bool held)
         {
             if (!env.CanAct)
             {
                 _state = State.Idle;
-                _castStarted = false;
                 return;
             }
 
@@ -68,7 +70,6 @@ namespace ClassicUO.Game.Managers
                     if (held)
                     {
                         _lastCastWasCure = env.IsPoisoned;
-                        _castStarted = false;
                         env.Cast(_lastCastWasCure ? env.CureSpellId : env.HealSpellId);
                         _stallUntil = env.Now + env.CastStartGraceMs;
                         _state = State.WaitingForCursor;
@@ -95,14 +96,15 @@ namespace ClassicUO.Game.Managers
                     {
                         // Cast is genuinely in progress — keep waiting and push the grace forward so a
                         // slow cast is never prematurely treated as failed (no double-cast).
-                        _castStarted = true;
                         _stallUntil = env.Now + env.CastStartGraceMs;
                     }
-                    else if (_castStarted || env.Now > _stallUntil)
+                    else if (env.Now > _stallUntil)
                     {
-                        // Either the cast began and then died with no cursor (e.g. damage disrupted it),
-                        // or it never registered within the grace window. Recast quickly rather than stall.
-                        _castStarted = false;
+                        // The cursor never appeared within the grace window. Note we do NOT recast the
+                        // instant IsCasting drops to false: the client clears its casting flag on any HP
+                        // change, so a hit landing mid-cast would otherwise cancel a heal that is still in
+                        // flight. Waiting for the deadline lets the in-flight cursor still arrive; only a
+                        // genuine no-show (true interrupt, fizzle, or never-registered cast) falls through.
                         _interruptUntil = env.Now + env.InterruptRetryMs;
                         _state = State.InterruptRetry;
                     }

--- a/src/ClassicUO.Client/Game/Managers/SelfHealTimings.cs
+++ b/src/ClassicUO.Client/Game/Managers/SelfHealTimings.cs
@@ -1,0 +1,55 @@
+using System;
+
+namespace ClassicUO.Game.Managers
+{
+    /// <summary>
+    /// Computes self-heal loop timings from the player's Faster Casting (FC) and Faster Cast
+    /// Recovery (FCR) for the active spell school. Pure and unit-tested.
+    ///
+    /// Magery: recovery base 6, FC cap 2.   Chivalry: recovery base 7, FC cap 4.
+    /// recovery = max(0, base - FCR) x 0.25s.   cast = max(0.25s, spellBase - FC x 0.25s).
+    /// Base cast times: Heal 1.0s, Cure 1.25s, Close Wounds 1.5s, Cleanse by Fire 1.0s.
+    /// </summary>
+    public static class SelfHealTimings
+    {
+        private const double MageryHealBaseSec = 1.0;    // Heal
+        private const double MageryCureBaseSec = 1.25;   // Cure
+        private const double ChivalryHealBaseSec = 1.5;  // Close Wounds
+        private const double ChivalryCureBaseSec = 1.0;  // Cleanse by Fire
+        private const double CastFloorSec = 0.25;        // server cast-time floor
+        private const double FcStepSec = 0.25;           // each FC point shaves 0.25s
+        private const int RecoveryStepMs = 250;          // each FCR point = 0.25s recovery
+        private const int GraceMarginMs = 400;           // latency/jitter pad over the longest cast
+
+        public const int MageryFcCap = 2;
+        public const int ChivalryFcCap = 4;
+        public const int MageryFcrCap = 6;
+        public const int ChivalryFcrCap = 7;
+
+        public static int FcCap(bool chivalry) => chivalry ? ChivalryFcCap : MageryFcCap;
+        public static int FcrCap(bool chivalry) => chivalry ? ChivalryFcrCap : MageryFcrCap;
+
+        /// <summary>
+        /// Returns the loop timings for the given school + FC/FCR.
+        /// recastDelayMs = the cast recovery (pad after a successful heal);
+        /// castStartGraceMs = the longest of the heal/cure cast times plus a latency margin.
+        /// FC/FCR are clamped to the school caps.
+        /// </summary>
+        public static (int recastDelayMs, int castStartGraceMs) Compute(bool chivalry, int fc, int fcr)
+        {
+            int recoveryBase = chivalry ? 7 : 6;
+            fc = Math.Clamp(fc, 0, FcCap(chivalry));
+            fcr = Math.Clamp(fcr, 0, FcrCap(chivalry));
+
+            int recoveryMs = Math.Max(0, recoveryBase - fcr) * RecoveryStepMs;
+
+            double healBase = chivalry ? ChivalryHealBaseSec : MageryHealBaseSec;
+            double cureBase = chivalry ? ChivalryCureBaseSec : MageryCureBaseSec;
+            double healCastSec = Math.Max(CastFloorSec, healBase - fc * FcStepSec);
+            double cureCastSec = Math.Max(CastFloorSec, cureBase - fc * FcStepSec);
+            int longestCastMs = (int)Math.Round(Math.Max(healCastSec, cureCastSec) * 1000.0);
+
+            return (recoveryMs, longestCastMs + GraceMarginMs);
+        }
+    }
+}

--- a/src/ClassicUO.Client/Game/Managers/SelfHealTimings.cs
+++ b/src/ClassicUO.Client/Game/Managers/SelfHealTimings.cs
@@ -51,5 +51,21 @@ namespace ClassicUO.Game.Managers
 
             return (recoveryMs, longestCastMs + GraceMarginMs);
         }
+
+        private const int PingPadMultiplier = 2;   // pad the verify window by ~one round-trip of slack
+        private const int MaxPingMs = 1000;         // clamp absurd/garbage ping readings
+
+        /// <summary>
+        /// Cure-verify window: how long to wait for the poison-cleared status before recasting Cure.
+        /// The clear arrives via a server health-bar packet ~one round-trip after we self-target, so a
+        /// fixed window (e.g. 600ms) is too short on a 150-200ms connection — the guard times out and
+        /// fires a redundant second cure. We pad the configured base by 2x the current ping so the
+        /// window scales with latency. ping is clamped so a bad reading can't blow the window up.
+        /// </summary>
+        public static int CureVerifyWindow(int configuredMs, int pingMs)
+        {
+            int pad = Math.Clamp(pingMs, 0, MaxPingMs) * PingPadMultiplier;
+            return Math.Max(0, configuredMs) + pad;
+        }
     }
 }

--- a/src/ClassicUO.Client/Game/Managers/SpellVisualRange/SpellVisualRangeManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/SpellVisualRange/SpellVisualRangeManager.cs
@@ -38,6 +38,14 @@ namespace ClassicUO.Game.Managers.SpellVisualRange
         private SpellRangeInfo currentSpell { get; set; }
 
         /// <summary>
+        /// Monotonic tick of the last time the server reported a cast failure (a <see cref="stopAtClilocs"/>
+        /// message: concentration disturbed, insufficient mana/reagents, frozen, etc.). Consumers can compare
+        /// this against when they issued a cast to know it genuinely failed — vs. a benign casting-flag drop —
+        /// and react immediately instead of waiting out a timeout.
+        /// </summary>
+        public long LastCastFailedTick { get; private set; }
+
+        /// <summary>
         /// An instance of a cast timer bar. May be null, depending on profile settings
         /// </summary>
         private static CastTimerProgressBar _castTimerBar;
@@ -75,7 +83,14 @@ namespace ClassicUO.Game.Managers.SpellVisualRange
         public void OnClilocReceived(int cliloc) =>
             Task.Factory.StartNew(() =>
             {
-                if (isCasting && stopAtClilocs.Contains(cliloc)) ClearCasting();
+                if (stopAtClilocs.Contains(cliloc))
+                {
+                    // Record the failure regardless of our isCasting flag: a damage packet may have
+                    // already cleared isCasting before this disrupt cliloc arrives (packet ordering),
+                    // and consumers still need to know the cast just failed.
+                    LastCastFailedTick = ClassicUO.Time.Ticks;
+                    if (isCasting) ClearCasting();
+                }
             });
 
         private void SetCasting(SpellRangeInfo spell)

--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -227,6 +227,7 @@ namespace ClassicUO.Game.Scenes
             OrganizerAgent.Load();
             GraphicsReplacement.Load();
             SpellBarManager.Load();
+            SelfHealManager.Load();
             if(ProfileManager.CurrentProfile.EnableCaveBorder)
                 StaticFilters.ApplyCaveTileBorder();
 
@@ -368,6 +369,7 @@ namespace ClassicUO.Game.Scenes
             JournalFilterManager.Instance.Save();
 
             SpellBarManager.Unload();
+            SelfHealManager.Unload();
             _autoUnequipActionManager?.Dispose();
             ObjectActionQueue.Instance.Clear();
 
@@ -826,6 +828,7 @@ namespace ClassicUO.Game.Scenes
             SelectedObject.TranslatedMousePositionByViewport = Camera.MouseToWorldPosition();
 
             base.Update();
+            SelfHealManager.Update();
 
             // Check if we're waiting for window resize to complete
             if (_waitingForWindowResize)

--- a/src/ClassicUO.Client/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameSceneInputHandler.cs
@@ -1489,6 +1489,7 @@ namespace ClassicUO.Game.Scenes
             if (CanExecuteMacro())
             {
                 SpellBarManager.KeyPress(key, e.mod);
+                SelfHealManager.HandleKeyDown(key, e.mod, e.repeat);
 
                 Macro macro = _world.Macros.FindMacro(
                     key,

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/AgentTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/AgentTab.cs
@@ -12,6 +12,7 @@ public static class AgentTab
         tabs.AddTab("Auto Buy", AutoBuyAgentTabContent.Build);
         tabs.AddTab("Auto Sell", AutoSellAgentTabContent.Build);
         tabs.AddTab("Bandage", BandageAgentTabContent.Build);
+        tabs.AddTab("Self Heal", SelfHealTabContent.Build);
         tabs.AddTab("Organizer", OrganizerAgentTabContent.Build);
         tabs.AddTab("Stat Lock", AutoStatLockAgentTabContent.Build);
         tabs.SelectFirst();

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/GeneralTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/GeneralTab.cs
@@ -14,6 +14,7 @@ public static class GeneralTab
         tabs.AddTab("Spell Indicators", SpellIndicatorTabContent.Build);
         tabs.AddTab("Friends", FriendsListTabContent.Build);
         tabs.AddTab("Pathfinding", PathfindingTabContent.Build);
+        tabs.AddTab("Self Heal", SelfHealTabContent.Build);
         tabs.SelectFirst();
         return tabs;
     }

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/GeneralTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/GeneralTab.cs
@@ -14,7 +14,6 @@ public static class GeneralTab
         tabs.AddTab("Spell Indicators", SpellIndicatorTabContent.Build);
         tabs.AddTab("Friends", FriendsListTabContent.Build);
         tabs.AddTab("Pathfinding", PathfindingTabContent.Build);
-        tabs.AddTab("Self Heal", SelfHealTabContent.Build);
         tabs.SelectFirst();
         return tabs;
     }

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/SelfHealTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/SelfHealTabContent.cs
@@ -93,6 +93,22 @@ public static class SelfHealTabContent
         root.Widgets.Add(normalPanel);
         root.Widgets.Add(editPanel);
 
+        // Recast delay ("recuperation"): pad after a successful heal before the next cast.
+        root.Widgets.Add(new MyraLabel("Recast delay / recuperation (ms):", MyraLabel.TextStyle.P));
+        root.Widgets.Add(MyraHSlider.SliderWithLabel(
+            "ms pad after a heal before recasting (lower = faster)",
+            out _,
+            v => profile.SelfHeal_RecastDelayMs = (int)v,
+            min: 0, max: 1000, value: profile.SelfHeal_RecastDelayMs));
+
+        // Cast start grace: how long a cast may take to register before treating it as failed.
+        root.Widgets.Add(new MyraLabel("Cast start grace (ms):", MyraLabel.TextStyle.P));
+        root.Widgets.Add(MyraHSlider.SliderWithLabel(
+            "ms to wait for a cast to register before retrying (bounds the post-interrupt stall)",
+            out _,
+            v => profile.SelfHeal_CastStartGraceMs = (int)v,
+            min: 200, max: 3000, value: profile.SelfHeal_CastStartGraceMs));
+
         // Cure recheck delay: how long to wait for poison to clear before recasting Cure.
         root.Widgets.Add(new MyraLabel("Cure recheck delay (ms):", MyraLabel.TextStyle.P));
         root.Widgets.Add(MyraHSlider.SliderWithLabel(

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/SelfHealTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/SelfHealTabContent.cs
@@ -22,13 +22,19 @@ public static class SelfHealTabContent
 
         root.Widgets.Add(new MyraLabel("Self Heal", MyraLabel.TextStyle.H2));
         root.Widgets.Add(new MyraLabel(
-            "Hold the bound key to cast Heal on yourself (Cure when poisoned). Release to stop.",
+            "Hold the bound key to heal yourself (cure when poisoned). Release to stop.",
             MyraLabel.TextStyle.P));
 
         root.Widgets.Add(MyraCheckButton.CreateWithCallback(
             profile.SelfHeal_Enabled,
             b => profile.SelfHeal_Enabled = b,
             "Enable self heal", "Enable or disable the hold-to-heal hotkey"));
+
+        root.Widgets.Add(MyraCheckButton.CreateWithCallback(
+            profile.SelfHeal_UseChivalry,
+            b => profile.SelfHeal_UseChivalry = b,
+            "Use Chivalry (Close Wounds / Cleanse by Fire)",
+            "Off = Magery (Heal / Cure). On = Chivalry: Close Wounds to heal, Cleanse by Fire to cure poison."));
 
         string KeyDisplay()
         {

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/SelfHealTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/SelfHealTabContent.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using ClassicUO.Configuration;
+using ClassicUO.Game.Managers;
 using ClassicUO.Game.UI.MyraWindows.Widgets;
 using ClassicUO.Input;
 using Myra.Graphics2D.UI;
@@ -18,6 +19,20 @@ public static class SelfHealTabContent
         SDL.SDL_Keymod capturedMod = SDL.SDL_Keymod.SDL_KMOD_NONE;
         Action? unsubscribe = null;
 
+        // The recast + grace sliders are auto-filled from FC/FCR (and stay manually editable).
+        MyraHSlider recastSlider = null!;
+        MyraHSlider graceSlider = null!;
+
+        void ApplyFcFcr()
+        {
+            var (recast, grace) = SelfHealTimings.Compute(
+                profile.SelfHeal_UseChivalry, profile.SelfHeal_FC, profile.SelfHeal_FCR);
+            profile.SelfHeal_RecastDelayMs = recast;
+            profile.SelfHeal_CastStartGraceMs = grace;
+            recastSlider.Value = recast;   // programmatic set -> updates the label, not ValueChangedByUser
+            graceSlider.Value = grace;
+        }
+
         var root = new VerticalStackPanel { Spacing = 6 };
 
         root.Widgets.Add(new MyraLabel("Self Heal", MyraLabel.TextStyle.H2));
@@ -32,7 +47,7 @@ public static class SelfHealTabContent
 
         root.Widgets.Add(MyraCheckButton.CreateWithCallback(
             profile.SelfHeal_UseChivalry,
-            b => profile.SelfHeal_UseChivalry = b,
+            b => { profile.SelfHeal_UseChivalry = b; ApplyFcFcr(); },   // school changes recovery base + caps
             "Use Chivalry (Close Wounds / Cleanse by Fire)",
             "Off = Magery (Heal / Cure). On = Chivalry: Close Wounds to heal, Cleanse by Fire to cure poison."));
 
@@ -99,19 +114,32 @@ public static class SelfHealTabContent
         root.Widgets.Add(normalPanel);
         root.Widgets.Add(editPanel);
 
-        // Recast delay ("recuperation"): pad after a successful heal before the next cast.
+        // Faster Casting / Recovery -> auto-computes the recast & grace below for your school.
+        root.Widgets.Add(new MyraLabel("Your FC / FCR (auto-sets recast & grace):", MyraLabel.TextStyle.P));
+        root.Widgets.Add(MyraHSlider.SliderWithLabel(
+            "Faster Casting (FC) - Magery caps at 2, Chivalry at 4 (2 if you have Magery/Mysticism 70+)",
+            out _,
+            v => { profile.SelfHeal_FC = (int)v; ApplyFcFcr(); },
+            min: 0, max: 4, value: profile.SelfHeal_FC));
+        root.Widgets.Add(MyraHSlider.SliderWithLabel(
+            "Faster Cast Recovery (FCR) - Magery caps at 6, Chivalry at 7",
+            out _,
+            v => { profile.SelfHeal_FCR = (int)v; ApplyFcFcr(); },
+            min: 0, max: 7, value: profile.SelfHeal_FCR));
+
+        // Recast delay ("recuperation"): pad after a successful heal before the next cast. Auto from FCR.
         root.Widgets.Add(new MyraLabel("Recast delay / recuperation (ms):", MyraLabel.TextStyle.P));
         root.Widgets.Add(MyraHSlider.SliderWithLabel(
-            "ms pad after a heal before recasting (lower = faster)",
-            out _,
+            "ms pad after a heal before recasting (auto from FCR; lower = faster)",
+            out recastSlider,
             v => profile.SelfHeal_RecastDelayMs = (int)v,
-            min: 0, max: 1000, value: profile.SelfHeal_RecastDelayMs));
+            min: 0, max: 2000, value: profile.SelfHeal_RecastDelayMs));
 
-        // Cast start grace: how long a cast may take to register before treating it as failed.
+        // Cast start grace: how long a cast may take to register before treating it as failed. Auto from FC.
         root.Widgets.Add(new MyraLabel("Cast start grace (ms):", MyraLabel.TextStyle.P));
         root.Widgets.Add(MyraHSlider.SliderWithLabel(
-            "ms to wait for a cast to register before retrying (bounds the post-interrupt stall)",
-            out _,
+            "ms to wait for a cast to register before retrying (auto from FC; bounds the post-interrupt stall)",
+            out graceSlider,
             v => profile.SelfHeal_CastStartGraceMs = (int)v,
             min: 200, max: 3000, value: profile.SelfHeal_CastStartGraceMs));
 

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/SelfHealTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/SelfHealTabContent.cs
@@ -1,0 +1,139 @@
+#nullable enable
+using System;
+using ClassicUO.Configuration;
+using ClassicUO.Game.UI.MyraWindows.Widgets;
+using ClassicUO.Input;
+using Myra.Graphics2D.UI;
+using SDL3;
+
+namespace ClassicUO.Game.UI.MyraWindows.Widgets.Assistant;
+
+public static class SelfHealTabContent
+{
+    public static Widget Build()
+    {
+        Profile profile = ProfileManager.CurrentProfile;
+
+        SDL.SDL_Keycode capturedKey = SDL.SDL_Keycode.SDLK_UNKNOWN;
+        SDL.SDL_Keymod capturedMod = SDL.SDL_Keymod.SDL_KMOD_NONE;
+        Action? unsubscribe = null;
+
+        var root = new VerticalStackPanel { Spacing = 6 };
+
+        root.Widgets.Add(new MyraLabel("Self Heal", MyraLabel.TextStyle.H2));
+        root.Widgets.Add(new MyraLabel(
+            "Hold the bound key to cast Heal on yourself (Cure when poisoned). Release to stop.",
+            MyraLabel.TextStyle.P));
+
+        root.Widgets.Add(MyraCheckButton.CreateWithCallback(
+            profile.SelfHeal_Enabled,
+            b => profile.SelfHeal_Enabled = b,
+            "Enable self heal", "Enable or disable the hold-to-heal hotkey"));
+
+        string KeyDisplay()
+        {
+            if (profile.SelfHeal_Key == 0) return "None";
+            string s = KeysTranslator.TryGetKey((SDL.SDL_Keycode)profile.SelfHeal_Key, (SDL.SDL_Keymod)profile.SelfHeal_Mod);
+            return string.IsNullOrEmpty(s) ? "None" : s;
+        }
+
+        var keyLabel = new MyraLabel("Hotkey: " + KeyDisplay(), MyraLabel.TextStyle.P);
+        root.Widgets.Add(keyLabel);
+
+        var normalPanel = new HorizontalStackPanel { Spacing = 4 };
+        var editPanel = new HorizontalStackPanel { Spacing = 4, Visible = false };
+
+        void StopListening()
+        {
+            capturedKey = SDL.SDL_Keycode.SDLK_UNKNOWN;
+            capturedMod = SDL.SDL_Keymod.SDL_KMOD_NONE;
+            unsubscribe?.Invoke();
+            unsubscribe = null;
+            normalPanel.Visible = true;
+            editPanel.Visible = false;
+            keyLabel.Text = "Hotkey: " + KeyDisplay();
+        }
+
+        normalPanel.Widgets.Add(new MyraButton("Set", () =>
+        {
+            StopListening();
+            capturedKey = SDL.SDL_Keycode.SDLK_UNKNOWN;
+            capturedMod = SDL.SDL_Keymod.SDL_KMOD_NONE;
+            normalPanel.Visible = false;
+            editPanel.Visible = true;
+            keyLabel.Text = "Press a key...";
+
+            void Handler(string hotkey)
+            {
+                (capturedKey, capturedMod) = ParseHotKeyString(hotkey);
+                keyLabel.Text = "Press a key... " + KeysTranslator.TryGetKey(capturedKey, capturedMod);
+            }
+
+            Keyboard.KeyDownEvent += Handler;
+            unsubscribe = () => Keyboard.KeyDownEvent -= Handler;
+        }));
+        normalPanel.Widgets.Add(new MyraButton("Clear", () =>
+        {
+            profile.SelfHeal_Key = 0;
+            profile.SelfHeal_Mod = 0;
+            keyLabel.Text = "Hotkey: " + KeyDisplay();
+        }));
+
+        editPanel.Widgets.Add(new MyraButton("Apply", () =>
+        {
+            if (capturedKey != SDL.SDL_Keycode.SDLK_UNKNOWN)
+            {
+                profile.SelfHeal_Key = (int)capturedKey;
+                profile.SelfHeal_Mod = (int)capturedMod;
+            }
+            StopListening();
+        }));
+        editPanel.Widgets.Add(new MyraButton("Cancel", StopListening));
+
+        root.Widgets.Add(normalPanel);
+        root.Widgets.Add(editPanel);
+
+        // Cure recheck delay: how long to wait for poison to clear before recasting Cure.
+        root.Widgets.Add(new MyraLabel("Cure recheck delay (ms):", MyraLabel.TextStyle.P));
+        root.Widgets.Add(MyraHSlider.SliderWithLabel(
+            "ms before recasting Cure if still poisoned",
+            out _,
+            v => profile.SelfHeal_CureVerifyMs = (int)v,
+            min: 100, max: 2000, value: profile.SelfHeal_CureVerifyMs));
+
+        // Interrupt retry delay: how fast to recast after a cast is disrupted (e.g. by damage).
+        root.Widgets.Add(new MyraLabel("Interrupt retry delay (ms):", MyraLabel.TextStyle.P));
+        root.Widgets.Add(MyraHSlider.SliderWithLabel(
+            "ms before recasting after a cast is interrupted",
+            out _,
+            v => profile.SelfHeal_InterruptRetryMs = (int)v,
+            min: 0, max: 1000, value: profile.SelfHeal_InterruptRetryMs));
+
+        return root;
+    }
+
+    private static (SDL.SDL_Keycode key, SDL.SDL_Keymod mod) ParseHotKeyString(string hotkey)
+    {
+        SDL.SDL_Keycode key = SDL.SDL_Keycode.SDLK_UNKNOWN;
+        SDL.SDL_Keymod mod = SDL.SDL_Keymod.SDL_KMOD_NONE;
+
+        if (string.IsNullOrEmpty(hotkey))
+            return (key, mod);
+
+        foreach (string part in hotkey.Split('+'))
+        {
+            switch (part.ToUpperInvariant())
+            {
+                case "CTRL":  mod |= SDL.SDL_Keymod.SDL_KMOD_CTRL;  break;
+                case "SHIFT": mod |= SDL.SDL_Keymod.SDL_KMOD_SHIFT; break;
+                case "ALT":   mod |= SDL.SDL_Keymod.SDL_KMOD_ALT;   break;
+                default:
+                    if (Enum.TryParse<SDL.SDL_Keycode>(part, true, out SDL.SDL_Keycode parsed))
+                        key = parsed;
+                    break;
+            }
+        }
+
+        return (key, mod);
+    }
+}

--- a/tests/ClassicUO.UnitTests/Game/Managers/SelfHealStateMachineTest.cs
+++ b/tests/ClassicUO.UnitTests/Game/Managers/SelfHealStateMachineTest.cs
@@ -14,6 +14,8 @@ namespace ClassicUO.UnitTests.Game.Managers
             public bool IsPoisoned { get; set; }
             public bool IsTargetingAfterCast { get; set; }
             public bool IsCasting { get; set; }
+            public long RecastDelayMs { get; set; } = SelfHealStateMachine.DefaultRecastDelayMs;
+            public long CastStartGraceMs { get; set; } = SelfHealStateMachine.DefaultCastStartGraceMs;
             public long CureVerifyMs { get; set; } = SelfHealStateMachine.DefaultCureVerifyMs;
             public long InterruptRetryMs { get; set; } = SelfHealStateMachine.DefaultInterruptRetryMs;
             public List<int> Casts { get; } = new();
@@ -66,26 +68,11 @@ namespace ClassicUO.UnitTests.Game.Managers
             sm.Tick(env, held: true);
             env.IsTargetingAfterCast = true;
             sm.Tick(env, held: false);
-            env.Now += SelfHealStateMachine.SettleMs + 1;
+            env.Now += env.RecastDelayMs + 1;
             sm.Tick(env, held: false);
             sm.Tick(env, held: false);
 
             env.Casts.Should().HaveCount(1);
-        }
-
-        [Fact]
-        public void Timeout_NoCursor_RetriesWhileHeld()
-        {
-            var env = new FakeEnv();
-            var sm = new SelfHealStateMachine();
-
-            sm.Tick(env, held: true);
-            env.IsTargetingAfterCast = false;
-            env.Now += SelfHealStateMachine.CastWaitMs + 1;
-            sm.Tick(env, held: true);                 // past deadline -> back to Idle (no new cast yet)
-            env.Casts.Should().HaveCount(1);
-            sm.Tick(env, held: true);                 // Idle + held -> cast #2
-            env.Casts.Should().HaveCount(2);
         }
 
         [Fact]
@@ -165,7 +152,7 @@ namespace ClassicUO.UnitTests.Game.Managers
         }
 
         [Fact]
-        public void CastInterrupted_RetriesAfterShortDelayNotFullTimeout()
+        public void CastInterrupted_AfterStarting_RetriesFast()
         {
             var env = new FakeEnv();
             var sm = new SelfHealStateMachine();
@@ -177,12 +164,31 @@ namespace ClassicUO.UnitTests.Game.Managers
             sm.Tick(env, held: true);            // detects interruption -> InterruptRetry
             env.Casts.Should().HaveCount(1);     // not recast yet
 
-            env.Now += env.InterruptRetryMs + 1; // only the short delay, well under CastWaitMs
+            env.Now += env.InterruptRetryMs + 1; // only the short retry delay
             sm.Tick(env, held: true);            // InterruptRetry -> Idle
             sm.Tick(env, held: true);            // Idle + held -> recast
 
             env.Casts.Should().HaveCount(2);
-            env.Now.Should().BeLessThan(SelfHealStateMachine.CastWaitMs); // retried fast, not after the timeout
+            env.Now.Should().BeLessThan(SelfHealStateMachine.DefaultCastStartGraceMs); // fast, not a long stall
+        }
+
+        [Fact]
+        public void CastNeverRegisters_RetriesAfterGraceNotLongStall()
+        {
+            var env = new FakeEnv();
+            var sm = new SelfHealStateMachine();
+
+            sm.Tick(env, held: true);            // cast, WaitingForCursor; IsCasting never goes true
+            sm.Tick(env, held: true);            // within grace -> keep waiting (no premature recast)
+            env.Casts.Should().HaveCount(1);
+
+            env.Now += env.CastStartGraceMs + 1; // grace elapsed with no cursor and no casting
+            sm.Tick(env, held: true);            // -> InterruptRetry
+            env.Now += env.InterruptRetryMs + 1;
+            sm.Tick(env, held: true);            // InterruptRetry -> Idle
+            sm.Tick(env, held: true);            // recast
+
+            env.Casts.Should().HaveCount(2);
         }
 
         [Fact]
@@ -192,7 +198,7 @@ namespace ClassicUO.UnitTests.Game.Managers
             var sm = new SelfHealStateMachine();
 
             sm.Tick(env, held: true);            // cast, WaitingForCursor; IsCasting still false (not registered yet)
-            sm.Tick(env, held: true);            // must NOT treat the not-yet-started cast as interrupted
+            sm.Tick(env, held: true);            // within grace, no cursor -> must NOT recast
             sm.Tick(env, held: true);
 
             env.Casts.Should().HaveCount(1);     // still waiting, no premature recast

--- a/tests/ClassicUO.UnitTests/Game/Managers/SelfHealStateMachineTest.cs
+++ b/tests/ClassicUO.UnitTests/Game/Managers/SelfHealStateMachineTest.cs
@@ -20,6 +20,7 @@ namespace ClassicUO.UnitTests.Game.Managers
             public long CastStartGraceMs { get; set; } = SelfHealStateMachine.DefaultCastStartGraceMs;
             public long CureVerifyMs { get; set; } = SelfHealStateMachine.DefaultCureVerifyMs;
             public long InterruptRetryMs { get; set; } = SelfHealStateMachine.DefaultInterruptRetryMs;
+            public long LastCastFailedAt { get; set; }
             public List<int> Casts { get; } = new();
             public int TargetSelfCount { get; private set; }
             public void Cast(int spellId) => Casts.Add(spellId);
@@ -175,6 +176,40 @@ namespace ClassicUO.UnitTests.Game.Managers
             sm.Tick(env, held: true);            // Idle + held -> recast
 
             env.Casts.Should().HaveCount(2);
+        }
+
+        [Fact]
+        public void ServerReportsCastFailed_RetriesImmediatelyNotAfterGrace()
+        {
+            // A genuine failure (concentration disturbed / out of mana, etc.) is reported by the server
+            // via a cliloc. We should retry right away rather than waiting out the full cast grace.
+            var env = new FakeEnv();
+            var sm = new SelfHealStateMachine();
+
+            sm.Tick(env, held: true);                 // cast, WaitingForCursor (castIssuedAt = 0)
+            env.Now += 50;
+            env.LastCastFailedAt = env.Now;            // server: that cast was disrupted
+            sm.Tick(env, held: true);                  // sees failure -> InterruptRetry (no grace wait)
+            env.Casts.Should().HaveCount(1);
+
+            env.Now += env.InterruptRetryMs + 1;
+            sm.Tick(env, held: true);                  // InterruptRetry -> Idle
+            sm.Tick(env, held: true);                  // recast
+            env.Casts.Should().HaveCount(2);
+            env.Now.Should().BeLessThan(SelfHealStateMachine.DefaultCastStartGraceMs); // fast, not grace-bound
+        }
+
+        [Fact]
+        public void StaleFailureBeforeThisCast_DoesNotTriggerRetry()
+        {
+            // A failure recorded BEFORE the current cast was issued must not be mistaken for this cast failing.
+            var env = new FakeEnv { LastCastFailedAt = 100 };
+            var sm = new SelfHealStateMachine();
+
+            env.Now = 500;
+            sm.Tick(env, held: true);                  // cast at Now=500 (castIssuedAt=500), stale failure=100
+            sm.Tick(env, held: true);                  // failure(100) < castIssuedAt(500) -> ignored, keep waiting
+            env.Casts.Should().HaveCount(1);           // no premature recast
         }
 
         [Fact]

--- a/tests/ClassicUO.UnitTests/Game/Managers/SelfHealStateMachineTest.cs
+++ b/tests/ClassicUO.UnitTests/Game/Managers/SelfHealStateMachineTest.cs
@@ -14,6 +14,8 @@ namespace ClassicUO.UnitTests.Game.Managers
             public bool IsPoisoned { get; set; }
             public bool IsTargetingAfterCast { get; set; }
             public bool IsCasting { get; set; }
+            public int HealSpellId { get; set; } = SelfHealStateMachine.MageryHealSpellId;
+            public int CureSpellId { get; set; } = SelfHealStateMachine.MageryCureSpellId;
             public long RecastDelayMs { get; set; } = SelfHealStateMachine.DefaultRecastDelayMs;
             public long CastStartGraceMs { get; set; } = SelfHealStateMachine.DefaultCastStartGraceMs;
             public long CureVerifyMs { get; set; } = SelfHealStateMachine.DefaultCureVerifyMs;
@@ -32,7 +34,7 @@ namespace ClassicUO.UnitTests.Game.Managers
 
             sm.Tick(env, held: true);
 
-            env.Casts.Should().ContainSingle().Which.Should().Be(SelfHealStateMachine.HealSpellId);
+            env.Casts.Should().ContainSingle().Which.Should().Be(SelfHealStateMachine.MageryHealSpellId);
         }
 
         [Fact]
@@ -43,7 +45,7 @@ namespace ClassicUO.UnitTests.Game.Managers
 
             sm.Tick(env, held: true);
 
-            env.Casts.Should().ContainSingle().Which.Should().Be(SelfHealStateMachine.CureSpellId);
+            env.Casts.Should().ContainSingle().Which.Should().Be(SelfHealStateMachine.MageryCureSpellId);
         }
 
         [Fact]
@@ -129,7 +131,7 @@ namespace ClassicUO.UnitTests.Game.Managers
             env.IsTargetingAfterCast = false;
             sm.Tick(env, held: true);            // Idle + held + not poisoned -> Heal
 
-            env.Casts.Should().Equal(SelfHealStateMachine.CureSpellId, SelfHealStateMachine.HealSpellId);
+            env.Casts.Should().Equal(SelfHealStateMachine.MageryCureSpellId, SelfHealStateMachine.MageryHealSpellId);
         }
 
         [Fact]
@@ -148,7 +150,7 @@ namespace ClassicUO.UnitTests.Game.Managers
             env.IsTargetingAfterCast = false;
             sm.Tick(env, held: true);            // Idle + held + still poisoned -> Cure again
 
-            env.Casts.Should().Equal(SelfHealStateMachine.CureSpellId, SelfHealStateMachine.CureSpellId);
+            env.Casts.Should().Equal(SelfHealStateMachine.MageryCureSpellId, SelfHealStateMachine.MageryCureSpellId);
         }
 
         [Fact]
@@ -202,6 +204,27 @@ namespace ClassicUO.UnitTests.Game.Managers
             sm.Tick(env, held: true);
 
             env.Casts.Should().HaveCount(1);     // still waiting, no premature recast
+        }
+
+        [Fact]
+        public void ChivalrySpellIds_CastCloseWoundsAndCleanseByFire()
+        {
+            var heal = new FakeEnv
+            {
+                HealSpellId = SelfHealStateMachine.ChivalryHealSpellId,
+                CureSpellId = SelfHealStateMachine.ChivalryCureSpellId,
+            };
+            new SelfHealStateMachine().Tick(heal, held: true);
+            heal.Casts.Should().ContainSingle().Which.Should().Be(SelfHealStateMachine.ChivalryHealSpellId); // Close Wounds
+
+            var cure = new FakeEnv
+            {
+                IsPoisoned = true,
+                HealSpellId = SelfHealStateMachine.ChivalryHealSpellId,
+                CureSpellId = SelfHealStateMachine.ChivalryCureSpellId,
+            };
+            new SelfHealStateMachine().Tick(cure, held: true);
+            cure.Casts.Should().ContainSingle().Which.Should().Be(SelfHealStateMachine.ChivalryCureSpellId); // Cleanse by Fire
         }
     }
 }

--- a/tests/ClassicUO.UnitTests/Game/Managers/SelfHealStateMachineTest.cs
+++ b/tests/ClassicUO.UnitTests/Game/Managers/SelfHealStateMachineTest.cs
@@ -154,7 +154,7 @@ namespace ClassicUO.UnitTests.Game.Managers
         }
 
         [Fact]
-        public void CastInterrupted_AfterStarting_RetriesFast()
+        public void CastingGoesQuietWithNoCursor_WaitsForGraceBeforeRecast()
         {
             var env = new FakeEnv();
             var sm = new SelfHealStateMachine();
@@ -162,16 +162,44 @@ namespace ClassicUO.UnitTests.Game.Managers
             sm.Tick(env, held: true);            // cast Heal, WaitingForCursor
             env.IsCasting = true;
             sm.Tick(env, held: true);            // observes cast in progress
-            env.IsCasting = false;               // damage interrupts the cast (no cursor)
-            sm.Tick(env, held: true);            // detects interruption -> InterruptRetry
-            env.Casts.Should().HaveCount(1);     // not recast yet
+            env.IsCasting = false;               // cast goes quiet, no cursor (true interrupt OR benign HP-clear)
+            sm.Tick(env, held: true);            // must NOT recast on the falling edge alone
+            env.Casts.Should().HaveCount(1);
 
-            env.Now += env.InterruptRetryMs + 1; // only the short retry delay
+            env.Now += env.CastStartGraceMs + 1; // only once the grace deadline passes with still no cursor...
+            sm.Tick(env, held: true);            // ...-> InterruptRetry
+            env.Casts.Should().HaveCount(1);     // still not recast (in the retry delay)
+
+            env.Now += env.InterruptRetryMs + 1;
             sm.Tick(env, held: true);            // InterruptRetry -> Idle
             sm.Tick(env, held: true);            // Idle + held -> recast
 
             env.Casts.Should().HaveCount(2);
-            env.Now.Should().BeLessThan(SelfHealStateMachine.DefaultCastStartGraceMs); // fast, not a long stall
+        }
+
+        [Fact]
+        public void BenignCastingFlap_CursorStillAppears_TargetsSelfWithoutRecast()
+        {
+            // Reproduces the real-world bug: UpdateHitpoints calls ClearCasting() on EVERY player HP
+            // change, so taking a hit mid-cast drops IsCasting to false even though the heal is still
+            // in flight. The loop must keep waiting for the cursor instead of cancelling and recasting.
+            var env = new FakeEnv();
+            var sm = new SelfHealStateMachine();
+
+            sm.Tick(env, held: true);            // cast Heal, WaitingForCursor
+            env.IsCasting = true;
+            sm.Tick(env, held: true);            // cast in progress
+            env.IsCasting = false;               // a hit lands -> ClearCasting() flaps IsCasting off
+            env.Now += 300;
+            sm.Tick(env, held: true);            // within grace, no cursor yet -> keep waiting
+            env.Casts.Should().HaveCount(1);     // MUST NOT recast (would cancel the in-flight heal)
+
+            env.IsTargetingAfterCast = true;     // the heal's cursor finally comes up
+            env.Now += 200;
+            sm.Tick(env, held: true);
+
+            env.TargetSelfCount.Should().Be(1);  // targeted the in-flight cast
+            env.Casts.Should().HaveCount(1);     // and never double-cast
         }
 
         [Fact]

--- a/tests/ClassicUO.UnitTests/Game/Managers/SelfHealStateMachineTest.cs
+++ b/tests/ClassicUO.UnitTests/Game/Managers/SelfHealStateMachineTest.cs
@@ -1,0 +1,201 @@
+using System.Collections.Generic;
+using ClassicUO.Game.Managers;
+using FluentAssertions;
+using Xunit;
+
+namespace ClassicUO.UnitTests.Game.Managers
+{
+    public class SelfHealStateMachineTest
+    {
+        private sealed class FakeEnv : ISelfHealEnv
+        {
+            public long Now { get; set; }
+            public bool CanAct { get; set; } = true;
+            public bool IsPoisoned { get; set; }
+            public bool IsTargetingAfterCast { get; set; }
+            public bool IsCasting { get; set; }
+            public long CureVerifyMs { get; set; } = SelfHealStateMachine.DefaultCureVerifyMs;
+            public long InterruptRetryMs { get; set; } = SelfHealStateMachine.DefaultInterruptRetryMs;
+            public List<int> Casts { get; } = new();
+            public int TargetSelfCount { get; private set; }
+            public void Cast(int spellId) => Casts.Add(spellId);
+            public void TargetSelf() => TargetSelfCount++;
+        }
+
+        [Fact]
+        public void Held_NotPoisoned_CastsHeal()
+        {
+            var env = new FakeEnv();
+            var sm = new SelfHealStateMachine();
+
+            sm.Tick(env, held: true);
+
+            env.Casts.Should().ContainSingle().Which.Should().Be(SelfHealStateMachine.HealSpellId);
+        }
+
+        [Fact]
+        public void Held_Poisoned_CastsCure()
+        {
+            var env = new FakeEnv { IsPoisoned = true };
+            var sm = new SelfHealStateMachine();
+
+            sm.Tick(env, held: true);
+
+            env.Casts.Should().ContainSingle().Which.Should().Be(SelfHealStateMachine.CureSpellId);
+        }
+
+        [Fact]
+        public void CursorUpAfterCast_TargetsSelf()
+        {
+            var env = new FakeEnv();
+            var sm = new SelfHealStateMachine();
+
+            sm.Tick(env, held: true);
+            env.IsTargetingAfterCast = true;
+            sm.Tick(env, held: true);
+
+            env.TargetSelfCount.Should().Be(1);
+        }
+
+        [Fact]
+        public void Release_StopsAfterInFlightCast()
+        {
+            var env = new FakeEnv();
+            var sm = new SelfHealStateMachine();
+
+            sm.Tick(env, held: true);
+            env.IsTargetingAfterCast = true;
+            sm.Tick(env, held: false);
+            env.Now += SelfHealStateMachine.SettleMs + 1;
+            sm.Tick(env, held: false);
+            sm.Tick(env, held: false);
+
+            env.Casts.Should().HaveCount(1);
+        }
+
+        [Fact]
+        public void Timeout_NoCursor_RetriesWhileHeld()
+        {
+            var env = new FakeEnv();
+            var sm = new SelfHealStateMachine();
+
+            sm.Tick(env, held: true);
+            env.IsTargetingAfterCast = false;
+            env.Now += SelfHealStateMachine.CastWaitMs + 1;
+            sm.Tick(env, held: true);                 // past deadline -> back to Idle (no new cast yet)
+            env.Casts.Should().HaveCount(1);
+            sm.Tick(env, held: true);                 // Idle + held -> cast #2
+            env.Casts.Should().HaveCount(2);
+        }
+
+        [Fact]
+        public void CannotAct_DoesNothing()
+        {
+            var env = new FakeEnv { CanAct = false };
+            var sm = new SelfHealStateMachine();
+
+            sm.Tick(env, held: true);
+
+            env.Casts.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void CanActFalseDuringWait_DoesNotTargetSelf()
+        {
+            var env = new FakeEnv();
+            var sm = new SelfHealStateMachine();
+
+            sm.Tick(env, held: true);            // cast, now WaitingForCursor
+            env.CanAct = false;                  // e.g. player died mid-cast
+            env.IsTargetingAfterCast = true;     // cursor would be up
+            sm.Tick(env, held: true);
+
+            env.TargetSelfCount.Should().Be(0);  // must not self-target when it can't act
+        }
+
+        [Fact]
+        public void ReleaseBeforeCursor_StillTargetsInFlightCast()
+        {
+            var env = new FakeEnv();
+            var sm = new SelfHealStateMachine();
+
+            sm.Tick(env, held: true);            // cast, WaitingForCursor
+            sm.Tick(env, held: false);           // released before cursor: still waiting
+            env.IsTargetingAfterCast = true;
+            sm.Tick(env, held: false);           // cursor up -> target self (finish in-flight)
+
+            env.TargetSelfCount.Should().Be(1);
+            env.Casts.Should().HaveCount(1);     // no new cast after release
+        }
+
+        [Fact]
+        public void Cured_WithinVerifyWindow_DoesNotRecastCure()
+        {
+            var env = new FakeEnv { IsPoisoned = true };
+            var sm = new SelfHealStateMachine();
+
+            sm.Tick(env, held: true);            // casts Cure, WaitingForCursor
+            env.IsTargetingAfterCast = true;
+            sm.Tick(env, held: true);            // target self -> VerifyingCure
+            env.IsPoisoned = false;              // cure landed
+            sm.Tick(env, held: true);            // verify sees cured -> Idle (no recast)
+            env.IsTargetingAfterCast = false;
+            sm.Tick(env, held: true);            // Idle + held + not poisoned -> Heal
+
+            env.Casts.Should().Equal(SelfHealStateMachine.CureSpellId, SelfHealStateMachine.HealSpellId);
+        }
+
+        [Fact]
+        public void StillPoisoned_AfterVerifyWindow_RecastsCure()
+        {
+            var env = new FakeEnv { IsPoisoned = true };
+            var sm = new SelfHealStateMachine();
+
+            sm.Tick(env, held: true);            // casts Cure, WaitingForCursor
+            env.IsTargetingAfterCast = true;
+            sm.Tick(env, held: true);            // target self -> VerifyingCure
+            sm.Tick(env, held: true);            // still poisoned, within window -> no recast
+            env.Casts.Should().HaveCount(1);
+            env.Now += env.CureVerifyMs + 1;
+            sm.Tick(env, held: true);            // verify window elapsed -> Idle
+            env.IsTargetingAfterCast = false;
+            sm.Tick(env, held: true);            // Idle + held + still poisoned -> Cure again
+
+            env.Casts.Should().Equal(SelfHealStateMachine.CureSpellId, SelfHealStateMachine.CureSpellId);
+        }
+
+        [Fact]
+        public void CastInterrupted_RetriesAfterShortDelayNotFullTimeout()
+        {
+            var env = new FakeEnv();
+            var sm = new SelfHealStateMachine();
+
+            sm.Tick(env, held: true);            // cast Heal, WaitingForCursor
+            env.IsCasting = true;
+            sm.Tick(env, held: true);            // observes cast in progress
+            env.IsCasting = false;               // damage interrupts the cast (no cursor)
+            sm.Tick(env, held: true);            // detects interruption -> InterruptRetry
+            env.Casts.Should().HaveCount(1);     // not recast yet
+
+            env.Now += env.InterruptRetryMs + 1; // only the short delay, well under CastWaitMs
+            sm.Tick(env, held: true);            // InterruptRetry -> Idle
+            sm.Tick(env, held: true);            // Idle + held -> recast
+
+            env.Casts.Should().HaveCount(2);
+            env.Now.Should().BeLessThan(SelfHealStateMachine.CastWaitMs); // retried fast, not after the timeout
+        }
+
+        [Fact]
+        public void CastNotYetStarted_DoesNotFalseTriggerInterrupt()
+        {
+            var env = new FakeEnv();
+            var sm = new SelfHealStateMachine();
+
+            sm.Tick(env, held: true);            // cast, WaitingForCursor; IsCasting still false (not registered yet)
+            sm.Tick(env, held: true);            // must NOT treat the not-yet-started cast as interrupted
+            sm.Tick(env, held: true);
+
+            env.Casts.Should().HaveCount(1);     // still waiting, no premature recast
+        }
+    }
+}

--- a/tests/ClassicUO.UnitTests/Game/Managers/SelfHealTimingsTest.cs
+++ b/tests/ClassicUO.UnitTests/Game/Managers/SelfHealTimingsTest.cs
@@ -66,5 +66,22 @@ namespace ClassicUO.UnitTests.Game.Managers
                 prev = recast;
             }
         }
+
+        [Fact]
+        public void CureVerifyWindow_PadsByTwicePing()
+        {
+            // 150-200ms ping: the fixed 600ms base was too short to see the poison-cleared packet,
+            // causing a redundant second cure. Padding by 2x ping widens it to land comfortably after.
+            SelfHealTimings.CureVerifyWindow(600, 0).Should().Be(600);
+            SelfHealTimings.CureVerifyWindow(600, 200).Should().Be(1000);   // 600 + 2*200
+        }
+
+        [Fact]
+        public void CureVerifyWindow_ClampsGarbagePing()
+        {
+            // A bad/huge ping reading must not blow the window up unbounded (clamped at 1000ms ping).
+            SelfHealTimings.CureVerifyWindow(600, 999999).Should().Be(600 + 2 * 1000);
+            SelfHealTimings.CureVerifyWindow(600, -50).Should().Be(600);    // negative ping ignored
+        }
     }
 }

--- a/tests/ClassicUO.UnitTests/Game/Managers/SelfHealTimingsTest.cs
+++ b/tests/ClassicUO.UnitTests/Game/Managers/SelfHealTimingsTest.cs
@@ -1,0 +1,70 @@
+using ClassicUO.Game.Managers;
+using FluentAssertions;
+using Xunit;
+
+namespace ClassicUO.UnitTests.Game.Managers
+{
+    public class SelfHealTimingsTest
+    {
+        // Magery: recovery base 6, longest cast = Cure (1.25s base).
+        [Fact]
+        public void Magery_Fcr6Fc2_NoRecovery_GraceCoversCure()
+        {
+            var (recast, grace) = SelfHealTimings.Compute(chivalry: false, fc: 2, fcr: 6);
+            recast.Should().Be(0);       // (6-6) -> 0ms recovery
+            grace.Should().Be(1150);     // max(Heal 500, Cure 750) + 400 margin
+        }
+
+        // Chivalry: recovery base 7, longest cast = Close Wounds (1.5s base).
+        [Fact]
+        public void Chivalry_Fcr6Fc2_HasRecovery_GraceCoversCloseWounds()
+        {
+            var (recast, grace) = SelfHealTimings.Compute(chivalry: true, fc: 2, fcr: 6);
+            recast.Should().Be(250);     // (7-6) x 250 = 250ms recovery
+            grace.Should().Be(1400);     // max(Close 1000, Cleanse 500) + 400
+        }
+
+        [Fact]
+        public void Chivalry_Fcr7Fc3_NoRecovery()
+        {
+            var (recast, grace) = SelfHealTimings.Compute(chivalry: true, fc: 3, fcr: 7);
+            recast.Should().Be(0);       // (7-7) -> 0
+            grace.Should().Be(1150);     // max(Close 750, Cleanse 250) + 400
+        }
+
+        [Fact]
+        public void Chivalry_Fcr7Fc4_CleanseHitsCastFloor()
+        {
+            var (recast, grace) = SelfHealTimings.Compute(chivalry: true, fc: 4, fcr: 7);
+            recast.Should().Be(0);
+            grace.Should().Be(900);      // max(Close 500, Cleanse floored 250) + 400
+        }
+
+        [Fact]
+        public void Magery_FcAboveCap_ClampsToCap()
+        {
+            // Magery FC cap is 2 - FC 4 must behave like FC 2.
+            SelfHealTimings.Compute(chivalry: false, fc: 4, fcr: 6)
+                .Should().Be(SelfHealTimings.Compute(chivalry: false, fc: 2, fcr: 6));
+        }
+
+        [Fact]
+        public void Magery_FcrAboveCap_ClampsToCap()
+        {
+            SelfHealTimings.Compute(chivalry: false, fc: 2, fcr: 7)
+                .Should().Be(SelfHealTimings.Compute(chivalry: false, fc: 2, fcr: 6));
+        }
+
+        [Fact]
+        public void HigherFcr_NeverIncreasesRecovery()
+        {
+            int prev = int.MaxValue;
+            for (int fcr = 0; fcr <= 7; fcr++)
+            {
+                int recast = SelfHealTimings.Compute(chivalry: true, fc: 2, fcr: fcr).recastDelayMs;
+                recast.Should().BeLessThanOrEqualTo(prev);
+                prev = recast;
+            }
+        }
+    }
+}


### PR DESCRIPTION
A native, UOSteam-style "mini heal" bound to a hotkey. While the key is **held** it casts a heal on self (and a cure when poisoned), auto-targeting self; **releasing** stops after the in-flight cast so you can move freely.

This is the assistive, transparent form of something players already script in Legion/Python today — kept deliberately narrow (single-target self heal/cure, human holding the key).

## Behaviour
- **Hold-to-act:** only heals while the bound key is physically held; release stops within one cast. Human-in-the-loop, not a fire-and-forget bot.
- **Magery or Chivalry:** a per-character toggle. Magery = Heal / Cure; Chivalry = Close Wounds / Cleanse by Fire.
- **Cure is verified**, not blindly re-cast: after a cure it waits for the poison to actually clear (configurable window) before re-curing.
- **Interrupt-aware:** a cast disrupted by damage is detected via `World.Player.IsCasting` and recast quickly instead of stalling for the full cast timeout.
- Real key-down (focus-gated, like macros/spell bar) / key-up input; respects `DisableHotkeys`; works regardless of Scroll Lock and the Spell Indicators setting.

## Timings
The loop's recast (recovery) and cast-start grace are **auto-computed from your FC/FCR** per spell school (Magery recovery base 6 / FC cap 2; Chivalry base 7 / FC cap 4; Close Wounds 1.5s, Cleanse 1.0s, Heal 1.0s, Cure 1.25s base casts, FC/FCR clamped to caps). The values fill editable sliders so they can still be tuned by hand.

## Config
New **"Self Heal"** tab under Assistant → **Agents** (next to Bandage): enable toggle, Magery/Chivalry toggle, hotkey capture, FC/FCR selectors, and the four timing sliders. All settings are per-character profile.

## Architecture
- `SelfHealStateMachine` — pure, dependency-free state machine behind an `ISelfHealEnv` interface (cast → wait-for-cursor → target-self → repeat, with cure-verify and interrupt-retry states).
- `SelfHealTimings` — pure FC/FCR → timings calculator.
- `SelfHealManager` — static manager wiring the live game env, key input, and per-frame `Update()`.
- **20 unit tests** (state machine + timing formulas). Full solution build: 0 errors.

## Notes for review
- Scoped to self heal/cure only — no targeting or combat automation.
- Heal/cure spell ids flow through the env, so adding Necro/Mysticism later is just more ids.
- Happy to add a **server-side opt-out** (a flag shards can use to hard-disable it) if that helps for stricter servers — just say the word.

Companion Scroll-Lock spell-bar fix already merged via #548.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a self-heal hotkey that automatically casts healing or poison-cure spells when held down
  * Added "Self Heal" settings tab to configure the hotkey binding, spell school selection (Magery/Chivalry), and timing parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->