### PR TITLE
Add scaling option for context menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ All notable changes to TazUO will be recorded here.
 * Added a single scaling option for all server-created gumps - [P.R 615](https://github.com/PlayTazUO/TazUO/pull/615) ([bittiez](https://github.com/bittiez))
 * Add option to disable the party-style health bar for party members - [P.R 620](https://github.com/PlayTazUO/TazUO/pull/620) ([bittiez](https://github.com/bittiez))
 * Added a clear (X) button to the nameplate manager search field - [P.R 621](https://github.com/PlayTazUO/TazUO/pull/621) ([bittiez](https://github.com/bittiez))
+* Added a scaling option for context menus - [P.R 623](https://github.com/PlayTazUO/TazUO/pull/623) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
 * Fixed simultaneous drag and resize occurring on resizable windows - [P.R #](https://github.com/PlayTazUO/TazUO/pull/#) ([yuval-po](https://github.com/yuval-po))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.14</AssemblyVersion>
-    <FileVersion>5.3.14</FileVersion>
+    <AssemblyVersion>5.3.15</AssemblyVersion>
+    <FileVersion>5.3.15</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -786,6 +786,8 @@ namespace ClassicUO.Configuration
 
         public double StatusGumpScale { get; set => SetProperty(ref field, Math.Clamp(value, 0.5d, 3.0d)); } = 1f;
 
+        public double ContextMenuScale { get; set => SetProperty(ref field, Math.Clamp(value, 0.5d, 3.0d)); } = 1f;
+
         /// <summary>
         /// Scale applied to every server created gump (and all of its controls).
         /// </summary>

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -5,7 +5,7 @@
 ; Missing keys are auto-appended with English defaults when
 ; this file's version is newer than the user's copy.
 ; -------------------------------------------------------
-_version=30
+_version=31
 accountname=Account Name
 accountcontextmenutooltip=Right click to select another account.
 music=Music

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -703,3 +703,5 @@ uimanager_toomanygumps=Warning: You have {0} '{1}' gumps open. This may cause pe
 ; Gump scaling
 gumpscaling_statusgump=Status Gump
 gumpscaling_statusgumpscaling=Status gump scaling
+gumpscaling_contextmenu=Context Menus
+gumpscaling_contextmenuscaling=Context menu scaling

--- a/src/ClassicUO.Client/Game/UI/Controls/ContextMenuControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ContextMenuControl.cs
@@ -1,5 +1,6 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
+using ClassicUO.Configuration;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.UI.Gumps;
 using ClassicUO.Input;
@@ -79,6 +80,7 @@ namespace ClassicUO.Game.UI.Controls
     {
         private readonly AlphaBlendControl _background;
         private List<ContextMenuShowMenu> _subMenus;
+        private readonly double _scale;
 
 
         public ContextMenuShowMenu(World world, List<ContextMenuItemEntry> list) : base(world, 0, 0)
@@ -91,6 +93,8 @@ namespace ClassicUO.Game.UI.Controls
             CanMove = false;
             AcceptMouseInput = true;
 
+            _scale = ProfileManager.CurrentProfile?.ContextMenuScale ?? 1.0;
+
 
             _background = new AlphaBlendControl(0.7f);
             Add(_background);
@@ -102,7 +106,7 @@ namespace ClassicUO.Game.UI.Controls
 
             for (int i = 0; i < list.Count; i++)
             {
-                var item = new ContextMenuItem(this, list[i]);
+                var item = new ContextMenuItem(this, list[i], _scale);
 
                 if (i > 0)
                 {
@@ -209,11 +213,13 @@ namespace ClassicUO.Game.UI.Controls
             private readonly GumpPic _selectedPic;
             private readonly ContextMenuShowMenu _subMenu;
             private readonly ContextMenuShowMenu _gump;
+            private readonly double _scale;
 
 
-            public ContextMenuItem(ContextMenuShowMenu parent, ContextMenuItemEntry entry)
+            public ContextMenuItem(ContextMenuShowMenu parent, ContextMenuItemEntry entry, double scale = 1.0)
             {
                 _gump = parent;
+                _scale = scale;
                 CanCloseWithRightClick = false;
                 _entry = entry;
 
@@ -224,23 +230,25 @@ namespace ClassicUO.Game.UI.Controls
                     0xFFFF,
                     0,
                     style: FontStyle.BlackBorder
-                )
-                {
-                    X = 25
-                };
+                );
+
+                _label.ApplyScale(_scale, scalePosition: false);
+                _label.X = (int)(25 * _scale);
 
                 Add(_label);
 
 
-                _selectedPic = new GumpPic(3, 0, 0x838, 0)
+                _selectedPic = new GumpPic((int)(3 * _scale), 0, 0x838, 0)
                 {
                     IsVisible = entry.IsSelected,
                     IsEnabled = false
                 };
 
+                _selectedPic.ApplyScale(_scale, scalePosition: false);
+
                 Add(_selectedPic);
 
-                Height = 25;
+                Height = (int)(25 * _scale);
 
 
                 _label.Y = (Height >> 1) - (_label.Height >> 1);
@@ -251,11 +259,11 @@ namespace ClassicUO.Game.UI.Controls
                     _selectedPic.Y = (Height >> 1) - (_selectedPic.Height >> 1);
                 }
 
-                Width = _label.X + _label.Width + 20;
+                Width = _label.X + _label.Width + (int)(20 * _scale);
 
-                if (Width < 100)
+                if (Width < (int)(100 * _scale))
                 {
-                    Width = 100;
+                    Width = (int)(100 * _scale);
                 }
 
                 // it is a bit tricky, but works :D
@@ -362,7 +370,7 @@ namespace ClassicUO.Game.UI.Controls
 
                 if (_entry.Items != null && _entry.Items.Count != 0)
                 {
-                    _moreMenuLabel.Draw(batcher, x + Width - _moreMenuLabel.Width, y + (Height >> 1) - (_moreMenuLabel.Height >> 1) - 1);
+                    _moreMenuLabel.Draw(batcher, x + Width - (int)(_moreMenuLabel.Width * _scale), y + (Height >> 1) - ((int)(_moreMenuLabel.Height * _scale) >> 1) - 1, _scale);
                 }
 
                 return true;

--- a/src/ClassicUO.Client/Game/UI/Controls/ContextMenuControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ContextMenuControl.cs
@@ -230,21 +230,23 @@ namespace ClassicUO.Game.UI.Controls
                     0xFFFF,
                     0,
                     style: FontStyle.BlackBorder
-                );
+                )
+                {
+                    X = 25
+                };
 
-                _label.ApplyScale(_scale, scalePosition: false);
-                _label.X = (int)(25 * _scale);
+                _label.ApplyScale(_scale);
 
                 Add(_label);
 
 
-                _selectedPic = new GumpPic((int)(3 * _scale), 0, 0x838, 0)
+                _selectedPic = new GumpPic(3, 0, 0x838, 0)
                 {
                     IsVisible = entry.IsSelected,
                     IsEnabled = false
                 };
 
-                _selectedPic.ApplyScale(_scale, scalePosition: false);
+                _selectedPic.ApplyScale(_scale);
 
                 Add(_selectedPic);
 

--- a/src/ClassicUO.Client/Game/UI/Controls/ContextMenuControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ContextMenuControl.cs
@@ -261,7 +261,7 @@ namespace ClassicUO.Game.UI.Controls
                     _selectedPic.Y = (Height >> 1) - (_selectedPic.Height >> 1);
                 }
 
-                Width = _label.X + _label.Width + (int)(20 * _scale);
+                Width = _label.X + _label.Width + (int)(25 * _scale);
 
                 if (Width < (int)(100 * _scale))
                 {
@@ -372,7 +372,7 @@ namespace ClassicUO.Game.UI.Controls
 
                 if (_entry.Items != null && _entry.Items.Count != 0)
                 {
-                    _moreMenuLabel.Draw(batcher, x + Width - (int)(_moreMenuLabel.Width * _scale), y + (Height >> 1) - ((int)(_moreMenuLabel.Height * _scale) >> 1) - 1, _scale);
+                    _moreMenuLabel.Draw(batcher, x + Width - (int)((_moreMenuLabel.Width + 5) * _scale), y + (Height >> 1) - ((int)(_moreMenuLabel.Height * _scale) >> 1) - 1, _scale);
                 }
 
                 return true;

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
@@ -4855,6 +4855,20 @@ namespace ClassicUO.Game.UI.Gumps
             (
                 new SliderWithLabel
                 (
+                    TazLang.Get("gumpscaling_contextmenu", "Context Menus"), 0, ThemeSettings.SLIDER_WIDTH, 50, 300,
+                    (int)(profile.ContextMenuScale * 100), (i) =>
+                    {
+                        //Must be cast even though VS thinks it's redundant.
+                        double v = (double)i / (double)100;
+                        profile.ContextMenuScale = v > 0 ? v : 1f;
+                    }
+                ), true, page
+            );
+
+            content.AddToRight
+            (
+                new SliderWithLabel
+                (
                     TazLang.Get("gumpscaling_servergump", "Server Gumps"), 0, ThemeSettings.SLIDER_WIDTH, 50, 300,
                     (int)(profile.ServerGumpScale * 100), (i) =>
                     {

--- a/src/ClassicUO.Client/Game/UI/Gumps/PopupMenuGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/PopupMenuGump.cs
@@ -1,5 +1,6 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
+using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Input;
@@ -27,15 +28,17 @@ namespace ClassicUO.Game.UI.Gumps
             CanCloseWithRightClick = true;
             _data = data;
 
+            double scale = ProfileManager.CurrentProfile?.ContextMenuScale ?? 1.0;
+
             var pic = new ResizePic(0x0A3C)
             {
                 Alpha = 0.75f
             };
 
             Add(pic);
-            int offsetY = 10;
+            int offsetY = (int)(10 * scale);
             bool arrowAdded = false;
-            int width = 0, height = 20;
+            int width = 0, height = (int)(20 * scale);
 
             for (int i = 0; i < data.Items.Length; i++)
             {
@@ -52,15 +55,14 @@ namespace ClassicUO.Game.UI.Gumps
                     Client.Game.UO.FileManager.Fonts.SetUseHTML(true, h);
                 }
 
-                var label = new Label(text, true, hue, font: 1)
-                {
-                    X = 10,
-                    Y = offsetY
-                };
+                var label = new Label(text, true, hue, font: 1);
+                label.ApplyScale(scale, scalePosition: false);
+                label.X = (int)(10 * scale);
+                label.Y = offsetY;
 
                 Client.Game.UO.FileManager.Fonts.SetUseHTML(false);
 
-                var box = new HitBox(10, offsetY, label.Width, label.Height)
+                var box = new HitBox((int)(10 * scale), offsetY, label.Width, label.Height)
                 {
                     Tag = item.Index
                 };
@@ -78,16 +80,16 @@ namespace ClassicUO.Game.UI.Gumps
                     arrowAdded = true;
 
                     // TODO: wat?
-                    Add
-                    (
-                        new Button(0, 0x15E6, 0x15E2, 0x15E2)
-                        {
-                            X = 20,
-                            Y = offsetY
-                        }
-                    );
+                    var arrow = new Button(0, 0x15E6, 0x15E2, 0x15E2)
+                    {
+                        X = (int)(20 * scale),
+                        Y = offsetY
+                    };
+                    arrow.ApplyScale(scale, scalePosition: false);
 
-                    height += 20;
+                    Add(arrow);
+
+                    height += (int)(20 * scale);
                 }
 
                 offsetY += label.Height;
@@ -103,9 +105,9 @@ namespace ClassicUO.Game.UI.Gumps
                 }
             }
 
-            width += 20;
+            width += (int)(20 * scale);
 
-            if (height <= 10 || width <= 20)
+            if (height <= (int)(10 * scale) || width <= (int)(20 * scale))
             {
                 Dispose();
             }
@@ -116,7 +118,7 @@ namespace ClassicUO.Game.UI.Gumps
 
                 foreach (HitBox box in FindControls<HitBox>())
                 {
-                    box.Width = width - 20;
+                    box.Width = width - (int)(20 * scale);
                 }
             }
         }

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/VideoTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/VideoTab.cs
@@ -262,6 +262,16 @@ public static class VideoTab
                 search: new SearchMetadata(TazLang.Get("gumpscaling_statusgumpscaling", "Status gump scaling"), Keywords: [kw.Scale])
             ),
             Option.Slider(
+                TazLang.Get("gumpscaling_contextmenuscaling", "Context menu scaling"),
+                50,
+                300,
+                new Accessor<float>(() => (int)(profile.ContextMenuScale * 100), newValue =>
+                {
+                    profile.ContextMenuScale = Math.Clamp(newValue / 100, 0.5f, 3.0f);
+                }),
+                search: new SearchMetadata(TazLang.Get("gumpscaling_contextmenuscaling", "Context menu scaling"), Keywords: [kw.Scale])
+            ),
+            Option.Slider(
                 TazLang.Get("gumpscaling_servergumpscaling", "Server gump scaling"),
                 50,
                 300,

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/VideoTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/VideoTab.cs
@@ -267,7 +267,7 @@ public static class VideoTab
                 300,
                 new Accessor<float>(() => (int)(profile.ContextMenuScale * 100), newValue =>
                 {
-                    profile.ContextMenuScale = Math.Clamp(newValue / 100, 0.5f, 3.0f);
+                    profile.ContextMenuScale = newValue / 100;
                 }),
                 search: new SearchMetadata(TazLang.Get("gumpscaling_contextmenuscaling", "Context menu scaling"), Keywords: [kw.Scale])
             ),


### PR DESCRIPTION
Add a ContextMenuScale profile setting (clamped 0.5-3.0) and wire it through ContextMenuShowMenu / ContextMenuItem so context menus scale their labels, selection icons, submenu indicators and layout, matching the existing status gump and paperdoll scaling. Expose the new slider in both the modern options gump and the Myra video options tab.