### PR TITLE
Prevent client crash from malformed localization format strings

### DIFF
--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.2</AssemblyVersion>
-    <FileVersion>5.3.2</FileVersion>
+    <AssemblyVersion>5.3.3</AssemblyVersion>
+    <FileVersion>5.3.3</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Configuration/TazLang.cs
+++ b/src/ClassicUO.Client/Configuration/TazLang.cs
@@ -24,8 +24,18 @@ namespace ClassicUO.Configuration
         {
             if(!_strings.TryGetValue(key, out string v))
                 return string.Empty;
-            
-            return string.Format(v, replace);
+
+            try
+            {
+                return string.Format(v, replace);
+            }
+            catch (FormatException ex)
+            {
+                // A malformed localization template (stray braces or a placeholder
+                // index beyond the supplied args) must never crash the client.
+                Log.Warn($"TazLang: invalid format string for key '{key}': {ex.Message}");
+                return v;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
TazLang.Get(key, string[]) called string.Format directly, so a localized template with a stray brace or a placeholder index beyond the supplied args threw FormatException and crashed the client during the draw loop (e.g. opening the Tinkerer art browser tab via ArtBrowserTabContent tooltips).

Wrap string.Format in a try/catch that logs the offending key and falls back to the raw template, so a bad translation can never take down the client.


Original crash:
```
System.FormatException: Format_IndexOutOfRange
   at System.String.FormatHelper(IFormatProvider provider, String format, ReadOnlySpan`1 args)
   at ClassicUO.Configuration.TazLang.Get(String key, String[] replace) in TazUO/src/ClassicUO.Client/Configuration/TazLang.cs:line 28
   ```