### PR TITLE
Fix Ctrl+LClick to open add-marker dialog instead of GoTo marker

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
@@ -3369,7 +3369,14 @@ public class WorldMapGump : ResizableGump
             if (button == MouseButtonType.Left && Keyboard.Ctrl && !Keyboard.Alt)
             {
                 CanvasToWorld(x, y, out int wX, out int wY);
-                GoToMarker(wX, wY, true);
+
+                WMapMarkerFile userFile = _markerFiles.Where(f => f.Name == USER_MARKERS_FILE).FirstOrDefault();
+                if (userFile == null)
+                    return;
+
+                UserMarkersGump existingGump = UIManager.GetGump<UserMarkersGump>();
+                existingGump?.Dispose();
+                UIManager.Add(new UserMarkersGump(World, wX, wY, userFile.Markers));
                 return;
             }
 


### PR DESCRIPTION
Ctrl+Left Click now opens UserMarkersGump so the user can add a persistent named marker at the clicked location, matching the original pre-PR-539 behavior. GoToMarker (temporary visual pin) is not the intended action here.