### PR TITLE
Add Peak(ms) column to ProfilerWindow, improve copy output

### DIFF
--- a/src/ClassicUO.Client/Game/UI/MyraWindows/ProfilerWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/ProfilerWindow.cs
@@ -85,23 +85,27 @@ namespace ClassicUO.Game.UI.MyraWindows
             if (data.Count == 0)
             {
                 Clipboard.SetClipboardText("No profiler data available.");
+                GameActions.Print("Copied to clipboard!", Constants.HUE_SUCCESS);
                 return;
             }
 
             double totalAvg = data.Sum(pd => pd.AverageTime);
             var sb = new StringBuilder();
             sb.AppendLine("TazUO Profiler Output");
-            sb.AppendLine($"{"Context",-30}  {"Avg(ms)",7}  {"Last(ms)",8}  {"% Total",7}");
-            sb.AppendLine(new string('-', 60));
+            sb.AppendLine($"{"Context",-40}  {"Avg(ms)",7}  {"Peak(ms)",8}  {"Last(ms)",8}  {"% Total",7}");
+            sb.AppendLine(new string('-', 76));
 
             foreach (Profiler.ProfileData pd in data)
             {
                 string name = string.Join(" > ", pd.Context);
+                if (name.Length > 40)
+                    name = name.Substring(name.Length - 40);
                 double pct = totalAvg > 0 ? 100.0 * pd.AverageTime / totalAvg : 0.0;
-                sb.AppendLine($"{name,-30}  {pd.AverageTime,7:F2}  {pd.LastTime,8:F2}  {pct,6:F1}%");
+                sb.AppendLine($"{name,-40}  {pd.AverageTime,7:F2}  {pd.PeakTime,8:F2}  {pd.LastTime,8:F2}  {pct,6:F1}%");
             }
 
             Clipboard.SetClipboardText(sb.ToString());
+            GameActions.Print("Copied to clipboard!", Constants.HUE_SUCCESS);
         }
 
         public override void Update()
@@ -141,6 +145,7 @@ namespace ClassicUO.Game.UI.MyraWindows
             grid.SetupWithHeaders(
                 GridColumnInfo.Fill("Context"),
                 GridColumnInfo.Numeric("Avg(ms)"),
+                GridColumnInfo.Numeric("Peak(ms)"),
                 GridColumnInfo.Numeric("Last(ms)"),
                 GridColumnInfo.Numeric("% Total")
             );
@@ -162,13 +167,17 @@ namespace ClassicUO.Game.UI.MyraWindows
                 if (isSlow) avgLabel.TextColor = Color.OrangeRed;
                 grid.AddWidget(avgLabel, row, 1);
 
+                var peakLabel = new MyraLabel($"{pd.PeakTime:F2}", MyraLabel.TextStyle.P) { HorizontalAlignment = HorizontalAlignment.Right };
+                if (isSlow) peakLabel.TextColor = Color.OrangeRed;
+                grid.AddWidget(peakLabel, row, 2);
+
                 var lastLabel = new MyraLabel($"{pd.LastTime:F2}", MyraLabel.TextStyle.P) { HorizontalAlignment = HorizontalAlignment.Right };
                 if (isSlow) lastLabel.TextColor = Color.OrangeRed;
-                grid.AddWidget(lastLabel, row, 2);
+                grid.AddWidget(lastLabel, row, 3);
 
                 var pctLabel = new MyraLabel($"{pct:F1}%", MyraLabel.TextStyle.P) { HorizontalAlignment = HorizontalAlignment.Right };
                 if (isSlow) pctLabel.TextColor = Color.OrangeRed;
-                grid.AddWidget(pctLabel, row, 3);
+                grid.AddWidget(pctLabel, row, 4);
 
                 row++;
             }

--- a/src/ClassicUO.Utility/Profiler.cs
+++ b/src/ClassicUO.Utility/Profiler.cs
@@ -169,6 +169,7 @@ namespace ClassicUO.Utility
             public static ProfileData Empty = new ProfileData(null, 0d);
             private uint m_LastIndex;
             private readonly double[] m_LastTimes = new double[ProfileTimeCount];
+            private double m_PeakTime;
 
             public ProfileData(string[] context, double time)
             {
@@ -178,6 +179,7 @@ namespace ClassicUO.Utility
             }
 
             public double LastTime => m_LastTimes[m_LastIndex % ProfileTimeCount];
+            public double PeakTime => m_PeakTime;
 
             public double TimeInContext
             {
@@ -232,6 +234,8 @@ namespace ClassicUO.Utility
 
                 m_LastTimes[m_LastIndex % ProfileTimeCount] = time;
                 m_LastIndex++;
+                if (time > m_PeakTime)
+                    m_PeakTime = time;
             }
 
             public override string ToString()


### PR DESCRIPTION
- Track peak (max) time in ProfileData via new PeakTime property
- Display Peak(ms) column in the profiler grid between Avg and Last
- Clipboard output: add Peak column, trim context names to last 40 chars, show "Copied to clipboard!" system message