### PR TITLE
Fix EndOfStreamException when loading world map marker icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ All notable changes to TazUO will be recorded here.
 * Fix: spell bar hotkeys not firing when Scroll Lock is on - [P.R 548](https://github.com/PlayTazUO/TazUO/pull/549) ([eddo87](https://github.com/eddo87))
 * Fixed UltimaLive block reloads leaving the reloaded map chunk untracked, so it could never be garbage collected and stayed loaded until relog - [P.R 556](https://github.com/PlayTazUO/TazUO/pull/556) ([bittiez](https://github.com/bittiez))
 * Fix IsFlying flag reference and add missing CantWalkOrRun speed mode - [P.R 560](https://github.com/PlayTazUO/TazUO/pull/560) ([bittiez](https://github.com/bittiez))
+* Fixed EndOfStreamException when loading world map marker icons (.cur/.ico) caused by reading the full pooled buffer instead of the actual stream length - [P.R 579](https://github.com/PlayTazUO/TazUO/pull/579) ([bittiez](https://github.com/bittiez))
 
 ### Legion
 * Added ModernNineSliceGump.SetLegionTexture to go along with zip files and custom png's - Use your own png for a 9-slice texture - ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.2.54</AssemblyVersion>
-    <FileVersion>5.2.54</FileVersion>
+    <AssemblyVersion>5.2.55</AssemblyVersion>
+    <FileVersion>5.2.55</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
@@ -928,7 +928,7 @@ public class WorldMapGump : ResizableGump
 
             try
             {
-                stream.ReadExactly(buffer, 0, buffer.Length);
+                stream.ReadExactly(buffer, 0, (int)stream.Length);
 
                 var reader = new StackDataReader(buffer.AsSpan(0, (int)stream.Length));
 


### PR DESCRIPTION
ArrayPool<byte>.Shared.Rent returns a buffer at least as large as requested, usually rounded up to the next power of two, so buffer.Length is typically larger than the source stream. Reading buffer.Length bytes with ReadExactly then ran past the end of the stream and threw EndOfStreamException (IO_EOF_ReadBeyondEOF). Read only stream.Length bytes, matching the span the reader already slices.