### PR TITLE
Add Script slot type to the Spell Bar

### DIFF
--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -80,6 +80,7 @@ spellbar_rightclicktoset=Right click to set slot
 spellbar_setspell=Set spell
 spellbar_quicksetspell=Quick set spell
 spellbar_setmacro=Set macro
+spellbar_setscript=Set script
 spellbar_setability=Set ability
 spellbar_ability_primary=Primary ability
 spellbar_ability_secondary=Secondary ability

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -5,7 +5,7 @@
 ; Missing keys are auto-appended with English defaults when
 ; this file's version is newer than the user's copy.
 ; -------------------------------------------------------
-_version=21
+_version=22
 accountname=Account Name
 accountcontextmenutooltip=Right click to select another account.
 music=Music

--- a/src/ClassicUO.Client/Game/Managers/SpellBarManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/SpellBarManager.cs
@@ -7,6 +7,7 @@ using System.Text.Json.Serialization;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Input;
+using ClassicUO.LegionScripting;
 using ClassicUO.Utility.Logging;
 using SDL3;
 
@@ -296,7 +297,7 @@ public class SpellBarManager
 }
 
 /// <summary>The kind of action stored in a single spell bar slot.</summary>
-public enum SpellBarSlotType { Empty = 0, Spell = 1, Macro = 2, Ability = 3 }
+public enum SpellBarSlotType { Empty = 0, Spell = 1, Macro = 2, Ability = 3, Script = 4 }
 
 /// <summary>
 /// A single spell bar slot. Holds one of: nothing, a spell, a macro, or a weapon
@@ -313,6 +314,9 @@ public class SpellBarSlot
     /// <summary>Macro name when <see cref="Type"/> is <see cref="SpellBarSlotType.Macro"/>.</summary>
     public string MacroName { get; set; }           // Type == Macro
 
+    /// <summary>Stable relative id (ScriptFile.RelativePath) when <see cref="Type"/> is <see cref="SpellBarSlotType.Script"/>.</summary>
+    public string ScriptId { get; set; }            // Type == Script
+
     /// <summary>True for the primary ability, false for the secondary, when <see cref="Type"/> is <see cref="SpellBarSlotType.Ability"/>.</summary>
     public bool AbilityPrimary { get; set; }        // Type == Ability (true = primary, false = secondary)
 
@@ -327,6 +331,24 @@ public class SpellBarSlot
     /// <summary>The spell id for spell slots, or -1 for any other type (used to match cast events).</summary>
     [JsonIgnore]
     public int CurrentSpellID => Type == SpellBarSlotType.Spell ? SpellId : -1;
+
+    /// <summary>The loaded script this slot points at (by RelativePath), or null.</summary>
+    [JsonIgnore]
+    public ScriptFile ResolvedScript =>
+        ClassicUO.LegionScripting.LegionScripting.LoadedScripts.FirstOrDefault(f => f.RelativePath == ScriptId);
+
+    /// <summary>True when this is a script slot whose script is currently running.</summary>
+    [JsonIgnore]
+    public bool IsScriptRunning => Type == SpellBarSlotType.Script && (ResolvedScript?.IsPlaying ?? false);
+
+    /// <summary>Friendly name for a script slot: the resolved file name, else the id's basename.</summary>
+    [JsonIgnore]
+    public string ScriptDisplayName =>
+        ResolvedScript?.FileName ??
+        (string.IsNullOrEmpty(ScriptId) ? string.Empty : System.IO.Path.GetFileName(ScriptId));
+
+    /// <summary>Toggle decision for a script slot: play when not already running.</summary>
+    public static bool ShouldPlay(bool isRunning) => !isRunning;
 
     /// <summary>Creates an empty slot.</summary>
     public static SpellBarSlot Empty() => new SpellBarSlot();
@@ -347,6 +369,15 @@ public class SpellBarSlot
             return Empty();
 
         return new SpellBarSlot { Type = SpellBarSlotType.Macro, MacroName = macro.Name };
+    }
+
+    /// <summary>Creates a script slot, or an empty slot when <paramref name="script"/> is null.</summary>
+    public static SpellBarSlot FromScript(ScriptFile script)
+    {
+        if (script == null)
+            return Empty();
+
+        return new SpellBarSlot { Type = SpellBarSlotType.Script, ScriptId = script.RelativePath };
     }
 
     /// <summary>Creates an ability slot for the primary (<paramref name="primary"/> true) or secondary ability.</summary>
@@ -377,6 +408,17 @@ public class SpellBarSlot
                     GameActions.UsePrimaryAbility(world);
                 else
                     GameActions.UseSecondaryAbility(world);
+                break;
+
+            case SpellBarSlotType.Script:
+                ScriptFile script = ResolvedScript;
+                if (script != null)
+                {
+                    if (ShouldPlay(script.IsPlaying))
+                        ClassicUO.LegionScripting.LegionScripting.PlayScript(script);
+                    else
+                        ClassicUO.LegionScripting.LegionScripting.StopScript(script);
+                }
                 break;
         }
     }
@@ -435,6 +477,10 @@ public class SpellBarSlot
                     return true;
                 }
                 break;
+
+            case SpellBarSlotType.Script:
+                text = ScriptDisplayName;
+                return !string.IsNullOrEmpty(text);
         }
 
         text = string.Empty;

--- a/src/ClassicUO.Client/Game/UI/Gumps/SpellBar/SpellBar.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/SpellBar/SpellBar.cs
@@ -488,7 +488,8 @@ public class SpellBar : Gump
             foreach (ScriptFile s in ClassicUO.LegionScripting.LegionScripting.LoadedScripts)
             {
                 ScriptFile script = s;
-                parent.Add(new ContextMenuItemEntry(script.FileName, () =>
+                // RelativePath (e.g. "group/loot.py") so same-named scripts in different groups are distinguishable.
+                parent.Add(new ContextMenuItemEntry(script.RelativePath, () =>
                 {
                     SetSlot(SpellBarSlot.FromScript(script), row, col);
                 }));

--- a/src/ClassicUO.Client/Game/UI/Gumps/SpellBar/SpellBar.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/SpellBar/SpellBar.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using ClassicUO.Assets;
+using ClassicUO.LegionScripting;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.Managers;
@@ -256,6 +257,7 @@ public class SpellBar : Gump
         private TextBox hotkeyLabel;
         private TextBox macroLabel;
         private ContextMenuItemEntry macroMenu;
+        private ContextMenuItemEntry scriptMenu;
         private Microsoft.Xna.Framework.Graphics.Texture2D castingTexture = SolidColorTextureCache.GetTexture(Color.Black);
         private DateTime savedStateTime;
 
@@ -313,15 +315,20 @@ public class SpellBar : Gump
             return this;
         }
 
-        /// <summary>Shows an abbreviation (capital letters) of the macro name inside the slot for macro slots, hidden otherwise.</summary>
+        /// <summary>Shows an abbreviation (capital letters) of the macro or script name inside the slot for macro/script slots, hidden otherwise.</summary>
         private void SetMacroLabel()
         {
             if (macroLabel == null)
                 return;
 
-            if (slot != null && slot.Type == SpellBarSlotType.Macro)
+            string name =
+                slot != null && slot.Type == SpellBarSlotType.Macro ? slot.MacroName :
+                slot != null && slot.Type == SpellBarSlotType.Script ? slot.ScriptDisplayName :
+                null;
+
+            if (!string.IsNullOrEmpty(name))
             {
-                macroLabel.SetText(AbbreviateMacroName(slot.MacroName));
+                macroLabel.SetText(AbbreviateMacroName(name));
                 macroLabel.Y = (Height - macroLabel.Height) >> 1;
                 macroLabel.IsVisible = true;
             }
@@ -389,6 +396,7 @@ public class SpellBar : Gump
             if (button == MouseButtonType.Right)
             {
                 GenMacroList(macroMenu);
+                GenScriptList(scriptMenu);
                 ContextMenu?.Show();
             }
 
@@ -446,6 +454,10 @@ public class SpellBar : Gump
             }));
             ContextMenu.Add(abilityMenu);
 
+            scriptMenu = new ContextMenuItemEntry(TazLang.Get("spellbar_setscript"));
+            GenScriptList(scriptMenu);
+            ContextMenu.Add(scriptMenu);
+
             ContextMenu.Add(new ContextMenuItemEntry(TazLang.Get("spellbar_clear"), () =>
             {
                 SetSlot(SpellBarSlot.Empty(), row, col);
@@ -464,6 +476,23 @@ public class SpellBar : Gump
                 {
                     SetSlot(SpellBarSlot.FromMacro(macro), row, col);
                 }));
+        }
+
+        private void GenScriptList(ContextMenuItemEntry parent)
+        {
+            if (parent == null)
+                return;
+
+            parent.Items.Clear();
+
+            foreach (ScriptFile s in ClassicUO.LegionScripting.LegionScripting.LoadedScripts)
+            {
+                ScriptFile script = s;
+                parent.Add(new ContextMenuItemEntry(script.FileName, () =>
+                {
+                    SetSlot(SpellBarSlot.FromScript(script), row, col);
+                }));
+            }
         }
 
         private List<ContextMenuItemEntry> GenSpellList()
@@ -547,6 +576,14 @@ public class SpellBar : Gump
 
         public override bool Draw(UltimaBatcher2D batcher, int x, int y)
         {
+            if (slot != null && slot.Type == SpellBarSlotType.Script)
+            {
+                const ushort runningHue = 0x0044; // green tint while the script runs
+                ushort wanted = slot.IsScriptRunning ? runningHue : SpellBarManager.SpellBarRows[row].RowHue;
+                if (background.Hue != wanted)
+                    background.Hue = wanted;
+            }
+
             if (slot != null && slot.Type == SpellBarSlotType.Ability)
             {
                 // The active primary/secondary ability follows the equipped weapon, so keep icon/hue/tooltip in sync.

--- a/src/ClassicUO.Client/Game/UI/Gumps/SpellBar/SpellBar.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/SpellBar/SpellBar.cs
@@ -41,6 +41,8 @@ public class SpellBar : Gump
         Build();
 
         EventSink.SpellCastBegin += EventSinkOnSpellCastBegin;
+        ClassicUO.LegionScripting.LegionScripting.ScriptStarted += OnScriptStarted;
+        ClassicUO.LegionScripting.LegionScripting.ScriptStopped += OnScriptStopped;
     }
 
     private void EventSinkOnSpellCastBegin(object sender, int e)
@@ -48,6 +50,18 @@ public class SpellBar : Gump
         foreach (SpellEntry entry in spellEntries)
             if (entry.CurrentSpellID == e)
                 entry.BeginTrackingCasting();
+    }
+
+    private void OnScriptStarted(object sender, ScriptFile e) => UpdateScriptHighlights(e, true);
+    private void OnScriptStopped(object sender, ScriptFile e) => UpdateScriptHighlights(e, false);
+
+    private void UpdateScriptHighlights(ScriptFile script, bool running)
+    {
+        if (script == null)
+            return;
+
+        foreach (SpellEntry entry in spellEntries)
+            entry.SetScriptRunning(script.RelativePath, running);
     }
 
     public override GumpType GumpType { get; } = GumpType.SpellBar;
@@ -209,6 +223,8 @@ public class SpellBar : Gump
     {
         base.Dispose();
         EventSink.SpellCastBegin -= EventSinkOnSpellCastBegin;
+        ClassicUO.LegionScripting.LegionScripting.ScriptStarted -= OnScriptStarted;
+        ClassicUO.LegionScripting.LegionScripting.ScriptStopped -= OnScriptStopped;
     }
 
     public override bool Draw(UltimaBatcher2D batcher, int x, int y)
@@ -252,6 +268,7 @@ public class SpellBar : Gump
         private AlphaBlendControl background;
         private int row, col;
         private bool trackCasting;
+        private bool scriptRunning;
         private World World;
         private Gump parentGump;
         private TextBox hotkeyLabel;
@@ -285,6 +302,10 @@ public class SpellBar : Gump
 
             icon.Hue = 0; // Draw() re-applies the active highlight for ability slots
             SetMacroLabel();
+
+            // Seed the script running-highlight once at assignment (events keep it updated thereafter).
+            scriptRunning = this.slot.IsScriptRunning;
+            ApplyScriptHighlight();
 
             if (!this.slot.IsEmpty)
             {
@@ -575,16 +596,27 @@ public class SpellBar : Gump
 
         private void resetStates() => trackCasting = false;
 
+        /// <summary>
+        /// Updates this slot's running highlight when its script starts/stops. Driven by
+        /// LegionScripting's ScriptStarted/ScriptStopped events, so there is no per-frame scan.
+        /// </summary>
+        public void SetScriptRunning(string scriptId, bool running)
+        {
+            if (slot == null || slot.Type != SpellBarSlotType.Script || slot.ScriptId != scriptId)
+                return;
+
+            scriptRunning = running;
+            ApplyScriptHighlight();
+        }
+
+        private void ApplyScriptHighlight()
+        {
+            const ushort runningHue = 0x0044; // green tint while the script runs
+            background.Hue = scriptRunning ? runningHue : SpellBarManager.SpellBarRows[row].RowHue;
+        }
+
         public override bool Draw(UltimaBatcher2D batcher, int x, int y)
         {
-            if (slot != null && slot.Type == SpellBarSlotType.Script)
-            {
-                const ushort runningHue = 0x0044; // green tint while the script runs
-                ushort wanted = slot.IsScriptRunning ? runningHue : SpellBarManager.SpellBarRows[row].RowHue;
-                if (background.Hue != wanted)
-                    background.Hue = wanted;
-            }
-
             if (slot != null && slot.Type == SpellBarSlotType.Ability)
             {
                 // The active primary/secondary ability follows the equipped weapon, so keep icon/hue/tooltip in sync.

--- a/src/ClassicUO.Client/LegionScripting/ScriptFile.cs
+++ b/src/ClassicUO.Client/LegionScripting/ScriptFile.cs
@@ -48,10 +48,17 @@ public partial class ScriptFile : IDisposable
             return string.Empty;
 
         string full = fullPath.Replace('\\', '/');
-        string root = (scriptRoot ?? string.Empty).Replace('\\', '/');
+        string root = (scriptRoot ?? string.Empty).Replace('\\', '/').TrimEnd('/');
 
-        if (root.Length > 0 && full.StartsWith(root, System.StringComparison.Ordinal))
-            full = full.Substring(root.Length);
+        // Strip the root only on a path-segment boundary, so a sibling dir that merely shares
+        // the root as a string prefix (e.g. ".../LegionScripts2/...") is not stripped.
+        if (root.Length > 0)
+        {
+            if (full.Equals(root, System.StringComparison.Ordinal))
+                full = string.Empty;
+            else if (full.StartsWith(root + "/", System.StringComparison.Ordinal))
+                full = full.Substring(root.Length);
+        }
 
         return full.TrimStart('/');
     }

--- a/src/ClassicUO.Client/LegionScripting/ScriptFile.cs
+++ b/src/ClassicUO.Client/LegionScripting/ScriptFile.cs
@@ -50,9 +50,8 @@ public partial class ScriptFile : IDisposable
         string full = fullPath.Replace('\\', '/');
         string root = (scriptRoot ?? string.Empty).Replace('\\', '/');
 
-        int i = root.Length > 0 ? full.IndexOf(root, System.StringComparison.Ordinal) : -1;
-        if (i >= 0)
-            full = full.Substring(i + root.Length);
+        if (root.Length > 0 && full.StartsWith(root, System.StringComparison.Ordinal))
+            full = full.Substring(root.Length);
 
         return full.TrimStart('/');
     }

--- a/src/ClassicUO.Client/LegionScripting/ScriptFile.cs
+++ b/src/ClassicUO.Client/LegionScripting/ScriptFile.cs
@@ -33,6 +33,30 @@ public partial class ScriptFile : IDisposable
 
     public bool IsPlaying => ScriptThread != null;
 
+    /// <summary>
+    /// Stable, portable identifier: the script's path relative to the LegionScripts root,
+    /// normalized to '/'. Unique across groups/subgroups and zip entries
+    /// (zip form: "<relative-zip>::<entry>"). Used to bind scripts to UI without colliding
+    /// on bare file names.
+    /// </summary>
+    public string RelativePath => ToRelativeId(LegionScripting.ScriptPath, FullPath);
+
+    /// <summary>Computes <see cref="RelativePath"/> from a scripts root and a full path. Pure.</summary>
+    public static string ToRelativeId(string scriptRoot, string fullPath)
+    {
+        if (string.IsNullOrEmpty(fullPath))
+            return string.Empty;
+
+        string full = fullPath.Replace('\\', '/');
+        string root = (scriptRoot ?? string.Empty).Replace('\\', '/');
+
+        int i = root.Length > 0 ? full.IndexOf(root, System.StringComparison.Ordinal) : -1;
+        if (i >= 0)
+            full = full.Substring(i + root.Length);
+
+        return full.TrimStart('/');
+    }
+
     public enum ScriptType
     {
         Python,

--- a/tests/ClassicUO.UnitTests/Game/LegionScript/ScriptFileRelativePathTest.cs
+++ b/tests/ClassicUO.UnitTests/Game/LegionScript/ScriptFileRelativePathTest.cs
@@ -1,0 +1,46 @@
+using ClassicUO.LegionScripting;
+using FluentAssertions;
+using Xunit;
+
+namespace ClassicUO.UnitTests.Game.LegionScript
+{
+    public class ScriptFileRelativePathTest
+    {
+        private const string Root = "C:/uo/LegionScripts";
+
+        [Fact]
+        public void StripsRoot_ForNormalFile()
+        {
+            ScriptFile.ToRelativeId(Root, "C:/uo/LegionScripts/group/sub/loot.py")
+                .Should().Be("group/sub/loot.py");
+        }
+
+        [Fact]
+        public void NormalizesBackslashes()
+        {
+            ScriptFile.ToRelativeId(@"C:\uo\LegionScripts", @"C:\uo\LegionScripts\group\loot.py")
+                .Should().Be("group/loot.py");
+        }
+
+        [Fact]
+        public void KeepsZipEntryForm()
+        {
+            ScriptFile.ToRelativeId(Root, "C:/uo/LegionScripts/pack.zip::entry/x.py")
+                .Should().Be("pack.zip::entry/x.py");
+        }
+
+        [Fact]
+        public void SameNameDifferentGroups_AreDistinct()
+        {
+            string a = ScriptFile.ToRelativeId(Root, "C:/uo/LegionScripts/groupA/loot.py");
+            string b = ScriptFile.ToRelativeId(Root, "C:/uo/LegionScripts/groupB/loot.py");
+            a.Should().NotBe(b);
+        }
+
+        [Fact]
+        public void EmptyFullPath_ReturnsEmpty()
+        {
+            ScriptFile.ToRelativeId(Root, "").Should().BeEmpty();
+        }
+    }
+}

--- a/tests/ClassicUO.UnitTests/Game/LegionScript/ScriptFileRelativePathTest.cs
+++ b/tests/ClassicUO.UnitTests/Game/LegionScript/ScriptFileRelativePathTest.cs
@@ -42,5 +42,13 @@ namespace ClassicUO.UnitTests.Game.LegionScript
         {
             ScriptFile.ToRelativeId(Root, "").Should().BeEmpty();
         }
+
+        [Fact]
+        public void RootMatchedAsPrefixOnly_NotMidPath()
+        {
+            // The root appears mid-path, not as a prefix, so nothing should be stripped.
+            ScriptFile.ToRelativeId(Root, "D:/elsewhere/C:/uo/LegionScripts/x.py")
+                .Should().Be("D:/elsewhere/C:/uo/LegionScripts/x.py");
+        }
     }
 }

--- a/tests/ClassicUO.UnitTests/Game/LegionScript/ScriptFileRelativePathTest.cs
+++ b/tests/ClassicUO.UnitTests/Game/LegionScript/ScriptFileRelativePathTest.cs
@@ -50,5 +50,14 @@ namespace ClassicUO.UnitTests.Game.LegionScript
             ScriptFile.ToRelativeId(Root, "D:/elsewhere/C:/uo/LegionScripts/x.py")
                 .Should().Be("D:/elsewhere/C:/uo/LegionScripts/x.py");
         }
+
+        [Fact]
+        public void SiblingDirSharingRootPrefix_NotStripped()
+        {
+            // A sibling dir whose name merely shares the root as a string prefix
+            // (LegionScripts2) must NOT be stripped — only a real path-segment boundary counts.
+            ScriptFile.ToRelativeId(Root, "C:/uo/LegionScripts2/loot.py")
+                .Should().Be("C:/uo/LegionScripts2/loot.py");
+        }
     }
 }

--- a/tests/ClassicUO.UnitTests/Game/Managers/SpellBarScriptSlotTest.cs
+++ b/tests/ClassicUO.UnitTests/Game/Managers/SpellBarScriptSlotTest.cs
@@ -1,0 +1,33 @@
+using ClassicUO.Game.Managers;
+using FluentAssertions;
+using Xunit;
+
+namespace ClassicUO.UnitTests.Game.Managers
+{
+    public class SpellBarScriptSlotTest
+    {
+        [Fact]
+        public void ShouldPlay_WhenNotRunning_True()
+        {
+            SpellBarSlot.ShouldPlay(isRunning: false).Should().BeTrue();
+        }
+
+        [Fact]
+        public void ShouldPlay_WhenRunning_False()
+        {
+            SpellBarSlot.ShouldPlay(isRunning: true).Should().BeFalse();
+        }
+
+        [Fact]
+        public void FromScript_Null_ReturnsEmpty()
+        {
+            SpellBarSlot.FromScript(null).IsEmpty.Should().BeTrue();
+        }
+
+        [Fact]
+        public void ScriptSlotType_HasValue4()
+        {
+            ((int)SpellBarSlotType.Script).Should().Be(4);
+        }
+    }
+}


### PR DESCRIPTION
## Description

Adds a native **Script** slot type to the Spell Bar — bind a Legion (Python) script to a slot/hotkey and toggle it. Extends the existing `SpellBarSlot` types (Spell / Macro / Ability) with `Script`.

- Right-click a slot → **Set script** lists your loaded Legion scripts.
- Click the slot (or its hotkey) **toggles** the script: runs it if stopped, stops it if running.
- The slot shows the script's name and a **green highlight while it's running**.
- Scripts are matched by a **stable relative path** (group/sub/file, including zip entries), so two same-named scripts in different groups don't collide, and bindings persist across relog/reinstall.

Previously a script had to be wrapped in a `togglelscript` ClientCommand macro and bound via *Set macro*; this removes that indirection.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing
- [x] Built the client successfully
- [x] In game smoke tests
- Unit tests: 10 added and passing (`ScriptFileRelativePathTest`, `SpellBarScriptSlotTest`).

## Screenshots (if applicable)
Screenshots are available on Discord.

## Additional Notes
- Extends the recently-added `SpellBarSlotType` (Spell/Macro/Ability) with `Script = 4`, mirroring the Macro slot (`FromScript`, `Activate` toggle, tooltip, label, running highlight).
- Identity uses a new `ScriptFile.RelativePath`; the existing `playlscript`/`togglelscript` commands keep their filename matching (unchanged — out of scope).
- Pairs with the spell-bar macro/ability work already on dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Script slots can now be added to the spell bar for quick script execution and management.
  * Context menu option added to configure scripts on spell bar slots.
  * Active scripts are visually distinguished from inactive ones in the spell bar.
  * Script display names shown on spell bar labels.

* **Tests**
  * Added unit tests for script slot functionality and identifier generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->