### PR TITLE
Make ShowTargetIndicator the sole gate for target bracket graphics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ All notable changes to TazUO will be recorded here.
 * Fixed web map markers disappearing after changing facets - the live event stream is now kept alive across map changes so markers refresh correctly when recalling between facets - [P.R 619](https://github.com/PlayTazUO/TazUO/pull/619) ([bittiez](https://github.com/bittiez))
 * Game cursor now uses a consistent style across all maps instead of changing on non-zero maps - [P.R 622](https://github.com/PlayTazUO/TazUO/pull/622) ([bittiez](https://github.com/bittiez))
 * Fixed camera smoothly panning across the map on a teleport (dungeon entrance/exit, recall, gate) instead of snapping to the new location when Camera Smoothing is enabled - [P.R 633](https://github.com/PlayTazUO/TazUO/pull/633) ([bittiez](https://github.com/bittiez))
+* Fixed the Show Target Indicator option not hiding the target bracket graphics while the new target system was enabled; the option now solely controls the brackets - [P.R #](https://github.com/PlayTazUO/TazUO/pull/#) ([bittiez](https://github.com/bittiez))
 
 ### Legion
 * Added ModernNineSliceGump.SetLegionTexture to go along with zip files and custom png's - Use your own png for a 9-slice texture - ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.17</AssemblyVersion>
-    <FileVersion>5.3.17</FileVersion>
+    <AssemblyVersion>5.3.18</AssemblyVersion>
+    <FileVersion>5.3.18</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/Managers/HealthLinesManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/HealthLinesManager.cs
@@ -45,7 +45,6 @@ namespace ClassicUO.Game.Managers
             }
 
             int showWhen = ProfileManager.CurrentProfile.MobileHPShowWhen;
-            bool useNewTargetSystem = ProfileManager.CurrentProfile.UseNewTargetSystem;
             Renderer.Animations.Animations animations = Client.Game.UO.Animations;
             bool isEnabled = IsEnabled;
 
@@ -65,7 +64,7 @@ namespace ClassicUO.Game.Managers
                     _world.TargetManager.SelectedTarget == mobile ||
                     _world.TargetManager.NewTargetSystemSerial == mobile)
                 {
-                    newTargSystem = (useNewTargetSystem || showTargetIndicator) && _world.TargetManager.NewTargetSystemSerial == mobile;
+                    newTargSystem = showTargetIndicator && _world.TargetManager.NewTargetSystemSerial == mobile;
                     passive = false;
                     forceDraw = true;
                 }


### PR DESCRIPTION
The new-target bracket gumps were gated by (UseNewTargetSystem || ShowTargetIndicator), so toggling ShowTargetIndicator off had no effect whenever UseNewTargetSystem was enabled (its default). Gate bracket drawing solely on ShowTargetIndicator so the toggle reliably shows/hides the graphics, and drop the now-unused useNewTargetSystem local.