### PR TITLE
Convert Add/Edit User Marker gump to a Myra window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to TazUO will be recorded here.
 * Add highlight low contrast grid items option - [P.R 563](https://github.com/PlayTazUO/TazUO/pull/563) ([Nesci28](https://github.com/Nesci28))
 * Add option to select and copy text in journal - [P.R 575](https://github.com/PlayTazUO/TazUO/pull/575) ([Nesci28](https://github.com/Nesci28))
 * Add Script slot type to the Spell Bar - [P.R 568](https://github.com/PlayTazUO/TazUO/pull/568) ([eddo87](https://github.com/eddo87))
+* Converted the Add/Edit User Marker world map window to a Myra window - [P.R 588](https://github.com/PlayTazUO/TazUO/pull/588) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
 * Fixed crash reading BWT-compressed UOP animations caused by returning a non-pooled buffer to the array pool - [P.R 532](https://github.com/PlayTazUO/TazUO/pull/532) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.2.61</AssemblyVersion>
-    <FileVersion>5.2.61</FileVersion>
+    <AssemblyVersion>5.2.62</AssemblyVersion>
+    <FileVersion>5.2.62</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Gumps/MarkersManagerGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/MarkersManagerGump.cs
@@ -447,8 +447,6 @@ namespace ClassicUO.Game.UI.Gumps
                         var editUserMarkerGump = new UserMarkersGump(_gump.World, _marker.X, _marker.Y, _markers, _marker.ColorName, _marker.MarkerIconName, true, _idx);
                         editUserMarkerGump.EditEnd += OnEditEnd;
 
-                        UIManager.Add(editUserMarkerGump);
-
                         break;
                     case (int)ButtonsOption.REMOVE_MARKER_BTN:
                         RemoveMarkerEvent.Raise(_idx);

--- a/src/ClassicUO.Client/Game/UI/Gumps/UserMarkerGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/UserMarkerGump.cs
@@ -1,36 +1,37 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using ClassicUO.Utility;
 using ClassicUO.Configuration;
+using ClassicUO.Utility;
+using ClassicUO.Game.Managers;
 using ClassicUO.Game.UI.Controls;
-using static ClassicUO.Game.UI.Gumps.WorldMapGump;
-using ClassicUO.Assets;
+using ClassicUO.Game.UI.MyraWindows.Widgets;
 using ClassicUO.Resources;
+using Myra.Graphics2D;
+using Myra.Graphics2D.UI;
+using static ClassicUO.Game.UI.Gumps.WorldMapGump;
 
 namespace ClassicUO.Game.UI.Gumps
 {
-    public sealed class UserMarkersGump : Gump
+    public sealed class UserMarkersGump : MyraControl
     {
-        private readonly StbTextBox _textBoxX;
-        private readonly StbTextBox _textBoxY;
-        private readonly StbTextBox _markerName;
+        private readonly World _world;
 
-        private const ushort HUE_FONT = 0xFFFF;
-        private const ushort LABEL_OFFSET = 40;
-        private const ushort Y_OFFSET = 30;
+        private readonly MyraInputBox _textBoxX;
+        private readonly MyraInputBox _textBoxY;
+        private readonly MyraInputBox _markerName;
 
-        private readonly Combobox _colorsCombo;
         private readonly string[] _colors;
+        private int _selectedColorIndex;
 
-        private readonly Combobox _iconsCombo;
         private readonly string[] _icons;
+        private readonly bool _hasIcons;
+        private int _selectedIconIndex;
 
         private readonly List<WMapMarker> _markers;
         private readonly int _markerIdx;
 
-        private const int MAX_CORD_LEN = 10;
         private const int MAX_NAME_LEN = 25;
 
         private const int MAP_MIN_CORD = 0;
@@ -41,18 +42,12 @@ namespace ClassicUO.Game.UI.Gumps
 
         public event EventHandler EditEnd;
 
-        private enum ButtonsOption
+        internal UserMarkersGump(World world, int x, int y, List<WMapMarker> markers, string color = "none", string icon = "exit", bool isEdit = false, int markerIdx = -1)
+            : base(isEdit ? ResGumps.EditMarker : ResGumps.AddMarker)
         {
-            ADD_BTN,
-            EDIT_BTN,
-            CANCEL_BTN,
-        }
+            _world = world;
 
-        internal UserMarkersGump(World world, int x, int y, List<WMapMarker> markers, string color = "none", string icon = "exit", bool isEdit = false, int markerIdx = -1) : base(world, 0, 0)
-        {
-            CanMove = true;
-
-            _mapMaxX= Client.Game.UO.FileManager.Maps.MapsDefaultSize[world.MapIndex, 0];
+            _mapMaxX = Client.Game.UO.FileManager.Maps.MapsDefaultSize[world.MapIndex, 0];
             _mapMaxY = Client.Game.UO.FileManager.Maps.MapsDefaultSize[world.MapIndex, 1];
 
             _markers = markers;
@@ -71,193 +66,85 @@ namespace ClassicUO.Game.UI.Gumps
             if (selectedColor < 0)
                 selectedColor = 0;
 
-            var markersGumpBackground = new AlphaBlendControl
-            {
-                Width = 320,
-                Height = 220,
-                X = Client.Game.Scene.Camera.Bounds.Width / 2 - 125,
-                Y = 150,
-                Alpha = 0.7f,
-                CanMove = true,
-                CanCloseWithRightClick = true,
-                AcceptMouseInput = true
-            };
+            _hasIcons = _icons.Length > 0;
+            _selectedColorIndex = selectedColor;
+            _selectedIconIndex = selectedIcon;
 
-            Add(markersGumpBackground);
-
-            if (!isEdit)
-                Add(new Label(ResGumps.AddMarker, true, HUE_FONT, 0, 255, FontStyle.BlackBorder)
-                {
-                    X = markersGumpBackground.X + 100,
-                    Y = markersGumpBackground.Y + 3,
-                });
-            else
-                Add(new Label(ResGumps.EditMarker, true, HUE_FONT, 0, 255, FontStyle.BlackBorder)
-                {
-                    X = markersGumpBackground.X + 100,
-                    Y = markersGumpBackground.Y + 3,
-                });
+            var layout = new VerticalStackPanel { Spacing = 6, Padding = new Thickness(8) };
 
             // X Field
-            int fx = markersGumpBackground.X + 5;
-            int fy = markersGumpBackground.Y + 25;
-            Add(new ResizePic(0x0BB8)
+            layout.Widgets.Add(BuildLabeledRow(ResGumps.MarkerX, _textBoxX = new MyraInputBox
             {
-                X = fx + LABEL_OFFSET,
-                Y = fy,
-                Width = 90,
-                Height = 25
-            });
-
-            _textBoxX = new StbTextBox(
-                0xFF,
-                MAX_CORD_LEN,
-                90,
-                true,
-                FontStyle.BlackBorder | FontStyle.Fixed
-            )
-            {
-                X = fx + LABEL_OFFSET,
-                Y = fy,
-                Width = 90,
-                Height = 25,
-                Text = x.ToString()
-            };
-            Add(_textBoxX);
-            Add(new Label(ResGumps.MarkerX, true, HUE_FONT, 0, 255, FontStyle.BlackBorder) { X = fx, Y = fy });
+                Text = x.ToString(),
+                Width = 200,
+                InputFilter = MyraInputBox.DigitInputFilter
+            }));
 
             // Y Field
-            fy += Y_OFFSET;
-            Add(new ResizePic(0x0BB8)
+            layout.Widgets.Add(BuildLabeledRow(ResGumps.MarkerY, _textBoxY = new MyraInputBox
             {
-                X = fx + LABEL_OFFSET,
-                Y = fy,
-                Width = 90,
-                Height = 25
-            });
-
-            _textBoxY = new StbTextBox(
-                0xFF,
-                MAX_CORD_LEN,
-                90,
-                true,
-                FontStyle.BlackBorder | FontStyle.Fixed
-            )
-            {
-                X = fx + LABEL_OFFSET,
-                Y = fy,
-                Width = 90,
-                Height = 25,
-                Text = y.ToString()
-            };
-            Add(_textBoxY);
-            Add(new Label(ResGumps.MarkerY, true, HUE_FONT, 0, 255, FontStyle.BlackBorder) { X = fx, Y = fy });
+                Text = y.ToString(),
+                Width = 200,
+                InputFilter = MyraInputBox.DigitInputFilter
+            }));
 
             // Marker Name field
-            fy += Y_OFFSET;
-            Add(new ResizePic(0x0BB8)
+            layout.Widgets.Add(BuildLabeledRow(ResGumps.MarkerName, _markerName = new MyraInputBox
             {
-                X = fx + LABEL_OFFSET,
-                Y = fy,
-                Width = 250,
-                Height = 25
-            });
-
-            _markerName = new StbTextBox(
-                0xFF,
-                MAX_NAME_LEN,
-                250,
-                true,
-                FontStyle.BlackBorder | FontStyle.Fixed
-            )
-            {
-                X = fx + LABEL_OFFSET,
-                Y = fy,
-                Width = 250,
-                Height = 25,
-                Text = markerName
-            };
-            Add(_markerName);
-            Add(new Label(ResGumps.MarkerName, true, HUE_FONT, 0, 255, FontStyle.BlackBorder) { X = fx, Y = fy });
+                Text = markerName,
+                Width = 200
+            }));
 
             // Color Combobox
-            fy += Y_OFFSET;
-            _colorsCombo = new Combobox
-                (
-                    fx + LABEL_OFFSET,
-                    fy,
-                    250,
-                    _colors,
-                    selectedColor
-                );
-            Add(_colorsCombo);
-            Add(new Label(ResGumps.MarkerColor, true, HUE_FONT, 0, 255, FontStyle.BlackBorder) { X = fx, Y = fy });
+            layout.Widgets.Add(BuildLabeledRow(ResGumps.MarkerColor,
+                BuildCombo(_colors, selectedColor, idx => _selectedColorIndex = idx)));
 
-            if (_icons.Length > 0)
+            // Icon combobox
+            if (_hasIcons)
             {
-                // Icon combobox
-                fy += Y_OFFSET;
-                _iconsCombo = new Combobox
-                    (
-                        fx + LABEL_OFFSET,
-                        fy,
-                        250,
-                        _icons,
-                        selectedIcon
-                    );
-                Add(_iconsCombo);
-                Add(new Label(ResGumps.MarkerIcon, true, HUE_FONT, 0, 255, FontStyle.BlackBorder) { X = fx, Y = fy });
+                layout.Widgets.Add(BuildLabeledRow(ResGumps.MarkerIcon,
+                    BuildCombo(_icons, selectedIcon, idx => _selectedIconIndex = idx)));
             }
 
-            // Buttons Add and Edit depend of state
-            if (!isEdit)
-            {
-                Add
-                (
-                    new NiceButton
-                        (
-                            markersGumpBackground.X + 13,
-                            markersGumpBackground.Y + markersGumpBackground.Height - 30,
-                            60,
-                            25,
-                            ButtonAction.Activate,
-                            ResGumps.CreateMarker
-                        )
-                    { ButtonParameter = (int)ButtonsOption.ADD_BTN, IsSelectable = false }
-                );
-            }
-            else
-            {
-                Add
-                (
-                    new NiceButton
-                        (
-                            markersGumpBackground.X + 13,
-                            markersGumpBackground.Y + markersGumpBackground.Height - 30,
-                            60,
-                            25,
-                            ButtonAction.Activate,
-                            ResGumps.Edit
-                        )
-                    { ButtonParameter = (int)ButtonsOption.EDIT_BTN, IsSelectable = false }
-                );
-            }
+            // Buttons Add/Edit and Cancel depend on state
+            var btnRow = new HorizontalStackPanel { Spacing = 8, HorizontalAlignment = HorizontalAlignment.Right };
+            btnRow.Widgets.Add(new MyraButton(isEdit ? ResGumps.Edit : ResGumps.CreateMarker, isEdit ? EditMarker : (Action)AddNewMarker));
+            btnRow.Widgets.Add(new MyraButton(ResGumps.Cancel, Dispose));
+            layout.Widgets.Add(btnRow);
 
-            Add
-            (
-                new NiceButton
-                    (
-                        markersGumpBackground.X + 78,
-                        markersGumpBackground.Y + markersGumpBackground.Height - 30,
-                        60,
-                        25,
-                        ButtonAction.Activate,
-                        ResGumps.Cancel
-                    )
-                { ButtonParameter = (int)ButtonsOption.CANCEL_BTN, IsSelectable = false }
-            );
+            SetRootContent(layout);
+            CenterInViewPort();
+            UIManager.Add(this);
+            BringOnTop();
+        }
 
-            SetInScreen();
+        private static HorizontalStackPanel BuildLabeledRow(string label, Widget widget)
+        {
+            var row = new HorizontalStackPanel { Spacing = 4, VerticalAlignment = VerticalAlignment.Center };
+            row.Widgets.Add(new MyraLabel(label, MyraLabel.TextStyle.P) { Width = 90 });
+            row.Widgets.Add(widget);
+            return row;
+        }
+
+        private static Widget BuildCombo(string[] items, int selectedIndex, Action<int> onChange)
+        {
+#pragma warning disable CS0612, CS0618
+            var combo = new ComboBox { VerticalAlignment = VerticalAlignment.Center, Width = 200 };
+
+            foreach (var item in items)
+                combo.Items.Add(new ListItem(item));
+
+            if (selectedIndex >= 0 && selectedIndex < items.Length)
+                combo.SelectedIndex = selectedIndex;
+
+            combo.SelectedIndexChanged += (_, _) =>
+            {
+                if (combo.SelectedIndex.HasValue)
+                    onChange(combo.SelectedIndex.Value);
+            };
+#pragma warning restore CS0612, CS0618
+
+            return combo;
         }
 
         private void EditMarker()
@@ -317,12 +204,15 @@ namespace ClassicUO.Game.UI.Gumps
             if (string.IsNullOrEmpty(markerName))
                 return null;
 
+            if (markerName.Length > MAX_NAME_LEN)
+                markerName = markerName.Substring(0, MAX_NAME_LEN);
+
             if (markerName.Contains(","))
                 markerName = markerName.Replace(",", "");
 
-            int mapIdx = World.MapIndex;
-            string color = _colors[_colorsCombo.SelectedIndex];
-            string icon = _iconsCombo == null ? string.Empty : _icons[_iconsCombo.SelectedIndex];
+            int mapIdx = _world.MapIndex;
+            string color = _colors[_selectedColorIndex];
+            string icon = _hasIcons ? _icons[_selectedIconIndex] : string.Empty;
 
             var marker = new WMapMarker
             {
@@ -343,22 +233,6 @@ namespace ClassicUO.Game.UI.Gumps
             marker.MarkerIconName = icon;
 
             return marker;
-        }
-
-        public override void OnButtonClick(int buttonId)
-        {
-            switch (buttonId)
-            {
-                case (int)ButtonsOption.ADD_BTN:
-                    AddNewMarker();
-                    break;
-                case (int)ButtonsOption.EDIT_BTN:
-                    EditMarker();
-                    break;
-                case (int)ButtonsOption.CANCEL_BTN:
-                    Dispose();
-                    break;
-            }
         }
     }
 }

--- a/src/ClassicUO.Client/Game/UI/Gumps/UserMarkerGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/UserMarkerGump.cs
@@ -16,8 +16,6 @@ namespace ClassicUO.Game.UI.Gumps
 {
     public sealed class UserMarkersGump : MyraControl
     {
-        private readonly World _world;
-
         private readonly MyraInputBox _textBoxX;
         private readonly MyraInputBox _textBoxY;
         private readonly MyraInputBox _markerName;
@@ -31,6 +29,7 @@ namespace ClassicUO.Game.UI.Gumps
 
         private readonly List<WMapMarker> _markers;
         private readonly int _markerIdx;
+        private readonly int _mapIndex;
 
         private const int MAX_NAME_LEN = 25;
 
@@ -42,16 +41,19 @@ namespace ClassicUO.Game.UI.Gumps
 
         public event EventHandler EditEnd;
 
-        internal UserMarkersGump(World world, int x, int y, List<WMapMarker> markers, string color = "none", string icon = "exit", bool isEdit = false, int markerIdx = -1)
+        internal UserMarkersGump(World world, int x, int y, List<WMapMarker> markers, string color = "none", string icon = "exit", bool isEdit = false, int markerIdx = -1, int? mapIndex = null)
             : base(isEdit ? ResGumps.EditMarker : ResGumps.AddMarker)
         {
-            _world = world;
-
-            _mapMaxX = Client.Game.UO.FileManager.Maps.MapsDefaultSize[world.MapIndex, 0];
-            _mapMaxY = Client.Game.UO.FileManager.Maps.MapsDefaultSize[world.MapIndex, 1];
-
             _markers = markers;
             _markerIdx = markerIdx;
+
+            // Persist against the map the marker actually belongs to: an existing marker keeps its
+            // own MapId on edit, new markers use the explicitly displayed map (the world map can
+            // free-view a different map than the player is currently on), falling back to the player's map.
+            _mapIndex = isEdit && _markerIdx >= 0 ? _markers[_markerIdx].MapId : mapIndex ?? world.MapIndex;
+
+            _mapMaxX = Client.Game.UO.FileManager.Maps.MapsDefaultSize[_mapIndex, 0];
+            _mapMaxY = Client.Game.UO.FileManager.Maps.MapsDefaultSize[_mapIndex, 1];
 
             _colors = new[] { "none", "red", "green", "blue", "purple", "black", "yellow", "white" };
             _icons = _markerIcons.Keys.ToArray();
@@ -210,7 +212,7 @@ namespace ClassicUO.Game.UI.Gumps
             if (markerName.Contains(","))
                 markerName = markerName.Replace(",", "");
 
-            int mapIdx = _world.MapIndex;
+            int mapIdx = _mapIndex;
             string color = _colors[_selectedColorIndex];
             string icon = _hasIcons ? _icons[_selectedIconIndex] : string.Empty;
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
@@ -3376,7 +3376,7 @@ public class WorldMapGump : ResizableGump
 
                 UserMarkersGump existingGump = UIManager.GetGump<UserMarkersGump>();
                 existingGump?.Dispose();
-                UIManager.Add(new UserMarkersGump(World, wX, wY, userFile.Markers));
+                new UserMarkersGump(World, wX, wY, userFile.Markers);
                 return;
             }
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
@@ -3376,7 +3376,7 @@ public class WorldMapGump : ResizableGump
 
                 UserMarkersGump existingGump = UIManager.GetGump<UserMarkersGump>();
                 existingGump?.Dispose();
-                new UserMarkersGump(World, wX, wY, userFile.Markers);
+                new UserMarkersGump(World, wX, wY, userFile.Markers, mapIndex: _map.Index);
                 return;
             }
 


### PR DESCRIPTION
Reimplement UserMarkersGump as a MyraControl instead of a classic Gump, using Myra widgets (input boxes, dropdowns, buttons) for the add/edit marker form on the world map. The window now adds itself to the UIManager on construction, so the WorldMapGump and MarkersManagerGump callers no longer add it manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized marker management and editing interface with updated UI components and improved layout system.
  * Enhanced marker selection controls for color and icon options.

* **Bug Fixes**
  * Improved marker name handling: names are now automatically truncated to maximum character limit and commas are stripped during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->