### PR TITLE
Add SetZoomLevel macro to set camera zoom to a specific value

### DIFF
--- a/src/ClassicUO.Client/Common/Enums/MacroType.cs
+++ b/src/ClassicUO.Client/Common/Enums/MacroType.cs
@@ -115,5 +115,6 @@ public enum MacroType
     SetOrganizerSource,
     LoopContainer,
     ToggleBuyAgent,
-    ToggleSellAgent
+    ToggleSellAgent,
+    SetZoomLevel
 }

--- a/src/ClassicUO.Client/Game/Managers/MacroManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/MacroManager.cs
@@ -2106,6 +2106,14 @@ namespace ClassicUO.Game.Managers
 
                     break;
 
+                case MacroType.SetZoomLevel:
+                    if (macro is MacroObjectString zoomStr && float.TryParse(zoomStr.Text, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out float zoomLevel))
+                    {
+                        Client.Game.Scene.Camera.Zoom = zoomLevel;
+                    }
+
+                    break;
+
                 case MacroType.ToggleChatVisibility:
                     UIManager.SystemChat?.ToggleChatVisibility();
 
@@ -2917,6 +2925,7 @@ namespace ClassicUO.Game.Managers
                 case MacroType.ClientCommand:
                 case MacroType.UseType:
                 case MacroType.SetOrganizerSource:
+                case MacroType.SetZoomLevel:
                     obj = new MacroObjectString(code, MacroSubType.MSC_NONE);
 
                     break;
@@ -3114,6 +3123,7 @@ namespace ClassicUO.Game.Managers
                 case MacroType.ClientCommand:
                 case MacroType.UseType:
                 case MacroType.SetOrganizerSource:
+                case MacroType.SetZoomLevel:
                     SubMenuType = 2;
 
                     break;


### PR DESCRIPTION
Adds a new MacroType.SetZoomLevel that accepts a float value (e.g. "1.5") via text input and sets the camera zoom directly, complementing the existing ZoomIn/ZoomOut/DefaultZoom subtypes of the Zoom macro.


