### PR TITLE
fix: Improve options window search

### DIFF
--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Options/OptionFragment.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Options/OptionFragment.cs
@@ -22,6 +22,12 @@ internal sealed class OptionFragment(Func<Widget> renderFactory, IEnumerable<Opt
     public bool InheritsSearch { get; set; } = true;
 
     /// <summary>
+    /// When <see langword="true"/>, a search hit against any descendant returns this fragment
+    /// as a single rendered unit rather than individual leaf entries.
+    /// </summary>
+    public bool IsSearchGroup { get; private set; }
+
+    /// <summary>
     /// Renders the fragment's container widget. Each call returns a new widget instance.
     /// </summary>
     public Widget Render() => renderFactory();
@@ -29,17 +35,67 @@ internal sealed class OptionFragment(Func<Widget> renderFactory, IEnumerable<Opt
     /// <inheritdoc/>
     public IEnumerable<OptionEntry> Match(SearchMetadata search)
     {
-        SearchMetadata? finalSearch = InheritsSearch ? SearchMetadata.Merge(Search, search) : Search;
-        return finalSearch == null
-            ? []
-            : children.SelectMany(c => c.Match(finalSearch));
+        SearchMetadata? searchParams = InheritsSearch ? SearchMetadata.Merge(Search, search) : Search;
+        if (searchParams == null)
+            yield break;
+
+        if (IsSearchGroup)
+        {
+            if (children.Any(c => c.Match(searchParams).Any()))
+                yield return new OptionEntry(Render, Search);
+            yield break;
+        }
+
+        foreach (OptionEntry entry in children.SelectMany(c => c.Match(searchParams)))
+            yield return entry;
     }
 
     /// <inheritdoc/>
     public IEnumerable<OptionEntry> GetOptions(SearchMetadata? inheritedSearch = null)
     {
+        if (IsSearchGroup)
+        {
+            SearchMetadata? ownMeta = InheritsSearch ? SearchMetadata.Merge(Search, inheritedSearch) : Search;
+            SearchMetadata? groupMeta = children
+                .SelectMany(c => c.GetOptions(null))
+                .Select(e => e.Search)
+                .OfType<SearchMetadata>()
+                .Aggregate(ownMeta, DeepMerge);
+            yield return new OptionEntry(Render, groupMeta ?? new SearchMetadata());
+            yield break;
+        }
+
         SearchMetadata? merged = InheritsSearch ? SearchMetadata.Merge(Search, inheritedSearch) : Search;
-        return children.SelectMany(c => c.GetOptions(merged));
+        foreach (OptionEntry entry in children.SelectMany(c => c.GetOptions(merged)))
+            yield return entry;
+    }
+
+    /// <summary>
+    /// Like <see cref="SearchMetadata.Merge"/> but concatenates both <c>SearchText</c> values
+    /// so that any descendant label remains substring-searchable from the group entry.
+    /// </summary>
+    private static SearchMetadata DeepMerge(SearchMetadata? a, SearchMetadata b)
+    {
+        string? combinedText = a?.SearchText == null ? b.SearchText
+            : b.SearchText == null ? a.SearchText
+            : $"{a.SearchText} {b.SearchText}";
+        string[] tags = [.. a?.Tags ?? [], .. b.Tags ?? []];
+        string[] keywords = [.. a?.Keywords ?? [], .. b.Keywords ?? []];
+        return new SearchMetadata(combinedText, tags.Distinct().ToArray(), keywords.Distinct().ToArray());
+    }
+
+    /// <summary>Marks this fragment as a search group and returns itself for fluent chaining</summary>
+    public OptionFragment AsSearchGroup()
+    {
+        IsSearchGroup = true;
+        return this;
+    }
+
+    /// <summary>Marks this fragment as a standalone node, i.e., one with search independent of its children and returns itself for fluent chaining</summary>
+    public OptionFragment AsStandalone()
+    {
+        IsSearchGroup = false;
+        return this;
     }
 
     /// <summary>Attaches <paramref name="search"/> as this fragment's own search metadata and returns itself</summary>

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Options/OptionsUi.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Options/OptionsUi.cs
@@ -71,8 +71,8 @@ internal static class OptionsUi
         PropertyBinder controlProp,
         params OptionContent[] children
     ) =>
-        new(
+        new OptionFragment(
             () => new CheckBoxGroup(controlProp, children.Select(c => c.Render()).ToArray()),
             children
-        );
+        ).AsSearchGroup();
 }

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/PaperdollTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/PaperdollTab.cs
@@ -15,7 +15,7 @@ public class PaperdollTab
         ModernOptionsGumpLanguage.KeywordsLang kw = lang.Kw;
         return OptionsUi.Vertical(
             GetModernPaperdollSection()
-        ).WithSearch(new SearchMetadata(lang.ButtonPaperdoll, Tags: [kw.Paperdoll, kw.Character, kw.Equipment]));
+        ).WithSearch(new SearchMetadata(lang.ButtonPaperdoll, [kw.Paperdoll, kw.Character, kw.Equipment]));
     }
 
     private static OptionFragment GetModernPaperdollSection()
@@ -36,7 +36,7 @@ public class PaperdollTab
                         profile.ModernPaperDollHue = newHue;
                         ModernPaperdoll.UpdateAllOptions();
                     }),
-                    search: new SearchMetadata(tuoLang.PaperdollHue, Keywords: [kw.Hue, kw.Color])
+                    new SearchMetadata(tuoLang.PaperdollHue, Keywords: [kw.Hue, kw.Color])
                 ),
                 Option.HuePicker(
                     tuoLang.DurabilityBarHue,
@@ -45,7 +45,7 @@ public class PaperdollTab
                         profile.ModernPaperDollDurabilityHue = newHue;
                         ModernPaperdoll.UpdateAllOptions();
                     }),
-                    search: new SearchMetadata(tuoLang.DurabilityBarHue, Keywords: [kw.Durability, kw.Bar, kw.Hue, kw.Color])
+                    new SearchMetadata(tuoLang.DurabilityBarHue, Keywords: [kw.Durability, kw.Bar, kw.Hue, kw.Color])
                 ),
                 Option.Slider(
                     tuoLang.ShowDurabilityBarBelow,

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/VideoTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/VideoTab.cs
@@ -256,10 +256,13 @@ public static class VideoTab
                     videoLang.GlobalScaling,
                     50,
                     Client.Game.MaxRenderScale * 100,
-                    new Accessor<float>(() => Client.Game.RenderScale * 100, newValue =>
-                    {
-                        scale = Math.Clamp(newValue / 100, 0.5f, Client.Game.MaxRenderScale);
-                    }),
+                    new Accessor<float>(
+                        () => Client.Game.RenderScale * 100,
+                        newValue =>
+                        {
+                            scale = Math.Clamp(newValue / 100, 0.5f, Client.Game.MaxRenderScale);
+                        }
+                    ),
                     search: new SearchMetadata(videoLang.GlobalScaling, Keywords: [kw.Global, kw.Scale])
                 ),
                 Option.Button(
@@ -275,7 +278,7 @@ public static class VideoTab
                     search: new SearchMetadata(lang.Apply)
                 )
             )
-        );
+        ).AsSearchGroup();
     }
 
     private static IOptionSource GetLightningSubTabContent()
@@ -284,22 +287,6 @@ public static class VideoTab
         ModernOptionsGumpLanguage.VideoTabLang lang = Language.Instance.GetModernOptionsGumpLanguage.VideoTab;
         ModernOptionsGumpLanguage.VideoTabLang.LightingSection lightLang = lang.Lighting;
         ModernOptionsGumpLanguage.KeywordsLang kw = Language.Instance.GetModernOptionsGumpLanguage.Kw;
-
-        void UpdateLight()
-        {
-            if (profile.UseCustomLightLevel)
-            {
-                World.Instance.Light.Overall = profile.LightLevelType == 1
-                    ? Math.Min(World.Instance.Light.RealOverall, profile.LightLevel)
-                    : profile.LightLevel;
-                World.Instance.Light.Personal = 0;
-            }
-            else
-            {
-                World.Instance.Light.Overall = World.Instance.Light.RealOverall;
-                World.Instance.Light.Personal = World.Instance.Light.RealPersonal;
-            }
-        }
 
         return OptionsUi.Vertical(
             Option.Checkbox(
@@ -346,6 +333,22 @@ public static class VideoTab
                 search: new SearchMetadata(lightLang.ColoredLight, Keywords: [kw.Color, kw.Light])
             )
         ).WithSearch(new SearchMetadata(lightLang.Label, Tags: [kw.Light]));
+
+        void UpdateLight()
+        {
+            if (profile.UseCustomLightLevel)
+            {
+                World.Instance.Light.Overall = profile.LightLevelType == 1
+                    ? Math.Min(World.Instance.Light.RealOverall, profile.LightLevel)
+                    : profile.LightLevel;
+                World.Instance.Light.Personal = 0;
+            }
+            else
+            {
+                World.Instance.Light.Overall = World.Instance.Light.RealOverall;
+                World.Instance.Light.Personal = World.Instance.Light.RealPersonal;
+            }
+        }
     }
 
     private static IOptionSource GetShadowSubTabContent()


### PR DESCRIPTION
## Description
Improve options window search behavior

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing
Local


## Additional Notes
Allows setting control groups to render in their entirety and participate in search results.
Minor additional cleanup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Options search now groups related settings together, making search results easier to scan and navigate.
  * Improved search coverage for paperdoll and video settings with richer related keywords.

* **Bug Fixes**
  * Search results now better merge related metadata, reducing fragmented matches across nested options.
  * Video and paperdoll settings are now surfaced more consistently in search.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->