### PR TITLE
Use consistent game cursor style across all maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ All notable changes to TazUO will be recorded here.
 * Pass the first click through to a Myra window so clicking a control on an unfocused window works in one click instead of requiring a focus click first - [P.R 604](https://github.com/PlayTazUO/TazUO/pull/604) ([bittiez](https://github.com/bittiez))
 * Fixed percent-type "Show Mobiles HP" text drifting in a radius around the mobile based on zoom level instead of staying centered on top - [P.R 608](https://github.com/PlayTazUO/TazUO/pull/608) ([bittiez](https://github.com/bittiez))
 * Fixed web map markers disappearing after changing facets - the live event stream is now kept alive across map changes so markers refresh correctly when recalling between facets - [P.R 619](https://github.com/PlayTazUO/TazUO/pull/619) ([bittiez](https://github.com/bittiez))
+* Game cursor now uses a consistent style across all maps instead of changing on non-zero maps - [P.R 622](https://github.com/PlayTazUO/TazUO/pull/622) ([bittiez](https://github.com/bittiez))
 
 ### Legion
 * Added ModernNineSliceGump.SetLegionTexture to go along with zip files and custom png's - Use your own png for a 9-slice texture - ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.13</AssemblyVersion>
-    <FileVersion>5.3.13</FileVersion>
+    <AssemblyVersion>5.3.14</AssemblyVersion>
+    <FileVersion>5.3.14</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/GameCursor.cs
+++ b/src/ClassicUO.Client/Game/GameCursor.cs
@@ -19,7 +19,7 @@ namespace ClassicUO.Game
 {
     public sealed class GameCursor
     {
-        private static readonly ushort[,] _cursorData = new ushort[3, 16]
+        private static readonly ushort[,] _cursorData = new ushort[2, 16]
         {
             {
                 0x206A,
@@ -56,31 +56,13 @@ namespace ClassicUO.Game
                 0x2060,
                 0x2061,
                 0x2062
-            },
-            {
-                0x206A,
-                0x206B,
-                0x206C,
-                0x206D,
-                0x206E,
-                0x206F,
-                0x2070,
-                0x2071,
-                0x2072,
-                0x2073,
-                0x2074,
-                0x2075,
-                0x2076,
-                0x2077,
-                0x2078,
-                0x2079
             }
         };
 
         private readonly Aura _aura;
         private readonly List<CustomBuildObject> _componentsList = new ();
         private readonly int[,] _cursorOffset = new int[2, 16];
-        private readonly IntPtr[,] _cursors_ptr = new IntPtr[3, 16];
+        private readonly IntPtr[,] _cursors_ptr = new IntPtr[2, 16];
         private ushort _graphic = 0x2073;
         private bool _needGraphicUpdate = true;
         private readonly List<Multi> _temp = new List<Multi>();
@@ -99,7 +81,7 @@ namespace ClassicUO.Game
             _tooltip = new Tooltip(world);
             _aura = new Aura(30);
 
-            for (int i = 0; i < 3; i++)
+            for (int i = 0; i < 2; i++)
             {
                 for (int j = 0; j < 16; j++)
                 {
@@ -107,7 +89,7 @@ namespace ClassicUO.Game
 
                     nint surface = Client.Game.UO.Arts.CreateCursorSurfacePtr(
                         id,
-                        (ushort)(i == 2 ? 0x0033 : 0),
+                        0,
                         out int hotX,
                         out int hotY
                     );
@@ -209,12 +191,7 @@ namespace ClassicUO.Game
                         id -= 0x206A;
                     }
 
-                    int war =
-                        _world.InGame && _world.Player.InWarMode
-                            ? 1
-                            : _world.InGame && _world.MapIndex != 0
-                                ? 2
-                                : 0;
+                    int war = _world.InGame && _world.Player.InWarMode ? 1 : 0;
 
                     ref IntPtr ptrCursor = ref _cursors_ptr[war, id];
 
@@ -501,16 +478,7 @@ namespace ClassicUO.Game
                 int offX = _cursorOffset[0, graphic];
                 int offY = _cursorOffset[1, graphic];
 
-                Vector3 hueVec;
-
-                if (_world.InGame && _world.MapIndex != 0 && !_world.Player.InWarMode)
-                {
-                    hueVec = ShaderHueTranslator.GetHueVector(0x0033);
-                }
-                else
-                {
-                    hueVec = ShaderHueTranslator.GetHueVector(0);
-                }
+                Vector3 hueVec = ShaderHueTranslator.GetHueVector(0);
 
                 ref readonly SpriteInfo artInfo = ref Client.Game.UO.Arts.GetArt(Graphic);
 


### PR DESCRIPTION
Remove the map-based cursor switching that tinted the cursor red (hue 0x0033) on non-zero maps. The cursor now uses the same map 0 style on all maps. Dropped the now-unused third cursor style/pointer entries.