### PR TITLE
Fix duplicate key crash when creating journal tab with existing name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ All notable changes to TazUO will be recorded here.
 * Show a clear, actionable message when graphics shaders fail to compile instead of crashing — points at outdated/unavailable OpenGL (Remote Desktop, a VM without 3D acceleration, or missing/outdated GPU drivers) and suggests updating drivers or switching renderer - [P.R 584](https://github.com/PlayTazUO/TazUO/pull/584) ([bittiez](https://github.com/bittiez))
 * Add option disable gargoyle flying animation - ([Nesci28](https://github.com/Nesci28))
 * Fixed NullReferenceException in ImprovedBuffGump when a buff icon's title cliloc is not found - [P.R 585](https://github.com/PlayTazUO/TazUO/pull/585) ([bittiez](https://github.com/bittiez))
+* Fixed crash when creating a journal tab with a name that already exists - [P.R 589](https://github.com/PlayTazUO/TazUO/pull/589) ([bittiez](https://github.com/bittiez))
 
 ### Legion
 * Added ModernNineSliceGump.SetLegionTexture to go along with zip files and custom png's - Use your own png for a 9-slice texture - ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.2.60</AssemblyVersion>
-    <FileVersion>5.2.60</FileVersion>
+    <AssemblyVersion>5.2.61</AssemblyVersion>
+    <FileVersion>5.2.61</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Gumps/ResizableJournal.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ResizableJournal.cs
@@ -124,7 +124,7 @@ namespace ClassicUO.Game.UI.Gumps
                 {
                     new PromptPopupWindow("New Tab", "Enter a tab name", entry =>
                     {
-                        if (!string.IsNullOrEmpty(entry))
+                        if (!string.IsNullOrEmpty(entry) && !ProfileManager.CurrentProfile.JournalTabs.ContainsKey(entry))
                         {
                             ProfileManager.CurrentProfile.JournalTabs.Add(entry, new MessageType[] { MessageType.Regular });
                             ResizableJournal.ReloadTabs = true;


### PR DESCRIPTION
Adding a new journal tab with a name that already exists threw ArgumentException (Argument_AddingDuplicateWithKey) from Dictionary.Add. Guard against existing keys before adding.