### PR TITLE
Fix NullReferenceException in ImprovedBuffGump when buff title cliloc is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ All notable changes to TazUO will be recorded here.
 * Missing required UO data files now show a clear error message naming the file and data directory instead of crashing with a crash report - [P.R 583](https://github.com/PlayTazUO/TazUO/pull/583) ([bittiez](https://github.com/bittiez))
 * Show a clear, actionable message when graphics shaders fail to compile instead of crashing — points at outdated/unavailable OpenGL (Remote Desktop, a VM without 3D acceleration, or missing/outdated GPU drivers) and suggests updating drivers or switching renderer - [P.R 584](https://github.com/PlayTazUO/TazUO/pull/584) ([bittiez](https://github.com/bittiez))
 * Add option disable gargoyle flying animation - ([Nesci28](https://github.com/Nesci28))
+* Fixed NullReferenceException in ImprovedBuffGump when a buff icon's title cliloc is not found - [P.R 585](https://github.com/PlayTazUO/TazUO/pull/585) ([bittiez](https://github.com/bittiez))
 
 ### Legion
 * Added ModernNineSliceGump.SetLegionTexture to go along with zip files and custom png's - Use your own png for a 9-slice texture - ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.2.59</AssemblyVersion>
-    <FileVersion>5.2.59</FileVersion>
+    <AssemblyVersion>5.2.60</AssemblyVersion>
+    <FileVersion>5.2.60</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Gumps/ImprovedBuffGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ImprovedBuffGump.cs
@@ -36,7 +36,7 @@ namespace ClassicUO.Game.UI.Gumps
         {
             if (icon != null)
             {
-                var coolDownBar = new CoolDownBar(World, TimeSpan.FromMilliseconds(icon.Timer - Time.Ticks), icon.Title.Replace("<br>", " "), ProfileManager.CurrentProfile.ImprovedBuffBarHue, 0, 0, icon.Graphic, icon.Type, true);
+                var coolDownBar = new CoolDownBar(World, TimeSpan.FromMilliseconds(icon.Timer - Time.Ticks), (icon.Title ?? string.Empty).Replace("<br>", " "), ProfileManager.CurrentProfile.ImprovedBuffBarHue, 0, 0, icon.Graphic, icon.Type, true);
                 coolDownBar.SetTooltip(icon.Text);
                 BuffBarManager.AddCoolDownBar(coolDownBar, _direction, _box);
                 _box.Add(coolDownBar);

--- a/src/ClassicUO.Client/Network/PacketHandlers/BuffDebuff.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers/BuffDebuff.cs
@@ -57,7 +57,7 @@ internal static class BuffDebuff
                         (int)titleCliloc,
                         args,
                         true
-                    );
+                    ) ?? string.Empty;
 
                     arg_length = p.ReadUInt16BE();
                     string args_2 = p.ReadUnicodeLE();


### PR DESCRIPTION
Clilocs.Translate() returns null when a cliloc ID is not found, causing icon.Title.Replace() to throw on open. Guard at the packet handler (source) and defensively in AddBuff (crash site).