### PR TITLE
Fix web map markers disappearing after changing facets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ All notable changes to TazUO will be recorded here.
 * Show a suggested fix for the "OpenGL 2.1 support is required!" graphics device error, advising users to update their drivers or try the `-force_driver 1`, `2`, or `3` launch args - [P.R 595](https://github.com/PlayTazUO/TazUO/pull/595) ([bittiez](https://github.com/bittiez))
 * Pass the first click through to a Myra window so clicking a control on an unfocused window works in one click instead of requiring a focus click first - [P.R 604](https://github.com/PlayTazUO/TazUO/pull/604) ([bittiez](https://github.com/bittiez))
 * Fixed percent-type "Show Mobiles HP" text drifting in a radius around the mobile based on zoom level instead of staying centered on top - [P.R 608](https://github.com/PlayTazUO/TazUO/pull/608) ([bittiez](https://github.com/bittiez))
+* Fixed web map markers disappearing after changing facets - the live event stream is now kept alive across map changes so markers refresh correctly when recalling between facets - [P.R 619](https://github.com/PlayTazUO/TazUO/pull/619) ([bittiez](https://github.com/bittiez))
 
 ### Legion
 * Added ModernNineSliceGump.SetLegionTexture to go along with zip files and custom png's - Use your own png for a 9-slice texture - ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.10</AssemblyVersion>
-    <FileVersion>5.3.10</FileVersion>
+    <AssemblyVersion>5.3.11</AssemblyVersion>
+    <FileVersion>5.3.11</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/Managers/MapWebServer.cs
+++ b/src/ClassicUO.Client/Game/Managers/MapWebServer.cs
@@ -319,6 +319,11 @@ namespace ClassicUO.Game.Managers
                 {
                     if (World.Instance == null || !World.Instance.InGame)
                     {
+                        // Emit an SSE comment heartbeat so a client that disconnected
+                        // while we are out of the world surfaces as a broken pipe and
+                        // gets cleaned up promptly, instead of lingering until the next
+                        // successful data write.
+                        SendHeartbeat(response, "waiting-for-world");
                         Thread.Sleep(500);
                         continue;
                     }
@@ -353,6 +358,7 @@ namespace ClassicUO.Game.Managers
                         // thread). Skip this update but keep the connection alive so the
                         // client keeps receiving fresh data once the world has settled.
                         Log.Warn($"Map Web Server: failed to build event update: {ex.Message}");
+                        SendHeartbeat(response, "skipped-transient-update");
                         Thread.Sleep(500);
                         continue;
                     }
@@ -379,6 +385,16 @@ namespace ClassicUO.Game.Managers
                 }
                 try { response.Close(); } catch { }
             }
+        }
+
+        // Writes an SSE comment line (": ...") which carries no data event but keeps the
+        // stream active. A failed write throws, which lets the caller's loop tear the
+        // connection down and remove the stale client.
+        private static void SendHeartbeat(HttpListenerResponse response, string note)
+        {
+            byte[] heartbeat = Encoding.UTF8.GetBytes($": {note}\n\n");
+            response.OutputStream.Write(heartbeat, 0, heartbeat.Length);
+            response.OutputStream.Flush();
         }
 
         private object GetPartyData()

--- a/src/ClassicUO.Client/Game/Managers/MapWebServer.cs
+++ b/src/ClassicUO.Client/Game/Managers/MapWebServer.cs
@@ -304,30 +304,63 @@ namespace ClassicUO.Game.Managers
 
             try
             {
-                // Keep connection alive and send updates
-                while (_isRunning && World.Instance != null && World.Instance.InGame)
+                // Keep the connection alive for as long as the server is running.
+                //
+                // We intentionally do NOT break out of this loop when the player is
+                // briefly out of the world (e.g. while recalling/changing facets). The
+                // map index setter momentarily sets Map = null, so World.InGame flips to
+                // false for a frame. Previously that exited the loop and tore down the
+                // SSE connection on every facet change, and the browser did not reliably
+                // reconnect - leaving the web map frozen with stale live data. The most
+                // visible symptom was that markers from the previous facet would never
+                // refresh again ("markers gone forever" after recalling back). Instead we
+                // simply skip sending updates until the player is back in the world.
+                while (_isRunning)
                 {
-                    var data = new
+                    if (World.Instance == null || !World.Instance.InGame)
                     {
-                        mapIndex = World.Instance.MapIndex,
-                        player = new
+                        Thread.Sleep(500);
+                        continue;
+                    }
+
+                    string message;
+
+                    try
+                    {
+                        var data = new
                         {
-                            x = World.Instance.Player?.X ?? 0,
-                            y = World.Instance.Player?.Y ?? 0,
-                            name = World.Instance.Player?.Name ?? ""
-                        },
-                        party = GetPartyData(),
-                        guild = GetGuildData(),
-                        markers = GetMarkersData(),
-                        mobiles = GetMobilesData(),
-                        journal = MainThreadQueue.InvokeOnMainThread(() => GetNewJournalEntries(clientState))
-                    };
+                            mapIndex = World.Instance.MapIndex,
+                            player = new
+                            {
+                                x = World.Instance.Player?.X ?? 0,
+                                y = World.Instance.Player?.Y ?? 0,
+                                name = World.Instance.Player?.Name ?? ""
+                            },
+                            party = GetPartyData(),
+                            guild = GetGuildData(),
+                            markers = GetMarkersData(),
+                            mobiles = GetMobilesData(),
+                            journal = MainThreadQueue.InvokeOnMainThread(() => GetNewJournalEntries(clientState))
+                        };
 
-                    string json = JsonSerializer.Serialize(data);
+                        message = $"data: {JsonSerializer.Serialize(data)}\n\n";
+                    }
+                    catch (Exception ex)
+                    {
+                        // Gathering data can transiently fail while the world is being
+                        // rebuilt during a map change (collections such as the party,
+                        // guild and mobile lists get cleared/repopulated on another
+                        // thread). Skip this update but keep the connection alive so the
+                        // client keeps receiving fresh data once the world has settled.
+                        Log.Warn($"Map Web Server: failed to build event update: {ex.Message}");
+                        Thread.Sleep(500);
+                        continue;
+                    }
 
-                    string message = $"data: {json}\n\n";
                     byte[] buffer = Encoding.UTF8.GetBytes(message);
 
+                    // A failure writing to the stream means the client really
+                    // disconnected; let it propagate to exit the loop and clean up.
                     response.OutputStream.Write(buffer, 0, buffer.Length);
                     response.OutputStream.Flush();
 
@@ -1494,9 +1527,13 @@ namespace ClassicUO.Game.Managers
 
                     if (document.getElementById('followPlayer').checked) {
                         centerOnPlayer();
-                    } else {
-                        draw();
                     }
+
+                    // Always redraw after applying fresh live data. centerOnPlayer() only
+                    // updates the target offset and relies on the animation loop to redraw,
+                    // which is skipped when the player is stationary - so without this the
+                    // newly received markers/mobiles would not appear until the player moved.
+                    draw();
                 }
             };
 


### PR DESCRIPTION
The browser/web map only refreshes its marker list through the live Server-Sent Events stream (/api/events). When the player recalled to another facet, World.MapIndex's setter momentarily sets Map = null, so World.InGame flipped false for a frame. The SSE loop condition exited on that, tearing down the connection on every facet change, and the browser did not reliably reconnect. The web client was then frozen on the new facet's (empty) marker set - so markers vanished and never came back even after recalling to the original facet, while the 30s map-texture poll kept the map image looking correct.

- Keep the SSE connection alive across map changes: skip sending while the player is briefly out of the world instead of breaking the loop, and tolerate transient payload-build failures (party/guild/mobile collections are cleared and repopulated on another thread during a map change) without dropping the connection. Write failures still break out to clean up a genuinely disconnected client.
- Always redraw the canvas after applying fresh live data. centerOnPlayer() only updates the target offset and relies on the animation loop, which is skipped when the player is stationary, so freshly received markers would otherwise not render until the player moved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved live map streaming so the connection stays active during temporary world transitions instead of stopping unexpectedly.
  * Made map updates more resilient during brief loading or map-change states, reducing dropped live updates.
  * Ensured the map redraws after each incoming live update, even when the player isn’t moving.
  * Kept follow-player behavior intact while making map refreshes more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->