### PR TITLE
Add HotKeys page to the Assistant window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to TazUO will be recorded here.
 * Add option to select and copy text in journal - [P.R 575](https://github.com/PlayTazUO/TazUO/pull/575) ([Nesci28](https://github.com/Nesci28))
 * Add Script slot type to the Spell Bar - [P.R 568](https://github.com/PlayTazUO/TazUO/pull/568) ([eddo87](https://github.com/eddo87))
 * Converted the Add/Edit User Marker world map window to a Myra window - [P.R 588](https://github.com/PlayTazUO/TazUO/pull/588) ([bittiez](https://github.com/bittiez))
+* Add HotKeys tab in the Assistant window: bind keyboard combos and mouse buttons/wheel to spells, macros, script toggles, skills, consumables, weapon abilities, and Self Heal (Magery/Chivalry); editable bindings, per-character storage, a bindable master disable toggle, two-way macro-hotkey sync with the Macros tab, and conflict detection that clears the old macro/SpellBar binding - ([eddo87](https://github.com/eddo87))
 
 ### Fixes
 * Fixed crash reading BWT-compressed UOP animations caused by returning a non-pooled buffer to the array pool - [P.R 532](https://github.com/PlayTazUO/TazUO/pull/532) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -5,7 +5,7 @@
 ; Missing keys are auto-appended with English defaults when
 ; this file's version is newer than the user's copy.
 ; -------------------------------------------------------
-_version=24
+_version=29
 accountname=Account Name
 accountcontextmenutooltip=Right click to select another account.
 music=Music
@@ -144,6 +144,48 @@ gridhighlight_export_success=Saved highlight export to: {0}
 gridhighlight_import_dialog=Import grid highlight settings
 gridhighlight_import_success=Imported highlight config from: {0}
 gridhighlight_import_error=Error importing highlight config
+
+; HotKeys tab
+hotkeys_disableall=Disable all hotkeys
+hotkeys_disableall_tooltip=Master switch: temporarily disables all hotkey dispatch without removing your bindings.
+hotkeys_selfheal=Self Heal
+hotkeys_enable=Enabled
+hotkeys_addhotkey=Add Hotkey
+hotkeys_category=Category
+hotkeys_action=Action
+hotkeys_settrigger=Set Trigger
+hotkeys_pressakey=Press a key...
+hotkeys_apply=Apply
+hotkeys_cancel=Cancel
+hotkeys_clear=Clear
+hotkeys_remove=Remove
+hotkeys_none=None
+hotkeys_mouse3=Mouse3
+hotkeys_mouse4=Mouse4
+hotkeys_mouse5=Mouse5
+hotkeys_wheelup=Wheel Up
+hotkeys_wheeldown=Wheel Down
+hotkeys_conflict_title=Hotkey conflict
+hotkeys_conflict_body=This trigger is already used by:
+hotkeys_assignanyway=Assign anyway (removes old)
+hotkeys_targetitem=Target an item to set
+hotkeys_edit=Edit
+hotkeys_togglehotkeys=Toggle Hotkeys
+hotkeys_macro_conflict_title=Macro already bound
+hotkeys_macro_conflict_body=This macro already has a key set in the Macros tab:
+hotkeys_macro_update=Update the macro's key to this trigger
+hotkeys_add=Add
+hotkeys_select_or_add=Select or add a hotkey to edit
+hotkeys_magery=Magery
+hotkeys_chivalry=Chivalry
+hotkeys_section_general=General
+hotkeys_section_editor=Edit Binding
+hotkeys_section_bindings=Bindings
+hotkeys_currenttrigger=Current trigger:
+hotkeys_keyboard=Keyboard:
+hotkeys_mouse=Mouse:
+hotkeys_nokey=(no key)
+hotkeys_toggle_key=Toggle key:
 
 ; Grid highlight - config
 gridhighlight_config_title=Properties configuration (separated by a new line)

--- a/src/ClassicUO.Client/Game/Data/HotKeyAction.cs
+++ b/src/ClassicUO.Client/Game/Data/HotKeyAction.cs
@@ -1,0 +1,166 @@
+using System.Linq;
+using ClassicUO.Configuration;
+using ClassicUO.Game.GameObjects;
+using ClassicUO.Game.Managers;
+
+namespace ClassicUO.Game.Data;
+
+public enum HotKeyActionType
+{
+    Spell = 0,
+    Macro = 1,
+    Script = 2,
+    Skill = 3,
+    Consumable = 4,
+    Ability = 5,
+    ToggleHotkeys = 6,
+    SelfHeal = 7,
+}
+
+public class CustomConsumable
+{
+    public string Label { get; set; } = "";
+    public int Graphic { get; set; }
+    public int Hue { get; set; } = -1; // -1 = any
+}
+
+public class HotKeyAction
+{
+    public HotKeyActionType Type { get; set; }
+    public int SpellId { get; set; }
+    public string MacroName { get; set; } = "";
+    public string ScriptPath { get; set; } = "";
+    public int SkillIndex { get; set; } = -1;
+    public int ConsumableGraphic { get; set; }
+    public int ConsumableHue { get; set; } = -1;
+    public string ConsumableLabel { get; set; } = "";
+    public bool AbilityPrimary { get; set; } = true;
+    public bool SelfHealChivalry { get; set; } = false; // false = Magery, true = Chivalry
+
+    public string DisplayName(World world)
+    {
+        switch (Type)
+        {
+            case HotKeyActionType.Spell:
+            {
+                var def = SpellDefinition.FullIndexGetSpell(SpellId);
+                return def != null && !string.IsNullOrEmpty(def.Name) ? def.Name : "Spell (missing)";
+            }
+            case HotKeyActionType.Macro:
+            {
+                var macro = world?.Macros?.FindMacro(MacroName);
+                return macro != null ? $"Macro: {MacroName}" : $"Macro: {MacroName} (missing)";
+            }
+            case HotKeyActionType.Script:
+            {
+                var script = ResolveScript();
+                return script != null ? $"Script: {script.FileName}" : $"Script: {ScriptPath} (missing)";
+            }
+            case HotKeyActionType.Skill:
+            {
+                var skills = world?.Player?.Skills;
+                if (skills != null && SkillIndex >= 0 && SkillIndex < skills.Length)
+                    return $"Skill: {skills[SkillIndex].Name}";
+                return "Skill (missing)";
+            }
+            case HotKeyActionType.Consumable:
+                return string.IsNullOrEmpty(ConsumableLabel) ? "Consumable" : ConsumableLabel;
+            case HotKeyActionType.Ability:
+                return AbilityPrimary ? "Primary Ability" : "Secondary Ability";
+            case HotKeyActionType.ToggleHotkeys:
+                return "Toggle Hotkeys";
+            case HotKeyActionType.SelfHeal:
+                return SelfHealChivalry ? "Self Heal (Chivalry)" : "Self Heal (Magery)";
+            default:
+                return "Unknown";
+        }
+    }
+
+    public void Activate(World world)
+    {
+        if (world == null)
+            return;
+
+        switch (Type)
+        {
+            case HotKeyActionType.Spell:
+                GameActions.CastSpell(SpellId);
+                break;
+
+            case HotKeyActionType.Macro:
+            {
+                var macro = world.Macros?.FindMacro(MacroName);
+                if (macro?.Items is MacroObject mo)
+                {
+                    world.Macros.SetMacroToExecute(mo);
+                    world.Macros.WaitForTargetTimer = 0;
+                    world.Macros.Update();
+                }
+                else
+                    GameActions.Print(world, $"HotKey: macro '{MacroName}' not found.");
+                break;
+            }
+
+            case HotKeyActionType.Script:
+            {
+                var script = ResolveScript();
+                if (script == null)
+                {
+                    GameActions.Print(world, $"HotKey: script '{ScriptPath}' not found.");
+                    break;
+                }
+                if (script.IsPlaying)
+                    LegionScripting.LegionScripting.StopScript(script);
+                else
+                    LegionScripting.LegionScripting.PlayScript(script);
+                break;
+            }
+
+            case HotKeyActionType.Skill:
+                if (SkillIndex < 0)
+                {
+                    GameActions.Print(world, "HotKey: no skill set.");
+                    break;
+                }
+                GameActions.UseSkill(SkillIndex);
+                break;
+
+            case HotKeyActionType.Consumable:
+            {
+                ushort? hue = ConsumableHue < 0 ? null : (ushort)ConsumableHue;
+                var item = world.Player?.FindItemByGraphicAndHue((ushort)ConsumableGraphic, hue);
+                if (item != null)
+                    GameActions.DoubleClick(world, item.Serial);
+                else
+                    GameActions.Print(world, $"HotKey: no '{ConsumableLabel}' found.");
+                break;
+            }
+
+            case HotKeyActionType.Ability:
+                if (AbilityPrimary)
+                    GameActions.UsePrimaryAbility(world);
+                else
+                    GameActions.UseSecondaryAbility(world);
+                break;
+
+            case HotKeyActionType.ToggleHotkeys:
+            {
+                var profile = ProfileManager.CurrentProfile;
+                if (profile != null)
+                {
+                    profile.DisableHotkeys = !profile.DisableHotkeys;
+                    GameActions.Print(world, $"Hotkeys {(profile.DisableHotkeys ? "disabled" : "enabled")}.");
+                }
+                break;
+            }
+
+            case HotKeyActionType.SelfHeal:
+                // NO-OP: SelfHealManager performs the real hold-to-heal via the profile.
+                // Matching here returns handled=true so the macro fallback is suppressed.
+                break;
+        }
+    }
+
+    private LegionScripting.ScriptFile ResolveScript()
+        => LegionScripting.LegionScripting.LoadedScripts.FirstOrDefault(s => s.RelativePath == ScriptPath);
+}

--- a/src/ClassicUO.Client/Game/Data/HotKeyEntry.cs
+++ b/src/ClassicUO.Client/Game/Data/HotKeyEntry.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace ClassicUO.Game.Data;
+
+public class HotKeyEntry
+{
+    public HotKeyTrigger Trigger { get; set; } = new();
+    public bool Enabled { get; set; } = true;
+    public HotKeyAction Action { get; set; } = new();
+}
+
+public class HotKeySettings
+{
+    public List<HotKeyEntry> Entries { get; set; } = new();
+    public List<CustomConsumable> CustomConsumables { get; set; } = new();
+}
+
+[JsonSerializable(typeof(HotKeySettings), GenerationMode = JsonSourceGenerationMode.Metadata)]
+[JsonSerializable(typeof(HotKeyEntry), GenerationMode = JsonSourceGenerationMode.Metadata)]
+[JsonSerializable(typeof(HotKeyTrigger), GenerationMode = JsonSourceGenerationMode.Metadata)]
+[JsonSerializable(typeof(HotKeyAction), GenerationMode = JsonSourceGenerationMode.Metadata)]
+[JsonSerializable(typeof(CustomConsumable), GenerationMode = JsonSourceGenerationMode.Metadata)]
+public partial class HotKeySettingsContext : JsonSerializerContext { }

--- a/src/ClassicUO.Client/Game/Data/HotKeyTrigger.cs
+++ b/src/ClassicUO.Client/Game/Data/HotKeyTrigger.cs
@@ -1,0 +1,96 @@
+using ClassicUO.Input;
+using SDL3;
+
+namespace ClassicUO.Game.Data;
+
+public enum HotKeyTriggerKind
+{
+    None = 0,
+    Keyboard = 1,
+    MouseButton = 2,
+    MouseWheel = 3,
+}
+
+public class HotKeyTrigger
+{
+    public HotKeyTriggerKind Kind { get; set; } = HotKeyTriggerKind.None;
+    public int Key { get; set; }        // (int)SDL.SDL_Keycode
+    public int Button { get; set; }     // (int)MouseButtonType
+    public bool WheelUp { get; set; }
+    public int Mod { get; set; }        // (int)SDL.SDL_Keymod (normalized)
+
+    // Strip lock keys and consolidate left/right modifiers — identical rules to
+    // SpellBarManager / SelfHealManager so all three systems agree on a combo.
+    public static SDL.SDL_Keymod NormalizeMods(SDL.SDL_Keymod mod)
+    {
+        mod &= ~SDL.SDL_Keymod.SDL_KMOD_NUM;
+        mod &= ~SDL.SDL_Keymod.SDL_KMOD_CAPS;
+        mod &= ~SDL.SDL_Keymod.SDL_KMOD_SCROLL;
+        mod &= ~SDL.SDL_Keymod.SDL_KMOD_MODE;
+
+        if ((mod & (SDL.SDL_Keymod.SDL_KMOD_LCTRL | SDL.SDL_Keymod.SDL_KMOD_RCTRL)) != 0)
+        {
+            mod &= ~(SDL.SDL_Keymod.SDL_KMOD_LCTRL | SDL.SDL_Keymod.SDL_KMOD_RCTRL);
+            mod |= SDL.SDL_Keymod.SDL_KMOD_CTRL;
+        }
+        if ((mod & (SDL.SDL_Keymod.SDL_KMOD_LSHIFT | SDL.SDL_Keymod.SDL_KMOD_RSHIFT)) != 0)
+        {
+            mod &= ~(SDL.SDL_Keymod.SDL_KMOD_LSHIFT | SDL.SDL_Keymod.SDL_KMOD_RSHIFT);
+            mod |= SDL.SDL_Keymod.SDL_KMOD_SHIFT;
+        }
+        if ((mod & (SDL.SDL_Keymod.SDL_KMOD_LALT | SDL.SDL_Keymod.SDL_KMOD_RALT)) != 0)
+        {
+            mod &= ~(SDL.SDL_Keymod.SDL_KMOD_LALT | SDL.SDL_Keymod.SDL_KMOD_RALT);
+            mod |= SDL.SDL_Keymod.SDL_KMOD_ALT;
+        }
+        return mod;
+    }
+
+    public bool MatchesKeyboard(SDL.SDL_Keycode key, SDL.SDL_Keymod mod)
+        => Kind == HotKeyTriggerKind.Keyboard
+           && Key == (int)key
+           && (int)NormalizeMods(mod) == Mod;
+
+    public bool MatchesMouseButton(MouseButtonType button, SDL.SDL_Keymod mod)
+        => Kind == HotKeyTriggerKind.MouseButton
+           && Button == (int)button
+           && (int)NormalizeMods(mod) == Mod;
+
+    public bool MatchesWheel(bool up, SDL.SDL_Keymod mod)
+        => Kind == HotKeyTriggerKind.MouseWheel
+           && WheelUp == up
+           && (int)NormalizeMods(mod) == Mod;
+
+    public string Describe()
+    {
+        switch (Kind)
+        {
+            case HotKeyTriggerKind.Keyboard:
+                return KeysTranslator.TryGetKey((SDL.SDL_Keycode)Key, (SDL.SDL_Keymod)Mod);
+            case HotKeyTriggerKind.MouseButton:
+                string mods = ModPrefix();
+                string btn = (MouseButtonType)Button switch
+                {
+                    MouseButtonType.Middle => "Mouse3",
+                    MouseButtonType.XButton1 => "Mouse4",
+                    MouseButtonType.XButton2 => "Mouse5",
+                    _ => "Mouse",
+                };
+                return mods + btn;
+            case HotKeyTriggerKind.MouseWheel:
+                return ModPrefix() + (WheelUp ? "Wheel Up" : "Wheel Down");
+            default:
+                return "";
+        }
+    }
+
+    private string ModPrefix()
+    {
+        var m = (SDL.SDL_Keymod)Mod;
+        string s = "";
+        if ((m & SDL.SDL_Keymod.SDL_KMOD_CTRL) != 0) s += "Ctrl+";
+        if ((m & SDL.SDL_Keymod.SDL_KMOD_SHIFT) != 0) s += "Shift+";
+        if ((m & SDL.SDL_Keymod.SDL_KMOD_ALT) != 0) s += "Alt+";
+        return s;
+    }
+}

--- a/src/ClassicUO.Client/Game/Managers/HotKeyManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/HotKeyManager.cs
@@ -1,0 +1,354 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using ClassicUO.Configuration;
+using ClassicUO.Game.Data;
+using ClassicUO.Input;
+using ClassicUO.Utility.Logging;
+using SDL3;
+
+namespace ClassicUO.Game.Managers;
+
+public static class HotKeyManager
+{
+    public const int MaxCustomConsumables = 4;
+
+    public static List<HotKeyEntry> Entries { get; private set; } = new();
+    public static List<CustomConsumable> CustomConsumables { get; private set; } = new();
+
+    /// <summary>
+    /// Raised after any persisted mutation (always at the end of <see cref="Save"/>).
+    /// UI tabs subscribe to live-refresh their already-built widgets when data changes
+    /// in another context. Subscribers MUST unsubscribe when their window closes.
+    /// </summary>
+    public static event System.Action Changed;
+
+    public static bool AddCustomConsumable(CustomConsumable c)
+    {
+        if (CustomConsumables.Count >= MaxCustomConsumables)
+            return false;
+        CustomConsumables.Add(c);
+        return true;
+    }
+
+    private static string FilePath()
+    {
+        string dir = ProfileManager.ProfilePath;
+        return string.IsNullOrEmpty(dir) ? null : Path.Combine(dir, "HotKeys.json");
+    }
+
+    public static void Load()
+    {
+        Entries = new();
+        CustomConsumables = new();
+
+        string path = FilePath();
+        if (path == null || !File.Exists(path))
+            return;
+
+        try
+        {
+            var s = JsonSerializer.Deserialize(File.ReadAllText(path), HotKeySettingsContext.Default.HotKeySettings);
+            if (s != null)
+            {
+                Entries = s.Entries ?? new();
+                CustomConsumables = s.CustomConsumables ?? new();
+            }
+        }
+        catch (System.Exception e)
+        {
+            Log.Error($"Failed to load HotKeys.json: {e}");
+        }
+    }
+
+    public static void Save()
+    {
+        string path = FilePath();
+        if (path == null)
+            return;
+
+        try
+        {
+            var s = new HotKeySettings { Entries = Entries, CustomConsumables = CustomConsumables };
+            File.WriteAllText(path, JsonSerializer.Serialize(s, HotKeySettingsContext.Default.HotKeySettings));
+        }
+        catch (System.Exception e)
+        {
+            Log.Error($"Failed to save HotKeys.json: {e}");
+        }
+
+        Changed?.Invoke();
+    }
+
+    private static bool HotkeysDisabled => ProfileManager.CurrentProfile?.DisableHotkeys ?? false;
+
+    // Pure matcher (no Activate) so dispatch + gating are unit-testable.
+    public static bool TestDispatch(HotKeyTrigger incoming, SDL.SDL_Keymod mod, out HotKeyEntry matched)
+    {
+        matched = null;
+        bool disabled = HotkeysDisabled;
+
+        foreach (var e in Entries)
+        {
+            if (!e.Enabled || e.Trigger == null)
+                continue;
+            // While hotkeys are disabled, only a ToggleHotkeys binding may fire (so it can re-enable).
+            if (disabled && e.Action?.Type != HotKeyActionType.ToggleHotkeys)
+                continue;
+
+            bool hit = incoming.Kind switch
+            {
+                HotKeyTriggerKind.Keyboard    => e.Trigger.MatchesKeyboard((SDL.SDL_Keycode)incoming.Key, mod),
+                HotKeyTriggerKind.MouseButton => e.Trigger.MatchesMouseButton((MouseButtonType)incoming.Button, mod),
+                HotKeyTriggerKind.MouseWheel  => e.Trigger.MatchesWheel(incoming.WheelUp, mod),
+                _ => false,
+            };
+            if (hit)
+            {
+                matched = e;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static bool KeyPress(SDL.SDL_Keycode key, SDL.SDL_Keymod mod)
+        => Dispatch(new HotKeyTrigger { Kind = HotKeyTriggerKind.Keyboard, Key = (int)key }, mod);
+
+    public static bool MousePress(MouseButtonType button, SDL.SDL_Keymod mod)
+        => Dispatch(new HotKeyTrigger { Kind = HotKeyTriggerKind.MouseButton, Button = (int)button }, mod);
+
+    public static bool WheelPress(bool up, SDL.SDL_Keymod mod)
+        => Dispatch(new HotKeyTrigger { Kind = HotKeyTriggerKind.MouseWheel, WheelUp = up }, mod);
+
+    private static bool Dispatch(HotKeyTrigger incoming, SDL.SDL_Keymod mod)
+    {
+        if (!TestDispatch(incoming, mod, out var matched))
+            return false;
+        matched.Action?.Activate(Client.Game?.UO?.World);
+        return true;
+    }
+
+    // Returns human-readable descriptions of any existing binding that uses this trigger.
+    public static List<string> FindConflicts(HotKeyTrigger trigger, HotKeyEntry ignore = null)
+    {
+        var conflicts = new List<string>();
+        var world = Client.Game?.UO?.World;
+        var mod = (SDL.SDL_Keymod)trigger.Mod;
+
+        foreach (var e in Entries)
+        {
+            if (ReferenceEquals(e, ignore))
+                continue;
+            if (e.Trigger == null)
+                continue;
+            bool hit = trigger.Kind switch
+            {
+                HotKeyTriggerKind.Keyboard    => e.Trigger.MatchesKeyboard((SDL.SDL_Keycode)trigger.Key, mod),
+                HotKeyTriggerKind.MouseButton => e.Trigger.MatchesMouseButton((MouseButtonType)trigger.Button, mod),
+                HotKeyTriggerKind.MouseWheel  => e.Trigger.MatchesWheel(trigger.WheelUp, mod),
+                _ => false,
+            };
+            if (hit)
+                conflicts.Add($"HotKey: {e.Action?.DisplayName(world)}");
+        }
+
+        // Macros (same trigger kinds the macro system supports)
+        var macros = world?.Macros;
+        if (macros != null)
+        {
+            bool alt = (mod & SDL.SDL_Keymod.SDL_KMOD_ALT) != 0;
+            bool ctrl = (mod & SDL.SDL_Keymod.SDL_KMOD_CTRL) != 0;
+            bool shift = (mod & SDL.SDL_Keymod.SDL_KMOD_SHIFT) != 0;
+
+            Macro m = trigger.Kind switch
+            {
+                HotKeyTriggerKind.Keyboard    => macros.FindMacro((SDL.SDL_Keycode)trigger.Key, alt, ctrl, shift),
+                HotKeyTriggerKind.MouseButton => macros.FindMacro((MouseButtonType)trigger.Button, alt, ctrl, shift),
+                HotKeyTriggerKind.MouseWheel  => macros.FindMacro(trigger.WheelUp, alt, ctrl, shift),
+                _ => null,
+            };
+            if (m != null)
+                conflicts.Add($"Macro: {m.Name}");
+        }
+
+        if (trigger.Kind == HotKeyTriggerKind.Keyboard)
+        {
+            SDL.SDL_Keycode[] keys = SpellBarManager.GetHotKeys();
+            SDL.SDL_Keymod[] mods = SpellBarManager.GetModKeys();
+            if (keys != null && mods != null)
+            {
+                for (int i = 0; i < keys.Length && i < mods.Length; i++)
+                {
+                    if ((int)keys[i] == trigger.Key &&
+                        (int)HotKeyTrigger.NormalizeMods(mods[i]) == (int)HotKeyTrigger.NormalizeMods((SDL.SDL_Keymod)trigger.Mod))
+                    {
+                        conflicts.Add($"SpellBar slot {i}");
+                    }
+                }
+            }
+        }
+
+        return conflicts;
+    }
+
+    private static SDL.SDL_Keymod ModsFromBools(bool alt, bool ctrl, bool shift)
+    {
+        SDL.SDL_Keymod m = SDL.SDL_Keymod.SDL_KMOD_NONE;
+        if (alt) m |= SDL.SDL_Keymod.SDL_KMOD_ALT;
+        if (ctrl) m |= SDL.SDL_Keymod.SDL_KMOD_CTRL;
+        if (shift) m |= SDL.SDL_Keymod.SDL_KMOD_SHIFT;
+        return m;
+    }
+
+    public static HotKeyTrigger TriggerFromMacro(Macro m)
+    {
+        if (m == null)
+            return new HotKeyTrigger { Kind = HotKeyTriggerKind.None };
+
+        int mod = (int)HotKeyTrigger.NormalizeMods(ModsFromBools(m.Alt, m.Ctrl, m.Shift));
+
+        if (m.Key != SDL.SDL_Keycode.SDLK_UNKNOWN)
+            return new HotKeyTrigger { Kind = HotKeyTriggerKind.Keyboard, Key = (int)m.Key, Mod = mod };
+        if (m.MouseButton != MouseButtonType.None)
+            return new HotKeyTrigger { Kind = HotKeyTriggerKind.MouseButton, Button = (int)m.MouseButton, Mod = mod };
+        if (m.WheelScroll)
+            return new HotKeyTrigger { Kind = HotKeyTriggerKind.MouseWheel, WheelUp = m.WheelUp, Mod = mod };
+
+        return new HotKeyTrigger { Kind = HotKeyTriggerKind.None };
+    }
+
+    public static void ApplyTriggerToMacro(Macro m, HotKeyTrigger t)
+    {
+        if (m == null || t == null)
+            return;
+
+        m.Key = SDL.SDL_Keycode.SDLK_UNKNOWN;
+        m.MouseButton = MouseButtonType.None;
+        m.WheelScroll = false;
+        m.WheelUp = false;
+
+        var mod = (SDL.SDL_Keymod)t.Mod;
+        m.Alt = (mod & SDL.SDL_Keymod.SDL_KMOD_ALT) != 0;
+        m.Ctrl = (mod & SDL.SDL_Keymod.SDL_KMOD_CTRL) != 0;
+        m.Shift = (mod & SDL.SDL_Keymod.SDL_KMOD_SHIFT) != 0;
+
+        switch (t.Kind)
+        {
+            case HotKeyTriggerKind.Keyboard:    m.Key = (SDL.SDL_Keycode)t.Key; break;
+            case HotKeyTriggerKind.MouseButton: m.MouseButton = (MouseButtonType)t.Button; break;
+            case HotKeyTriggerKind.MouseWheel:  m.WheelScroll = true; m.WheelUp = t.WheelUp; break;
+        }
+    }
+
+    /// <summary>
+    /// "Assign anyway": removes the old binding for <paramref name="trigger"/> everywhere it
+    /// promised — conflicting HotKey entries (disabling Profile.SelfHeal if a SelfHeal entry
+    /// was among them), the bound macro, and the SpellBar slot (keyboard only).
+    /// The entry being edited (<paramref name="keepEntry"/>) and the entry's own macro
+    /// (<paramref name="keepMacroName"/>) are left intact. Does NOT call Save() — the caller's
+    /// Finalize persists the HotKey entries; macro/SpellBar are persisted here directly.
+    /// </summary>
+    public static void ClearTriggerEverywhere(HotKeyTrigger trigger, HotKeyEntry keepEntry, string keepMacroName)
+    {
+        if (trigger == null)
+            return;
+
+        var mod = (SDL.SDL_Keymod)trigger.Mod;
+
+        // ── HotKey entries ──────────────────────────────────────────────────
+        var matches = new List<HotKeyEntry>();
+        foreach (var e in Entries)
+        {
+            if (ReferenceEquals(e, keepEntry))
+                continue;
+            if (e.Trigger == null)
+                continue;
+            bool hit = trigger.Kind switch
+            {
+                HotKeyTriggerKind.Keyboard    => e.Trigger.MatchesKeyboard((SDL.SDL_Keycode)trigger.Key, mod),
+                HotKeyTriggerKind.MouseButton => e.Trigger.MatchesMouseButton((MouseButtonType)trigger.Button, mod),
+                HotKeyTriggerKind.MouseWheel  => e.Trigger.MatchesWheel(trigger.WheelUp, mod),
+                _ => false,
+            };
+            if (hit)
+                matches.Add(e);
+        }
+
+        foreach (var e in matches)
+        {
+            if (e.Action?.Type == HotKeyActionType.SelfHeal)
+            {
+                var p = ProfileManager.CurrentProfile;
+                if (p != null)
+                {
+                    p.SelfHeal_Key = 0;
+                    p.SelfHeal_Enabled = false;
+                }
+            }
+        }
+        Entries.RemoveAll(e => matches.Contains(e));
+
+        // ── Macro ───────────────────────────────────────────────────────────
+        var macros = Client.Game?.UO?.World?.Macros;
+        if (macros != null)
+        {
+            bool alt = (mod & SDL.SDL_Keymod.SDL_KMOD_ALT) != 0;
+            bool ctrl = (mod & SDL.SDL_Keymod.SDL_KMOD_CTRL) != 0;
+            bool shift = (mod & SDL.SDL_Keymod.SDL_KMOD_SHIFT) != 0;
+
+            Macro FindBound() => trigger.Kind switch
+            {
+                HotKeyTriggerKind.Keyboard    => macros.FindMacro((SDL.SDL_Keycode)trigger.Key, alt, ctrl, shift),
+                HotKeyTriggerKind.MouseButton => macros.FindMacro((MouseButtonType)trigger.Button, alt, ctrl, shift),
+                HotKeyTriggerKind.MouseWheel  => macros.FindMacro(trigger.WheelUp, alt, ctrl, shift),
+                _ => null,
+            };
+
+            Macro m = FindBound();
+            while (m != null)
+            {
+                // Guard against an infinite loop: never clear (and thus never re-find)
+                // the entry's own macro — stop when that's the only match left.
+                if (m.Name == keepMacroName)
+                    break;
+
+                m.Key = SDL.SDL_Keycode.SDLK_UNKNOWN;
+                m.MouseButton = MouseButtonType.None;
+                m.WheelScroll = false;
+                m.WheelUp = false;
+                m.Alt = false;
+                m.Ctrl = false;
+                m.Shift = false;
+                m.ControllerButtons = null;
+
+                macros.Save();
+                OnMacroKeyChanged(m);
+
+                m = FindBound();
+            }
+        }
+
+        // ── SpellBar (keyboard only) ────────────────────────────────────────
+        if (trigger.Kind == HotKeyTriggerKind.Keyboard)
+            SpellBarManager.ClearHotKeyForKey((SDL.SDL_Keycode)trigger.Key, (SDL.SDL_Keymod)trigger.Mod);
+    }
+
+    public static void OnMacroKeyChanged(Macro m)
+    {
+        if (m == null)
+            return;
+
+        bool changed = false;
+        foreach (var e in Entries)
+        {
+            if (e.Action?.Type == HotKeyActionType.Macro && e.Action.MacroName == m.Name)
+            {
+                e.Trigger = TriggerFromMacro(m); // fresh instance per entry (no aliasing)
+                changed = true;
+            }
+        }
+        if (changed)
+            Save();
+    }
+}

--- a/src/ClassicUO.Client/Game/Managers/SpellBarManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/SpellBarManager.cs
@@ -277,7 +277,7 @@ public class SpellBarManager
         enabled = true;
     }
 
-    public static void Unload()
+    public static void Save()
     {
         try
         {
@@ -288,6 +288,48 @@ public class SpellBarManager
         {
             Log.Error(e.ToString());
         }
+    }
+
+    public static void Unload()
+    {
+        Save();
+    }
+
+    /// <summary>
+    /// Clears any SpellBar slot keyboard hotkey matching the given key+mod (modifiers
+    /// normalized the same way as HotKeyTrigger). Leaves controller bindings untouched.
+    /// Persists and refreshes the on-screen bar when anything changed.
+    /// </summary>
+    public static bool ClearHotKeyForKey(SDL.SDL_Keycode key, SDL.SDL_Keymod mod)
+    {
+        if (spellBarSettings == null)
+            return false;
+
+        SDL.SDL_Keymod normalizedMod = ClassicUO.Game.Data.HotKeyTrigger.NormalizeMods(mod);
+
+        SDL.SDL_Keycode[] keys = GetHotKeys();
+        SDL.SDL_Keymod[] mods = GetModKeys();
+        if (keys == null || mods == null)
+            return false;
+
+        bool cleared = false;
+        for (int i = 0; i < keys.Length && i < mods.Length; i++)
+        {
+            if (keys[i] == key &&
+                ClassicUO.Game.Data.HotKeyTrigger.NormalizeMods(mods[i]) == normalizedMod)
+            {
+                SetButtons(i, SDL.SDL_Keymod.SDL_KMOD_NONE, SDL.SDL_Keycode.SDLK_UNKNOWN, null);
+                cleared = true;
+            }
+        }
+
+        if (cleared)
+        {
+            Save();
+            Game.UI.Gumps.SpellBar.SpellBar.Instance?.SetupHotkeyLabels();
+        }
+
+        return cleared;
     }
 
     private static void SetDefaults() => SpellBarRows = [new SpellBarRow()

--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -227,6 +227,7 @@ namespace ClassicUO.Game.Scenes
             OrganizerAgent.Load();
             GraphicsReplacement.Load();
             SpellBarManager.Load();
+            HotKeyManager.Load();
             SelfHealManager.Load();
             if(ProfileManager.CurrentProfile.EnableCaveBorder)
                 StaticFilters.ApplyCaveTileBorder();
@@ -369,6 +370,7 @@ namespace ClassicUO.Game.Scenes
             JournalFilterManager.Instance.Save();
 
             SpellBarManager.Unload();
+            HotKeyManager.Save();
             SelfHealManager.Unload();
             _autoUnequipActionManager?.Dispose();
             ObjectActionQueue.Instance.Clear();

--- a/src/ClassicUO.Client/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameSceneInputHandler.cs
@@ -1147,6 +1147,12 @@ namespace ClassicUO.Game.Scenes
         {
             if (CanExecuteMacro())
             {
+                SDL.SDL_Keymod mod = (Keyboard.Ctrl ? SDL.SDL_Keymod.SDL_KMOD_CTRL : SDL.SDL_Keymod.SDL_KMOD_NONE)
+                    | (Keyboard.Shift ? SDL.SDL_Keymod.SDL_KMOD_SHIFT : SDL.SDL_Keymod.SDL_KMOD_NONE)
+                    | (Keyboard.Alt ? SDL.SDL_Keymod.SDL_KMOD_ALT : SDL.SDL_Keymod.SDL_KMOD_NONE);
+                if (HotKeyManager.MousePress(button, mod))
+                    return true;
+
                 Macro macro = _world.Macros.FindMacro(button, Keyboard.Alt, Keyboard.Ctrl, Keyboard.Shift);
 
                 if (macro != null && button != MouseButtonType.None)
@@ -1224,6 +1230,12 @@ namespace ClassicUO.Game.Scenes
             // this check specifically targets the Shop Gump. This is the least invasive, if imperfect solution right now.
             if (CanExecuteMacro() && UIManager.TopMostControl is not ShopGump)
             {
+                SDL.SDL_Keymod mod = (Keyboard.Ctrl ? SDL.SDL_Keymod.SDL_KMOD_CTRL : SDL.SDL_Keymod.SDL_KMOD_NONE)
+                    | (Keyboard.Shift ? SDL.SDL_Keymod.SDL_KMOD_SHIFT : SDL.SDL_Keymod.SDL_KMOD_NONE)
+                    | (Keyboard.Alt ? SDL.SDL_Keymod.SDL_KMOD_ALT : SDL.SDL_Keymod.SDL_KMOD_NONE);
+                if (HotKeyManager.WheelPress(up, mod))
+                    return true;
+
                 Macro macro = _world.Macros.FindMacro(up, Keyboard.Alt, Keyboard.Ctrl, Keyboard.Shift);
 
                 if (macro != null)
@@ -1491,12 +1503,11 @@ namespace ClassicUO.Game.Scenes
                 SpellBarManager.KeyPress(key, e.mod);
                 SelfHealManager.HandleKeyDown(key, e.mod, e.repeat);
 
-                Macro macro = _world.Macros.FindMacro(
-                    key,
-                    Keyboard.Alt,
-                    Keyboard.Ctrl,
-                    Keyboard.Shift
-                );
+                bool hotkeyHandled = HotKeyManager.KeyPress(key, e.mod);
+
+                Macro macro = hotkeyHandled
+                    ? null
+                    : _world.Macros.FindMacro(key, Keyboard.Alt, Keyboard.Ctrl, Keyboard.Shift);
 
                 if (macro != null && key != SDL.SDL_Keycode.SDLK_UNKNOWN)
                 {

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/AssistantWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/AssistantWindow.cs
@@ -5,6 +5,7 @@ using ClassicUO.Game.UI.MyraWindows.Widgets;
 using ClassicUO.Game.UI.MyraWindows.Widgets.Assistant;
 using ClassicUO.Game.UI.MyraWindows.Widgets.Assistant.Agents;
 using ClassicUO.Game.UI.MyraWindows.Widgets.Assistant.Filters;
+using ClassicUO.Game.UI.MyraWindows.Widgets.Assistant.HotKeys;
 using ClassicUO.Game.UI.MyraWindows.Widgets.Assistant.ItemDatabase;
 using ClassicUO.Game.UI.MyraWindows.Widgets.Assistant.Macros;
 using ClassicUO.Game.UI.MyraWindows.Widgets.Assistant.Skills;
@@ -47,6 +48,7 @@ public class AssistantWindow : MyraControl
         base.Dispose();
 
         MacrosTabContent.Cleanup();
+        HotKeysTabContent.Cleanup();
 
         EventSink.SkillValueChangedEvent -= EventSkillUpdated;
         EventSink.SkillBaseChangedEvent -= EventSkillUpdated;
@@ -61,6 +63,7 @@ public class AssistantWindow : MyraControl
         tabs.AddTab("Filters", FiltersTab.Build);
         tabs.AddTab("Item Database", ItemDatabaseTabContent.Build);
         tabs.AddTab("Macros", () => MacrosTabContent.Build(this));
+        tabs.AddTab("HotKeys", () => HotKeysTabContent.Build(this));
         tabs.AddTab("Skills", () => _skillsTabContent = new());
         tabs.SelectFirst();
         SetRootContent(tabs);

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/MyraStyle.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/MyraStyle.cs
@@ -174,6 +174,19 @@ public static class MyraStyle
         grid.RowSpacing = 1;
     }
 
+    /// <summary>
+    /// Wraps a section's content panel in a subtle bordered "card": a 1px border using
+    /// the standard grid border color, a faint dark background, and small padding.
+    /// </summary>
+    public static Panel ApplySectionPanelStyle(Panel p)
+    {
+        p.Padding = new Thickness(6);
+        p.BorderThickness = new Thickness(1);
+        p.Border = new SolidBrush(GridBorderColor);
+        p.Background = new SolidBrush(new Color(0, 0, 0, 25));
+        return p;
+    }
+
     public static Button ApplyButtonDangerStyle(Button button)
     {
         button.Background = _ninePatchButtonDangerUp;

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/HotKeys/HotKeysTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/HotKeys/HotKeysTabContent.cs
@@ -1,0 +1,1157 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using ClassicUO.Configuration;
+using ClassicUO.Game.Data;
+using ClassicUO.Game.GameObjects;
+using ClassicUO.Game.Managers;
+using ClassicUO.Game.UI.Controls;
+using ClassicUO.Input;
+using Myra.Graphics2D;
+using Myra.Graphics2D.UI;
+using SDL3;
+
+namespace ClassicUO.Game.UI.MyraWindows.Widgets.Assistant.HotKeys;
+
+public static class HotKeysTabContent
+{
+    // Opacity applied to a keyless (draft) binding row's cell widgets so it reads as muted.
+    private const float DimOpacity = 0.5f;
+
+    // Static unsubscribe actions for the independent capture paths so that
+    // Cleanup() can stop any in-progress capture when the window closes.
+    private static Action? _editorUnsubscribe;
+    private static Action? _toggleUnsubscribe;
+
+    // The HotKeyManager.Changed handler installed by Build(). Stored so Cleanup() can
+    // detach it; otherwise reopening the window stacks handlers that fire into disposed widgets.
+    private static Action? _changedHandler;
+
+    /// <summary>Call when the owning window closes to unsubscribe any active key-capture handler.</summary>
+    public static void Cleanup()
+    {
+        _editorUnsubscribe?.Invoke();
+        _editorUnsubscribe = null;
+        _toggleUnsubscribe?.Invoke();
+        _toggleUnsubscribe = null;
+
+        if (_changedHandler != null)
+        {
+            HotKeyManager.Changed -= _changedHandler;
+            _changedHandler = null;
+        }
+    }
+
+    private static readonly (string Label, int Graphic)[] FixedPotions =
+    {
+        ("Heal Potion", 0x0F0C),
+        ("Cure Potion", 0x0F07),
+        ("Refresh Potion", 0x0F0B),
+        ("Strength Potion", 0x0F09),
+        ("Agility Potion", 0x0F08),
+    };
+
+    public static Widget Build(MyraControl owner)
+    {
+        Profile? profile = ProfileManager.CurrentProfile;
+        if (profile == null)
+            return new MyraLabel("Profile not loaded", MyraLabel.TextStyle.P);
+
+        World? world = Client.Game?.UO?.World;
+
+        // ── Selection state (mirrors MacrosTabContent's selectedMacro) ───────
+        HotKeyEntry? selectedEntry = null;
+
+        var root = new VerticalStackPanel { Spacing = 6 };
+
+        // ── General section: master toggle + dedicated "toggle all hotkeys" key ──
+        root.Widgets.Add(new MyraSpacer(15, 5));
+        root.Widgets.Add(new MyraLabel(TazLang.Get("hotkeys_section_general"), MyraLabel.TextStyle.H2));
+        Widget masterRow = BuildMasterRow(profile, out Action? refreshToggleLabel);
+        var generalPanel = MyraStyle.ApplySectionPanelStyle(new Panel());
+        generalPanel.Widgets.Add(masterRow);
+        root.Widgets.Add(generalPanel);
+
+        // ── Toolbar (Add) and master/detail panels ───────────────────────────
+        var toolbar = new HorizontalStackPanel { Spacing = 2 };
+
+        var listPanel   = new VerticalStackPanel { Spacing = 2 };
+        var editorPanel = new VerticalStackPanel { Spacing = 4 };
+
+        void BuildBindingList()
+        {
+            listPanel.Widgets.Clear();
+
+            if (HotKeyManager.Entries.Count == 0)
+            {
+                listPanel.Widgets.Add(new MyraLabel(TazLang.Get("hotkeys_none"), MyraLabel.TextStyle.P));
+                return;
+            }
+
+            var grid = new MyraGrid();
+            grid.SetupWithHeaders(
+                GridColumnInfo.Auto(TazLang.Get("hotkeys_settrigger")),
+                GridColumnInfo.Fill(TazLang.Get("hotkeys_action")),
+                GridColumnInfo.Auto(TazLang.Get("hotkeys_enable"), alignRight: true),
+                GridColumnInfo.Auto(TazLang.Get("hotkeys_edit"), alignRight: true),
+                GridColumnInfo.Auto(TazLang.Get("hotkeys_remove"), alignRight: true)
+            );
+
+            int dataRow = 1;
+            foreach (HotKeyEntry entry in HotKeyManager.Entries)
+            {
+                HotKeyEntry captured = entry;
+
+                // A keyless draft (Kind == None) never fires in dispatch (matchers require a
+                // specific Kind) so render it muted until it has a real trigger. Only the
+                // Trigger/Action TEXT is dimmed; the Enable/Edit/Remove controls stay full
+                // opacity so they remain obviously usable.
+                bool keyless = captured.Trigger == null || captured.Trigger.Kind == HotKeyTriggerKind.None;
+                float textOpacity = keyless ? DimOpacity : 1f;
+
+                string triggerText = keyless
+                    ? TazLang.Get("hotkeys_nokey")
+                    : captured.Trigger?.Describe() ?? TazLang.Get("hotkeys_none");
+                var triggerLbl = new MyraLabel(triggerText, MyraLabel.TextStyle.P) { Opacity = textOpacity };
+                var actionLbl = new MyraLabel(captured.Action.DisplayName(world), MyraLabel.TextStyle.P) { Opacity = textOpacity };
+                var enableChk = MyraCheckButton.CreateWithCallback(
+                    captured.Enabled,
+                    b =>
+                    {
+                        captured.Enabled = b;
+                        if (captured.Action.Type == HotKeyActionType.SelfHeal)
+                            profile.SelfHeal_Enabled = b;
+                        HotKeyManager.Save();
+                    });
+                enableChk.HorizontalAlignment = HorizontalAlignment.Center;
+
+                var editBtn = new MyraButton(TazLang.Get("hotkeys_edit"), () =>
+                {
+                    selectedEntry = captured;
+                    BuildBindingList();
+                    BuildEditor();
+                }) { HorizontalAlignment = HorizontalAlignment.Right };
+
+                var removeBtn = MyraStyle.ApplyButtonDangerStyle(new MyraButton(TazLang.Get("hotkeys_remove"), () =>
+                {
+                    if (captured.Action.Type == HotKeyActionType.SelfHeal)
+                        profile.SelfHeal_Enabled = false;
+                    HotKeyManager.Entries.Remove(captured);
+                    if (ReferenceEquals(selectedEntry, captured))
+                        selectedEntry = null;
+                    HotKeyManager.Save();
+                    BuildBindingList();
+                    BuildEditor();
+                }));
+                removeBtn.HorizontalAlignment = HorizontalAlignment.Right;
+
+                grid.AddWidget(triggerLbl, dataRow, 0);
+                grid.AddWidget(actionLbl, dataRow, 1);
+                grid.AddWidget(enableChk, dataRow, 2);
+                grid.AddWidget(editBtn, dataRow, 3);
+                grid.AddWidget(removeBtn, dataRow, 4);
+                dataRow++;
+            }
+
+            listPanel.Widgets.Add(grid);
+        }
+
+        // (Re)build the detail editor for the currently selected entry.
+        void BuildEditor()
+        {
+            // Switching editors must unsubscribe any in-progress capture handler.
+            _editorUnsubscribe?.Invoke();
+            _editorUnsubscribe = null;
+
+            editorPanel.Widgets.Clear();
+
+            if (selectedEntry == null)
+            {
+                editorPanel.Widgets.Add(new MyraLabel(TazLang.Get("hotkeys_select_or_add"), MyraLabel.TextStyle.H3));
+                return;
+            }
+
+            editorPanel.Widgets.Add(BuildEntryEditor(owner, world, selectedEntry, BuildBindingList));
+        }
+
+        // ── Add button: create a dimmed keyless draft and open its editor ────
+        toolbar.Widgets.Add(new MyraButton(TazLang.Get("hotkeys_add"), () =>
+        {
+            SpellDefinition[] spells = SpellDefinition.GetAllSpells();
+            var draft = new HotKeyEntry
+            {
+                Enabled = true,
+                Trigger = new HotKeyTrigger { Kind = HotKeyTriggerKind.None },
+                Action = new HotKeyAction
+                {
+                    Type = HotKeyActionType.Spell,
+                    SpellId = spells.Length > 0 ? spells[0].ID : 0,
+                },
+            };
+            HotKeyManager.Entries.Add(draft);
+            HotKeyManager.Save();
+            selectedEntry = draft;
+            BuildBindingList();
+            BuildEditor();
+        }));
+
+        // ── Vertical layout: editor (always present) → Add → binding list ────
+        // The editor panel takes the vertical spot the removed SelfHeal row vacated.
+        root.Widgets.Add(new MyraSpacer(15, 5));
+        root.Widgets.Add(new MyraLabel(TazLang.Get("hotkeys_section_editor"), MyraLabel.TextStyle.H2));
+        var editorFrame = MyraStyle.ApplySectionPanelStyle(new Panel());
+        editorFrame.Widgets.Add(editorPanel);
+        root.Widgets.Add(editorFrame);
+
+        root.Widgets.Add(new MyraSpacer(15, 5));
+        root.Widgets.Add(new MyraLabel(TazLang.Get("hotkeys_section_bindings"), MyraLabel.TextStyle.H2));
+        root.Widgets.Add(toolbar);
+        var listScroll = new ScrollViewer { MaxHeight = 450, Content = listPanel };
+        root.Widgets.Add(listScroll);
+
+        BuildBindingList();
+        BuildEditor();
+
+        // ── Live cross-context refresh ───────────────────────────────────────
+        // When data changes elsewhere (e.g. the Macros tab updates a macro key and
+        // OnMacroKeyChanged rewrites the matching HotKey entry's trigger), re-render
+        // the already-built list + the toggle key label. BuildBindingList
+        // only READS Entries and builds widgets — the enable/remove callbacks call
+        // Save() on user action, never during a rebuild — so there is no re-entrant
+        // Save→Changed loop.
+        //
+        // Any previously installed handler (from a prior window that wasn't cleaned up)
+        // is detached first as a safety net; Cleanup() is the normal detach path.
+        if (_changedHandler != null)
+            HotKeyManager.Changed -= _changedHandler;
+
+        _changedHandler = () =>
+        {
+            BuildBindingList();
+            refreshToggleLabel?.Invoke();
+        };
+        HotKeyManager.Changed += _changedHandler;
+
+        // ── Reconcile SelfHeal → profile ─────────────────────────────────────
+        // SelfHealManager reads the profile (not HotKeyManager). After load, push the
+        // FIRST SelfHeal entry that has a keyboard trigger into the profile so the
+        // manager uses current values.
+        ReconcileSelfHeal(profile);
+
+        return root;
+    }
+
+    // Push the first keyboard-triggered SelfHeal entry's values into the profile.
+    private static void ReconcileSelfHeal(Profile profile)
+    {
+        foreach (HotKeyEntry e in HotKeyManager.Entries)
+        {
+            if (e.Action?.Type != HotKeyActionType.SelfHeal)
+                continue;
+            if (e.Trigger == null || e.Trigger.Kind != HotKeyTriggerKind.Keyboard)
+                continue;
+
+            profile.SelfHeal_Key = e.Trigger.Key;
+            profile.SelfHeal_Mod = (int)HotKeyTrigger.NormalizeMods((SDL.SDL_Keymod)e.Trigger.Mod);
+            profile.SelfHeal_UseChivalry = e.Action.SelfHealChivalry;
+            profile.SelfHeal_Enabled = e.Enabled;
+            return;
+        }
+    }
+
+    // ───────────────────────────────────────────────────────────────────────
+    // Master row: "Disable all hotkeys" checkbox + dedicated keyboard control to
+    // bind the single ToggleHotkeys entry (keyboard-only capture, modeled on the
+    // SelfHeal row). The toggle binding is stored as a HotKeyEntry in
+    // HotKeyManager.Entries with Action.Type == ToggleHotkeys.
+    // refreshLabel re-reads the current binding and updates the displayed key.
+    // ───────────────────────────────────────────────────────────────────────
+    private static Widget BuildMasterRow(Profile profile, out Action refreshLabel)
+    {
+        var panel = new VerticalStackPanel { Spacing = 4 };
+
+        // "Disable all hotkeys" is the master kill-switch; give it its own line.
+        var disableChk = MyraCheckButton.CreateWithCallback(
+            profile.DisableHotkeys,
+            b => profile.DisableHotkeys = b,
+            TazLang.Get("hotkeys_disableall"),
+            TazLang.Get("hotkeys_disableall_tooltip"));
+        panel.Widgets.Add(disableChk);
+
+        // Toggle-key control on its own sub-row beneath the checkbox.
+        var row = new HorizontalStackPanel { Spacing = 4 };
+
+        static HotKeyEntry? FindToggleEntry()
+        {
+            foreach (HotKeyEntry e in HotKeyManager.Entries)
+                if (e.Action?.Type == HotKeyActionType.ToggleHotkeys)
+                    return e;
+            return null;
+        }
+
+        string DisplayKey()
+        {
+            HotKeyEntry? e = FindToggleEntry();
+            return e?.Trigger != null ? e.Trigger.Describe() : TazLang.Get("hotkeys_none");
+        }
+
+        var keyLabel = new MyraLabel(DisplayKey(), MyraLabel.TextStyle.P);
+
+        var normalPanel = new HorizontalStackPanel { Spacing = 4 };
+        var editPanel = new HorizontalStackPanel { Spacing = 4, Visible = false };
+
+        SDL.SDL_Keycode capturedKey = SDL.SDL_Keycode.SDLK_UNKNOWN;
+        SDL.SDL_Keymod capturedMod = SDL.SDL_Keymod.SDL_KMOD_NONE;
+        Action? unsubscribe = null;
+
+        void Stop()
+        {
+            unsubscribe?.Invoke();
+            unsubscribe = null;
+            _toggleUnsubscribe = null;
+            capturedKey = SDL.SDL_Keycode.SDLK_UNKNOWN;
+            capturedMod = SDL.SDL_Keymod.SDL_KMOD_NONE;
+            keyLabel.Text = DisplayKey();
+            normalPanel.Visible = true;
+            editPanel.Visible = false;
+        }
+
+        normalPanel.Widgets.Add(new MyraButton(TazLang.Get("hotkeys_settrigger"), () =>
+        {
+            Stop();
+            keyLabel.Text = TazLang.Get("hotkeys_pressakey");
+            normalPanel.Visible = false;
+            editPanel.Visible = true;
+
+            void Handler(string hotkey)
+            {
+                (capturedKey, capturedMod) = ParseHotKeyString(hotkey);
+                keyLabel.Text = KeysTranslator.TryGetKey(capturedKey, capturedMod);
+            }
+
+            Keyboard.KeyDownEvent += Handler;
+            unsubscribe = () => Keyboard.KeyDownEvent -= Handler;
+            _toggleUnsubscribe = unsubscribe;
+        }));
+
+        normalPanel.Widgets.Add(MyraStyle.ApplyButtonDangerStyle(new MyraButton(TazLang.Get("hotkeys_clear"), () =>
+        {
+            Stop();
+            HotKeyManager.Entries.RemoveAll(e => e.Action?.Type == HotKeyActionType.ToggleHotkeys);
+            HotKeyManager.Save();
+            keyLabel.Text = DisplayKey();
+        })));
+
+        // Apply the captured key to the single ToggleHotkeys entry, running a
+        // conflict check first (reusing the shared dialog).
+        void Apply()
+        {
+            if (capturedKey == SDL.SDL_Keycode.SDLK_UNKNOWN)
+            {
+                Stop();
+                return;
+            }
+
+            var trigger = new HotKeyTrigger
+            {
+                Kind = HotKeyTriggerKind.Keyboard,
+                Key = (int)capturedKey,
+                Mod = (int)HotKeyTrigger.NormalizeMods(capturedMod),
+            };
+
+            HotKeyEntry? existing = FindToggleEntry();
+
+            void Commit()
+            {
+                HotKeyEntry? toggle = FindToggleEntry();
+                if (toggle != null)
+                {
+                    toggle.Trigger = trigger;
+                }
+                else
+                {
+                    HotKeyManager.Entries.Add(new HotKeyEntry
+                    {
+                        Trigger = trigger,
+                        Enabled = true,
+                        Action = new HotKeyAction { Type = HotKeyActionType.ToggleHotkeys },
+                    });
+                }
+                HotKeyManager.Save();
+                Stop();
+            }
+
+            List<string> conflicts = HotKeyManager.FindConflicts(trigger, existing);
+            if (conflicts.Count == 0)
+            {
+                Commit();
+                return;
+            }
+
+            ShowConflictDialog(conflicts, ok =>
+            {
+                if (!ok)
+                {
+                    Stop();
+                    return;
+                }
+
+                // Assign anyway: clear the old binding for this trigger everywhere
+                // (HotKey entries, macro, SpellBar) except the toggle entry itself.
+                HotKeyManager.ClearTriggerEverywhere(trigger, existing, null);
+
+                Commit();
+            });
+        }
+
+        editPanel.Widgets.Add(new MyraButton(TazLang.Get("hotkeys_apply"), Apply));
+        editPanel.Widgets.Add(new MyraButton(TazLang.Get("hotkeys_cancel"), Stop));
+
+        row.Widgets.Add(new MyraLabel(TazLang.Get("hotkeys_toggle_key"), MyraLabel.TextStyle.P));
+        row.Widgets.Add(keyLabel);
+
+        var actions = new VerticalStackPanel();
+        actions.Widgets.Add(normalPanel);
+        actions.Widgets.Add(editPanel);
+        row.Widgets.Add(actions);
+
+        panel.Widgets.Add(row);
+
+        // Live-refresh: only touch the label when not mid-capture (don't clobber
+        // the "Press a key..." prompt).
+        refreshLabel = () =>
+        {
+            if (normalPanel.Visible)
+                keyLabel.Text = DisplayKey();
+        };
+
+        return panel;
+    }
+
+    // ───────────────────────────────────────────────────────────────────────
+    // Detail editor: edits the SELECTED entry live. category -> action picker ->
+    // trigger capture -> Apply (commits the captured trigger to the entry). Action
+    // edits are written through to selectedEntry.Action + Save() as the user picks.
+    // ───────────────────────────────────────────────────────────────────────
+    private static Widget BuildEntryEditor(MyraControl owner, World? world, HotKeyEntry entry, Action rebuildList)
+    {
+        var panel = new VerticalStackPanel { Spacing = 4 };
+
+        // The action being edited IS the entry's action; edits write through + Save.
+        HotKeyAction action = entry.Action;
+
+        // SelfHeal write-through targets the profile (SelfHealManager reads it, not HotKeyManager).
+        Profile? profile = ProfileManager.CurrentProfile;
+
+        // Mouse/wheel trigger buttons (assigned below). Held here so BuildActionPicker's
+        // UpdateTriggerButtons() can toggle their visibility (SelfHeal is keyboard-only).
+        MyraButton[] mouseButtons = Array.Empty<MyraButton>();
+
+        // Trigger capture rows. Declared up front so BuildActionPicker's UpdateTriggerButtons()
+        // (which can run via owner.Defer before the capture section is built) sees them assigned.
+        var triggerStack = new VerticalStackPanel { Spacing = 4 };
+        var keyboardRow = new HorizontalStackPanel { Spacing = 4 };
+        var mouseRow = new HorizontalStackPanel { Spacing = 4 };
+
+        // Trigger capture state (for the Apply button).
+        HotKeyTriggerKind triggerKind = HotKeyTriggerKind.None;
+        SDL.SDL_Keycode capturedKey = SDL.SDL_Keycode.SDLK_UNKNOWN;
+        SDL.SDL_Keymod capturedMod = SDL.SDL_Keymod.SDL_KMOD_NONE;
+        int capturedButton = 0;
+        bool capturedWheelUp = false;
+        Action? unsubscribe = null;
+        // Tracks whether the user has explicitly captured a trigger this editor session.
+        // Macro adopt-on-pick only pre-fills the trigger when this is still false.
+        bool userCapturedTrigger = false;
+
+        // ── Category combo ───────────────────────────────────────────────────
+        // ToggleHotkeys is intentionally NOT listed here: it is bound via the dedicated
+        // key control on the master "Disable all hotkeys" row (single source of truth).
+        var categoryNames = new[] { "Spell", "Macro", "Script", "Skill", "Consumable", "Ability", TazLang.Get("hotkeys_selfheal") };
+        var categoryValues = new[]
+        {
+            HotKeyActionType.Spell, HotKeyActionType.Macro, HotKeyActionType.Script,
+            HotKeyActionType.Skill, HotKeyActionType.Consumable, HotKeyActionType.Ability,
+            HotKeyActionType.SelfHeal,
+        };
+
+        var categoryRow = new HorizontalStackPanel { Spacing = 4 };
+        categoryRow.Widgets.Add(new MyraLabel(TazLang.Get("hotkeys_category"), MyraLabel.TextStyle.P));
+
+#pragma warning disable CS0612, CS0618
+        var categoryCombo = new ComboBox { Width = 200, VerticalAlignment = VerticalAlignment.Center };
+        foreach (string n in categoryNames)
+            categoryCombo.Items.Add(new ListItem(n));
+
+        int initialCategoryIndex = 0;
+        int foundCat = Array.IndexOf(categoryValues, action.Type);
+        if (foundCat >= 0) initialCategoryIndex = foundCat;
+        categoryCombo.SelectedIndex = initialCategoryIndex;
+#pragma warning restore CS0612, CS0618
+        categoryRow.Widgets.Add(categoryCombo);
+        panel.Widgets.Add(categoryRow);
+
+        // ── Action picker (rebuilt per category) ─────────────────────────────
+        var actionPickerPanel = new VerticalStackPanel { Spacing = 4 };
+        panel.Widgets.Add(actionPickerPanel);
+
+        var triggerLabel = new MyraLabel(entry.Trigger?.Describe() ?? TazLang.Get("hotkeys_none"), MyraLabel.TextStyle.TableHeader);
+
+        SDL.SDL_Keymod CurrentMods()
+        {
+            SDL.SDL_Keymod m = SDL.SDL_Keymod.SDL_KMOD_NONE;
+            if (Keyboard.Ctrl) m |= SDL.SDL_Keymod.SDL_KMOD_CTRL;
+            if (Keyboard.Shift) m |= SDL.SDL_Keymod.SDL_KMOD_SHIFT;
+            if (Keyboard.Alt) m |= SDL.SDL_Keymod.SDL_KMOD_ALT;
+            return m;
+        }
+
+        // Pre-fill the captured trigger from an existing HotKeyTrigger (initial state or macro adopt).
+        // userCaptured: true when the user explicitly captured this (locks out macro adopt).
+        void PrefillTrigger(HotKeyTrigger? t, bool userCaptured)
+        {
+            if (t == null || t.Kind == HotKeyTriggerKind.None)
+                return;
+
+            triggerKind = t.Kind;
+            capturedKey = SDL.SDL_Keycode.SDLK_UNKNOWN;
+            capturedButton = 0;
+            capturedWheelUp = false;
+            capturedMod = (SDL.SDL_Keymod)t.Mod;
+
+            switch (t.Kind)
+            {
+                case HotKeyTriggerKind.Keyboard:    capturedKey = (SDL.SDL_Keycode)t.Key; break;
+                case HotKeyTriggerKind.MouseButton: capturedButton = t.Button; break;
+                case HotKeyTriggerKind.MouseWheel:  capturedWheelUp = t.WheelUp; break;
+            }
+
+            if (userCaptured)
+                userCapturedTrigger = true;
+
+            triggerLabel.Text = t.Describe();
+        }
+
+        // True when a macro should adopt its current key into the (still-empty) trigger.
+        bool ShouldAdoptMacroTrigger() => !userCapturedTrigger && triggerKind == HotKeyTriggerKind.None
+                                          && (entry.Trigger == null || entry.Trigger.Kind == HotKeyTriggerKind.None);
+
+        void BuildActionPicker()
+        {
+            actionPickerPanel.Widgets.Clear();
+
+            HotKeyActionType type = categoryCombo.SelectedIndex is { } idx && idx >= 0 && idx < categoryValues.Length
+                ? categoryValues[idx]
+                : HotKeyActionType.Spell;
+
+            action.Type = type;
+
+            var row = new HorizontalStackPanel { Spacing = 4 };
+            row.Widgets.Add(new MyraLabel(TazLang.Get("hotkeys_action"), MyraLabel.TextStyle.P));
+
+            switch (type)
+            {
+                case HotKeyActionType.Spell:
+                {
+                    SpellDefinition[] spells = SpellDefinition.GetAllSpells();
+#pragma warning disable CS0612, CS0618
+                    var combo = new ComboBox { Width = 200, VerticalAlignment = VerticalAlignment.Center };
+                    foreach (SpellDefinition s in spells)
+                        combo.Items.Add(new ListItem(s.Name));
+
+                    int sel = -1;
+                    if (action.Type == HotKeyActionType.Spell)
+                    {
+                        for (int i = 0; i < spells.Length; i++)
+                            if (spells[i].ID == action.SpellId) { sel = i; break; }
+                    }
+                    if (sel < 0) sel = spells.Length > 0 ? 0 : -1;
+                    combo.SelectedIndex = sel >= 0 ? sel : null;
+                    if (sel >= 0) action.SpellId = spells[sel].ID; // initial build: set without Save
+                    combo.SelectedIndexChanged += (_, _) =>
+                    {
+                        if (combo.SelectedIndex is { } i && i >= 0 && i < spells.Length)
+                        {
+                            action.SpellId = spells[i].ID;
+                            HotKeyManager.Save();
+                        }
+                    };
+#pragma warning restore CS0612, CS0618
+                    row.Widgets.Add(combo);
+                    break;
+                }
+
+                case HotKeyActionType.Macro:
+                {
+                    List<Macro> macros = world?.Macros?.GetAllMacros() ?? new List<Macro>();
+#pragma warning disable CS0612, CS0618
+                    var combo = new ComboBox { Width = 200, VerticalAlignment = VerticalAlignment.Center };
+                    foreach (Macro m in macros)
+                        combo.Items.Add(new ListItem(m.Name));
+
+                    int sel = -1;
+                    if (action.Type == HotKeyActionType.Macro)
+                    {
+                        for (int i = 0; i < macros.Count; i++)
+                            if (macros[i].Name == action.MacroName) { sel = i; break; }
+                    }
+                    if (sel < 0) sel = macros.Count > 0 ? 0 : -1;
+                    combo.SelectedIndex = sel >= 0 ? sel : null;
+
+                    void ApplyMacro(int i, bool save)
+                    {
+                        if (i < 0 || i >= macros.Count) return;
+                        action.MacroName = macros[i].Name;
+                        // Adopt-on-pick: when the entry has no trigger yet, pre-fill the
+                        // trigger from the macro's current key and write it to the entry.
+                        if (ShouldAdoptMacroTrigger())
+                        {
+                            HotKeyTrigger adopted = HotKeyManager.TriggerFromMacro(macros[i]);
+                            PrefillTrigger(adopted, userCaptured: false);
+                            if (adopted.Kind != HotKeyTriggerKind.None)
+                                entry.Trigger = adopted;
+                        }
+                        if (save) HotKeyManager.Save();
+                    }
+                    ApplyMacro(sel, save: false); // initial build: set without Save
+                    combo.SelectedIndexChanged += (_, _) =>
+                    {
+                        if (combo.SelectedIndex is { } i) ApplyMacro(i, save: true);
+                    };
+#pragma warning restore CS0612, CS0618
+                    row.Widgets.Add(combo);
+                    break;
+                }
+
+                case HotKeyActionType.Script:
+                {
+                    List<ClassicUO.LegionScripting.ScriptFile> scripts = ClassicUO.LegionScripting.LegionScripting.LoadedScripts;
+#pragma warning disable CS0612, CS0618
+                    var combo = new ComboBox { Width = 200, VerticalAlignment = VerticalAlignment.Center };
+                    foreach (ClassicUO.LegionScripting.ScriptFile sf in scripts)
+                        combo.Items.Add(new ListItem(sf.FileName));
+
+                    int sel = -1;
+                    if (action.Type == HotKeyActionType.Script)
+                    {
+                        for (int i = 0; i < scripts.Count; i++)
+                            if (scripts[i].RelativePath == action.ScriptPath) { sel = i; break; }
+                    }
+                    if (sel < 0) sel = scripts.Count > 0 ? 0 : -1;
+                    combo.SelectedIndex = sel >= 0 ? sel : null;
+                    if (sel >= 0) action.ScriptPath = scripts[sel].RelativePath; // initial build: set without Save
+                    combo.SelectedIndexChanged += (_, _) =>
+                    {
+                        if (combo.SelectedIndex is { } i && i >= 0 && i < scripts.Count)
+                        {
+                            action.ScriptPath = scripts[i].RelativePath;
+                            HotKeyManager.Save();
+                        }
+                    };
+#pragma warning restore CS0612, CS0618
+                    row.Widgets.Add(combo);
+                    break;
+                }
+
+                case HotKeyActionType.Skill:
+                {
+                    Skill[] skills = world?.Player?.Skills ?? Array.Empty<Skill>();
+#pragma warning disable CS0612, CS0618
+                    var combo = new ComboBox { Width = 200, VerticalAlignment = VerticalAlignment.Center };
+                    foreach (Skill sk in skills)
+                        combo.Items.Add(new ListItem(sk.Name));
+
+                    int sel = -1;
+                    if (action.Type == HotKeyActionType.Skill &&
+                        action.SkillIndex >= 0 && action.SkillIndex < skills.Length)
+                        sel = action.SkillIndex;
+                    if (sel < 0) sel = skills.Length > 0 ? 0 : -1;
+                    combo.SelectedIndex = sel >= 0 ? sel : null;
+                    action.SkillIndex = sel >= 0 ? sel : -1; // initial build: set without Save
+                    combo.SelectedIndexChanged += (_, _) =>
+                    {
+                        if (combo.SelectedIndex is { } i && i >= 0 && i < skills.Length)
+                        {
+                            action.SkillIndex = i;
+                            HotKeyManager.Save();
+                        }
+                    };
+#pragma warning restore CS0612, CS0618
+                    row.Widgets.Add(combo);
+                    break;
+                }
+
+                case HotKeyActionType.Consumable:
+                {
+                    var options = new List<(string Label, int Graphic, int Hue)>();
+                    foreach (var p in FixedPotions)
+                        options.Add((p.Label, p.Graphic, -1));
+                    foreach (CustomConsumable c in HotKeyManager.CustomConsumables)
+                        options.Add((c.Label, c.Graphic, c.Hue));
+
+#pragma warning disable CS0612, CS0618
+                    var combo = new ComboBox { Width = 200, VerticalAlignment = VerticalAlignment.Center };
+                    foreach (var o in options)
+                        combo.Items.Add(new ListItem(o.Label));
+
+                    int sel = -1;
+                    if (action.Type == HotKeyActionType.Consumable)
+                    {
+                        for (int i = 0; i < options.Count; i++)
+                            if (options[i].Graphic == action.ConsumableGraphic &&
+                                options[i].Hue == action.ConsumableHue) { sel = i; break; }
+                    }
+                    if (sel < 0) sel = options.Count > 0 ? 0 : -1;
+                    combo.SelectedIndex = sel >= 0 ? sel : null;
+
+                    void ApplyConsumable(int i, bool save)
+                    {
+                        if (i < 0 || i >= options.Count) return;
+                        action.ConsumableLabel = options[i].Label;
+                        action.ConsumableGraphic = options[i].Graphic;
+                        action.ConsumableHue = options[i].Hue;
+                        if (save) HotKeyManager.Save();
+                    }
+                    ApplyConsumable(sel, save: false); // initial build: set without Save
+                    combo.SelectedIndexChanged += (_, _) =>
+                    {
+                        if (combo.SelectedIndex is { } i) ApplyConsumable(i, save: true);
+                    };
+#pragma warning restore CS0612, CS0618
+                    row.Widgets.Add(combo);
+
+                    row.Widgets.Add(new MyraButton(TazLang.Get("hotkeys_targetitem"), () =>
+                        TargetCustomConsumable(BuildActionPicker)));
+                    break;
+                }
+
+                case HotKeyActionType.Ability:
+                {
+                    var abilityNames = new[] { "Primary", "Secondary" };
+#pragma warning disable CS0612, CS0618
+                    var combo = new ComboBox { Width = 200, VerticalAlignment = VerticalAlignment.Center };
+                    foreach (string n in abilityNames)
+                        combo.Items.Add(new ListItem(n));
+
+                    int sel = 0;
+                    if (action.Type == HotKeyActionType.Ability)
+                        sel = action.AbilityPrimary ? 0 : 1;
+                    combo.SelectedIndex = sel;
+                    action.AbilityPrimary = sel == 0; // initial build: set without Save
+                    combo.SelectedIndexChanged += (_, _) =>
+                    {
+                        action.AbilityPrimary = combo.SelectedIndex == 0;
+                        HotKeyManager.Save();
+                    };
+#pragma warning restore CS0612, CS0618
+                    row.Widgets.Add(combo);
+                    break;
+                }
+
+                case HotKeyActionType.SelfHeal:
+                {
+                    var schoolNames = new[] { TazLang.Get("hotkeys_magery"), TazLang.Get("hotkeys_chivalry") };
+#pragma warning disable CS0612, CS0618
+                    var combo = new ComboBox { Width = 200, VerticalAlignment = VerticalAlignment.Center };
+                    foreach (string n in schoolNames)
+                        combo.Items.Add(new ListItem(n));
+
+                    int sel = action.SelfHealChivalry ? 1 : 0;
+                    combo.SelectedIndex = sel;
+
+                    void ApplySchool()
+                    {
+                        action.SelfHealChivalry = combo.SelectedIndex == 1;
+                        if (profile != null)
+                            profile.SelfHeal_UseChivalry = action.SelfHealChivalry;
+                        HotKeyManager.Save();
+                    }
+                    ApplySchool();
+                    combo.SelectedIndexChanged += (_, _) => ApplySchool();
+#pragma warning restore CS0612, CS0618
+                    row.Widgets.Add(combo);
+                    break;
+                }
+            }
+
+            actionPickerPanel.Widgets.Add(row);
+            UpdateTriggerButtons();
+        }
+
+        categoryCombo.SelectedIndexChanged += (_, _) =>
+        {
+            categoryCombo.Desktop?.HideContextMenu();
+            owner.Defer(BuildActionPicker);
+        };
+
+        // ── Trigger capture rows (Keyboard sub-row + Mouse sub-row) ───────────
+        keyboardRow.Widgets.Add(new MyraLabel(TazLang.Get("hotkeys_keyboard"), MyraLabel.TextStyle.P));
+        mouseRow.Widgets.Add(new MyraLabel(TazLang.Get("hotkeys_mouse"), MyraLabel.TextStyle.P));
+
+        void StopCapture()
+        {
+            unsubscribe?.Invoke();
+            unsubscribe = null;
+            _editorUnsubscribe = null;
+        }
+
+        // Reset the entry's trigger to Kind=None (re-dims the row) and clears capture state.
+        void ClearTrigger()
+        {
+            StopCapture();
+            triggerKind = HotKeyTriggerKind.None;
+            capturedKey = SDL.SDL_Keycode.SDLK_UNKNOWN;
+            capturedMod = SDL.SDL_Keymod.SDL_KMOD_NONE;
+            capturedButton = 0;
+            capturedWheelUp = false;
+            userCapturedTrigger = false;
+            triggerLabel.Text = TazLang.Get("hotkeys_none");
+            entry.Trigger = new HotKeyTrigger { Kind = HotKeyTriggerKind.None };
+            // SelfHeal entry: also disable the profile-driven hold-to-heal.
+            if (action.Type == HotKeyActionType.SelfHeal && profile != null)
+            {
+                profile.SelfHeal_Key = 0;
+                profile.SelfHeal_Enabled = false;
+            }
+            HotKeyManager.Save();
+            rebuildList();
+        }
+
+        HotKeyTrigger? BuildTrigger()
+        {
+            switch (triggerKind)
+            {
+                case HotKeyTriggerKind.Keyboard:
+                    if (capturedKey == SDL.SDL_Keycode.SDLK_UNKNOWN) return null;
+                    return new HotKeyTrigger
+                    {
+                        Kind = HotKeyTriggerKind.Keyboard,
+                        Key = (int)capturedKey,
+                        Mod = (int)HotKeyTrigger.NormalizeMods(capturedMod),
+                    };
+                case HotKeyTriggerKind.MouseButton:
+                    return new HotKeyTrigger
+                    {
+                        Kind = HotKeyTriggerKind.MouseButton,
+                        Button = capturedButton,
+                        Mod = (int)HotKeyTrigger.NormalizeMods(capturedMod),
+                    };
+                case HotKeyTriggerKind.MouseWheel:
+                    return new HotKeyTrigger
+                    {
+                        Kind = HotKeyTriggerKind.MouseWheel,
+                        WheelUp = capturedWheelUp,
+                        Mod = (int)HotKeyTrigger.NormalizeMods(capturedMod),
+                    };
+                default:
+                    return null;
+            }
+        }
+
+        // Keyboard live-capture button.
+        keyboardRow.Widgets.Add(new MyraButton(TazLang.Get("hotkeys_pressakey"), () =>
+        {
+            StopCapture();
+            triggerLabel.Text = TazLang.Get("hotkeys_pressakey");
+
+            void Handler(string hotkey)
+            {
+                (capturedKey, capturedMod) = ParseHotKeyString(hotkey);
+                triggerKind = HotKeyTriggerKind.Keyboard;
+                userCapturedTrigger = true;
+                triggerLabel.Text = KeysTranslator.TryGetKey(capturedKey, capturedMod);
+            }
+
+            Keyboard.KeyDownEvent += Handler;
+            unsubscribe = () => Keyboard.KeyDownEvent -= Handler;
+            _editorUnsubscribe = unsubscribe;
+        }));
+
+        void SetMouseButton(int button, string display)
+        {
+            StopCapture();
+            capturedMod = CurrentMods();
+            capturedButton = button;
+            triggerKind = HotKeyTriggerKind.MouseButton;
+            userCapturedTrigger = true;
+            triggerLabel.Text = display;
+        }
+
+        void SetWheel(bool up, string display)
+        {
+            StopCapture();
+            capturedMod = CurrentMods();
+            capturedWheelUp = up;
+            triggerKind = HotKeyTriggerKind.MouseWheel;
+            userCapturedTrigger = true;
+            triggerLabel.Text = display;
+        }
+
+        // SelfHeal hold-to-heal needs key-up, so it is keyboard-only: hide the
+        // mouse/wheel buttons for that category. UpdateTriggerButtons() is called from
+        // BuildActionPicker so the visibility tracks category changes.
+        mouseButtons = new[]
+        {
+            new MyraButton(TazLang.Get("hotkeys_mouse3"),
+                () => SetMouseButton((int)MouseButtonType.Middle, TazLang.Get("hotkeys_mouse3"))) { Tooltip = "Middle mouse button" },
+            new MyraButton(TazLang.Get("hotkeys_mouse4"),
+                () => SetMouseButton((int)MouseButtonType.XButton1, TazLang.Get("hotkeys_mouse4"))) { Tooltip = "Side button (back)" },
+            new MyraButton(TazLang.Get("hotkeys_mouse5"),
+                () => SetMouseButton((int)MouseButtonType.XButton2, TazLang.Get("hotkeys_mouse5"))) { Tooltip = "Side button (forward)" },
+            new MyraButton(TazLang.Get("hotkeys_wheelup"),
+                () => SetWheel(true, TazLang.Get("hotkeys_wheelup"))) { Tooltip = TazLang.Get("hotkeys_wheelup") },
+            new MyraButton(TazLang.Get("hotkeys_wheeldown"),
+                () => SetWheel(false, TazLang.Get("hotkeys_wheeldown"))) { Tooltip = TazLang.Get("hotkeys_wheeldown") },
+        };
+        foreach (MyraButton b in mouseButtons)
+            mouseRow.Widgets.Add(b);
+
+        // SelfHeal is keyboard-only: hide the whole Mouse sub-row (and its buttons) for it.
+        void UpdateTriggerButtons()
+        {
+            bool keyboardOnly = action.Type == HotKeyActionType.SelfHeal;
+            mouseRow.Visible = !keyboardOnly;
+            foreach (MyraButton b in mouseButtons)
+                b.Visible = !keyboardOnly;
+        }
+
+        triggerStack.Widgets.Add(keyboardRow);
+        triggerStack.Widgets.Add(mouseRow);
+        panel.Widgets.Add(triggerStack);
+
+        var captureLabelRow = new HorizontalStackPanel { Spacing = 4 };
+        captureLabelRow.Widgets.Add(new MyraLabel(TazLang.Get("hotkeys_currenttrigger"), MyraLabel.TextStyle.P));
+        captureLabelRow.Widgets.Add(triggerLabel);
+        panel.Widgets.Add(captureLabelRow);
+
+        // ── Apply / Clear ─────────────────────────────────────────────────────
+        var buttonRow = new HorizontalStackPanel { Spacing = 4 };
+        buttonRow.Widgets.Add(new MyraButton(TazLang.Get("hotkeys_apply"), () =>
+        {
+            HotKeyTrigger? trigger = BuildTrigger();
+            if (trigger == null)
+            {
+                GameActions.Print(world, "HotKey: set a trigger first.", 32);
+                return;
+            }
+
+            // Finalize: commit the trigger to the entry, persist, refresh.
+            void Finalize(HotKeyTrigger finalTrigger)
+            {
+                entry.Trigger = finalTrigger;
+                // SelfHeal write-through: SelfHealManager reads these profile fields.
+                if (action.Type == HotKeyActionType.SelfHeal && profile != null &&
+                    finalTrigger.Kind == HotKeyTriggerKind.Keyboard)
+                {
+                    profile.SelfHeal_Key = finalTrigger.Key;
+                    profile.SelfHeal_Mod = (int)HotKeyTrigger.NormalizeMods((SDL.SDL_Keymod)finalTrigger.Mod);
+                    profile.SelfHeal_Enabled = true;
+                }
+                HotKeyManager.Save();
+                StopCapture();
+                rebuildList();
+            }
+
+            // Runs the HotKey/Macro/SpellBar conflict check, then finalizes with the given trigger.
+            void ConflictThenFinalize(HotKeyTrigger finalTrigger)
+            {
+                List<string> conflicts = HotKeyManager.FindConflicts(finalTrigger, entry);
+                if (conflicts.Count == 0)
+                {
+                    Finalize(finalTrigger);
+                    return;
+                }
+
+                ShowConflictDialog(conflicts, ok =>
+                {
+                    if (!ok) return;
+                    // Don't wipe the entry's own macro when this is a Macro entry.
+                    string? keepMacroName = action.Type == HotKeyActionType.Macro ? action.MacroName : null;
+                    RemoveConflictingEntries(finalTrigger, entry, keepMacroName);
+                    Finalize(finalTrigger);
+                });
+            }
+
+            // Macro category: collapse macro-binding + conflict resolution into ONE dialog.
+            if (action.Type == HotKeyActionType.Macro)
+            {
+                Macro? target = world?.Macros?.FindMacro(action.MacroName);
+                HotKeyTrigger existing = HotKeyManager.TriggerFromMacro(target);
+
+                bool sameAsExisting = existing.Kind == trigger.Kind &&
+                                      existing.Key == trigger.Key &&
+                                      existing.Button == trigger.Button &&
+                                      existing.WheelUp == trigger.WheelUp &&
+                                      existing.Mod == trigger.Mod;
+
+                if (target == null || existing.Kind == HotKeyTriggerKind.None || sameAsExisting)
+                {
+                    // Unbound / already matches: write-through then finalize with the new trigger.
+                    if (target != null)
+                    {
+                        HotKeyManager.ApplyTriggerToMacro(target, trigger);
+                        world?.Macros?.Save();
+                    }
+                    ConflictThenFinalize(trigger);
+                }
+                else
+                {
+                    // The macro has a DIFFERENT binding: a single OK/Cancel dialog with a
+                    // default-checked "update the macro's key" tick, plus any conflict warnings.
+                    List<string> conflicts = HotKeyManager.FindConflicts(trigger, entry);
+
+                    var content = new VerticalStackPanel { Spacing = 4 };
+                    foreach (string c in conflicts)
+                        content.Widgets.Add(new MyraLabel(c, MyraLabel.TextStyle.P));
+                    content.Widgets.Add(new MyraLabel(
+                        TazLang.Get("hotkeys_macro_conflict_body") + "\n" +
+                        action.MacroName + ": " + existing.Describe(),
+                        MyraLabel.TextStyle.P));
+                    content.Widgets.Add(new MyraSpacer(10, 2));
+
+                    var updateCheck = new MyraCheckButton(TazLang.Get("hotkeys_macro_update"), isChecked: true);
+                    content.Widgets.Add(updateCheck);
+
+                    _ = new MyraDialog(TazLang.Get("hotkeys_macro_conflict_title"), content, ok =>
+                    {
+                        if (!ok) return; // Cancel: leave the entry's trigger unchanged.
+
+                        HotKeyTrigger finalTrigger;
+                        if (updateCheck.IsChecked)
+                        {
+                            // Update the macro's key to the new trigger.
+                            HotKeyManager.ApplyTriggerToMacro(target, trigger);
+                            world?.Macros?.Save();
+                            finalTrigger = trigger;
+                        }
+                        else
+                        {
+                            // Keep the macro's key: finalize the entry with the macro's EXISTING trigger.
+                            finalTrigger = existing;
+                        }
+
+                        // Remove any conflicting bindings sharing the FINAL trigger (except this
+                        // entry and its own macro — Update just set it / Keep keeps its key).
+                        RemoveConflictingEntries(finalTrigger, entry, action.MacroName);
+                        Finalize(finalTrigger);
+                    });
+                }
+
+                return;
+            }
+
+            // Non-macro categories: standard conflict check + finalize.
+            ConflictThenFinalize(trigger);
+        }));
+
+        buttonRow.Widgets.Add(MyraStyle.ApplyButtonDangerStyle(new MyraButton(TazLang.Get("hotkeys_clear"), ClearTrigger)));
+
+        panel.Widgets.Add(buttonRow);
+
+        // Build the initial action picker for the selected category.
+        BuildActionPicker();
+
+        // Pre-fill the captured trigger from the entry's current trigger (if any).
+        PrefillTrigger(entry.Trigger, userCaptured: true);
+
+        return panel;
+    }
+
+    // "Assign anyway": clear the old binding for finalTrigger everywhere it conflicts —
+    // HotKey entries (except the one being edited), the bound macro (except the entry's own
+    // macro, identified by keepMacroName), the SpellBar slot, and Profile.SelfHeal.
+    private static void RemoveConflictingEntries(HotKeyTrigger finalTrigger, HotKeyEntry? keep, string? keepMacroName)
+    {
+        HotKeyManager.ClearTriggerEverywhere(finalTrigger, keep, keepMacroName);
+    }
+
+    // ───────────────────────────────────────────────────────────────────────
+    // Conflict dialog
+    // ───────────────────────────────────────────────────────────────────────
+    private static void ShowConflictDialog(List<string> conflicts, Action<bool> onResult)
+    {
+        var content = new VerticalStackPanel { Spacing = 4 };
+        content.Widgets.Add(new MyraLabel(TazLang.Get("hotkeys_conflict_body"), MyraLabel.TextStyle.P));
+        foreach (string c in conflicts)
+            content.Widgets.Add(new MyraLabel(c, MyraLabel.TextStyle.P));
+        content.Widgets.Add(new MyraSpacer(10, 2));
+        content.Widgets.Add(new MyraLabel(
+            "OK = " + TazLang.Get("hotkeys_assignanyway") + "  /  Cancel = " + TazLang.Get("hotkeys_cancel"),
+            MyraLabel.TextStyle.P));
+
+        // OK => assign anyway (removes old); Cancel => discard.
+        _ = new MyraDialog(TazLang.Get("hotkeys_conflict_title"), content, onResult);
+    }
+
+    // ───────────────────────────────────────────────────────────────────────
+    // Target an item to set (custom consumable)
+    // ───────────────────────────────────────────────────────────────────────
+    private static void TargetCustomConsumable(Action onAdded)
+    {
+        World? world = Client.Game?.UO?.World;
+        if (world?.TargetManager == null)
+            return;
+
+        if (HotKeyManager.CustomConsumables.Count >= HotKeyManager.MaxCustomConsumables)
+        {
+            GameActions.Print(world, $"HotKey: custom consumable limit ({HotKeyManager.MaxCustomConsumables}) reached.", 32);
+            return;
+        }
+
+        GameActions.Print(world, TazLang.Get("hotkeys_targetitem"));
+        world.TargetManager.SetTargeting(targeted =>
+        {
+            if (targeted is not Entity entity || !SerialHelper.IsItem(entity))
+                return;
+
+            int graphic = entity.Graphic;
+            int hue = entity.Hue;
+
+            var labelBox = new MyraInputBox { MinWidth = 150, Text = entity.Name ?? "" };
+            _ = new MyraDialog(TazLang.Get("hotkeys_targetitem"), labelBox, ok =>
+            {
+                if (!ok) return;
+                string label = string.IsNullOrWhiteSpace(labelBox.Text) ? $"Item 0x{graphic:X4}" : labelBox.Text;
+                bool added = HotKeyManager.AddCustomConsumable(new CustomConsumable
+                {
+                    Label = label,
+                    Graphic = graphic,
+                    Hue = hue,
+                });
+                if (!added)
+                    GameActions.Print(world, $"HotKey: custom consumable limit ({HotKeyManager.MaxCustomConsumables}) reached.", 32);
+                else
+                    HotKeyManager.Save();
+                onAdded();
+            });
+        });
+    }
+
+    // ───────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ───────────────────────────────────────────────────────────────────────
+    private static (SDL.SDL_Keycode key, SDL.SDL_Keymod mod) ParseHotKeyString(string hotkey)
+    {
+        SDL.SDL_Keycode key = SDL.SDL_Keycode.SDLK_UNKNOWN;
+        SDL.SDL_Keymod mod = SDL.SDL_Keymod.SDL_KMOD_NONE;
+
+        if (string.IsNullOrEmpty(hotkey))
+            return (key, mod);
+
+        foreach (string part in hotkey.Split('+'))
+        {
+            switch (part.ToUpperInvariant())
+            {
+                case "CTRL": mod |= SDL.SDL_Keymod.SDL_KMOD_CTRL; break;
+                case "SHIFT": mod |= SDL.SDL_Keymod.SDL_KMOD_SHIFT; break;
+                case "ALT": mod |= SDL.SDL_Keymod.SDL_KMOD_ALT; break;
+                default:
+                    if (Enum.TryParse<SDL.SDL_Keycode>(part, true, out SDL.SDL_Keycode parsed))
+                        key = parsed;
+                    break;
+            }
+        }
+
+        return (key, mod);
+    }
+}

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Macros/MacrosTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Macros/MacrosTabContent.cs
@@ -22,6 +22,9 @@ public static class MacrosTabContent
     private static readonly Dictionary<MacroType, int> _macroTypeToDisplayIndex;
 
     private static Action? _cleanupAction;
+    // HotKeyManager.Changed handler (live macro-list refresh). Stored so Cleanup() can
+    // detach it; otherwise reopening the window stacks handlers that fire into disposed widgets.
+    private static Action? _changedHandler;
     /// <summary>Call when the owning window closes to unsubscribe any active hotkey-capture handler and re-enable hotkeys.</summary>
     public static void Cleanup() => _cleanupAction?.Invoke();
 
@@ -125,6 +128,7 @@ public static class MacrosTabContent
 
             CancelCapture();
             MarkDirty();
+            HotKeyManager.OnMacroKeyChanged(selectedMacro);
         }
 
         // ── BuildMacroList ────────────────────────────────────────────────────
@@ -712,7 +716,24 @@ public static class MacrosTabContent
         BuildMacroList();
         BuildEditor();
 
-        _cleanupAction = CancelCapture;
+        // Live-refresh the macro list when HotKey data changes in another context
+        // (e.g. a HotKeys-tab edit writes through to a macro's key). BuildMacroList
+        // only reads macro state and rebuilds widgets, so this is safe to call here.
+        // Detach any handler left over from a prior (uncleaned) window first.
+        if (_changedHandler != null)
+            HotKeyManager.Changed -= _changedHandler;
+        _changedHandler = BuildMacroList;
+        HotKeyManager.Changed += _changedHandler;
+
+        _cleanupAction = () =>
+        {
+            CancelCapture();
+            if (_changedHandler != null)
+            {
+                HotKeyManager.Changed -= _changedHandler;
+                _changedHandler = null;
+            }
+        };
 
         var root = new VerticalStackPanel { Spacing = 2 };
         root.Widgets.Add(toolbar);

--- a/tests/ClassicUO.UnitTests/HotKeyActionTests.cs
+++ b/tests/ClassicUO.UnitTests/HotKeyActionTests.cs
@@ -1,0 +1,28 @@
+using ClassicUO.Game.Data;
+using FluentAssertions;
+using Xunit;
+
+namespace ClassicUO.UnitTests;
+
+public class HotKeyActionTests
+{
+    [Fact]
+    public void DisplayName_for_consumable_uses_label()
+    {
+        var a = new HotKeyAction { Type = HotKeyActionType.Consumable, ConsumableLabel = "Heal Potion" };
+        a.DisplayName(null).Should().Be("Heal Potion");
+    }
+
+    [Fact]
+    public void DisplayName_for_ability_reports_primary_or_secondary()
+    {
+        new HotKeyAction { Type = HotKeyActionType.Ability, AbilityPrimary = true }.DisplayName(null).Should().Be("Primary Ability");
+        new HotKeyAction { Type = HotKeyActionType.Ability, AbilityPrimary = false }.DisplayName(null).Should().Be("Secondary Ability");
+    }
+
+    [Fact]
+    public void DisplayName_for_toggle_hotkeys()
+    {
+        new HotKeyAction { Type = HotKeyActionType.ToggleHotkeys }.DisplayName(null).Should().Be("Toggle Hotkeys");
+    }
+}

--- a/tests/ClassicUO.UnitTests/HotKeyManagerCollection.cs
+++ b/tests/ClassicUO.UnitTests/HotKeyManagerCollection.cs
@@ -1,0 +1,6 @@
+using Xunit;
+
+namespace ClassicUO.UnitTests;
+
+[CollectionDefinition("HotKeyManager")]
+public class HotKeyManagerCollection { }

--- a/tests/ClassicUO.UnitTests/HotKeyManagerTests.cs
+++ b/tests/ClassicUO.UnitTests/HotKeyManagerTests.cs
@@ -1,0 +1,123 @@
+using ClassicUO.Game.Data;
+using ClassicUO.Game.Managers;
+using ClassicUO.Input;
+using FluentAssertions;
+using SDL3;
+using Xunit;
+
+namespace ClassicUO.UnitTests;
+
+[Collection("HotKeyManager")] // serial: static state
+public class HotKeyManagerTests
+{
+    private static HotKeyEntry Kb(SDL.SDL_Keycode k, SDL.SDL_Keymod m = SDL.SDL_Keymod.SDL_KMOD_NONE)
+        => new() { Trigger = new HotKeyTrigger { Kind = HotKeyTriggerKind.Keyboard, Key = (int)k, Mod = (int)m },
+                   Action = new HotKeyAction { Type = HotKeyActionType.Ability, AbilityPrimary = true } };
+
+    [Fact]
+    public void TestDispatch_matches_keyboard_entry()
+    {
+        HotKeyManager.Entries.Clear();
+        HotKeyManager.Entries.Add(Kb(SDL.SDL_Keycode.SDLK_F1, SDL.SDL_Keymod.SDL_KMOD_CTRL));
+
+        HotKeyManager.TestDispatch(
+            new HotKeyTrigger { Kind = HotKeyTriggerKind.Keyboard, Key = (int)SDL.SDL_Keycode.SDLK_F1 },
+            SDL.SDL_Keymod.SDL_KMOD_LCTRL, out var matched).Should().BeTrue();
+        matched.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void TestDispatch_ignores_disabled_entry()
+    {
+        HotKeyManager.Entries.Clear();
+        var e = Kb(SDL.SDL_Keycode.SDLK_F1);
+        e.Enabled = false;
+        HotKeyManager.Entries.Add(e);
+
+        HotKeyManager.TestDispatch(
+            new HotKeyTrigger { Kind = HotKeyTriggerKind.Keyboard, Key = (int)SDL.SDL_Keycode.SDLK_F1 },
+            SDL.SDL_Keymod.SDL_KMOD_NONE, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void AddCustomConsumable_caps_at_four()
+    {
+        HotKeyManager.CustomConsumables.Clear();
+        for (int i = 0; i < 4; i++)
+            HotKeyManager.AddCustomConsumable(new CustomConsumable { Label = $"c{i}", Graphic = i }).Should().BeTrue();
+        HotKeyManager.AddCustomConsumable(new CustomConsumable { Label = "c5", Graphic = 5 }).Should().BeFalse();
+        HotKeyManager.CustomConsumables.Should().HaveCount(4);
+    }
+
+    [Fact]
+    public void TestDispatch_matches_toggle_hotkeys_entry()
+    {
+        HotKeyManager.Entries.Clear();
+        HotKeyManager.Entries.Add(new HotKeyEntry
+        {
+            Trigger = new HotKeyTrigger { Kind = HotKeyTriggerKind.Keyboard, Key = (int)SDL.SDL_Keycode.SDLK_PAUSE },
+            Action = new HotKeyAction { Type = HotKeyActionType.ToggleHotkeys },
+        });
+        HotKeyManager.TestDispatch(
+            new HotKeyTrigger { Kind = HotKeyTriggerKind.Keyboard, Key = (int)SDL.SDL_Keycode.SDLK_PAUSE },
+            SDL.SDL_Keymod.SDL_KMOD_NONE, out var matched).Should().BeTrue();
+        matched.Action.Type.Should().Be(HotKeyActionType.ToggleHotkeys);
+    }
+
+    [Fact]
+    public void TriggerFromMacro_and_back_roundtrip_keyboard()
+    {
+        var m = new Macro("t") { Key = SDL.SDL_Keycode.SDLK_F3, Ctrl = true };
+        var t = HotKeyManager.TriggerFromMacro(m);
+        t.Kind.Should().Be(HotKeyTriggerKind.Keyboard);
+        t.Key.Should().Be((int)SDL.SDL_Keycode.SDLK_F3);
+        t.Mod.Should().Be((int)SDL.SDL_Keymod.SDL_KMOD_CTRL);
+
+        var m2 = new Macro("t2");
+        HotKeyManager.ApplyTriggerToMacro(m2, t);
+        m2.Key.Should().Be(SDL.SDL_Keycode.SDLK_F3);
+        m2.Ctrl.Should().BeTrue();
+        m2.MouseButton.Should().Be(MouseButtonType.None);
+        m2.WheelScroll.Should().BeFalse();
+    }
+
+    [Fact]
+    public void TriggerFromMacro_handles_mouse_and_wheel()
+    {
+        var mb = new Macro("mb") { MouseButton = MouseButtonType.XButton1 };
+        HotKeyManager.TriggerFromMacro(mb).Kind.Should().Be(HotKeyTriggerKind.MouseButton);
+        HotKeyManager.TriggerFromMacro(mb).Button.Should().Be((int)MouseButtonType.XButton1);
+
+        var w = new Macro("w") { WheelScroll = true, WheelUp = true };
+        var wt = HotKeyManager.TriggerFromMacro(w);
+        wt.Kind.Should().Be(HotKeyTriggerKind.MouseWheel);
+        wt.WheelUp.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TriggerFromMacro_unbound_is_none()
+    {
+        HotKeyManager.TriggerFromMacro(new Macro("u")).Kind.Should().Be(HotKeyTriggerKind.None);
+    }
+
+    [Fact]
+    public void OnMacroKeyChanged_updates_referencing_entries()
+    {
+        HotKeyManager.Entries.Clear();
+        HotKeyManager.Entries.Add(new HotKeyEntry
+        {
+            Trigger = new HotKeyTrigger { Kind = HotKeyTriggerKind.Keyboard, Key = (int)SDL.SDL_Keycode.SDLK_A },
+            Action = new HotKeyAction { Type = HotKeyActionType.Macro, MacroName = "MyMacro" },
+        });
+        HotKeyManager.Entries.Add(new HotKeyEntry
+        {
+            Trigger = new HotKeyTrigger { Kind = HotKeyTriggerKind.Keyboard, Key = (int)SDL.SDL_Keycode.SDLK_Z },
+            Action = new HotKeyAction { Type = HotKeyActionType.Macro, MacroName = "OtherMacro" },
+        });
+        var m = new Macro("MyMacro") { Key = SDL.SDL_Keycode.SDLK_B, Shift = true };
+        HotKeyManager.OnMacroKeyChanged(m);
+        HotKeyManager.Entries[0].Trigger.Key.Should().Be((int)SDL.SDL_Keycode.SDLK_B);
+        HotKeyManager.Entries[0].Trigger.Mod.Should().Be((int)SDL.SDL_Keymod.SDL_KMOD_SHIFT);
+        HotKeyManager.Entries[1].Trigger.Key.Should().Be((int)SDL.SDL_Keycode.SDLK_Z);
+    }
+}

--- a/tests/ClassicUO.UnitTests/HotKeySettingsSerializationTests.cs
+++ b/tests/ClassicUO.UnitTests/HotKeySettingsSerializationTests.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using ClassicUO.Game.Data;
+using FluentAssertions;
+using SDL3;
+using Xunit;
+
+namespace ClassicUO.UnitTests;
+
+public class HotKeySettingsSerializationTests
+{
+    [Fact]
+    public void Roundtrips_all_trigger_kinds_and_action_fields()
+    {
+        var settings = new HotKeySettings
+        {
+            Entries = new List<HotKeyEntry>
+            {
+                new() { Trigger = new HotKeyTrigger { Kind = HotKeyTriggerKind.Keyboard, Key = (int)SDL.SDL_Keycode.SDLK_F1, Mod = (int)SDL.SDL_Keymod.SDL_KMOD_CTRL },
+                        Action = new HotKeyAction { Type = HotKeyActionType.Spell, SpellId = 1 } },
+                new() { Trigger = new HotKeyTrigger { Kind = HotKeyTriggerKind.MouseButton, Button = 4 },
+                        Action = new HotKeyAction { Type = HotKeyActionType.Script, ScriptPath = "group/farm.py" } },
+                new() { Trigger = new HotKeyTrigger { Kind = HotKeyTriggerKind.MouseWheel, WheelUp = true },
+                        Action = new HotKeyAction { Type = HotKeyActionType.Consumable, ConsumableGraphic = 0x0F0C, ConsumableHue = -1, ConsumableLabel = "Heal" } },
+            },
+            CustomConsumables = new List<CustomConsumable>
+            {
+                new() { Label = "My Apple", Graphic = 0x2FD8, Hue = 0 },
+            },
+        };
+
+        string json = JsonSerializer.Serialize(settings, HotKeySettingsContext.Default.HotKeySettings);
+        var back = JsonSerializer.Deserialize(json, HotKeySettingsContext.Default.HotKeySettings);
+
+        back.Entries.Should().HaveCount(3);
+        back.Entries[0].Trigger.Key.Should().Be((int)SDL.SDL_Keycode.SDLK_F1);
+        back.Entries[1].Trigger.Button.Should().Be(4);
+        back.Entries[2].Action.ConsumableLabel.Should().Be("Heal");
+        back.CustomConsumables.Should().ContainSingle(c => c.Label == "My Apple");
+    }
+}

--- a/tests/ClassicUO.UnitTests/HotKeyTriggerTests.cs
+++ b/tests/ClassicUO.UnitTests/HotKeyTriggerTests.cs
@@ -1,0 +1,61 @@
+using ClassicUO.Game.Data;
+using ClassicUO.Input;
+using FluentAssertions;
+using SDL3;
+using Xunit;
+
+namespace ClassicUO.UnitTests;
+
+public class HotKeyTriggerTests
+{
+    [Fact]
+    public void NormalizeMods_strips_lock_keys_and_consolidates_left_right()
+    {
+        var raw = SDL.SDL_Keymod.SDL_KMOD_LCTRL | SDL.SDL_Keymod.SDL_KMOD_NUM | SDL.SDL_Keymod.SDL_KMOD_RSHIFT;
+        var norm = HotKeyTrigger.NormalizeMods(raw);
+        norm.Should().Be(SDL.SDL_Keymod.SDL_KMOD_CTRL | SDL.SDL_Keymod.SDL_KMOD_SHIFT);
+    }
+
+    [Fact]
+    public void MatchesKeyboard_matches_same_key_and_mod_after_normalization()
+    {
+        var t = new HotKeyTrigger
+        {
+            Kind = HotKeyTriggerKind.Keyboard,
+            Key = (int)SDL.SDL_Keycode.SDLK_F1,
+            Mod = (int)SDL.SDL_Keymod.SDL_KMOD_CTRL,
+        };
+        t.MatchesKeyboard(SDL.SDL_Keycode.SDLK_F1, SDL.SDL_Keymod.SDL_KMOD_LCTRL | SDL.SDL_Keymod.SDL_KMOD_CAPS).Should().BeTrue();
+        t.MatchesKeyboard(SDL.SDL_Keycode.SDLK_F2, SDL.SDL_Keymod.SDL_KMOD_LCTRL).Should().BeFalse();
+        t.MatchesKeyboard(SDL.SDL_Keycode.SDLK_F1, SDL.SDL_Keymod.SDL_KMOD_NONE).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Keyboard_trigger_never_matches_mouse_and_vice_versa()
+    {
+        var kb = new HotKeyTrigger { Kind = HotKeyTriggerKind.Keyboard, Key = (int)SDL.SDL_Keycode.SDLK_F1 };
+        kb.MatchesMouseButton(MouseButtonType.XButton1, SDL.SDL_Keymod.SDL_KMOD_NONE).Should().BeFalse();
+
+        var mb = new HotKeyTrigger { Kind = HotKeyTriggerKind.MouseButton, Button = (int)MouseButtonType.XButton1 };
+        mb.MatchesKeyboard(SDL.SDL_Keycode.SDLK_F1, SDL.SDL_Keymod.SDL_KMOD_NONE).Should().BeFalse();
+        mb.MatchesMouseButton(MouseButtonType.XButton1, SDL.SDL_Keymod.SDL_KMOD_NONE).Should().BeTrue();
+    }
+
+    [Fact]
+    public void MatchesWheel_respects_direction_and_mod()
+    {
+        var t = new HotKeyTrigger { Kind = HotKeyTriggerKind.MouseWheel, WheelUp = true, Mod = (int)SDL.SDL_Keymod.SDL_KMOD_SHIFT };
+        t.MatchesWheel(true, SDL.SDL_Keymod.SDL_KMOD_RSHIFT).Should().BeTrue();
+        t.MatchesWheel(false, SDL.SDL_Keymod.SDL_KMOD_RSHIFT).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Describe_renders_each_kind()
+    {
+        new HotKeyTrigger { Kind = HotKeyTriggerKind.Keyboard, Key = (int)SDL.SDL_Keycode.SDLK_F1, Mod = (int)SDL.SDL_Keymod.SDL_KMOD_CTRL }
+            .Describe().Should().NotBeNullOrEmpty();
+        new HotKeyTrigger { Kind = HotKeyTriggerKind.MouseButton, Button = (int)MouseButtonType.XButton1 }.Describe().Should().Be("Mouse4");
+        new HotKeyTrigger { Kind = HotKeyTriggerKind.MouseWheel, WheelUp = true }.Describe().Should().Be("Wheel Up");
+        new HotKeyTrigger { Kind = HotKeyTriggerKind.None }.Describe().Should().Be("");
+    }
+}


### PR DESCRIPTION
## Summary

Adds a centralized **HotKeys** tab to the Assistant window — a single place to manage key/mouse bindings, like other UO assistants (UOSteam/Razor/ClassicAssist). It is independent of the existing SpellBar/Macro systems and gates only the legacy macro fallback in dispatch.

Bindable triggers: **keyboard combos** and **mouse buttons / wheel** (with modifiers). Bindable actions: **Spell, Macro, Script (toggle), Skill, Consumable, Weapon Ability, Self Heal (Magery/Chivalry)**.

## Features
- **Macros-style UX:** an *Add* button drops a new inline-editable row that stays dimmed (keyless, never fires) until you set a key, then renders normally. Bindings are editable (change key, action, or target).
- **Per-character storage** in `HotKeys.json` via a source-generated `JsonSerializerContext`.
- **Master "disable all hotkeys" toggle** that is itself bindable to a key (exempt from its own disable gate, like the macro toggle).
- **Two-way macro sync:** changing a macro's key in the Macros tab updates the matching HotKey entry and vice-versa.
- **Conflict detection:** when a key is already used by a macro, a SpellBar slot, another hotkey, or Self Heal, you're warned — and on confirm the old binding is actually cleared from that macro/SpellBar slot/SelfHeal config.
- **Self Heal** is surfaced as a category (Magery/Chivalry); `SelfHealManager` continues to drive the hold-to-heal from the profile fields.

## Implementation
- New: `HotKeyTrigger`, `HotKeyAction`, `HotKeyEntry`/`HotKeySettings` (Game/Data), `HotKeyManager` (Game/Managers), `HotKeysTabContent` (Assistant UI).
- Modified: `GameSceneInputHandler` (keyboard + mouse/wheel dispatch hooks), `GameScene` (load/save lifecycle), `AssistantWindow` (tab), `SpellBarManager` (clear-by-key helper + `Save`), `MacrosTabContent` (sync hook), `MyraStyle` (section-panel helper), `language.ini`, `CHANGELOG.md`.

## Tests
17 xUnit + FluentAssertions tests covering the trigger model + modifier normalization, action dispatch/`DisplayName`, JSON round-trip, manager matching/conflicts, and macro↔trigger sync. UI/dispatch verified in-client.

## Notes
- Per-character only for v1; SpellBar spell↔key is conflict-detect-only (SpellBar keys are per-column, not per-spell).
- Version bump in `ClassicUO.Client.csproj` intentionally left for the maintainer at release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HotKeys tab in the Assistant window for managing hotkey bindings
  * Support for keyboard, mouse button, and mouse wheel triggers
  * Master toggle to disable/enable all hotkeys
  * Automatic two-way synchronization between hotkey and macro bindings
  * Conflict detection across hotkeys, macros, and spellbars
  * Per-character hotkey storage with custom consumable configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->