### PR TITLE
Add clear (X) button to nameplate search field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ All notable changes to TazUO will be recorded here.
 * Added individual scaling support for the Status Gump - [P.R 614](https://github.com/PlayTazUO/TazUO/pull/614) ([bittiez](https://github.com/bittiez))
 * Added a single scaling option for all server-created gumps - [P.R 615](https://github.com/PlayTazUO/TazUO/pull/615) ([bittiez](https://github.com/bittiez))
 * Add option to disable the party-style health bar for party members - [P.R 620](https://github.com/PlayTazUO/TazUO/pull/620) ([bittiez](https://github.com/bittiez))
+* Added a clear (X) button to the nameplate manager search field - [P.R 621](https://github.com/PlayTazUO/TazUO/pull/621) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
 * Fixed simultaneous drag and resize occurring on resizable windows - [P.R #](https://github.com/PlayTazUO/TazUO/pull/#) ([yuval-po](https://github.com/yuval-po))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.12</AssemblyVersion>
-    <FileVersion>5.3.12</FileVersion>
+    <AssemblyVersion>5.3.13</AssemblyVersion>
+    <FileVersion>5.3.13</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Gumps/NameOverHeadHandlerGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/NameOverHeadHandlerGump.cs
@@ -101,10 +101,29 @@ namespace ClassicUO.Game.UI.Gumps
 
 
 
-            Add(new AlphaBlendControl() { Y = stayActive.Height + stayActive.Y, Width = 150, Height = 20, Hue = 0x0481 });
-            Add(searchBox = new StbTextBox(0, -1, 150, hue: 0xFFFF) { Y = stayActive.Height + stayActive.Y, Width = 150, Height = 20 });
+            int searchY = stayActive.Height + stayActive.Y;
+            Add(new AlphaBlendControl() { Y = searchY, Width = 150, Height = 20, Hue = 0x0481 });
+            Add(searchBox = new StbTextBox(0, -1, 134, hue: 0xFFFF) { Y = searchY, Width = 134, Height = 20 });
             searchBox.Text = NameOverHeadManager.Search;
             searchBox.TextChanged += (s, e) => { NameOverHeadManager.Search = searchBox.Text; };
+
+            Label clearSearch;
+            Add
+            (
+                clearSearch = new Label("X", true, 0xFFFF, font: 1)
+                {
+                    AcceptMouseInput = true,
+                    X = 138
+                }
+            );
+            clearSearch.Y = searchY + ((20 - clearSearch.Height) >> 1);
+            clearSearch.SetTooltip("Clear search");
+            clearSearch.MouseUp += (s, e) =>
+            {
+                searchBox.Text = "";
+                NameOverHeadManager.Search = "";
+                UIManager.KeyboardFocusControl = searchBox; //Return focus to the input in case clicking the X moved it
+            };
 
             DrawChoiceButtons();
         }


### PR DESCRIPTION
Adds an "X" button on the right side of the NameOverHeadHandlerGump search input. Clicking it clears the text, resets the nameplate search filter, and returns keyboard focus to the input field.