### PR TITLE
Change journal filter to partial match instead of exact match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to TazUO will be recorded here.
 * Add option to select and copy text in journal - [P.R 575](https://github.com/PlayTazUO/TazUO/pull/575) ([Nesci28](https://github.com/Nesci28))
 * Add Script slot type to the Spell Bar - [P.R 568](https://github.com/PlayTazUO/TazUO/pull/568) ([eddo87](https://github.com/eddo87))
 * Converted the Add/Edit User Marker world map window to a Myra window - [P.R 588](https://github.com/PlayTazUO/TazUO/pull/588) ([bittiez](https://github.com/bittiez))
+* Journal filters now match partial messages (case-insensitive contains) instead of requiring exact matches - [P.R 593](https://github.com/PlayTazUO/TazUO/pull/593) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
 * Fixed crash reading BWT-compressed UOP animations caused by returning a non-pooled buffer to the array pool - [P.R 532](https://github.com/PlayTazUO/TazUO/pull/532) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.2.62</AssemblyVersion>
-    <FileVersion>5.2.62</FileVersion>
+    <AssemblyVersion>5.2.63</AssemblyVersion>
+    <FileVersion>5.2.63</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/Managers/JournalFilterManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/JournalFilterManager.cs
@@ -35,8 +35,11 @@ public class JournalFilterManager
 
     public bool IgnoreMessage(string message)
     {
-        if(_filters.Contains(message))
-            return true;
+        foreach (string filter in _filters)
+        {
+            if (message.Contains(filter, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
         return false;
     }
 


### PR DESCRIPTION
Filters now check if the message contains the filter string (case-insensitive) rather than requiring an exact match.