### PR TITLE
feat: option to disable gargoyle animations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ All notable changes to TazUO will be recorded here.
 * Fixed NullReferenceException in ArtLoader/MultiLoader when art or multi data files are missing, replacing the cryptic crash with a clear FileNotFoundException pointing at the UO data directory - [P.R 582](https://github.com/PlayTazUO/TazUO/pull/582) ([bittiez](https://github.com/bittiez))
 * Missing required UO data files now show a clear error message naming the file and data directory instead of crashing with a crash report - [P.R 583](https://github.com/PlayTazUO/TazUO/pull/583) ([bittiez](https://github.com/bittiez))
 * Show a clear, actionable message when graphics shaders fail to compile instead of crashing — points at outdated/unavailable OpenGL (Remote Desktop, a VM without 3D acceleration, or missing/outdated GPU drivers) and suggests updating drivers or switching renderer - [P.R 584](https://github.com/PlayTazUO/TazUO/pull/584) ([bittiez](https://github.com/bittiez))
+* Add option disable gargoyle flying animation - ([Nesci28](https://github.com/Nesci28))
 
 ### Legion
 * Added ModernNineSliceGump.SetLegionTexture to go along with zip files and custom png's - Use your own png for a 9-slice texture - ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.2.58</AssemblyVersion>
-    <FileVersion>5.2.58</FileVersion>
+    <AssemblyVersion>5.2.59</AssemblyVersion>
+    <FileVersion>5.2.59</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -196,6 +196,7 @@ namespace ClassicUO.Configuration
         public bool TreeToStumps { get; set => SetProperty(ref field, value); }
         public bool EnableCaveBorder { get; set => SetProperty(ref field, value); }
         public bool HideVegetation { get; set => SetProperty(ref field, value); }
+        public bool DisableGargoyleFlyingAnimation { get; set => SetProperty(ref field, value); }
         public int FieldsType { get; set => SetProperty(ref field, value); } // 0 = normal, 1 = static, 2 = tile
         public bool NoColorObjectsOutOfRange { get; set => SetProperty(ref field, value); }
         public bool UseCircleOfTransparency { get; set => SetProperty(ref field, value); }

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -5,7 +5,7 @@
 ; Missing keys are auto-appended with English defaults when
 ; this file's version is newer than the user's copy.
 ; -------------------------------------------------------
-_version=23
+_version=24
 accountname=Account Name
 accountcontextmenutooltip=Right click to select another account.
 music=Music
@@ -475,6 +475,7 @@ versionhistory_desc=Version history can now be found on our GitHub repo CHANGELO
 versionhistory_main=Main branch changelog
 versionhistory_dev=Dev branch changelog
 auto_open_doors_hidden=Open doors while hidden
+disable_gargoyle_flying_animation=Disable gargoyle flying animation
 
 ; Name overhead assign control
 nameoverhead_sethotkey=Set hotkey:

--- a/src/ClassicUO.Client/Game/GameObjects/EntityTextContainer.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/EntityTextContainer.cs
@@ -173,7 +173,7 @@ namespace ClassicUO.Game.GameObjects
 
                 if (Parent is Mobile m)
                 {
-                    if (m.IsGargoyle && m.IsFlying)
+                    if (m.IsGargoyle && m.IsFlyingAnimationEnabled)
                     {
                         offY += 22;
                     }

--- a/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
@@ -177,6 +177,9 @@ namespace ClassicUO.Game.GameObjects
         public bool IsFlying =>
             Client.Game.UO.Version >= ClientVersion.CV_7000 && (Flags & Flags.Flying) != 0;
 
+        public bool IsFlyingAnimationEnabled =>
+            IsFlying && (!IsGargoyle || !(_profile ?? Profile.DefaultPreviewProfile).DisableGargoyleFlyingAnimation);
+
         public virtual bool InWarMode
         {
             get => (Flags & Flags.WarMode) != 0;
@@ -518,7 +521,7 @@ namespace ClassicUO.Game.GameObjects
                         return;
                     }
 
-                    if (IsGargoyle && IsFlying)
+                    if (IsGargoyle && IsFlyingAnimationEnabled)
                     {
                         if (RandomHelper.GetValue(0, 2) != 0)
                         {
@@ -990,7 +993,7 @@ namespace ClassicUO.Game.GameObjects
 
             Point p = RealScreenPosition;
 
-            if (IsGargoyle && IsFlying)
+            if (IsGargoyle && IsFlyingAnimationEnabled)
             {
                 p.Y -= 22;
             }

--- a/src/ClassicUO.Client/Game/GameObjects/MobileAnimation.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/MobileAnimation.cs
@@ -130,7 +130,7 @@ namespace ClassicUO.Game.GameObjects
             }
             else
             {
-                if (mobile.IsFlying)
+                if (mobile.IsFlyingAnimationEnabled)
                 {
                     result = 19;
                 }
@@ -1152,7 +1152,7 @@ namespace ClassicUO.Game.GameObjects
                                     result = 25;
                                 }
                             }
-                            else if (mobile.IsGargoyle && mobile.IsFlying) // TODO: what's up when it is dead?
+                            else if (mobile.IsGargoyle && mobile.IsFlyingAnimationEnabled) // TODO: what's up when it is dead?
                             {
                                 if (mobile.InWarMode)
                                 {
@@ -1253,7 +1253,7 @@ namespace ClassicUO.Game.GameObjects
                                                     }
                                                 }
                                             }
-                                            else if (mobile.IsGargoyle && mobile.IsFlying)
+                                            else if (mobile.IsGargoyle && mobile.IsFlyingAnimationEnabled)
                                             {
                                                 result = 64;
                                             }
@@ -1290,7 +1290,7 @@ namespace ClassicUO.Game.GameObjects
                         if ((flags & AnimationFlags.UseUopAnimation) != 0)
                         {
                             // i'm not sure here if it's necessary the isgargoyle
-                            if (mobile.IsGargoyle && mobile.IsFlying)
+                            if (mobile.IsGargoyle && mobile.IsFlyingAnimationEnabled)
                             {
                                 if (isRun)
                                 {
@@ -1365,7 +1365,7 @@ namespace ClassicUO.Game.GameObjects
 
                                 if (hand2Graphic < 0x0240 || hand2Graphic > 0x03E1)
                                 {
-                                    if (mobile.IsGargoyle && mobile.IsFlying)
+                                    if (mobile.IsGargoyle && mobile.IsFlyingAnimationEnabled)
                                     {
                                         if (isRun)
                                         {
@@ -1394,7 +1394,7 @@ namespace ClassicUO.Game.GameObjects
                                     {
                                         if (HAND2_BASE_ANIMID[i] == hand2Graphic)
                                         {
-                                            if (mobile.IsGargoyle && mobile.IsFlying)
+                                            if (mobile.IsGargoyle && mobile.IsFlyingAnimationEnabled)
                                             {
                                                 if (isRun)
                                                 {
@@ -1423,7 +1423,7 @@ namespace ClassicUO.Game.GameObjects
                                 }
                             }
                         }
-                        else if (mobile.IsGargoyle && mobile.IsFlying)
+                        else if (mobile.IsGargoyle && mobile.IsFlyingAnimationEnabled)
                         {
                             result = 62;
                         }
@@ -1663,7 +1663,7 @@ namespace ClassicUO.Game.GameObjects
                     default:
                         if (
                             mobile.IsGargoyle
-                            && mobile.IsFlying
+                            && mobile.IsFlyingAnimationEnabled
                             && animations.AnimationExists(mobile.Graphic, 71)
                         )
                         {
@@ -1688,7 +1688,7 @@ namespace ClassicUO.Game.GameObjects
                     case 7:
                         if (
                             mobile.IsGargoyle
-                            && mobile.IsFlying
+                            && mobile.IsFlyingAnimationEnabled
                             && animations.AnimationExists(mobile.Graphic, 72)
                         )
                         {
@@ -1814,7 +1814,7 @@ namespace ClassicUO.Game.GameObjects
                 {
                     if (
                         mobile.IsGargoyle
-                        && mobile.IsFlying
+                            && mobile.IsFlyingAnimationEnabled
                         && animations.AnimationExists(mobile.Graphic, 77)
                     )
                     {
@@ -2047,7 +2047,7 @@ namespace ClassicUO.Game.GameObjects
                     {
                         case 1:
                         case 2:
-                            if (mobile.IsGargoyle && mobile.IsFlying)
+                            if (mobile.IsGargoyle && mobile.IsFlyingAnimationEnabled)
                             {
                                 return 76;
                             }
@@ -2055,7 +2055,7 @@ namespace ClassicUO.Game.GameObjects
                             return 17;
                     }
 
-                    if (mobile.IsGargoyle && mobile.IsFlying)
+                    if (mobile.IsGargoyle && mobile.IsFlyingAnimationEnabled)
                     {
                         return 75;
                     }

--- a/src/ClassicUO.Client/Game/Managers/HealthLinesManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/HealthLinesManager.cs
@@ -123,7 +123,7 @@ namespace ClassicUO.Game.Managers
                                 Point p1 = p;
                                 p1.Y -= height + centerY + 8 + 22;
 
-                                if (mobile.IsGargoyle && mobile.IsFlying)
+                                if (mobile.IsGargoyle && mobile.IsFlyingAnimationEnabled)
                                 {
                                     p1.Y -= 22;
                                 }

--- a/src/ClassicUO.Client/Game/Managers/SpellVisualRange/CastTimerProgressBar.cs
+++ b/src/ClassicUO.Client/Game/Managers/SpellVisualRange/CastTimerProgressBar.cs
@@ -61,7 +61,7 @@ public class CastTimerProgressBar : Gump
                 if (vp == null) return false;
 
                 x = vp.Location.X + (int)(m.RealScreenPosition.X - (m.Offset.X + 22 + 5));
-                y = vp.Location.Y + (int)(m.RealScreenPosition.Y - ((m.Offset.Y - m.Offset.Z) - (height + centerY + 15) + (m.IsGargoyle && m.IsFlying ? -22 : !m.IsMounted ? 22 : 0)));
+                y = vp.Location.Y + (int)(m.RealScreenPosition.Y - ((m.Offset.Y - m.Offset.Z) - (height + centerY + 15) + (m.IsGargoyle && m.IsFlyingAnimationEnabled ? -22 : !m.IsMounted ? 22 : 0)));
 
                 batcher.Draw(_background, new Rectangle(x, y, _barBounds.Width, _barBounds.Height), _barBounds, _hue);
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
@@ -252,6 +252,15 @@ namespace ClassicUO.Game.UI.Gumps
             content.BlankLine();
 
             content.AddToRight
+            (
+                new CheckboxWithLabel(TazLang.Get("disable_gargoyle_flying_animation", "Disable gargoyle flying animation"), isChecked: profile.DisableGargoyleFlyingAnimation,
+                    valueChanged: (b) => { profile.DisableGargoyleFlyingAnimation = b; }),
+                true, page
+            );
+
+            content.BlankLine();
+
+            content.AddToRight
             (c = new CheckboxWithLabel(lang.GetGeneral.SallosEasyGrab, isChecked: profile.SallosEasyGrab, valueChanged: (b) => { profile.SallosEasyGrab = b; }),
                 true, page);
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/NameOverheadGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/NameOverheadGump.cs
@@ -671,7 +671,7 @@ namespace ClassicUO.Game.UI.Gumps
                       + (m.Offset.Y - m.Offset.Z)
                       - (height + centerY + 15) * m.Scale
                       + (
-                          m.IsGargoyle && m.IsFlying
+                          m.IsGargoyle && m.IsFlyingAnimationEnabled
                               ? -22
                               : !m.IsMounted
                                   ? 22


### PR DESCRIPTION
## Description
Adds a profile setting and Modern Options checkbox to disable gargoyle flying
animations.

When enabled, flying gargoyles use grounded animation behavior instead of flying-
specific animation groups, including idle animations. Related overhead UI
positioning is kept in sync for name text, health lines, overhead gumps, and cast
timer placement.

Grounded gargoyle animation mappings are preserved so non-flying gargoyle actions
continue to resolve normally.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing
Smoke tests

## Screenshots (if applicable)
N/A

## Additional Notes
No related GitHub issue or Discord discussion link provided.