### PR TITLE
Reapply looted corpse hue when corpse is readded due to range

### DIFF
--- a/src/ClassicUO.Client/Network/PacketHandlers/Helpers/ObjectHelpers.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers/Helpers/ObjectHelpers.cs
@@ -135,6 +135,12 @@ public static class ObjectHelpers
 
             item.FixHue(hue);
 
+            // FixHue above overwrites the hue with the server-provided value, which clobbers
+            // the looted-corpse hue applied via AddCorpse when the graphic was set. Re-apply it
+            // so previously looted corpses keep their hue when removed and readded due to range.
+            if (graphic == 0x2006)
+                AutoLootManager.ApplyLootedHueIfNeeded(item);
+
             if (count == 0)
                 count = 1;
 


### PR DESCRIPTION
The looted-corpse hue was applied via AddCorpse when the graphic was set, but ObjectHelpers.UpdateGameObject's subsequent FixHue call overwrote it with the server-provided hue. This caused the looted hue to be lost when a corpse left and reentered view range. Reapply ApplyLootedHueIfNeeded after FixHue for corpses so the hue persists across recreation.
