### PR TITLE
Add option to disable party specific health bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ All notable changes to TazUO will be recorded here.
 * Add Skill slot type to the Spell Bar - [P.R 613](https://github.com/PlayTazUO/TazUO/pull/613) ([bittiez](https://github.com/bittiez))
 * Added individual scaling support for the Status Gump - [P.R 614](https://github.com/PlayTazUO/TazUO/pull/614) ([bittiez](https://github.com/bittiez))
 * Added a single scaling option for all server-created gumps - [P.R 615](https://github.com/PlayTazUO/TazUO/pull/615) ([bittiez](https://github.com/bittiez))
+* Add option to disable the party-style health bar for party members - [P.R 620](https://github.com/PlayTazUO/TazUO/pull/620) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
 * Fixed simultaneous drag and resize occurring on resizable windows - [P.R #](https://github.com/PlayTazUO/TazUO/pull/#) ([yuval-po](https://github.com/yuval-po))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.11</AssemblyVersion>
-    <FileVersion>5.3.11</FileVersion>
+    <AssemblyVersion>5.3.12</AssemblyVersion>
+    <FileVersion>5.3.12</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Configuration/Language.cs
+++ b/src/ClassicUO.Client/Configuration/Language.cs
@@ -930,7 +930,6 @@ namespace ClassicUO.Configuration
             public string OldStatusGump { get; set; } = "Use old status gump";
             public string PartyInviteGump { get; set; } = "Show party invite gump";
             public string ModernHealthBars { get; set; } = "Use modern health bar gumps";
-            public string UsePartyHealthBars { get; set; } = "Use party health bar style for party members";
             public string ModernHPBlackBG { get; set; } = "Use black background";
             public string SaveHPBars { get; set; } = "Save health bars on logout";
             public string CloseHPGumpsWhen { get; set; } = "Close health bars when";

--- a/src/ClassicUO.Client/Configuration/Language.cs
+++ b/src/ClassicUO.Client/Configuration/Language.cs
@@ -930,6 +930,7 @@ namespace ClassicUO.Configuration
             public string OldStatusGump { get; set; } = "Use old status gump";
             public string PartyInviteGump { get; set; } = "Show party invite gump";
             public string ModernHealthBars { get; set; } = "Use modern health bar gumps";
+            public string UsePartyHealthBars { get; set; } = "Use party health bar style for party members";
             public string ModernHPBlackBG { get; set; } = "Use black background";
             public string SaveHPBars { get; set; } = "Save health bars on logout";
             public string CloseHPGumpsWhen { get; set; } = "Close health bars when";

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -338,6 +338,7 @@ namespace ClassicUO.Configuration
         public bool PartyInviteGump { get; set => SetProperty(ref field, value); } = true;
         public bool CustomBarsToggled { get; set => SetProperty(ref field, value); }
         public bool CBBlackBGToggled { get; set => SetProperty(ref field, value); }
+        public bool UsePartyHealthBars { get; set => SetProperty(ref field, value); } = true;
 
         public bool ShowInfoBar { get; set => SetProperty(ref field, value); }
         public int InfoBarHighlightType { get; set => SetProperty(ref field, value); } // 0 = text colour changes, 1 = underline

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -5,7 +5,7 @@
 ; Missing keys are auto-appended with English defaults when
 ; this file's version is newer than the user's copy.
 ; -------------------------------------------------------
-_version=29
+_version=30
 accountname=Account Name
 accountcontextmenutooltip=Right click to select another account.
 music=Music
@@ -437,6 +437,9 @@ nameplate_health_purple=Purple
 nameplate_health_white=White
 nameplate_health_gray=Gray
 nameplate_health_black=Black
+
+; Health Bars
+healthbar_usepartystyle=Use party health bar style for party members
 gridcontainer_renamecontainer=Rename container
 gridcontainer_rename_title=Rename Container
 gridcontainer_rename_desc=Type in a custom name for this container.

--- a/src/ClassicUO.Client/Game/UI/Gumps/HealthBarGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/HealthBarGump.cs
@@ -36,6 +36,9 @@ namespace ClassicUO.Game.UI.Gumps
         public bool IsLastAttackBar { get; set; }
         public static BaseHealthBarGump LastAttackBar { get; set; }
         protected bool HasBeenBuilt { get; set; }
+
+        /// <summary>Tracks whether the gump was last built with the compact party style, so a live toggle of <see cref="Profile.UsePartyHealthBars"/> can trigger a rebuild.</summary>
+        protected bool BuiltAsPartyBar { get; set; }
         protected World _world;
 
         protected BaseHealthBarGump(World world, Entity entity) : this(world, 0, 0)
@@ -479,6 +482,15 @@ namespace ClassicUO.Game.UI.Gumps
             && mobile.IsRenamable
             && entity != World.Player
             && !World.Party.Contains(LocalSerial);
+
+        /// <summary>
+        /// Whether this bar should be drawn using the special compact party style.
+        /// Returns true only when the entity is in the party and the user has not
+        /// disabled the party health bar style via <see cref="Profile.UsePartyHealthBars"/>.
+        /// </summary>
+        protected bool ShowPartyStyleBar =>
+            World.Party.Contains(LocalSerial)
+            && (ProfileManager.CurrentProfile?.UsePartyHealthBars ?? true);
     }
 
     public class HealthBarGumpCustom : BaseHealthBarGump
@@ -558,7 +570,14 @@ namespace ClassicUO.Game.UI.Gumps
                 return;
             }
 
-            bool inparty = World.Party.Contains(LocalSerial);
+            if (BuiltAsPartyBar != ShowPartyStyleBar)
+            {
+                RequestUpdateContents();
+
+                return;
+            }
+
+            bool inparty = ShowPartyStyleBar;
 
 
             ushort textColor = 0x0386;
@@ -937,8 +956,9 @@ namespace ClassicUO.Game.UI.Gumps
 
             Entity entity = World.Get(LocalSerial);
 
+            BuiltAsPartyBar = ShowPartyStyleBar;
 
-            if (World.Party.Contains(LocalSerial))
+            if (ShowPartyStyleBar)
             {
                 Height = HPB_HEIGHT_MULTILINE;
                 Width = HPB_WIDTH;
@@ -1642,7 +1662,9 @@ namespace ClassicUO.Game.UI.Gumps
 
             Entity entity = World.Get(LocalSerial);
 
-            if (World.Party.Contains(LocalSerial))
+            BuiltAsPartyBar = ShowPartyStyleBar;
+
+            if (ShowPartyStyleBar)
             {
                 Add
                 (
@@ -1909,7 +1931,14 @@ namespace ClassicUO.Game.UI.Gumps
                 return;
             }
 
-            bool inparty = World.Party.Contains(LocalSerial);
+            if (BuiltAsPartyBar != ShowPartyStyleBar)
+            {
+                RequestUpdateContents();
+
+                return;
+            }
+
+            bool inparty = ShowPartyStyleBar;
 
 
             ushort textColor = Settings.Hue_Text;

--- a/src/ClassicUO.Client/Game/UI/Gumps/HealthBarGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/HealthBarGump.cs
@@ -546,6 +546,10 @@ namespace ClassicUO.Game.UI.Gumps
             Clear();
             Children.Clear();
 
+            _normalHits = false;
+            _poisoned = false;
+            _yellowHits = false;
+
             _background = null;
             _hpLineRed = _manaLineRed = _stamLineRed = null;
             _buttonHeal1 = _buttonHeal2 = null;
@@ -1641,6 +1645,11 @@ namespace ClassicUO.Game.UI.Gumps
         {
             Clear();
             Children.Clear();
+
+            _oldHits = _oldMana = _oldStam = -1;
+            _normalHits = false;
+            _poisoned = false;
+            _yellowHits = false;
 
             _background = _hpLineRed = _manaLineRed = _stamLineRed = null;
             _buttonHeal1 = _buttonHeal2 = null;

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/HealthBarsTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/HealthBarsTab.cs
@@ -26,6 +26,8 @@ public static class HealthBarsTab
         ModernOptionsGumpLanguage.TazUO tuoLang = lang.GetTazUO;
         ModernOptionsGumpLanguage.KeywordsLang kw = lang.Kw;
 
+        string usePartyHealthBarsLabel = TazLang.Get("healthbar_usepartystyle", "Use party health bar style for party members");
+
         return OptionsUi.Vertical(
             OptionsUi.CheckBoxGroup(
                 new PropertyBinder(new Accessor<bool>(() => profile.CustomBarsToggled), genLang.ModernHealthBars),
@@ -36,9 +38,9 @@ public static class HealthBarsTab
                 )
             ).WithSearch(new SearchMetadata(genLang.ModernHealthBars, Keywords: [kw.Modern])),
             Option.Checkbox(
-                genLang.UsePartyHealthBars,
+                usePartyHealthBarsLabel,
                 new Accessor<bool>(() => profile.UsePartyHealthBars),
-                search: new SearchMetadata(genLang.UsePartyHealthBars, Keywords: [kw.Party, kw.HealthBar])
+                search: new SearchMetadata(usePartyHealthBarsLabel, Keywords: [kw.Party, kw.HealthBar])
             ),
             Option.Checkbox(
                 genLang.SaveHPBars,

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/HealthBarsTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/HealthBarsTab.cs
@@ -36,6 +36,11 @@ public static class HealthBarsTab
                 )
             ).WithSearch(new SearchMetadata(genLang.ModernHealthBars, Keywords: [kw.Modern])),
             Option.Checkbox(
+                genLang.UsePartyHealthBars,
+                new Accessor<bool>(() => profile.UsePartyHealthBars),
+                search: new SearchMetadata(genLang.UsePartyHealthBars, Keywords: [kw.Party, kw.HealthBar])
+            ),
+            Option.Checkbox(
                 genLang.SaveHPBars,
                 new Accessor<bool>(() => profile.SaveHealthbars),
                 search: new SearchMetadata(genLang.SaveHPBars, Keywords: [kw.Save])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new health bar setting to let party members use the party-style health bar layout.
  * The health bar UI now updates automatically when this party-style setting changes.
* **Bug Fixes**
  * Health bars now rebuild correctly when switching between party and non-party display styles.
* **Documentation**
  * Added a new localized label for the party health bar option and updated the language file version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->