### PR TITLE
Reload dynamic maps only on facet size change and resync the world so…

### DIFF
--- a/src/ClassicUO.Assets/MapLoader.cs
+++ b/src/ClassicUO.Assets/MapLoader.cs
@@ -324,6 +324,28 @@ namespace ClassicUO.Assets
                 heights[index] = height;
             }
 
+            if (count == MAPS_COUNT && count <= existing)
+            {
+                bool changed = false;
+
+                for (int i = 0; i < count; i++)
+                {
+                    if (MapsDefaultSize[i, 0] != widths[i] || MapsDefaultSize[i, 1] != heights[i])
+                    {
+                        changed = true;
+
+                        break;
+                    }
+                }
+
+                if (!changed)
+                {
+                    Log.Trace($"Server map definitions unchanged [count: {count}], skipping reload");
+
+                    return;
+                }
+            }
+
             string[] parts = new string[count];
 
             for (int i = 0; i < count; i++)

--- a/src/ClassicUO.Client/Game/UltimaLive.cs
+++ b/src/ClassicUO.Client/Game/UltimaLive.cs
@@ -323,6 +323,11 @@ namespace ClassicUO.Game
                     p.Seek(14);
                     byte mapCount = p.ReadUInt8();
 
+                    if (p.Length < 15 + mapCount * 5)
+                    {
+                        return;
+                    }
+
                     var defs = new (int index, int width, int height)[mapCount];
 
                     for (int i = 0; i < mapCount; i++)
@@ -348,7 +353,8 @@ namespace ClassicUO.Game
                     maps.ApplyServerMapDefinitions(defs);
 
                     if (activeMap >= 0 &&
-                        (maps.MapBlocksSize[activeMap, 0] != beforeW || maps.MapBlocksSize[activeMap, 1] != beforeH))
+                        (activeMap >= maps.MapBlocksSize.GetLength(0) ||
+                         maps.MapBlocksSize[activeMap, 0] != beforeW || maps.MapBlocksSize[activeMap, 1] != beforeH))
                     {
                         world.ReloadCurrentMap();
                     }

--- a/src/ClassicUO.Client/Game/UltimaLive.cs
+++ b/src/ClassicUO.Client/Game/UltimaLive.cs
@@ -334,9 +334,21 @@ namespace ClassicUO.Game
                         defs[i] = (index, width, height);
                     }
 
-                    Client.Game.UO.FileManager.Maps.ApplyServerMapDefinitions(defs);
+                    var maps = Client.Game.UO.FileManager.Maps;
 
-                    if (world != null && world.InGame)
+                    int activeMap = (world != null && world.InGame) ? world.MapIndex : -1;
+                    int beforeW = 0, beforeH = 0;
+
+                    if (activeMap >= 0 && activeMap < maps.MapBlocksSize.GetLength(0))
+                    {
+                        beforeW = maps.MapBlocksSize[activeMap, 0];
+                        beforeH = maps.MapBlocksSize[activeMap, 1];
+                    }
+
+                    maps.ApplyServerMapDefinitions(defs);
+
+                    if (activeMap >= 0 &&
+                        (maps.MapBlocksSize[activeMap, 0] != beforeW || maps.MapBlocksSize[activeMap, 1] != beforeH))
                     {
                         world.ReloadCurrentMap();
                     }

--- a/src/ClassicUO.Client/Game/World.cs
+++ b/src/ClassicUO.Client/Game/World.cs
@@ -10,6 +10,7 @@ using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.Map;
 using ClassicUO.Game.UI.Gumps;
+using ClassicUO.Network;
 using Microsoft.Xna.Framework;
 using MathHelper = ClassicUO.Utility.MathHelper;
 using ClassicUO.Configuration;
@@ -249,6 +250,9 @@ namespace ClassicUO.Game
 
             int index = Map.Index;
 
+            if (index < 0 || index >= MapLoader.MAPS_COUNT)
+                index = 0;
+
             InternalMapChangeClear(true);
 
             ushort x = Player.X;
@@ -258,14 +262,13 @@ namespace ClassicUO.Game
             Map.Destroy();
             Map = null;
 
-            if (index < 0 || index >= MapLoader.MAPS_COUNT)
-                index = 0;
-
             Client.Game.UO.FileManager.Maps.LoadMap(index, ClientFeatures.Flags.HasFlag(CharacterListFlags.CLF_UNLOCK_FELUCCA_AREAS));
             Map = new Map.Map(this, index);
 
             Player.SetInWorldTile(x, y, z);
             Player.ClearSteps();
+
+            AsyncNetClient.Socket.Send_Resync();
 
             if (Client.Game.UO.GameCursor != null)
             {

--- a/src/ClassicUO.Client/Game/World.cs
+++ b/src/ClassicUO.Client/Game/World.cs
@@ -10,7 +10,6 @@ using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.Map;
 using ClassicUO.Game.UI.Gumps;
-using ClassicUO.Network;
 using Microsoft.Xna.Framework;
 using MathHelper = ClassicUO.Utility.MathHelper;
 using ClassicUO.Configuration;
@@ -253,11 +252,11 @@ namespace ClassicUO.Game
             if (index < 0 || index >= MapLoader.MAPS_COUNT)
                 index = 0;
 
-            InternalMapChangeClear(true);
-
             ushort x = Player.X;
             ushort y = Player.Y;
             sbyte z = Player.Z;
+
+            UnlinkEntitiesFromMap();
 
             Map.Destroy();
             Map = null;
@@ -268,7 +267,7 @@ namespace ClassicUO.Game
             Player.SetInWorldTile(x, y, z);
             Player.ClearSteps();
 
-            AsyncNetClient.Socket.Send_Resync();
+            RelinkEntitiesToMap();
 
             if (Client.Game.UO.GameCursor != null)
             {
@@ -1018,6 +1017,54 @@ namespace ClassicUO.Game
             ActiveSpellIcons.Clear();
 
             SkillsRequested = false;
+        }
+
+        private void UnlinkEntitiesFromMap()
+        {
+            foreach (Mobile mobile in Mobiles.Values)
+            {
+                mobile.RemoveFromTile();
+            }
+
+            foreach (Item item in Items.Values)
+            {
+                if (item.OnGround)
+                {
+                    item.RemoveFromTile();
+                }
+            }
+
+            foreach (House house in HouseManager.Houses)
+            {
+                foreach (Multi component in house.Components)
+                {
+                    component.RemoveFromTile();
+                }
+            }
+        }
+
+        private void RelinkEntitiesToMap()
+        {
+            foreach (Mobile mobile in Mobiles.Values)
+            {
+                if (mobile != Player)
+                {
+                    mobile.SetInWorldTile(mobile.X, mobile.Y, mobile.Z);
+                }
+            }
+
+            foreach (Item item in Items.Values)
+            {
+                if (item.OnGround)
+                {
+                    item.SetInWorldTile(item.X, item.Y, item.Z);
+                }
+            }
+
+            foreach (House house in HouseManager.Houses)
+            {
+                house.Generate(true);
+            }
         }
 
         private void InternalMapChangeClear(bool noplayer)


### PR DESCRIPTION
## Description
Dynamic map packet forced a refresh of the game world, where the server provided the packet back. The refresh caused the visible chunks to be reset until the client re-requested the data from the server.

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing
Loaded into the world without fix. All items are invisible until you run out of the chunk and back in.
Patched loader to request resync from the server after determining world state. Loaded in and everything is back, multi's items etc.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced unnecessary map reloads when server-provided map layouts are unchanged.
  * Reloads only when the active map’s dimensions have changed.

* **Bug Fixes**
  * Added validation for incomplete map definition data.
  * Improved map switching and reloading to preserve players, characters, items, and housing correctly.
  * Restores game entities to their proper locations after map updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->