### PR TITLE
Show error message instead of crashing on missing required UO files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ All notable changes to TazUO will be recorded here.
 * Fix IsFlying flag reference and add missing CantWalkOrRun speed mode - [P.R 560](https://github.com/PlayTazUO/TazUO/pull/560) ([bittiez](https://github.com/bittiez))
 * Fixed EndOfStreamException when loading world map marker icons (.cur/.ico) caused by reading the full pooled buffer instead of the actual stream length - [P.R 579](https://github.com/PlayTazUO/TazUO/pull/579) ([bittiez](https://github.com/bittiez))
 * Fixed NullReferenceException in ArtLoader/MultiLoader when art or multi data files are missing, replacing the cryptic crash with a clear FileNotFoundException pointing at the UO data directory - [P.R 582](https://github.com/PlayTazUO/TazUO/pull/582) ([bittiez](https://github.com/bittiez))
+* Missing required UO data files now show a clear error message naming the file and data directory instead of crashing with a crash report - [P.R 583](https://github.com/PlayTazUO/TazUO/pull/583) ([bittiez](https://github.com/bittiez))
 
 ### Legion
 * Added ModernNineSliceGump.SetLegionTexture to go along with zip files and custom png's - Use your own png for a 9-slice texture - ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.2.56</AssemblyVersion>
-    <FileVersion>5.2.56</FileVersion>
+    <AssemblyVersion>5.2.57</AssemblyVersion>
+    <FileVersion>5.2.57</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Client.cs
+++ b/src/ClassicUO.Client/Client.cs
@@ -193,7 +193,27 @@ namespace ClassicUO
             Log.Trace($"Protocol: {Protocol}");
 
             FileManager = new UOFileManager(clientVersion, clientPath);
-            FileManager.Load(Settings.GlobalSettings.UseVerdata, Settings.GlobalSettings.Language, Settings.GlobalSettings.MapsLayouts);
+
+            try
+            {
+                FileManager.Load(Settings.GlobalSettings.UseVerdata, Settings.GlobalSettings.Language, Settings.GlobalSettings.MapsLayouts);
+            }
+            catch (FileNotFoundException ex)
+            {
+                string missing = !string.IsNullOrEmpty(ex.FileName) ? ex.FileName : ex.Message;
+
+                Log.Error($"Missing required UO data file while loading: {ex}");
+
+                Client.ShowErrorMessage(
+                    "A required Ultima Online data file could not be found:\n\n" +
+                    $"{missing}\n\n" +
+                    "Please verify your UO data files are present in:\n" +
+                    $"{clientPath}");
+
+                // Exit cleanly so the global unhandled-exception handler does not
+                // generate a crash log/report for what is a missing-files setup issue.
+                Environment.Exit(0);
+            }
 
             StaticFilters.Load(FileManager.TileData);
             BuffTable.Load();

--- a/src/ClassicUO.Utility/FileSystemHelper.cs
+++ b/src/ClassicUO.Utility/FileSystemHelper.cs
@@ -64,7 +64,7 @@ namespace ClassicUO.Utility
         {
             if (!File.Exists(path))
             {
-                throw new FileNotFoundException(path);
+                throw new FileNotFoundException($"Required file not found: {path}", path);
             }
         }
 


### PR DESCRIPTION
Wrap UOFileManager.Load() in LoadUOFiles() with a catch for FileNotFoundException so a missing required data file (art, hues, tiledata, skills, etc.) surfaces a native Client.ShowErrorMessage dialog naming the file and the data directory, then exits cleanly instead of triggering the unhandled-exception crash log/report.

Also enrich FileSystemHelper.EnsureFileExists to set the exception message and FileName so the centralized handler can report which file is missing.