### PR TITLE
Add skill support to the SpellBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ All notable changes to TazUO will be recorded here.
 * Added a world map context menu option to choose the double click action between toggling the lock state and toggling fullscreen - [P.R 602](https://github.com/PlayTazUO/TazUO/pull/602) ([bittiez](https://github.com/bittiez))
 * Added a "Loot Hovered Item" macro that grabs whatever item the mouse is hovering over — grid containers, regular containers, paperdoll, modern paperdoll, items on the ground, and item nameplates - [P.R 603](https://github.com/PlayTazUO/TazUO/pull/603) ([bittiez](https://github.com/bittiez))
 * Added a warning when more than 100 gumps of the same type are open at once - [P.R #](https://github.com/PlayTazUO/TazUO/pull/#) ([bittiez](https://github.com/bittiez))
-* Add Skill slot type to the Spell Bar - [P.R #](https://github.com/PlayTazUO/TazUO/pull/#) ([bittiez](https://github.com/bittiez))
+* Add Skill slot type to the Spell Bar - [P.R 613](https://github.com/PlayTazUO/TazUO/pull/613) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
 * Fixed simultaneous drag and resize occurring on resizable windows - [P.R #](https://github.com/PlayTazUO/TazUO/pull/#) ([yuval-po](https://github.com/yuval-po))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to TazUO will be recorded here.
 * Added a world map context menu option to choose the double click action between toggling the lock state and toggling fullscreen - [P.R 602](https://github.com/PlayTazUO/TazUO/pull/602) ([bittiez](https://github.com/bittiez))
 * Added a "Loot Hovered Item" macro that grabs whatever item the mouse is hovering over — grid containers, regular containers, paperdoll, modern paperdoll, items on the ground, and item nameplates - [P.R 603](https://github.com/PlayTazUO/TazUO/pull/603) ([bittiez](https://github.com/bittiez))
 * Added a warning when more than 100 gumps of the same type are open at once - [P.R #](https://github.com/PlayTazUO/TazUO/pull/#) ([bittiez](https://github.com/bittiez))
+* Add Skill slot type to the Spell Bar - [P.R #](https://github.com/PlayTazUO/TazUO/pull/#) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
 * Fixed simultaneous drag and resize occurring on resizable windows - [P.R #](https://github.com/PlayTazUO/TazUO/pull/#) ([yuval-po](https://github.com/yuval-po))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.7</AssemblyVersion>
-    <FileVersion>5.3.7</FileVersion>
+    <AssemblyVersion>5.3.8</AssemblyVersion>
+    <FileVersion>5.3.8</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -5,7 +5,7 @@
 ; Missing keys are auto-appended with English defaults when
 ; this file's version is newer than the user's copy.
 ; -------------------------------------------------------
-_version=26
+_version=27
 accountname=Account Name
 accountcontextmenutooltip=Right click to select another account.
 music=Music

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -81,6 +81,7 @@ spellbar_setspell=Set spell
 spellbar_quicksetspell=Quick set spell
 spellbar_setmacro=Set macro
 spellbar_setscript=Set script
+spellbar_setskill=Set skill
 spellbar_setability=Set ability
 spellbar_ability_primary=Primary ability
 spellbar_ability_secondary=Secondary ability

--- a/src/ClassicUO.Client/Game/Managers/SpellBarManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/SpellBarManager.cs
@@ -297,7 +297,7 @@ public class SpellBarManager
 }
 
 /// <summary>The kind of action stored in a single spell bar slot.</summary>
-public enum SpellBarSlotType { Empty = 0, Spell = 1, Macro = 2, Ability = 3, Script = 4 }
+public enum SpellBarSlotType { Empty = 0, Spell = 1, Macro = 2, Ability = 3, Script = 4, Skill = 5 }
 
 /// <summary>
 /// A single spell bar slot. Holds one of: nothing, a spell, a macro, or a weapon
@@ -316,6 +316,9 @@ public class SpellBarSlot
 
     /// <summary>Stable relative id (ScriptFile.RelativePath) when <see cref="Type"/> is <see cref="SpellBarSlotType.Script"/>.</summary>
     public string ScriptId { get; set; }            // Type == Script
+
+    /// <summary>Skill index (matches <see cref="GameActions.UseSkill"/>) when <see cref="Type"/> is <see cref="SpellBarSlotType.Skill"/>.</summary>
+    public int SkillIndex { get; set; } = -1;       // Type == Skill
 
     /// <summary>True for the primary ability, false for the secondary, when <see cref="Type"/> is <see cref="SpellBarSlotType.Ability"/>.</summary>
     public bool AbilityPrimary { get; set; }        // Type == Ability (true = primary, false = secondary)
@@ -346,6 +349,24 @@ public class SpellBarSlot
     public string ScriptDisplayName =>
         ResolvedScript?.FileName ??
         (string.IsNullOrEmpty(ScriptId) ? string.Empty : System.IO.Path.GetFileName(ScriptId));
+
+    /// <summary>Friendly name for a skill slot, resolved from the skill data files, or empty.</summary>
+    [JsonIgnore]
+    public string SkillDisplayName
+    {
+        get
+        {
+            var skills = Client.Game?.UO?.FileManager?.Skills?.Skills;
+            if (skills == null)
+                return string.Empty;
+
+            foreach (var s in skills)
+                if (s.Index == SkillIndex)
+                    return s.Name;
+
+            return string.Empty;
+        }
+    }
 
     /// <summary>Toggle decision for a script slot: play when not already running.</summary>
     public static bool ShouldPlay(bool isRunning) => !isRunning;
@@ -383,6 +404,15 @@ public class SpellBarSlot
     /// <summary>Creates an ability slot for the primary (<paramref name="primary"/> true) or secondary ability.</summary>
     public static SpellBarSlot FromAbility(bool primary) => new SpellBarSlot { Type = SpellBarSlotType.Ability, AbilityPrimary = primary };
 
+    /// <summary>Creates a skill slot, or an empty slot when <paramref name="skillIndex"/> is negative.</summary>
+    public static SpellBarSlot FromSkill(int skillIndex)
+    {
+        if (skillIndex < 0)
+            return Empty();
+
+        return new SpellBarSlot { Type = SpellBarSlotType.Skill, SkillIndex = skillIndex };
+    }
+
     /// <summary>Performs the slot's action: casts the spell, runs the macro, or triggers the ability.</summary>
     public void Activate(World world)
     {
@@ -419,6 +449,11 @@ public class SpellBarSlot
                     else
                         ClassicUO.LegionScripting.LegionScripting.StopScript(script);
                 }
+                break;
+
+            case SpellBarSlotType.Skill:
+                if (SkillIndex >= 0)
+                    GameActions.UseSkill(SkillIndex);
                 break;
         }
     }
@@ -480,6 +515,10 @@ public class SpellBarSlot
 
             case SpellBarSlotType.Script:
                 text = ScriptDisplayName;
+                return !string.IsNullOrEmpty(text);
+
+            case SpellBarSlotType.Skill:
+                text = SkillDisplayName;
                 return !string.IsNullOrEmpty(text);
         }
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/SpellBar/SpellBar.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/SpellBar/SpellBar.cs
@@ -345,6 +345,7 @@ public class SpellBar : Gump
             string name =
                 slot != null && slot.Type == SpellBarSlotType.Macro ? slot.MacroName :
                 slot != null && slot.Type == SpellBarSlotType.Script ? slot.ScriptDisplayName :
+                slot != null && slot.Type == SpellBarSlotType.Skill ? slot.SkillDisplayName :
                 null;
 
             if (!string.IsNullOrEmpty(name))
@@ -479,6 +480,10 @@ public class SpellBar : Gump
             GenScriptList(scriptMenu);
             ContextMenu.Add(scriptMenu);
 
+            var skillMenu = new ContextMenuItemEntry(TazLang.Get("spellbar_setskill"));
+            GenSkillList(skillMenu);
+            ContextMenu.Add(skillMenu);
+
             ContextMenu.Add(new ContextMenuItemEntry(TazLang.Get("spellbar_clear"), () =>
             {
                 SetSlot(SpellBarSlot.Empty(), row, col);
@@ -513,6 +518,27 @@ public class SpellBar : Gump
                 parent.Add(new ContextMenuItemEntry(script.RelativePath, () =>
                 {
                     SetSlot(SpellBarSlot.FromScript(script), row, col);
+                }));
+            }
+        }
+
+        private void GenSkillList(ContextMenuItemEntry parent)
+        {
+            if (parent == null)
+                return;
+
+            parent.Items.Clear();
+
+            // Only skills that have a usable action (HasAction) can be invoked from the spell bar.
+            foreach (var skill in Client.Game.UO.FileManager.Skills.SortedSkills)
+            {
+                if (!skill.HasAction)
+                    continue;
+
+                int index = skill.Index;
+                parent.Add(new ContextMenuItemEntry(skill.Name, () =>
+                {
+                    SetSlot(SpellBarSlot.FromSkill(index), row, col);
                 }));
             }
         }

--- a/tests/ClassicUO.UnitTests/Game/Managers/SpellBarScriptSlotTest.cs
+++ b/tests/ClassicUO.UnitTests/Game/Managers/SpellBarScriptSlotTest.cs
@@ -29,5 +29,27 @@ namespace ClassicUO.UnitTests.Game.Managers
         {
             ((int)SpellBarSlotType.Script).Should().Be(4);
         }
+
+        [Fact]
+        public void SkillSlotType_HasValue5()
+        {
+            ((int)SpellBarSlotType.Skill).Should().Be(5);
+        }
+
+        [Fact]
+        public void FromSkill_Negative_ReturnsEmpty()
+        {
+            SpellBarSlot.FromSkill(-1).IsEmpty.Should().BeTrue();
+        }
+
+        [Fact]
+        public void FromSkill_ValidIndex_CreatesSkillSlot()
+        {
+            SpellBarSlot slot = SpellBarSlot.FromSkill(21); // Hiding
+
+            slot.IsEmpty.Should().BeFalse();
+            slot.Type.Should().Be(SpellBarSlotType.Skill);
+            slot.SkillIndex.Should().Be(21);
+        }
     }
 }


### PR DESCRIPTION
Adds a new Skill slot type to the spell bar alongside spells, macros, abilities, and scripts. Skill slots invoke usable skills (those with an action) via GameActions.UseSkill.

- New SpellBarSlotType.Skill and SkillIndex on SpellBarSlot
- FromSkill factory, Activate, tooltip, and display-name resolution
- "Set skill" context menu listing usable (HasAction) skills
- Slot abbreviation label for skill slots
- Unit tests for the new slot type