### PR TITLE
Pass first click through to focused Myra window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,6 @@ All notable changes to TazUO will be recorded here.
 ---
 ## In Development
 
-### Fixes
-* Pass the first click through to a Myra window so clicking a control on an unfocused window works in one click instead of requiring a focus click first - [P.R 604](https://github.com/PlayTazUO/TazUO/pull/604) ([bittiez](https://github.com/bittiez))
-
----
-
-## V5.3.0
-
 ### Features
 * Overhauled the options window with a new, modern UI (use command `old-options-window` to open legacy window) - [P.R #](https://github.com/PlayTazUO/TazUO/pull/#) ([yuval-po](https://github.com/yuval-po))
 * Added reorder support to CoolDown Bars - [P.R #](https://github.com/PlayTazUO/TazUO/pull/#) ([yuval-po](https://github.com/yuval-po))
@@ -89,6 +82,7 @@ All notable changes to TazUO will be recorded here.
 * Fixed NullReferenceException in ImprovedBuffGump when a buff icon's title cliloc is not found - [P.R 585](https://github.com/PlayTazUO/TazUO/pull/585) ([bittiez](https://github.com/bittiez))
 * Fixed crash when creating a journal tab with a name that already exists - [P.R 589](https://github.com/PlayTazUO/TazUO/pull/589) ([bittiez](https://github.com/bittiez))
 * Show a suggested fix for the "OpenGL 2.1 support is required!" graphics device error, advising users to update their drivers or try the `-force_driver 1`, `2`, or `3` launch args - [P.R 595](https://github.com/PlayTazUO/TazUO/pull/595) ([bittiez](https://github.com/bittiez))
+* Pass the first click through to a Myra window so clicking a control on an unfocused window works in one click instead of requiring a focus click first - [P.R 604](https://github.com/PlayTazUO/TazUO/pull/604) ([bittiez](https://github.com/bittiez))
 
 ### Legion
 * Added ModernNineSliceGump.SetLegionTexture to go along with zip files and custom png's - Use your own png for a 9-slice texture - ([bittiez](https://github.com/bittiez))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to TazUO will be recorded here.
 ---
 ## In Development
 
+### Fixes
+* Pass the first click through to a Myra window so clicking a control on an unfocused window works in one click instead of requiring a focus click first - [P.R 604](https://github.com/PlayTazUO/TazUO/pull/604) ([bittiez](https://github.com/bittiez))
+
 ---
 
 ## V5.3.0

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.0</AssemblyVersion>
-    <FileVersion>5.3.0</FileVersion>
+    <AssemblyVersion>5.3.1</AssemblyVersion>
+    <FileVersion>5.3.1</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Controls/MyraControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/MyraControl.cs
@@ -249,7 +249,15 @@ public class MyraControl : IGui
 
         batcher.FlushBatch(); //Required to draw myra on top of already drawn gumps
 
-        if (IsTopMost)
+        // Myra processes its own mouse/keyboard input inside Desktop.Render(). If we only ran
+        // that for the top-most window, the very first click on a background window would be spent
+        // by the UIManager promoting it to top-most (see UIManager.OnMouseButtonDown) and Myra would
+        // never see the click as a widget press. By also running the input pass while this is the
+        // window under the cursor (MouseOverControl, set during UIManager.Update() before Draw()),
+        // the click is passed through to Myra on the same frame, and hover frames keep Myra's mouse
+        // baseline fresh so the down-edge is detected. Only one window is ever MouseOverControl
+        // (front-most hit), so this does not cause click-through to overlapped windows.
+        if (IsTopMost || ReferenceEquals(UIManager.MouseOverControl, this))
         {
             _desktop.Render();
         }


### PR DESCRIPTION
Myra processes its own mouse/keyboard input inside Desktop.Render(), which MyraControl.Draw() only invoked for the top-most window. As a result, the first click on a background Myra window was consumed by the UIManager promoting it to top-most, and Myra never saw that click as a widget press, so users had to click once to focus and again to act.

Also run the Myra input pass while the window is the one under the cursor (UIManager.MouseOverControl, set during UIManager.Update() before Draw()). The click is now delivered to Myra on the same frame, and hover frames keep Myra's mouse baseline fresh so the press edge is detected. Only one window is ever MouseOverControl (front-most hit), so this does not introduce click-through to overlapped windows.