### PR TITLE
Add Textures tab to Tinkerer window

### DIFF
--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -204,6 +204,7 @@ tinkerer_tab_clilocs=Clilocs
 tinkerer_tab_hues=Hues
 tinkerer_tab_art=Art
 tinkerer_tab_land=Land
+tinkerer_tab_textures=Textures
 tinkerer_tab_gumps=Gumps
 
 ; Tinkerer - Art browser tab
@@ -262,6 +263,29 @@ tinkerer_land_next=Next >
 tinkerer_land_page=Page {0} of {1}
 tinkerer_land_tooltip_named={0} ({1}) — {2}
 tinkerer_land_tooltip={0} ({1})
+
+; Tinkerer - Texture browser tab
+tinkerer_texture_nodata=Texture data not available
+tinkerer_texture_selectprompt=Select a texture to view details.
+tinkerer_texture_noart=(No texture at this id)
+tinkerer_texture_zoomout=-
+tinkerer_texture_zoomin=+
+tinkerer_texture_zoomlevel={0}px
+tinkerer_texture_reset=Reset
+tinkerer_texture_texid=Texture ID: {0} ({1})
+tinkerer_texture_dimensions=Dimensions: {0} x {1}
+tinkerer_texture_dimensions_noart=Dimensions: No texture
+tinkerer_texture_unnamed=(unnamed)
+tinkerer_texture_usedby=Used by land: {0} ({1}) — {2}
+tinkerer_texture_usedby_none=Used by land: (none)
+tinkerer_texture_copyid=Copy ID
+tinkerer_texture_goto=Go to:
+tinkerer_texture_jumphint=Texture # or 0x..
+tinkerer_texture_jump=Jump
+tinkerer_texture_prev=< Prev
+tinkerer_texture_next=Next >
+tinkerer_texture_page=Page {0} of {1}
+tinkerer_texture_tooltip={0} ({1})
 
 ; Tinkerer - Gump browser tab
 tinkerer_gump_nodata=Gump data not available

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -5,7 +5,7 @@
 ; Missing keys are auto-appended with English defaults when
 ; this file's version is newer than the user's copy.
 ; -------------------------------------------------------
-_version=20
+_version=21
 accountname=Account Name
 accountcontextmenutooltip=Right click to select another account.
 music=Music

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Tinkerer/TextureBrowserTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Tinkerer/TextureBrowserTabContent.cs
@@ -1,0 +1,308 @@
+#nullable enable
+using System;
+using ClassicUO.Assets;
+using ClassicUO.Configuration;
+using ClassicUO.Renderer;
+using ClassicUO.Utility;
+using Microsoft.Xna.Framework;
+using Myra.Graphics2D;
+using Myra.Graphics2D.Brushes;
+using Myra.Graphics2D.UI;
+using SDL3;
+
+namespace ClassicUO.Game.UI.MyraWindows.Widgets.Assistant.Tinkerer;
+
+/// <summary>
+/// Tinkerer tab for browsing texmaps (the stretched land textures referenced by
+/// land tiles via their TexID). A paged square grid of textures on the left;
+/// clicking a cell shows an enlarged preview with zoom controls and metadata on
+/// the right, including which land graphics reference the texture.
+/// </summary>
+public static class TextureBrowserTabContent
+{
+    private const int COLS = 8;
+    private const int ROWS = 8;
+    private const int PAGE_SIZE = COLS * ROWS;
+    private const int CELL = 44;
+
+    private const int ZOOM_MIN = 32;
+    private const int ZOOM_MAX = 512;
+    private const int ZOOM_STEP = 32;
+    private const int ZOOM_DEFAULT = 128;
+
+    private static readonly SolidBrush SelectedBorder = new SolidBrush(Color.Gold);
+
+    public static Widget Build()
+    {
+        if (Client.Game?.UO?.Texmaps == null)
+            return new MyraLabel(TazLang.Get("tinkerer_texture_nodata", "Texture data not available"), MyraLabel.TextStyle.P);
+
+        // Texmaps are indexed by texture id; cap to the available texmap range.
+        int maxGraphic = TexmapsLoader.MAX_LAND_TEXTURES_DATA_INDEX_COUNT;
+        var entries = Client.Game.UO.FileManager?.Texmaps?.File?.Entries;
+        if (entries != null && entries.Length < maxGraphic)
+            maxGraphic = entries.Length;
+
+        int totalPages = Math.Max(1, (maxGraphic + PAGE_SIZE - 1) / PAGE_SIZE);
+
+        int currentPage = 0;
+        int selectedGraphic = -1;
+        int zoomSize = ZOOM_DEFAULT;
+
+        // --- Left (grid) column -------------------------------------------------
+        var gridPanel = new VerticalStackPanel { Spacing = 1 };
+        var pageLabel = new MyraLabel("", MyraLabel.TextStyle.P);
+        MyraButton prevBtn = null!;
+        MyraButton nextBtn = null!;
+
+        // --- Right (detail) column ---------------------------------------------
+        var detailPanel = new VerticalStackPanel { Spacing = 4, Width = 280 };
+
+        void BuildDetail()
+        {
+            detailPanel.Widgets.Clear();
+
+            if (selectedGraphic < 0)
+            {
+                detailPanel.Widgets.Add(new MyraLabel(
+                    TazLang.Get("tinkerer_texture_selectprompt", "Select a texture to view details."),
+                    MyraLabel.TextStyle.P));
+                return;
+            }
+
+            uint id = (uint)selectedGraphic;
+            ref readonly SpriteInfo tex = ref Client.Game.UO.Texmaps.GetTexmap(id);
+            bool hasArt = tex.Texture != null;
+
+            // Preview, scaled to the requested zoom while preserving aspect ratio.
+            if (hasArt)
+            {
+                var preview = new MyraTexmapTexture(id, zoomSize);
+                int natW = tex.UV.Width;
+                int natH = tex.UV.Height;
+                if (natW > 0 && natH > 0)
+                {
+                    float scale = (float)zoomSize / Math.Max(natW, natH);
+                    preview.Width = Math.Max(1, (int)Math.Round(natW * scale));
+                    preview.Height = Math.Max(1, (int)Math.Round(natH * scale));
+                    preview.MaxWidth = preview.Width;
+                    preview.MaxHeight = preview.Height;
+                }
+                detailPanel.Widgets.Add(new Panel
+                {
+                    Width = ZOOM_MAX,
+                    Height = zoomSize,
+                    Widgets = { Configure(preview) }
+                });
+            }
+            else
+            {
+                detailPanel.Widgets.Add(new MyraLabel(TazLang.Get("tinkerer_texture_noart", "(No texture at this id)"), MyraLabel.TextStyle.P));
+            }
+
+            // Zoom controls
+            var zoomRow = new HorizontalStackPanel { Spacing = 4, VerticalAlignment = VerticalAlignment.Center };
+            zoomRow.Widgets.Add(new MyraButton(TazLang.Get("tinkerer_texture_zoomout", "-"), () =>
+            {
+                zoomSize = Math.Max(ZOOM_MIN, zoomSize - ZOOM_STEP);
+                BuildDetail();
+            }));
+            zoomRow.Widgets.Add(new MyraLabel(TazLang.Get("tinkerer_texture_zoomlevel", new[] { zoomSize.ToString() }), MyraLabel.TextStyle.P));
+            zoomRow.Widgets.Add(new MyraButton(TazLang.Get("tinkerer_texture_zoomin", "+"), () =>
+            {
+                zoomSize = Math.Min(ZOOM_MAX, zoomSize + ZOOM_STEP);
+                BuildDetail();
+            }));
+            zoomRow.Widgets.Add(new MyraButton(TazLang.Get("tinkerer_texture_reset", "Reset"), () =>
+            {
+                zoomSize = ZOOM_DEFAULT;
+                BuildDetail();
+            }));
+            detailPanel.Widgets.Add(zoomRow);
+
+            // Info
+            detailPanel.Widgets.Add(new MyraLabel(
+                TazLang.Get("tinkerer_texture_texid", new[] { id.ToString(), $"0x{id:X4}" }), MyraLabel.TextStyle.P));
+            detailPanel.Widgets.Add(new MyraLabel(
+                hasArt
+                    ? TazLang.Get("tinkerer_texture_dimensions", new[] { tex.UV.Width.ToString(), tex.UV.Height.ToString() })
+                    : TazLang.Get("tinkerer_texture_dimensions_noart", "Dimensions: No texture"),
+                MyraLabel.TextStyle.P));
+
+            // Land tiles referencing this texture, if any.
+            int landGraphic = FindLandUsingTexture(id);
+            if (landGraphic >= 0)
+            {
+                var ld = Client.Game.UO.FileManager?.TileData?.LandData;
+                string name = ld != null && landGraphic < ld.Length && !string.IsNullOrEmpty(ld[landGraphic].Name)
+                    ? ld[landGraphic].Name
+                    : TazLang.Get("tinkerer_texture_unnamed", "(unnamed)");
+                detailPanel.Widgets.Add(new MyraLabel(
+                    TazLang.Get("tinkerer_texture_usedby", new[] { landGraphic.ToString(), $"0x{landGraphic:X4}", name }),
+                    MyraLabel.TextStyle.P));
+            }
+            else
+            {
+                detailPanel.Widgets.Add(new MyraLabel(
+                    TazLang.Get("tinkerer_texture_usedby_none", "Used by land: (none)"), MyraLabel.TextStyle.P));
+            }
+
+            detailPanel.Widgets.Add(new MyraButton(TazLang.Get("tinkerer_texture_copyid", "Copy ID"), () => SDL.SDL_SetClipboardText(id.ToString())));
+        }
+
+        void BuildPage()
+        {
+            if (currentPage < 0) currentPage = 0;
+            if (currentPage >= totalPages) currentPage = totalPages - 1;
+
+            gridPanel.Widgets.Clear();
+            pageLabel.Text = TazLang.Get("tinkerer_texture_page", new[] { (currentPage + 1).ToString(), totalPages.ToString() });
+            prevBtn.Enabled = currentPage > 0;
+            nextBtn.Enabled = currentPage < totalPages - 1;
+
+            int start = currentPage * PAGE_SIZE;
+
+            for (int r = 0; r < ROWS; r++)
+            {
+                var rowPanel = new HorizontalStackPanel { Spacing = 1 };
+                for (int c = 0; c < COLS; c++)
+                {
+                    int id = start + r * COLS + c;
+                    if (id >= maxGraphic)
+                    {
+                        rowPanel.Widgets.Add(new Panel { Width = CELL, Height = CELL });
+                        continue;
+                    }
+
+                    rowPanel.Widgets.Add(BuildCell(id, selectedGraphic, gfx =>
+                    {
+                        selectedGraphic = gfx;
+                        BuildPage();
+                        BuildDetail();
+                    }));
+                }
+                gridPanel.Widgets.Add(rowPanel);
+            }
+        }
+
+        void JumpTo(int id)
+        {
+            if (id < 0 || id >= maxGraphic) return;
+            selectedGraphic = id;
+            currentPage = id / PAGE_SIZE;
+            BuildPage();
+            BuildDetail();
+        }
+
+        var leftColumn = new VerticalStackPanel { Spacing = 4 };
+
+        // Jump-to-texture row
+        var jumpRow = new HorizontalStackPanel { Spacing = 4, VerticalAlignment = VerticalAlignment.Center };
+        var jumpBox = new MyraInputBox
+        {
+            HintText = TazLang.Get("tinkerer_texture_jumphint", "Texture # or 0x.."),
+            Width = 120,
+            InputFilter = MyraInputBox.HueInputFilter
+        };
+        void DoJump()
+        {
+            if (TryParseGraphic(jumpBox.Text, out int gfx))
+                JumpTo(gfx);
+        }
+        jumpBox.TextChangedByUser += (_, _) => DoJump();
+        jumpRow.Widgets.Add(new MyraLabel(TazLang.Get("tinkerer_texture_goto", "Go to:"), MyraLabel.TextStyle.P));
+        jumpRow.Widgets.Add(jumpBox);
+        jumpRow.Widgets.Add(new MyraButton(TazLang.Get("tinkerer_texture_jump", "Jump"), DoJump));
+        leftColumn.Widgets.Add(jumpRow);
+
+        // Pagination controls
+        prevBtn = new MyraButton(TazLang.Get("tinkerer_texture_prev", "< Prev"), () => { currentPage--; BuildPage(); }) { Enabled = false };
+        nextBtn = new MyraButton(TazLang.Get("tinkerer_texture_next", "Next >"), () => { currentPage++; BuildPage(); }) { Enabled = false };
+        var pageRow = new HorizontalStackPanel { Spacing = 6, VerticalAlignment = VerticalAlignment.Center };
+        pageRow.Widgets.Add(prevBtn);
+        pageRow.Widgets.Add(pageLabel);
+        pageRow.Widgets.Add(nextBtn);
+        leftColumn.Widgets.Add(pageRow);
+
+        leftColumn.Widgets.Add(new ScrollViewer { MaxHeight = 450, Content = gridPanel });
+
+        var root = new HorizontalStackPanel { Spacing = 12 };
+        root.Widgets.Add(leftColumn);
+        root.Widgets.Add(detailPanel);
+
+        BuildPage();
+        BuildDetail();
+        return root;
+    }
+
+    private static Widget BuildCell(int id, int selectedGraphic, Action<int> onSelect)
+    {
+        var cell = new Panel
+        {
+            Width = CELL,
+            Height = CELL,
+            BorderThickness = new Thickness(1),
+            Tooltip = BuildCellTooltip(id)
+        };
+
+        if (id == selectedGraphic)
+            cell.Border = SelectedBorder;
+
+        var art = new MyraTexmapTexture((uint)id, CELL - 4)
+        {
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center
+        };
+        cell.Widgets.Add(art);
+
+        cell.TouchDown += (_, _) => onSelect(id);
+        return cell;
+    }
+
+    private static string BuildCellTooltip(int id)
+    {
+        return TazLang.Get("tinkerer_texture_tooltip", new[] { id.ToString(), $"0x{id:X4}" });
+    }
+
+    /// <summary>
+    /// Returns the first land graphic whose TexID matches the given texture id,
+    /// or -1 if none reference it.
+    /// </summary>
+    private static int FindLandUsingTexture(uint texId)
+    {
+        var ld = Client.Game.UO.FileManager?.TileData?.LandData;
+        if (ld == null)
+            return -1;
+
+        for (int i = 0; i < ld.Length; i++)
+        {
+            if (ld[i].TexID == texId)
+                return i;
+        }
+
+        return -1;
+    }
+
+    private static bool TryParseGraphic(string? text, out int graphic)
+    {
+        graphic = 0;
+        if (string.IsNullOrWhiteSpace(text))
+            return false;
+
+        text = text.Trim();
+        if (text.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+        {
+            return int.TryParse(text.AsSpan(2), System.Globalization.NumberStyles.HexNumber,
+                System.Globalization.CultureInfo.InvariantCulture, out graphic);
+        }
+
+        return StringHelper.TryParseInt(text, out graphic);
+    }
+
+    private static Widget Configure(Widget w)
+    {
+        w.HorizontalAlignment = HorizontalAlignment.Center;
+        w.VerticalAlignment = VerticalAlignment.Center;
+        return w;
+    }
+}

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Tinkerer/TinkererTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Tinkerer/TinkererTab.cs
@@ -12,6 +12,7 @@ public static class TinkererTab
         tabs.AddTab(TazLang.Get("tinkerer_tab_hues", "Hues"), HueViewTabContent.Build);
         tabs.AddTab(TazLang.Get("tinkerer_tab_art", "Art"), ArtBrowserTabContent.Build);
         tabs.AddTab(TazLang.Get("tinkerer_tab_land", "Land"), LandBrowserTabContent.Build);
+        tabs.AddTab(TazLang.Get("tinkerer_tab_textures", "Textures"), TextureBrowserTabContent.Build);
         tabs.AddTab(TazLang.Get("tinkerer_tab_gumps", "Gumps"), GumpBrowserTabContent.Build);
         tabs.SelectFirst();
         return tabs;

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/MyraTexmapTexture.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/MyraTexmapTexture.cs
@@ -1,0 +1,32 @@
+#nullable enable
+using ClassicUO.Renderer;
+using Myra.Graphics2D.TextureAtlases;
+using Myra.Graphics2D.UI;
+
+namespace ClassicUO.Game.UI.MyraWindows.Widgets;
+
+/// <summary>
+/// A Myra Image widget that displays a UO texmap (the stretched land texture)
+/// by texture ID. Uses the correct UV sub-rectangle from the texture atlas so
+/// that only the target sprite is rendered. The atlas Texture2D is NOT owned
+/// here and must never be disposed — Myra's Image widget does not implement
+/// IDisposable, so there is no disposal risk.
+/// </summary>
+public class MyraTexmapTexture : Image
+{
+    public MyraTexmapTexture(uint texId, int maxSize = 36)
+    {
+        SpriteInfo texInfo = Client.Game.UO.Texmaps.GetTexmap(texId);
+
+        if (texInfo.Texture != null)
+        {
+            // texInfo.UV is the sub-rectangle within the shared atlas texture.
+            // Passing just the Texture2D would render the entire atlas page;
+            // supplying texInfo.UV scopes it to only this sprite.
+            Renderable = new TextureRegion(texInfo.Texture, texInfo.UV);
+        }
+
+        MaxWidth = maxSize;
+        MaxHeight = maxSize;
+    }
+}


### PR DESCRIPTION
Add a Textures tab that browses texmaps (the stretched land textures referenced by land tiles via their TexID), mirroring the existing Land tab. Includes a paged grid, zoom controls, jump-to-id, and a detail panel that shows the texture id, dimensions, and which land graphic references the texture.