### PR TITLE
Fix world map hotkeys: Ctrl+LClick sets marker, Ctrl+RClick pathfinds

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
@@ -3369,6 +3369,13 @@ public class WorldMapGump : ResizableGump
             if (button == MouseButtonType.Left && Keyboard.Ctrl && !Keyboard.Alt)
             {
                 CanvasToWorld(x, y, out int wX, out int wY);
+                GoToMarker(wX, wY, true);
+                return;
+            }
+
+            if (button == MouseButtonType.Right && Keyboard.Ctrl && !Keyboard.Alt)
+            {
+                CanvasToWorld(x, y, out int wX, out int wY);
                 _navDest = new Point(wX, wY);
                 _navDestSetTime = Environment.TickCount64;
                 _navPath = null;


### PR DESCRIPTION
Ctrl+Left Click now creates a temporary "Go To" marker at the clicked location. Ctrl+Right Click now triggers auto-walk pathfinding to the clicked location, matching the intended design.