### PR TITLE
Warn user when over 100 gumps of the same type are open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable changes to TazUO will be recorded here.
 * Added a centralized hotkey system with a Hotkeys tab in the Assistant window for viewing, rebinding, and conflict-checking hotkeys (including macros), plus a global hotkey shutoff - [P.R 591](https://github.com/PlayTazUO/TazUO/pull/591) ([bittiez](https://github.com/bittiez))
 * Added a world map context menu option to choose the double click action between toggling the lock state and toggling fullscreen - [P.R 602](https://github.com/PlayTazUO/TazUO/pull/602) ([bittiez](https://github.com/bittiez))
 * Added a "Loot Hovered Item" macro that grabs whatever item the mouse is hovering over — grid containers, regular containers, paperdoll, modern paperdoll, items on the ground, and item nameplates - [P.R 603](https://github.com/PlayTazUO/TazUO/pull/603) ([bittiez](https://github.com/bittiez))
+* Added a warning when more than 100 gumps of the same type are open at once - [P.R #](https://github.com/PlayTazUO/TazUO/pull/#) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
 * Fixed simultaneous drag and resize occurring on resizable windows - [P.R #](https://github.com/PlayTazUO/TazUO/pull/#) ([yuval-po](https://github.com/yuval-po))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.5</AssemblyVersion>
-    <FileVersion>5.3.5</FileVersion>
+    <AssemblyVersion>5.3.6</AssemblyVersion>
+    <FileVersion>5.3.6</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -5,7 +5,7 @@
 ; Missing keys are auto-appended with English defaults when
 ; this file's version is newer than the user's copy.
 ; -------------------------------------------------------
-_version=25
+_version=26
 accountname=Account Name
 accountcontextmenutooltip=Right click to select another account.
 music=Music
@@ -630,3 +630,6 @@ map_doubleclick_toggle_fullscreen=Toggle fullscreen
 
 ; Top bar gump
 topbargump_commandsentry=Client Commands
+
+; UI Manager
+uimanager_toomanygumps=Warning: You have {0} '{1}' gumps open. This may cause performance issues.

--- a/src/ClassicUO.Client/Game/Managers/UIManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/UIManager.cs
@@ -512,7 +512,7 @@ namespace ClassicUO.Game.Managers
 
             if (count > SAME_TYPE_GUMP_WARN_THRESHOLD)
             {
-                GameActions.PrintUserWarn(World.Instance, $"You have {count} '{t.Name}' gumps open. This may cause performance issues.");
+                GameActions.PrintUserWarn(World.Instance, TazLang.Get("uimanager_toomanygumps", new[] { count.ToString(), t.Name }));
             }
         }
 

--- a/src/ClassicUO.Client/Game/Managers/UIManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/UIManager.cs
@@ -40,6 +40,9 @@ namespace ClassicUO.Game.Managers
         private const int AXIS_LOCK_THRESHOLD_PIXELS = 10;
         private const float CTRL_DRAG_SPEED_MULTIPLIER = 0.5f;
 
+        // Warn the user when too many gumps of the same type are open at once
+        private const int SAME_TYPE_GUMP_WARN_THRESHOLD = 100;
+
         private static void ResetCtrlDragState()
         {
             _ctrlDragAxisDetermined = false;
@@ -489,6 +492,28 @@ namespace ClassicUO.Game.Managers
             _needSort = Gumps.Count > 1;
 
             RegisterGump(gump);
+
+            WarnIfTooManySameType(gump);
+        }
+
+        /// <summary>
+        /// Warn the user when they have more than <see cref="SAME_TYPE_GUMP_WARN_THRESHOLD"/>
+        /// gumps of the same type open at once. Only the count of the added gump's exact
+        /// type is reported, not the total number of gumps.
+        /// </summary>
+        private static void WarnIfTooManySameType(IGui gump)
+        {
+            Type t = gump.GetType();
+
+            if (!_gumpTypeList.TryGetValue(t, out List<IGui> list))
+                return;
+
+            int count = list.Count;
+
+            if (count > SAME_TYPE_GUMP_WARN_THRESHOLD)
+            {
+                GameActions.PrintUserWarn(World.Instance, $"You have {count} '{t.Name}' gumps open. This may cause performance issues.");
+            }
         }
 
         public static void Clear()


### PR DESCRIPTION
Add a warning in UIManager.Add that notifies the user when they have more than 100 gumps of the same type open at once. The check runs when a gump is added to the UIManager, reporting the gump type name and its current count. Only gumps of the same type are counted, not the total number of open gumps.