### PR TITLE
Optimize DrawWorld: texture-batch opaque draws, cut redundant per-fra…

### DIFF
--- a/src/ClassicUO.Client/Game/GameObjects/GameObject.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/GameObject.cs
@@ -80,6 +80,19 @@ namespace ClassicUO.Game.GameObjects
 
         public abstract bool CheckMouseSelection();
 
+        // Per-frame render caches (set during render-list build in GameSceneDrawingSorting).
+        // RenderSortKey groups opaque sprites by their atlas texture so the batcher can draw
+        // same-texture sprites together; the hardware depth buffer keeps layering correct
+        // regardless of submission order. CachedDepthZ avoids recomputing CalculateDepthZ().
+        public int RenderSortKey;
+        public float CachedDepthZ;
+
+        /// <summary>
+        /// Returns a cheap, stable key identifying the primary atlas texture this object draws
+        /// from, used to group same-texture opaque sprites in the render lists. Default 0.
+        /// </summary>
+        public virtual int GetRenderTextureKey() => 0;
+
         // FIXME: remove it
         public sbyte FoliageIndex = -1;
         public ushort OriginalGraphic => originalGraphic == 0 ? Graphic : originalGraphic;

--- a/src/ClassicUO.Client/Game/GameObjects/Views/ItemView.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Views/ItemView.cs
@@ -20,6 +20,8 @@ namespace ClassicUO.Game.GameObjects
     {
         private static EquipConvData? _equipConvData;
 
+        public override int GetRenderTextureKey() => ArtTextureKey(DisplayedGraphic);
+
         public override bool Draw(UltimaBatcher2D batcher, int posX, int posY, float depth)
         {
             if (IsDestroyed)

--- a/src/ClassicUO.Client/Game/GameObjects/Views/LandView.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Views/LandView.cs
@@ -4,6 +4,7 @@ using ClassicUO.Renderer;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
+using System.Runtime.CompilerServices;
 using ClassicUO.Game.Managers.SpellVisualRange;
 
 namespace ClassicUO.Game.GameObjects
@@ -16,6 +17,20 @@ namespace ClassicUO.Game.GameObjects
         private static float _cachedWaterSin;
         private static float _cachedWaterCos;
         private static uint _lastWaterAnimTicks;
+
+        public override int GetRenderTextureKey()
+        {
+            if (IsStretched)
+            {
+                ref readonly SpriteInfo texmap = ref Client.Game.UO.Texmaps.GetTexmap(
+                    Client.Game.UO.FileManager.TileData.LandData[Graphic].TexID
+                );
+                return texmap.Texture == null ? 0 : RuntimeHelpers.GetHashCode(texmap.Texture);
+            }
+
+            ref readonly SpriteInfo land = ref Client.Game.UO.Arts.GetLand(Graphic);
+            return land.Texture == null ? 0 : RuntimeHelpers.GetHashCode(land.Texture);
+        }
 
         public override bool Draw(UltimaBatcher2D batcher, int posX, int posY, float depth)
         {

--- a/src/ClassicUO.Client/Game/GameObjects/Views/MobileView.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Views/MobileView.cs
@@ -21,6 +21,12 @@ namespace ClassicUO.Game.GameObjects
         private int _startCharacterWaistY;
         private int _startCharacterKneesY;
 
+        // Mobiles draw many sub-sprites (body + mount + up to ~14 equipment layers) spread
+        // across several animation atlas pages, so a single representative texture key isn't
+        // meaningful. Use a fixed key so all mobiles cluster together in the animations list,
+        // separated from ground items (which carry their real art-atlas keys).
+        public override int GetRenderTextureKey() => int.MinValue;
+
         public override bool Draw(UltimaBatcher2D batcher, int posX, int posY, float depth)
         {
             if (IsDestroyed || !AllowedToDraw || !IsVisible)

--- a/src/ClassicUO.Client/Game/GameObjects/Views/MultiView.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Views/MultiView.cs
@@ -31,6 +31,8 @@ namespace ClassicUO.Game.GameObjects
             return r;
         }
 
+        public override int GetRenderTextureKey() => ArtTextureKey(Graphic);
+
         public override bool Draw(UltimaBatcher2D batcher, int posX, int posY, float depth)
         {
             if (!AllowedToDraw || IsDestroyed)

--- a/src/ClassicUO.Client/Game/GameObjects/Views/StaticView.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Views/StaticView.cs
@@ -62,6 +62,8 @@ namespace ClassicUO.Game.GameObjects
         /// <param name="posY">The Y screen position.</param>
         /// <param name="depth">The rendering depth for sorting.</param>
         /// <returns>True if the object was rendered, false if skipped.</returns>
+        public override int GetRenderTextureKey() => ArtTextureKey(GetDisplayGraphic(Graphic));
+
         public override bool Draw(UltimaBatcher2D batcher, int posX, int posY, float depth)
         {
             if (!AllowedToDraw || IsDestroyed)

--- a/src/ClassicUO.Client/Game/GameObjects/Views/View.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Views/View.cs
@@ -98,6 +98,19 @@ namespace ClassicUO.Game.GameObjects
             return (x + y) + (DEPTH_Z_OFFSET + z) * DEPTH_Z_SCALE;
         }
 
+        /// <summary>
+        /// Cheap, stable grouping key for the art-atlas page backing <paramref name="graphic"/>.
+        /// Same atlas texture -> same key, so sorting opaque render lists by it clusters
+        /// same-texture sprites and reduces batcher texture switches. Layering is unaffected
+        /// because the hardware depth buffer resolves opaque occlusion regardless of order.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected static int ArtTextureKey(ushort graphic)
+        {
+            ref readonly SpriteInfo info = ref Client.Game.UO.Arts.GetArt(graphic);
+            return info.Texture == null ? 0 : RuntimeHelpers.GetHashCode(info.Texture);
+        }
+
         public Rectangle GetOnScreenRectangle()
         {
             Rectangle prect = Rectangle.Empty;

--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -1233,6 +1233,14 @@ namespace ClassicUO.Game.Scenes
             batcher.SetBrightlight(ProfileManager.CurrentProfile.TerrainShadowsLevel * 0.1f);
             batcher.SetStencil(DepthStencilState.Default);
 
+            // Reorder opaque sprites so same-texture draws are adjacent, minimizing batcher
+            // texture switches. Layering is preserved by the hardware depth buffer (opaque
+            // occlusion is resolved by per-sprite depth, not submission order). The transparent
+            // list is intentionally NOT sorted - it must stay in back-to-front z-order.
+            _renderListStatics.Sort(_renderSortKeyComparison);
+            _renderListAnimations.Sort(_renderSortKeyComparison);
+            _renderListEffects.Sort(_renderSortKeyComparison);
+
             RenderedObjectsCount = 0;
             RenderedObjectsCount += DrawRenderList(batcher, _renderListStatics);
             RenderedObjectsCount += DrawRenderList(batcher, _renderListAnimations);
@@ -1284,6 +1292,10 @@ namespace ClassicUO.Game.Scenes
             }
         }
 
+        // Sorts opaque render lists by atlas-texture key to cluster same-texture draws.
+        private static readonly Comparison<GameObject> _renderSortKeyComparison =
+            static (a, b) => a.RenderSortKey.CompareTo(b.RenderSortKey);
+
         private int DrawRenderList(UltimaBatcher2D batcher, List<GameObject> renderList)
         {
             int done = 0;
@@ -1292,7 +1304,8 @@ namespace ClassicUO.Game.Scenes
             {
                 if (obj.Z <= _maxGroundZ)
                 {
-                    float depth = obj.CalculateDepthZ();
+                    // Depth was computed once during render-list build (PushToRenderList).
+                    float depth = obj.CachedDepthZ;
                     if (obj.Draw(batcher, obj.RealScreenPosition.X, obj.RealScreenPosition.Y, depth))
                     {
                         ++done;

--- a/src/ClassicUO.Client/Game/Scenes/GameSceneDrawingSorting.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameSceneDrawingSorting.cs
@@ -18,7 +18,7 @@ namespace ClassicUO.Game.Scenes
 {
     public partial class GameScene
     {
-        private static GameObject[] _foliages = new GameObject[100];
+        private static GameObject[] _foliages = new GameObject[256];
         private static readonly TreeUnion[] _treeInfos =
         {
             new TreeUnion(0x0D45, 0x0D4C),
@@ -626,17 +626,25 @@ namespace ClassicUO.Game.Scenes
                 return;
             }
 
-            // slow as fuck
+            // Compute the screen depth once per frame; reused below and at draw time.
+            obj.CachedDepthZ = obj.CalculateDepthZ();
+
+            // Pixel-perfect mouse selection used to run for every visible object every frame
+            // (the old "slow as fuck" path). Reject with a cheap bounding-box test first so the
+            // expensive per-pixel check only runs for objects actually under the cursor. Mobiles
+            // are few and their clickable area can extend past the body frame, so they skip the
+            // box shortcut and always run the precise check.
             if (
                 allowSelection
                 && obj.Z <= _maxGroundZ
                 && obj.AllowedToDraw
+                && (obj is Mobile || obj.GetOnScreenRectangle().Contains(SelectedObject.TranslatedMousePositionByViewport))
                 && obj.CheckMouseSelection()
             )
             {
                 if (SelectedObject.Object is GameObject prev)
                 {
-                    if (obj.CalculateDepthZ() >= prev.CalculateDepthZ())
+                    if (obj.CachedDepthZ >= prev.CachedDepthZ)
                     {
                         SelectedObject.Object = obj;
                     }
@@ -649,10 +657,15 @@ namespace ClassicUO.Game.Scenes
 
             if (obj.AlphaHue != byte.MaxValue)
             {
+                // Semi-transparent objects must stay in z-order (drawn last with depth-read);
+                // do not assign a texture sort key here.
                 _renderListTransparentObjects.Add(obj);
             }
             else
             {
+                // Group opaque sprites by atlas texture so the batcher can draw same-texture
+                // sprites together. Safe because the depth buffer resolves opaque layering.
+                obj.RenderSortKey = obj.GetRenderTextureKey();
                 renderList.Add(obj);
             }
         }


### PR DESCRIPTION
…me work

The world renderer already relies on the hardware depth buffer for opaque layering (depth is written per-sprite and the shader discards fully transparent texels), so opaque submission order does not affect correctness. Exploit that to reduce GPU draw calls and trim CPU hot spots in the render-list build, without changing layering.

- Group opaque sprites by atlas texture: add GetRenderTextureKey()/RenderSortKey on GameObject with per-view overrides (Static/Item/Multi use the art atlas, Land uses land/texmap atlas, Mobile clusters together) and sort the three opaque render lists before drawing. Reduces batcher texture switches. The semi-transparent list is left in z-order (drawn last with depth-read).
- Gate the per-object pixel-perfect mouse-selection check (the old "slow as fuck" path) behind a cheap on-screen bounding-box test so it only runs for objects under the cursor; mobiles still always run the precise check.
- Cache CalculateDepthZ() once per frame (CachedDepthZ) instead of recomputing it 2-3x per object during selection and drawing.
- Pre-size the foliage scratch array to avoid mid-frame reallocation.