### PR TITLE
Add bounding-box reject to mouse-selection hit tests

### DIFF
--- a/src/ClassicUO.Client/Game/GameObjects/Views/ItemView.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Views/ItemView.cs
@@ -494,25 +494,23 @@ namespace ClassicUO.Game.GameObjects
                     position.X -= index.Width;
                     position.Y -= index.Height;
 
-                    if (
-                        Client.Game.UO.Arts.PixelCheck(
-                            graphic,
-                            SelectedObject.TranslatedMousePositionByViewport.X - position.X,
-                            SelectedObject.TranslatedMousePositionByViewport.Y - position.Y
-                        )
-                    )
+                    int relX = SelectedObject.TranslatedMousePositionByViewport.X - position.X;
+                    int relY = SelectedObject.TranslatedMousePositionByViewport.Y - position.Y;
+
+                    // Cheap bounding-box reject before the expensive pixel-perfect check.
+                    // Pad by 5 so the stackable (+5,+5) sample below is never falsely rejected.
+                    if (!PointInSpriteBounds(relX, relY, index.Width, index.Height, pad: 5))
+                    {
+                        return false;
+                    }
+
+                    if (Client.Game.UO.Arts.PixelCheck(graphic, relX, relY))
                     {
                         return true;
                     }
                     else if (!IsMulti && !IsCoin && Amount > 1 && ItemData.IsStackable)
                     {
-                        if (
-                            Client.Game.UO.Arts.PixelCheck(
-                                graphic,
-                                SelectedObject.TranslatedMousePositionByViewport.X - position.X + 5,
-                                SelectedObject.TranslatedMousePositionByViewport.Y - position.Y + 5
-                            )
-                        )
+                        if (Client.Game.UO.Arts.PixelCheck(graphic, relX + 5, relY + 5))
                         {
                             return true;
                         }

--- a/src/ClassicUO.Client/Game/GameObjects/Views/MultiView.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Views/MultiView.cs
@@ -136,11 +136,16 @@ namespace ClassicUO.Game.GameObjects
                 position.X -= index.Width;
                 position.Y -= index.Height;
 
-                return Client.Game.UO.Arts.PixelCheck(
-                    Graphic,
-                    SelectedObject.TranslatedMousePositionByViewport.X - position.X,
-                    SelectedObject.TranslatedMousePositionByViewport.Y - position.Y
-                );
+                int relX = SelectedObject.TranslatedMousePositionByViewport.X - position.X;
+                int relY = SelectedObject.TranslatedMousePositionByViewport.Y - position.Y;
+
+                // Cheap bounding-box reject before the expensive pixel-perfect check.
+                if (!PointInSpriteBounds(relX, relY, index.Width, index.Height))
+                {
+                    return false;
+                }
+
+                return Client.Game.UO.Arts.PixelCheck(Graphic, relX, relY);
             }
 
             return false;

--- a/src/ClassicUO.Client/Game/GameObjects/Views/StaticView.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Views/StaticView.cs
@@ -166,11 +166,16 @@ namespace ClassicUO.Game.GameObjects
             position.X -= index.Width;
             position.Y -= index.Height;
 
-            return Client.Game.UO.Arts.PixelCheck(
-                graphic,
-                SelectedObject.TranslatedMousePositionByViewport.X - position.X,
-                SelectedObject.TranslatedMousePositionByViewport.Y - position.Y
-            );
+            int relX = SelectedObject.TranslatedMousePositionByViewport.X - position.X;
+            int relY = SelectedObject.TranslatedMousePositionByViewport.Y - position.Y;
+
+            // Cheap bounding-box reject before the expensive pixel-perfect check.
+            if (!PointInSpriteBounds(relX, relY, index.Width, index.Height))
+            {
+                return false;
+            }
+
+            return Client.Game.UO.Arts.PixelCheck(graphic, relX, relY);
         }
     }
 }

--- a/src/ClassicUO.Client/Game/GameObjects/Views/View.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Views/View.cs
@@ -111,6 +111,17 @@ namespace ClassicUO.Game.GameObjects
         }
 
         /// <summary>
+        /// Cheap broad-phase hit test: true if (relX, relY) lies inside the sprite rect.
+        /// Used to reject objects the cursor isn't over before doing the expensive
+        /// pixel-perfect <c>PixelCheck</c> (which pays a texture-id hash lookup first).
+        /// <paramref name="pad"/> widens the rect so the gate can never be tighter than
+        /// PixelCheck's own internal bounds, avoiding false negatives.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected static bool PointInSpriteBounds(int relX, int relY, int width, int height, int pad = 0)
+            => relX >= -pad && relX < width + pad && relY >= -pad && relY < height + pad;
+
+        /// <summary>
         /// Tests if the object is transparent at the given Z coordinate.
         /// Default implementation treats objects as opaque.
         /// </summary>


### PR DESCRIPTION
PushToRenderList runs CheckMouseSelection for every drawable object every frame. For statics, multis and ground items this jumped straight to Arts.PixelCheck, whose PixelPicker.Get does a texture-id hash lookup and varint decode before its own bounds check - paid for every object even though almost none are under the cursor.

Add a cheap PointInSpriteBounds gate (using the already-fetched art index dimensions) before PixelCheck in StaticView, MultiView and ItemView, so the expensive pixel-perfect check only runs when the cursor is actually over the sprite. This generalizes the FrameInfo broad-phase reject MobileView already does. The item branch pads by 5px to keep the stackable (+5,+5) sample correct, and the pad guarantees the gate is never tighter than PixelCheck's internal bounds so there are no false negatives.