### PR TITLE
Show a clear message when graphics shaders fail to compile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ All notable changes to TazUO will be recorded here.
 * Fixed EndOfStreamException when loading world map marker icons (.cur/.ico) caused by reading the full pooled buffer instead of the actual stream length - [P.R 579](https://github.com/PlayTazUO/TazUO/pull/579) ([bittiez](https://github.com/bittiez))
 * Fixed NullReferenceException in ArtLoader/MultiLoader when art or multi data files are missing, replacing the cryptic crash with a clear FileNotFoundException pointing at the UO data directory - [P.R 582](https://github.com/PlayTazUO/TazUO/pull/582) ([bittiez](https://github.com/bittiez))
 * Missing required UO data files now show a clear error message naming the file and data directory instead of crashing with a crash report - [P.R 583](https://github.com/PlayTazUO/TazUO/pull/583) ([bittiez](https://github.com/bittiez))
+* Show a clear, actionable message when graphics shaders fail to compile instead of crashing — points at outdated/unavailable OpenGL (Remote Desktop, a VM without 3D acceleration, or missing/outdated GPU drivers) and suggests updating drivers or switching renderer - [P.R 584](https://github.com/PlayTazUO/TazUO/pull/584) ([bittiez](https://github.com/bittiez))
 
 ### Legion
 * Added ModernNineSliceGump.SetLegionTexture to go along with zip files and custom png's - Use your own png for a 9-slice texture - ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.2.57</AssemblyVersion>
-    <FileVersion>5.2.57</FileVersion>
+    <AssemblyVersion>5.2.58</AssemblyVersion>
+    <FileVersion>5.2.58</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Client.cs
+++ b/src/ClassicUO.Client/Client.cs
@@ -246,5 +246,35 @@ namespace ClassicUO
         }
 
         public static void ShowErrorMessage(string msg) => SDL.SDL_ShowSimpleMessageBox(SDL.SDL_MessageBoxFlags.SDL_MESSAGEBOX_ERROR, "ERROR", msg, IntPtr.Zero);
+
+        /// <summary>
+        /// Guidance shown when the graphics shaders fail to compile. This almost always indicates an
+        /// environment problem (outdated/unavailable OpenGL) rather than a bug in the shader itself.
+        /// </summary>
+        public const string GraphicsShaderHelpMessage =
+            "TazUO could not compile its graphics shaders. This almost always means your system's OpenGL " +
+            "support is too old or unavailable - common causes are running over Remote Desktop, running in a " +
+            "virtual machine without 3D acceleration, or missing/outdated GPU drivers.\n\n" +
+            "Try: update your GPU drivers, run on the local console (not Remote Desktop), or change the renderer " +
+            "in settings (e.g. Vulkan).";
+
+        /// <summary>
+        /// Returns true when the exception was raised while compiling an effect/shader (e.g. the
+        /// MOJOSHADER_compileEffect failures produced by FNA3D when the host's OpenGL is unsupported).
+        /// </summary>
+        public static bool IsShaderCompileFailure(Exception ex)
+        {
+            for (Exception e = ex; e != null; e = e.InnerException)
+            {
+                if (e.Message != null &&
+                    (e.Message.Contains("MOJOSHADER", StringComparison.OrdinalIgnoreCase) ||
+                     e.Message.Contains("compileEffect", StringComparison.OrdinalIgnoreCase)))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 }

--- a/src/ClassicUO.Client/GameController.cs
+++ b/src/ClassicUO.Client/GameController.cs
@@ -124,7 +124,15 @@ namespace ClassicUO
             SetRefreshRate(Settings.GlobalSettings.FPS);
             SupportedRefreshRate = Settings.GlobalSettings.FPS;
 
-            _uoSpriteBatch = new UltimaBatcher2D(GraphicsDevice);
+            try
+            {
+                _uoSpriteBatch = new UltimaBatcher2D(GraphicsDevice);
+            }
+            catch (Exception ex) when (Client.IsShaderCompileFailure(ex))
+            {
+                Client.ShowErrorMessage(Client.GraphicsShaderHelpMessage);
+                throw; // preserve existing crash logging / report
+            }
 
             _filter = HandleSdlEvent;
             SDL_SetEventFilter(_filter, IntPtr.Zero);

--- a/src/ClassicUO.Client/Main.cs
+++ b/src/ClassicUO.Client/Main.cs
@@ -236,6 +236,11 @@ namespace ClassicUO
                            "This can sometimes occur if your operating system shuts down your graphics adapter to preserve power.";
                 }
 
+                if (e is Exception shaderException && Client.IsShaderCompileFailure(shaderException))
+                {
+                    return Client.GraphicsShaderHelpMessage;
+                }
+
                 if (e is Microsoft.Xna.Framework.Graphics.NoSuitableGraphicsDeviceException graphicsException &&
                     graphicsException.Message.Contains("Could not create swapchain!"))
                 {


### PR DESCRIPTION
When the host's OpenGL implementation is too old or unavailable (Remote Desktop's GDI Generic OpenGL 1.1, a VM without 3D acceleration, or missing/outdated GPU drivers), FNA3D/MojoShader fails to cross-compile the embedded effect to GLSL and throws an InvalidOperationException with a "MOJOSHADER_compileEffect" message during startup. Previously this surfaced as an opaque crash.

Detect this failure when creating the UltimaBatcher2D and show an SDL message box with actionable guidance (update GPU drivers, avoid Remote Desktop, try a different renderer), then rethrow so the existing crash logging is preserved. GetSuggestedFix now returns the same guidance so the crash log and report are self-explanatory too.