### PR TITLE
Add manually-triggered PR build workflow for all platforms

### DIFF
--- a/.github/workflows/tuo-pr-build.yml
+++ b/.github/workflows/tuo-pr-build.yml
@@ -1,0 +1,87 @@
+name: TUO-PR-Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull request number to build'
+        required: true
+        type: string
+
+env:
+  CUO_OUTPUT_PATH: 'build/dist'
+  CUO_PROJECT_PATH: "src/ClassicUO.Client/ClassicUO.Client.csproj"
+
+  DOTNET_NOLOGO: false
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  NUGET_XMLDOC_MODE: skip
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+            rid: win-x64
+          - os: ubuntu-latest
+            rid: linux-x64
+          - os: macos-latest
+            rid: osx-arm64
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Checkout PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr checkout ${{ github.event.inputs.pr_number }}
+
+      - name: Get submodules
+        run: |
+          git config --global url."https://".insteadOf git://
+          git submodule update --init --recursive
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10
+
+      - name: Build executable
+        run: dotnet publish ${{ env.CUO_PROJECT_PATH }} -c Release -o ${{ env.CUO_OUTPUT_PATH }} -r ${{ matrix.rid }}
+
+      - name: Zip all builds
+        shell: bash
+        run: |
+          mkdir -p flat
+
+          # Copy files excluding *.dSYM (folders or files), preserving subfolders
+          for d in "${{ env.CUO_OUTPUT_PATH }}" "${{ env.CUO_OUTPUT_PATH }}-Lib"; do
+            [ -d "$d" ] || continue
+
+            find "$d" \( -name '*.dSYM' -o -name '*.dSYM/' \) -prune -o -type f -print |
+            while IFS= read -r file; do
+              dest="flat/${file#$d/}"
+              mkdir -p "$(dirname "$dest")"
+              cp "$file" "$dest"
+            done
+          done
+
+          cd flat
+
+          echo "Runner OS: $RUNNER_OS"
+
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            # Use PowerShell Compress-Archive for Windows
+            pwsh -Command "Compress-Archive -Path * -DestinationPath ../${{ matrix.rid }}.zip -Force"
+          else
+            # Linux and macOS
+            zip -r ../${{ matrix.rid }}.zip .
+          fi
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.rid }}.zip
+          path: ${{ matrix.rid }}.zip
+          retention-days: 3

--- a/.github/workflows/tuo-pr-build.yml
+++ b/.github/workflows/tuo-pr-build.yml
@@ -8,6 +8,10 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+  pull-requests: read
+
 env:
   CUO_OUTPUT_PATH: 'build/dist'
   CUO_PROJECT_PATH: "src/ClassicUO.Client/ClassicUO.Client.csproj"
@@ -31,11 +35,14 @@ jobs:
             rid: osx-arm64
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Checkout PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr checkout ${{ github.event.inputs.pr_number }}
+          PR_NUMBER: ${{ github.event.inputs.pr_number }}
+        run: gh pr checkout "$PR_NUMBER"
 
       - name: Get submodules
         run: |


### PR DESCRIPTION
Builds the client for win-x64, linux-x64, and osx-arm64 from a selected PR and uploads each platform zip as a runner artifact (3-day retention). Unlike the dev deploy workflow, it does not create GitHub releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manually triggerable build workflow for pull requests.
  * Generates packaged builds for Windows, Linux, and macOS.
  * Uploads each platform build as a downloadable artifact for a limited retention period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->