### PR TITLE
Fix percent health text drifting around mobile based on zoom level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ All notable changes to TazUO will be recorded here.
 * Fixed crash when creating a journal tab with a name that already exists - [P.R 589](https://github.com/PlayTazUO/TazUO/pull/589) ([bittiez](https://github.com/bittiez))
 * Show a suggested fix for the "OpenGL 2.1 support is required!" graphics device error, advising users to update their drivers or try the `-force_driver 1`, `2`, or `3` launch args - [P.R 595](https://github.com/PlayTazUO/TazUO/pull/595) ([bittiez](https://github.com/bittiez))
 * Pass the first click through to a Myra window so clicking a control on an unfocused window works in one click instead of requiring a focus click first - [P.R 604](https://github.com/PlayTazUO/TazUO/pull/604) ([bittiez](https://github.com/bittiez))
+* Fixed percent-type "Show Mobiles HP" text drifting in a radius around the mobile based on zoom level instead of staying centered on top - [P.R 608](https://github.com/PlayTazUO/TazUO/pull/608) ([bittiez](https://github.com/bittiez))
 
 ### Legion
 * Added ModernNineSliceGump.SetLegionTexture to go along with zip files and custom png's - Use your own png for a 9-slice texture - ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.4</AssemblyVersion>
-    <FileVersion>5.3.4</FileVersion>
+    <AssemblyVersion>5.3.5</AssemblyVersion>
+    <FileVersion>5.3.5</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/Managers/HealthLinesManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/HealthLinesManager.cs
@@ -132,7 +132,13 @@ namespace ClassicUO.Game.Managers
                                     p1.Y += 22;
                                 }
 
-                                p1 = Client.Game.Scene.Camera.WorldToScreen(p1);
+                                // NOTE: Do NOT call Camera.WorldToScreen here. This overhead pass is
+                                // already drawn through a batcher begun with Camera.ViewTransformMatrix
+                                // (see GameScene.DrawOverheads), so the camera transform is applied
+                                // automatically. The health bar below uses world coordinates directly for
+                                // the same reason. Applying WorldToScreen manually transforms the position a
+                                // second time, which made the percent text drift in a radius around the
+                                // mobile as the zoom level changed instead of staying centered on top.
                                 p1.X -= (mobile.HitsTexture.Width >> 1) + 5;
                                 p1.Y -= mobile.HitsTexture.Height;
 


### PR DESCRIPTION
The percent-type "Show Mobiles HP" text was positioned with a manual Camera.WorldToScreen call before being drawn. However, the overhead pass is rendered through a batcher begun with Camera.ViewTransformMatrix (the same matrix WorldToScreen applies), so the camera transform was applied twice. At zoom 1 the matrix is near-identity so the bug was hidden, but at other zoom levels the double transform pushed the text outward in a radius around the mobile instead of staying centered on top.

Remove the redundant WorldToScreen call so the percent text uses world coordinates directly, matching how the health bar in the same method is already drawn.