### PR TITLE
Add server gump scaling support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ All notable changes to TazUO will be recorded here.
 * Added a warning when more than 100 gumps of the same type are open at once - [P.R #](https://github.com/PlayTazUO/TazUO/pull/#) ([bittiez](https://github.com/bittiez))
 * Add Skill slot type to the Spell Bar - [P.R 613](https://github.com/PlayTazUO/TazUO/pull/613) ([bittiez](https://github.com/bittiez))
 * Added individual scaling support for the Status Gump - [P.R 614](https://github.com/PlayTazUO/TazUO/pull/614) ([bittiez](https://github.com/bittiez))
+* Added a single scaling option for all server-created gumps - [P.R 615](https://github.com/PlayTazUO/TazUO/pull/615) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
 * Fixed simultaneous drag and resize occurring on resizable windows - [P.R #](https://github.com/PlayTazUO/TazUO/pull/#) ([yuval-po](https://github.com/yuval-po))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.9</AssemblyVersion>
-    <FileVersion>5.3.9</FileVersion>
+    <AssemblyVersion>5.3.10</AssemblyVersion>
+    <FileVersion>5.3.10</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -782,6 +782,11 @@ namespace ClassicUO.Configuration
 
         public double StatusGumpScale { get; set => SetProperty(ref field, Math.Clamp(value, 0.5d, 3.0d)); } = 1f;
 
+        /// <summary>
+        /// Scale applied to every server created gump (and all of its controls).
+        /// </summary>
+        public double ServerGumpScale { get; set => SetProperty(ref field, Math.Clamp(value, 0.5d, 3.0d)); } = 1f;
+
         public uint SOSGumpID { get; set => SetProperty(ref field, value); } = 1915258020;
 
         public bool ModernPaperdollAnchorEnabled { get; set => SetProperty(ref field, value); }

--- a/src/ClassicUO.Client/Game/UI/Controls/Button.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/Button.cs
@@ -220,19 +220,22 @@ namespace ClassicUO.Game.UI.Controls
             {
                 RenderedText textTexture = _fontTexture[_entered ? 1 : 0];
 
+                double scale = InternalScale;
+
                 if (FontCenter)
                 {
                     int yoffset = IsClicked ? 1 : 0;
 
                     textTexture.Draw(
                         batcher,
-                        x + ((Width - textTexture.Width) >> 1),
-                        y + yoffset + ((Height - textTexture.Height) >> 1)
+                        x + ((Width - (int)(textTexture.Width * scale)) >> 1),
+                        y + yoffset + ((Height - (int)(textTexture.Height * scale)) >> 1),
+                        scale
                     );
                 }
                 else
                 {
-                    textTexture.Draw(batcher, x, y);
+                    textTexture.Draw(batcher, x, y, scale);
                 }
             }
 

--- a/src/ClassicUO.Client/Game/UI/Controls/ButtonTileArt.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ButtonTileArt.cs
@@ -50,9 +50,12 @@ namespace ClassicUO.Game.UI.Controls
 
             if (artInfo.Texture != null)
             {
+                double scale = InternalScale;
+
                 batcher.Draw(
                     artInfo.Texture,
-                    new Vector2(x + _tileX, y + _tileY),
+                    new Rectangle(x + (int)(_tileX * scale), y + (int)(_tileY * scale),
+                        (int)(artInfo.UV.Width * scale), (int)(artInfo.UV.Height * scale)),
                     artInfo.UV,
                     hueVector
                 );

--- a/src/ClassicUO.Client/Game/UI/Controls/Checkbox.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/Checkbox.cs
@@ -91,14 +91,16 @@ namespace ClassicUO.Game.UI.Controls
                 IsChecked ? _active : _inactive
             );
 
+            double scale = InternalScale;
+
             batcher.Draw(
                 gumpInfo.Texture,
-                new Vector2(x, y),
+                new Rectangle(x, y, (int)(gumpInfo.UV.Width * scale), (int)(gumpInfo.UV.Height * scale)),
                 gumpInfo.UV,
                 ShaderHueTranslator.GetHueVector(0)
             );
 
-            _text.Draw(batcher, x + gumpInfo.UV.Width + 2, y);
+            _text.Draw(batcher, x + (int)((gumpInfo.UV.Width + 2) * scale), y, scale);
 
             return ok;
         }

--- a/src/ClassicUO.Client/Game/UI/Controls/CroppedText.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/CroppedText.cs
@@ -37,7 +37,7 @@ namespace ClassicUO.Game.UI.Controls
 
         public override bool Draw(UltimaBatcher2D batcher, int x, int y)
         {
-            _gameText.Draw(batcher, x, y);
+            _gameText.Draw(batcher, x, y, InternalScale);
 
             return base.Draw(batcher, x, y);
         }

--- a/src/ClassicUO.Client/Game/UI/Controls/HtmlControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/HtmlControl.cs
@@ -184,7 +184,7 @@ namespace ClassicUO.Game.UI.Controls
             _scrollBar.MinValue = 0;
 
             _scrollBar.MaxValue = /* _gameText.Height*/ /* Children.Sum(s => s.Height) - Height +*/
-                _gameText.Height - Height + (HasBackground ? 8 : 0);
+                (int)(_gameText.Height * InternalScale) - Height + (HasBackground ? 8 : 0);
 
             ScrollY = _scrollBar.Value;
 
@@ -192,6 +192,33 @@ namespace ClassicUO.Game.UI.Controls
 
             //if (Width != _gameText.Width)
             //    Width = _gameText.Width;
+        }
+
+        public override IGui ApplyScale(double scale, bool scalePosition = true, bool scaleSize = true, bool force = false)
+        {
+            base.ApplyScale(scale, scalePosition, scaleSize, force);
+
+            // The text texture is rendered at its native size and scaled at draw time, but the
+            // background and scrollbar are real children that need to follow the scaled box.
+            foreach (IGui child in Children)
+            {
+                if (child is ResizePic background)
+                {
+                    background.Width = Width - (HasScrollbar ? 16 : 0);
+                    background.Height = Height;
+                }
+            }
+
+            if (_scrollBar != null)
+            {
+                _scrollBar.X = Width - 14;
+                _scrollBar.Height = Height;
+            }
+
+            // Force the scroll range to be recalculated using the scaled content height.
+            WantUpdateSize = true;
+
+            return this;
         }
 
         public override void OnMouseWheel(MouseEventType delta)
@@ -220,7 +247,7 @@ namespace ClassicUO.Game.UI.Controls
                     _scrollBar.MinValue = 0;
 
                     _scrollBar.MaxValue = /* _gameText.Height*/ /*Children.Sum(s => s.Height) - Height */
-                        _gameText.Height - Height + (HasBackground ? 8 : 0);
+                        (int)(_gameText.Height * InternalScale) - Height + (HasBackground ? 8 : 0);
                 }
 
                 //_scrollBar.IsVisible = _scrollBar.MaxValue > _scrollBar.MinValue;
@@ -248,16 +275,25 @@ namespace ClassicUO.Game.UI.Controls
 
                 int offset = HasBackground ? 4 : 0;
 
-                _gameText?.Draw
-                (
-                    batcher,
-                    x + offset,
-                    y + offset,
-                    ScrollX,
-                    ScrollY,
-                    Width + ScrollX,
-                    Height + ScrollY
-                );
+                if (InternalScale == 1.0)
+                {
+                    _gameText?.Draw
+                    (
+                        batcher,
+                        x + offset,
+                        y + offset,
+                        ScrollX,
+                        ScrollY,
+                        Width + ScrollX,
+                        Height + ScrollY
+                    );
+                }
+                else
+                {
+                    // ScrollX/ScrollY are already in scaled display space; the clip region above
+                    // keeps the scaled text inside the control bounds.
+                    _gameText?.Draw(batcher, x + offset - ScrollX, y + offset - ScrollY, InternalScale, Alpha);
+                }
 
                 batcher.ClipEnd();
             }
@@ -276,7 +312,10 @@ namespace ClassicUO.Game.UI.Controls
                     {
                         WebLinkRect link = _gameText.Links[i];
 
-                        bool inbounds = link.Bounds.Contains(x, (_scrollBar == null ? 0 : _scrollBar.Value) + y);
+                        double linkScale = InternalScale;
+                        bool inbounds = link.Bounds.Contains(
+                            (int)(x / linkScale),
+                            (int)(((_scrollBar == null ? 0 : _scrollBar.Value) + y) / linkScale));
 
                         if (inbounds && Client.Game.UO.FileManager.Fonts.GetWebLink(link.LinkID, out WebLink result))
                         {

--- a/src/ClassicUO.Client/Game/UI/Controls/StaticPic.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/StaticPic.cs
@@ -96,6 +96,6 @@ namespace ClassicUO.Game.UI.Controls
             return base.Draw(batcher, x, y);
         }
 
-        public override bool Contains(int x, int y) => Client.Game.UO.Arts.PixelCheck(Graphic, x - Offset.X, y - Offset.Y);
+        public override bool Contains(int x, int y) => Client.Game.UO.Arts.PixelCheck(Graphic, x - Offset.X, y - Offset.Y, InternalScale);
     }
 }

--- a/src/ClassicUO.Client/Game/UI/Controls/StbTextBox.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/StbTextBox.cs
@@ -903,12 +903,12 @@ namespace ClassicUO.Game.UI.Controls
                 base.Draw(batcher, x, y);
                 if (!IsFocused && string.IsNullOrEmpty(_rendererText.Text) && _rendererPlaceholder != null)
                 {
-                    _rendererPlaceholder.Draw(batcher, x, y, 0.7f);
+                    _rendererPlaceholder.Draw(batcher, x, y, InternalScale, 0.7f);
                 }
                 else
                 {
                     DrawSelection(batcher, x, y);
-                    _rendererText.Draw(batcher, x, y);
+                    _rendererText.Draw(batcher, x, y, InternalScale);
                     DrawCaret(batcher, x, y);
                 }
                 batcher.ClipEnd();
@@ -928,6 +928,8 @@ namespace ClassicUO.Game.UI.Controls
 
             int selectStart = Math.Min(Stb.SelectStart, Stb.SelectEnd);
             int selectEnd = Math.Max(Stb.SelectStart, Stb.SelectEnd);
+
+            double scale = InternalScale;
 
             if (selectStart < selectEnd)
             {
@@ -970,10 +972,10 @@ namespace ClassicUO.Game.UI.Controls
                                 SolidColorTextureCache.GetTexture(SELECTION_COLOR),
                                 new Rectangle
                                 (
-                                    x + drawX + diffX,
-                                    y + drawY,
-                                    endX,
-                                    info.MaxHeight + 1
+                                    x + (int)((drawX + diffX) * scale),
+                                    y + (int)(drawY * scale),
+                                    (int)(endX * scale),
+                                    (int)((info.MaxHeight + 1) * scale)
                                 ),
                                 hueVector
                             );
@@ -988,10 +990,10 @@ namespace ClassicUO.Game.UI.Controls
                             SolidColorTextureCache.GetTexture(SELECTION_COLOR),
                             new Rectangle
                             (
-                                x + drawX + diffX,
-                                y + drawY,
-                                info.Width - drawX,
-                                info.MaxHeight + 1
+                                x + (int)((drawX + diffX) * scale),
+                                y + (int)(drawY * scale),
+                                (int)((info.Width - drawX) * scale),
+                                (int)((info.MaxHeight + 1) * scale)
                             ),
                             hueVector
                         );
@@ -1011,7 +1013,8 @@ namespace ClassicUO.Game.UI.Controls
         {
             if (HasKeyboardFocus)
             {
-                _rendererCaret.Draw(batcher, x + _caretScreenPosition.X, y + _caretScreenPosition.Y);
+                double scale = InternalScale;
+                _rendererCaret.Draw(batcher, x + (int)(_caretScreenPosition.X * scale), y + (int)(_caretScreenPosition.Y * scale), scale);
             }
         }
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
@@ -4902,6 +4902,20 @@ namespace ClassicUO.Game.UI.Gumps
                 ), true, page
             );
 
+            content.AddToRight
+            (
+                new SliderWithLabel
+                (
+                    TazLang.Get("gumpscaling_servergump", "Server Gumps"), 0, ThemeSettings.SLIDER_WIDTH, 50, 300,
+                    (int)(profile.ServerGumpScale * 100), (i) =>
+                    {
+                        //Must be cast even though VS thinks it's redundant.
+                        double v = (double)i / (double)100;
+                        profile.ServerGumpScale = v > 0 ? v : 1f;
+                    }
+                ), true, page
+            );
+
             SliderWithLabel s;
             content.AddToRight(
                 s = new SliderWithLabel(lang.GetTazUO.GlobalScale, 0, ThemeSettings.SLIDER_WIDTH, 50, 175,

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/VideoTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/VideoTab.cs
@@ -261,6 +261,16 @@ public static class VideoTab
                 }),
                 search: new SearchMetadata(TazLang.Get("gumpscaling_statusgumpscaling", "Status gump scaling"), Keywords: [kw.Scale])
             ),
+            Option.Slider(
+                TazLang.Get("gumpscaling_servergumpscaling", "Server gump scaling"),
+                50,
+                300,
+                new Accessor<float>(() => (int)(profile.ServerGumpScale * 100), newValue =>
+                {
+                    profile.ServerGumpScale = Math.Clamp(newValue / 100, 0.5f, 3.0f);
+                }),
+                search: new SearchMetadata(TazLang.Get("gumpscaling_servergumpscaling", "Server gump scaling"), Keywords: [kw.Scale])
+            ),
             OptionsUi.Horizontal(
                 Option.Slider(
                     videoLang.GlobalScaling,

--- a/src/ClassicUO.Client/Network/PacketHandlers/Helpers/GumpHelpers.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers/Helpers/GumpHelpers.cs
@@ -567,6 +567,17 @@ internal static class GumpHelpers
 
         gump.PacketGumpText = gumpTextBuilder.ToString();
 
+        // Apply the single server gump scale option to every control on this server created gump.
+        double serverGumpScale = ProfileManager.CurrentProfile?.ServerGumpScale ?? 1.0;
+
+        if (serverGumpScale != 1.0)
+        {
+            for (int i = 0; i < gump.Children.Count; i++)
+            {
+                gump.Children[i].ApplyScale(serverGumpScale);
+            }
+        }
+
         if (mustBeAdded)
             UIManager.Add(gump);
 

--- a/src/ClassicUO.Client/Network/PacketHandlers/Helpers/GumpHelpers.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers/Helpers/GumpHelpers.cs
@@ -671,6 +671,12 @@ internal static class GumpHelpers
                             gump.Dispose();
                         }));
                         gump.Add(menu);
+
+                        // The SOS menu is added after the scale pass above, so scale it here too.
+                        // Its X/Y are already derived from the scaled gump size, so don't scale the
+                        // menu's own position - only its size and the layout of its child controls.
+                        if (serverGumpScale != 1.0)
+                            ScaleControlTree(menu, serverGumpScale, scaleRootPosition: false);
                     }
 
         if (world.Player != null)
@@ -685,6 +691,21 @@ internal static class GumpHelpers
         NextGumpConfig.Apply(gump);
 
         return gump;
+    }
+
+    /// <summary>
+    /// Recursively applies the server gump scale to a control and all of its descendants.
+    /// Used for composite controls (whose visuals live in child controls) that are not handled
+    /// by the single top-level scale pass in <see cref="CreateGump"/>.
+    /// </summary>
+    private static void ScaleControlTree(IGui control, double scale, bool scaleRootPosition)
+    {
+        control.ApplyScale(scale, scalePosition: scaleRootPosition);
+
+        for (int i = 0; i < control.Children.Count; i++)
+        {
+            ScaleControlTree(control.Children[i], scale, scaleRootPosition: true);
+        }
     }
 
     public static void ApplyTrans(Gump gump, int current_page, int x, int y, int width, int height)

--- a/src/ClassicUO.Renderer/Arts/Art.cs
+++ b/src/ClassicUO.Renderer/Arts/Art.cs
@@ -237,6 +237,6 @@ namespace ClassicUO.Renderer.Arts
                 ? Rectangle.Empty
                 : _realArtBounds[idx];
 
-        public bool PixelCheck(uint idx, int x, int y) => _picker.Get(idx, x, y);
+        public bool PixelCheck(uint idx, int x, int y, double scale = 1f) => _picker.Get(idx, x, y, scale: scale);
     }
 }


### PR DESCRIPTION
Add a single ServerGumpScale profile option that uniformly scales every server-created gump and all of its controls. The scale is applied in GumpHelpers.CreateGump to each top-level control via the existing ApplyScale infrastructure, and a slider is exposed in both the modern options gump and the Myra video options tab.

Per-control scaling support added/verified for the controls used by server gumps:
- Checkbox/RadioButton, ButtonTileArt, Button caption, CroppedText, StaticPic (hit-test), HtmlControl and StbTextBox now honor InternalScale when drawing textures/text/carets/selection.
- GumpPic, Label, ResizePic, GumpPicTiled, CheckerTrans and RenderedMapArea already scale via their Width/Height-based drawing.
- Art.PixelCheck gains an optional scale parameter for scaled hit-testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new setting for server-created gump scaling, available in the app’s options.

* **Bug Fixes**
  * Improved scaling for buttons, checkboxes, text fields, HTML content, and images so they render more consistently at different sizes.
  * Fixed click and hit detection for scaled content, including links and image areas.
  * Adjusted server gump layouts so controls resize together with the chosen scale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->