### PR TITLE
Add memory and CPU usage stats to ProfilerWindow and make profiler available on non debug releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ All notable changes to TazUO will be recorded here.
 * Managed zlib is now a global setting, defaults to enabled on Linux and disabled on Windows/Mac, and the `-zlib` arg now persists the setting - [P.R 514](https://github.com/PlayTazUO/TazUO/pull/514) ([bittiez](https://github.com/bittiez))
 * Add option to disable corpse retry in autoloot - [P.R 525](https://github.com/PlayTazUO/TazUO/pull/525) ([bittiez](https://github.com/bittiez))
 * Corpse hueing from auto loot will now reapply when a corpse is removed and added back onto your screen - [P.R 557](https://github.com/PlayTazUO/TazUO/pull/557) ([bittiez](https://github.com/bittiez))
+* Corpse hueing from auto loot will now reapply when a corpse is removed and added back onto your screen - [P.R 607](https://github.com/PlayTazUO/TazUO/pull/607) ([bittiez](https://github.com/bittiez))
 
 ---
 

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.3</AssemblyVersion>
-    <FileVersion>5.3.3</FileVersion>
+    <AssemblyVersion>5.3.4</AssemblyVersion>
+    <FileVersion>5.3.4</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Gumps/TopBarGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/TopBarGump.cs
@@ -269,9 +269,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             var devSubmenu = new ContextMenuItemEntry("Developer");
             devSubmenu.Add(new ContextMenuItemEntry("Tinkerer", TinkererWindow.Show));
-#if DEBUG
             devSubmenu.Add(new ContextMenuItemEntry("Profiler", MyraWindows.ProfilerWindow.Show));
-#endif
             moreMenu.ContextMenu.Add(devSubmenu);
 
             startX += largeWidth + 1;

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/ProfilerWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/ProfilerWindow.cs
@@ -1,7 +1,10 @@
 #if DEBUG
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Game.UI.MyraWindows.Widgets;
@@ -18,7 +21,11 @@ namespace ClassicUO.Game.UI.MyraWindows
 
         private readonly VerticalStackPanel _dataPanel;
         private readonly MyraButton _toggleButton;
+        private readonly MyraLabel _statsLabel;
         private uint _lastUpdate;
+
+        private readonly CancellationTokenSource _cpuCts = new();
+        private volatile float _cpuPercent;
 
         public static void Show()
         {
@@ -44,6 +51,8 @@ namespace ClassicUO.Game.UI.MyraWindows
             buttons.Widgets.Add(new MyraButton("Reset", () => Profiler.Reset()));
             buttons.Widgets.Add(new MyraButton("Copy Output", CopyToClipboard));
 
+            _statsLabel = new MyraLabel(GetStatsLabel(), MyraLabel.TextStyle.P);
+
             var scrollViewer = new ScrollViewer
             {
                 MinWidth = 500,
@@ -59,12 +68,58 @@ namespace ClassicUO.Game.UI.MyraWindows
                 Padding = new Thickness(4),
             };
             root.Widgets.Add(buttons);
+            root.Widgets.Add(_statsLabel);
             root.Widgets.Add(scrollViewer);
 
             SetRootContent(root);
             CenterInViewPort();
 
+            _ = MonitorCpuAsync(_cpuCts.Token);
+
             UpdateDisplay();
+        }
+
+        /// <summary>
+        /// Continuously samples CPU usage in the background. The loop ends when the
+        /// window is disposed and its <see cref="CancellationTokenSource"/> is cancelled,
+        /// so no task is left running after the window closes.
+        /// </summary>
+        private async Task MonitorCpuAsync(CancellationToken token)
+        {
+            const int sampleWindowMs = 500;
+
+            while (!token.IsCancellationRequested)
+            {
+                try
+                {
+                    var startSnapshot = Environment.CpuUsage;
+                    var startTime = DateTime.UtcNow;
+
+                    await Task.Delay(sampleWindowMs, token);
+
+                    var endSnapshot = Environment.CpuUsage;
+                    var endTime = DateTime.UtcNow;
+
+                    var cpuTimeUsed = endSnapshot.TotalTime - startSnapshot.TotalTime;
+                    var realTimeElapsed = endTime - startTime;
+
+                    double cpuPercent = realTimeElapsed.TotalMilliseconds > 0
+                        ? (cpuTimeUsed.TotalMilliseconds / realTimeElapsed.TotalMilliseconds) / Environment.ProcessorCount * 100
+                        : 0.0;
+
+                    _cpuPercent = (float)Math.Clamp(Math.Round(cpuPercent, 2), 0.0, 100.0);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+            }
+        }
+
+        private string GetStatsLabel()
+        {
+            double memoryMb = Environment.WorkingSet / (1024.0 * 1024.0);
+            return $"Memory: {memoryMb:F1} MB    CPU: {_cpuPercent:F2}%";
         }
 
         private void OnToggle()
@@ -114,11 +169,35 @@ namespace ClassicUO.Game.UI.MyraWindows
         {
             base.Update();
 
+            // The close button (X) disposes through the base class without routing
+            // through Dispose(), so stop the CPU monitor here too once disposed.
+            if (IsDisposed)
+            {
+                StopCpuMonitor();
+                return;
+            }
+
             if (Time.Ticks - _lastUpdate > UPDATE_INTERVAL)
             {
                 _lastUpdate = Time.Ticks;
+                _statsLabel.Text = GetStatsLabel();
                 UpdateDisplay();
             }
+        }
+
+        public override void Dispose()
+        {
+            StopCpuMonitor();
+            base.Dispose();
+        }
+
+        private void StopCpuMonitor()
+        {
+            if (_cpuCts.IsCancellationRequested)
+                return;
+
+            _cpuCts.Cancel();
+            _cpuCts.Dispose();
         }
 
         private void UpdateDisplay()

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/ProfilerWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/ProfilerWindow.cs
@@ -25,7 +25,7 @@ namespace ClassicUO.Game.UI.MyraWindows
         private uint _lastUpdate;
 
         private readonly CancellationTokenSource _cpuCts = new();
-        private volatile float _cpuPercent;
+        private static volatile float _cpuPercent;
 
         public static void Show()
         {
@@ -92,16 +92,16 @@ namespace ClassicUO.Game.UI.MyraWindows
             {
                 try
                 {
-                    var startSnapshot = Environment.CpuUsage;
-                    var startTime = DateTime.UtcNow;
+                    Environment.ProcessCpuUsage startSnapshot = Environment.CpuUsage;
+                    DateTime startTime = DateTime.UtcNow;
 
                     await Task.Delay(sampleWindowMs, token);
 
-                    var endSnapshot = Environment.CpuUsage;
-                    var endTime = DateTime.UtcNow;
+                    Environment.ProcessCpuUsage endSnapshot = Environment.CpuUsage;
+                    DateTime endTime = DateTime.UtcNow;
 
-                    var cpuTimeUsed = endSnapshot.TotalTime - startSnapshot.TotalTime;
-                    var realTimeElapsed = endTime - startTime;
+                    TimeSpan cpuTimeUsed = endSnapshot.TotalTime - startSnapshot.TotalTime;
+                    TimeSpan realTimeElapsed = endTime - startTime;
 
                     double cpuPercent = realTimeElapsed.TotalMilliseconds > 0
                         ? (cpuTimeUsed.TotalMilliseconds / realTimeElapsed.TotalMilliseconds) / Environment.ProcessorCount * 100
@@ -116,7 +116,7 @@ namespace ClassicUO.Game.UI.MyraWindows
             }
         }
 
-        private string GetStatsLabel()
+        private static string GetStatsLabel()
         {
             double memoryMb = Environment.WorkingSet / (1024.0 * 1024.0);
             return $"Memory: {memoryMb:F1} MB    CPU: {_cpuPercent:F2}%";
@@ -135,7 +135,7 @@ namespace ClassicUO.Game.UI.MyraWindows
 
         private static void CopyToClipboard()
         {
-            List<Profiler.ProfileData> data = Profiler.AllFrameData
+            var data = Profiler.AllFrameData
                 .OrderByDescending(pd => pd.AverageTime)
                 .ToList();
 
@@ -149,6 +149,7 @@ namespace ClassicUO.Game.UI.MyraWindows
             double totalAvg = data.Sum(pd => pd.AverageTime);
             var sb = new StringBuilder();
             sb.AppendLine("TazUO Profiler Output");
+            sb.AppendLine(GetStatsLabel());
             sb.AppendLine($"{"Context",-40}  {"Avg(ms)",7}  {"Peak(ms)",8}  {"Last(ms)",8}  {"% Total",7}");
             sb.AppendLine(new string('-', 76));
 
@@ -210,7 +211,7 @@ namespace ClassicUO.Game.UI.MyraWindows
                 return;
             }
 
-            List<Profiler.ProfileData> data = Profiler.AllFrameData
+            var data = Profiler.AllFrameData
                 .OrderByDescending(pd => pd.AverageTime)
                 .ToList();
 

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/ProfilerWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/ProfilerWindow.cs
@@ -1,4 +1,3 @@
-#if DEBUG
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -268,4 +267,3 @@ namespace ClassicUO.Game.UI.MyraWindows
         }
     }
 }
-#endif

--- a/src/ClassicUO.Utility/Profiler.cs
+++ b/src/ClassicUO.Utility/Profiler.cs
@@ -36,7 +36,7 @@ namespace ClassicUO.Utility
 
         public static bool Enabled = false;
 
-        [Conditional("DEBUG")]
+        //[Conditional("DEBUG")]
         public static void BeginFrame()
         {
             if (!Enabled)
@@ -73,7 +73,7 @@ namespace ClassicUO.Utility
             m_BeginFrameTicks = _timer.ElapsedTicks;
         }
 
-        [Conditional("DEBUG")]
+        //[Conditional("DEBUG")]
         public static void EndFrame()
         {
             if (!Enabled)
@@ -85,7 +85,7 @@ namespace ClassicUO.Utility
             m_TotalTimeData.AddNewHitLength(LastFrameTimeMS);
         }
 
-        [Conditional("DEBUG")]
+        //[Conditional("DEBUG")]
         public static void EnterContext(string context_name)
         {
             if (!Enabled)
@@ -96,7 +96,7 @@ namespace ClassicUO.Utility
             m_Context.Add(new ContextAndTick(context_name, _timer.ElapsedTicks));
         }
 
-        [Conditional("DEBUG")]
+        //[Conditional("DEBUG")]
         public static void ExitContext(string context_name, bool errorNotInContext = false)
         {
             if (!Enabled)


### PR DESCRIPTION
Display current process working set (MB) and a live CPU usage percentage in the profiler window. CPU is sampled on a background task that is cancelled when the window closes so no task is left running behind it.