### PR TITLE
Exclude NameOverheadGumps from too-many-same-type gump warning

### DIFF
--- a/src/ClassicUO.Client/Game/Managers/UIManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/UIManager.cs
@@ -503,6 +503,11 @@ namespace ClassicUO.Game.Managers
         /// </summary>
         private static void WarnIfTooManySameType(IGui gump)
         {
+            // NameOverheadGumps are legitimately created in large numbers (one per
+            // entity name shown), so they should never trigger this warning.
+            if (gump is NameOverheadGump)
+                return;
+
             Type t = gump.GetType();
 
             if (!_gumpTypeList.TryGetValue(t, out List<IGui> list))


### PR DESCRIPTION
NameOverheadGumps are created one per entity name shown, so they can legitimately exceed the threshold without indicating a problem.