### PR TITLE
Snap camera on teleport instead of smoothly panning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ All notable changes to TazUO will be recorded here.
 * Fixed percent-type "Show Mobiles HP" text drifting in a radius around the mobile based on zoom level instead of staying centered on top - [P.R 608](https://github.com/PlayTazUO/TazUO/pull/608) ([bittiez](https://github.com/bittiez))
 * Fixed web map markers disappearing after changing facets - the live event stream is now kept alive across map changes so markers refresh correctly when recalling between facets - [P.R 619](https://github.com/PlayTazUO/TazUO/pull/619) ([bittiez](https://github.com/bittiez))
 * Game cursor now uses a consistent style across all maps instead of changing on non-zero maps - [P.R 622](https://github.com/PlayTazUO/TazUO/pull/622) ([bittiez](https://github.com/bittiez))
+* Fixed camera smoothly panning across the map on a teleport (dungeon entrance/exit, recall, gate) instead of snapping to the new location when Camera Smoothing is enabled - [P.R 633](https://github.com/PlayTazUO/TazUO/pull/633) ([bittiez](https://github.com/bittiez))
 
 ### Legion
 * Added ModernNineSliceGump.SetLegionTexture to go along with zip files and custom png's - Use your own png for a 9-slice texture - ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.16</AssemblyVersion>
-    <FileVersion>5.3.16</FileVersion>
+    <AssemblyVersion>5.3.17</AssemblyVersion>
+    <FileVersion>5.3.17</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/Scenes/GameSceneDrawingSorting.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameSceneDrawingSorting.cs
@@ -49,6 +49,8 @@ namespace ClassicUO.Game.Scenes
 
         // Smooth camera following
         private Vector2 _currentSmoothedOffset = Vector2.Zero;
+        private int _smoothLastPlayerX = int.MinValue,
+            _smoothLastPlayerY = int.MinValue;
 
 
         private readonly List<GameObject> _renderListStatics = new List<GameObject>();
@@ -1171,7 +1173,18 @@ namespace ClassicUO.Game.Scenes
             var targetOffset = new Vector2(winDrawOffsetX, winDrawOffsetY);
             float smoothingFactor = ProfileManager.CurrentProfile.CameraSmoothingFactor;
 
-            if (smoothingFactor > 0f)
+            // Detect a teleport (e.g. dungeon entrance/exit, recall, gate). A normal walk step
+            // never moves the player by more than one tile between updates, so anything larger
+            // must be an instant relocation. Snap the camera instead of panning across the map.
+            bool teleported =
+                _smoothLastPlayerX != int.MinValue
+                && (Math.Abs(_world.Player.X - _smoothLastPlayerX) > 1
+                    || Math.Abs(_world.Player.Y - _smoothLastPlayerY) > 1);
+
+            _smoothLastPlayerX = _world.Player.X;
+            _smoothLastPlayerY = _world.Player.Y;
+
+            if (smoothingFactor > 0f && !teleported)
             {
                 // Calculate distance to target
                 float distance = Vector2.Distance(_currentSmoothedOffset, targetOffset);


### PR DESCRIPTION
When CameraSmoothingFactor is enabled, the world draw offset was lerped toward the target every frame regardless of how far the player moved. On an instant relocation (dungeon entrance/exit, recall, gate) the target offset jumps 50+ tiles away and the camera slowly panned across the map to catch up.

Detect a teleport by a player tile jump larger than a single walk step and snap the camera to the target for that frame; normal step-by-step smoothing resumes immediately after.