### PR TITLE
Restore tooltips for mastery spell abilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ All notable changes to TazUO will be recorded here.
 * Game cursor now uses a consistent style across all maps instead of changing on non-zero maps - [P.R 622](https://github.com/PlayTazUO/TazUO/pull/622) ([bittiez](https://github.com/bittiez))
 * Fixed camera smoothly panning across the map on a teleport (dungeon entrance/exit, recall, gate) instead of snapping to the new location when Camera Smoothing is enabled - [P.R 633](https://github.com/PlayTazUO/TazUO/pull/633) ([bittiez](https://github.com/bittiez))
 * Fixed the Show Target Indicator option not hiding the target bracket graphics while the new target system was enabled; the option now solely controls the brackets - [P.R #](https://github.com/PlayTazUO/TazUO/pull/#) ([bittiez](https://github.com/bittiez))
+* Restored tooltips for mastery spell abilities that were dropped in the mastery spellbook rework - [P.R 635](https://github.com/PlayTazUO/TazUO/pull/635) ([bittiez](https://github.com/bittiez))
 
 ### Legion
 * Added ModernNineSliceGump.SetLegionTexture to go along with zip files and custom png's - Use your own png for a 9-slice texture - ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.18</AssemblyVersion>
-    <FileVersion>5.3.18</FileVersion>
+    <AssemblyVersion>5.3.19</AssemblyVersion>
+    <FileVersion>5.3.19</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/Data/SpellsMastery.cs
+++ b/src/ClassicUO.Client/Game/Data/SpellsMastery.cs
@@ -59,7 +59,7 @@ namespace ClassicUO.Game.Data
                 { 3, 1115691 },  // Resilience
                 { 4, 1115692 },  // Perseverance
                 { 5, 1115693 },  // Tribulation
-                { 6, 1155937 },  // Despair
+                { 6, 1115694 },  // Despair
                 { 7, 1155938 },  // Death Ray
                 { 8, 1155939 },  // Ethereal Burst
                 { 9, 1155940 },  // Nether Blast

--- a/src/ClassicUO.Client/Game/Data/SpellsMastery.cs
+++ b/src/ClassicUO.Client/Game/Data/SpellsMastery.cs
@@ -54,51 +54,51 @@ namespace ClassicUO.Game.Data
         private static readonly Dictionary<int, int> _spellTooltipClilocs =
             new Dictionary<int, int>
             {
-                { 1, 1115690 },  // Inspire
-                { 2, 1115691 },  // Invigorate
-                { 3, 1115692 },  // Resilience
-                { 4, 1115693 },  // Perseverance
-                { 5, 1115694 },  // Tribulation
-                { 6, 1155938 },  // Despair
-                { 7, 1155939 },  // Death Ray
-                { 8, 1155940 },  // Ethereal Burst
-                { 9, 1155941 },  // Nether Blast
-                { 10, 1155942 }, // Mystic Weapon
-                { 11, 1155943 }, // Command Undead
-                { 12, 1155944 }, // Conduit
-                { 13, 1155945 }, // Mana Shield
-                { 14, 1155946 }, // Summon Reaper
-                { 15, 1155947 }, // Enchanted Summoning
-                { 16, 1155948 }, // Anticipate Hit
-                { 17, 1155949 }, // Warcry
-                { 18, 1155950 }, // Intuition
-                { 19, 1155951 }, // Rejuvenate
-                { 20, 1155952 }, // Holy Fist
-                { 21, 1155953 }, // Shadow
-                { 22, 1155954 }, // White Tiger Form
-                { 23, 1155955 }, // Flaming Shot
-                { 24, 1155956 }, // Playing The Odds
-                { 25, 1155957 }, // Thrust
-                { 26, 1155958 }, // Pierce
-                { 27, 1155959 }, // Stagger
-                { 28, 1155960 }, // Toughness
-                { 29, 1155961 }, // Onslaught
-                { 30, 1155962 }, // Focused Eye
-                { 31, 1155963 }, // Elemental Fury
-                { 32, 1155964 }, // Called Shot
-                { 33, 1155965 }, // Warrior's Gifts
-                { 34, 1155966 }, // Shield Bash
-                { 35, 1155967 }, // Bodyguard
-                { 36, 1155968 }, // Heighten Senses
-                { 37, 1155969 }, // Tolerance
-                { 38, 1155970 }, // Injected Strike
-                { 39, 1155971 }, // Potency
-                { 40, 1155972 }, // Rampage
-                { 41, 1155973 }, // Fists of Fury
-                { 42, 1155974 }, // Knockout
-                { 43, 1155975 }, // Whispering
-                { 44, 1155976 }, // Combat Training
-                { 45, 1155977 }  // Boarding
+                { 1, 1115689 },  // Inspire
+                { 2, 1115690 },  // Invigorate
+                { 3, 1115691 },  // Resilience
+                { 4, 1115692 },  // Perseverance
+                { 5, 1115693 },  // Tribulation
+                { 6, 1155937 },  // Despair
+                { 7, 1155938 },  // Death Ray
+                { 8, 1155939 },  // Ethereal Burst
+                { 9, 1155940 },  // Nether Blast
+                { 10, 1155941 }, // Mystic Weapon
+                { 11, 1155942 }, // Command Undead
+                { 12, 1155943 }, // Conduit
+                { 13, 1155944 }, // Mana Shield
+                { 14, 1155945 }, // Summon Reaper
+                { 15, 1155946 }, // Enchanted Summoning
+                { 16, 1155947 }, // Anticipate Hit
+                { 17, 1155948 }, // Warcry
+                { 18, 1155949 }, // Intuition
+                { 19, 1155950 }, // Rejuvenate
+                { 20, 1155951 }, // Holy Fist
+                { 21, 1155952 }, // Shadow
+                { 22, 1155953 }, // White Tiger Form
+                { 23, 1155954 }, // Flaming Shot
+                { 24, 1155955 }, // Playing The Odds
+                { 25, 1155956 }, // Thrust
+                { 26, 1155957 }, // Pierce
+                { 27, 1155958 }, // Stagger
+                { 28, 1155959 }, // Toughness
+                { 29, 1155960 }, // Onslaught
+                { 30, 1155961 }, // Focused Eye
+                { 31, 1155962 }, // Elemental Fury
+                { 32, 1155963 }, // Called Shot
+                { 33, 1155964 }, // Warrior's Gifts
+                { 34, 1155965 }, // Shield Bash
+                { 35, 1155966 }, // Bodyguard
+                { 36, 1155967 }, // Heighten Senses
+                { 37, 1155968 }, // Tolerance
+                { 38, 1155969 }, // Injected Strike
+                { 39, 1155970 }, // Potency
+                { 40, 1155971 }, // Rampage
+                { 41, 1155972 }, // Fists of Fury
+                { 42, 1155973 }, // Knockout
+                { 43, 1155974 }, // Whispering
+                { 44, 1155975 }, // Combat Training
+                { 45, 1155976 }  // Boarding
             };
 
         public static readonly string SpellBookName = SpellBookType.Mastery.ToString();

--- a/src/ClassicUO.Client/Game/Data/SpellsMastery.cs
+++ b/src/ClassicUO.Client/Game/Data/SpellsMastery.cs
@@ -47,6 +47,60 @@ namespace ClassicUO.Game.Data
                 { 0x11A2CA, new[] { 33, 23, 24 } }
             };
 
+        // Maps a mastery ability id to the cliloc used for its tooltip description.
+        // These were previously derived from an arithmetic formula but several entries
+        // did not line up with the correct description, so they are listed explicitly
+        // here to be adjusted manually as needed.
+        private static readonly Dictionary<int, int> _spellTooltipClilocs =
+            new Dictionary<int, int>
+            {
+                { 1, 1115690 },  // Inspire
+                { 2, 1115691 },  // Invigorate
+                { 3, 1115692 },  // Resilience
+                { 4, 1115693 },  // Perseverance
+                { 5, 1115694 },  // Tribulation
+                { 6, 1155938 },  // Despair
+                { 7, 1155939 },  // Death Ray
+                { 8, 1155940 },  // Ethereal Burst
+                { 9, 1155941 },  // Nether Blast
+                { 10, 1155942 }, // Mystic Weapon
+                { 11, 1155943 }, // Command Undead
+                { 12, 1155944 }, // Conduit
+                { 13, 1155945 }, // Mana Shield
+                { 14, 1155946 }, // Summon Reaper
+                { 15, 1155947 }, // Enchanted Summoning
+                { 16, 1155948 }, // Anticipate Hit
+                { 17, 1155949 }, // Warcry
+                { 18, 1155950 }, // Intuition
+                { 19, 1155951 }, // Rejuvenate
+                { 20, 1155952 }, // Holy Fist
+                { 21, 1155953 }, // Shadow
+                { 22, 1155954 }, // White Tiger Form
+                { 23, 1155955 }, // Flaming Shot
+                { 24, 1155956 }, // Playing The Odds
+                { 25, 1155957 }, // Thrust
+                { 26, 1155958 }, // Pierce
+                { 27, 1155959 }, // Stagger
+                { 28, 1155960 }, // Toughness
+                { 29, 1155961 }, // Onslaught
+                { 30, 1155962 }, // Focused Eye
+                { 31, 1155963 }, // Elemental Fury
+                { 32, 1155964 }, // Called Shot
+                { 33, 1155965 }, // Warrior's Gifts
+                { 34, 1155966 }, // Shield Bash
+                { 35, 1155967 }, // Bodyguard
+                { 36, 1155968 }, // Heighten Senses
+                { 37, 1155969 }, // Tolerance
+                { 38, 1155970 }, // Injected Strike
+                { 39, 1155971 }, // Potency
+                { 40, 1155972 }, // Rampage
+                { 41, 1155973 }, // Fists of Fury
+                { 42, 1155974 }, // Knockout
+                { 43, 1155975 }, // Whispering
+                { 44, 1155976 }, // Combat Training
+                { 45, 1155977 }  // Boarding
+            };
+
         public static readonly string SpellBookName = SpellBookType.Mastery.ToString();
 
 
@@ -743,7 +797,17 @@ namespace ClassicUO.Game.Data
 
             return null;
         }
-        
+
+        public static int GetSpellTooltipCliloc(int spellId)
+        {
+            if (_spellTooltipClilocs.TryGetValue(spellId, out int cliloc))
+            {
+                return cliloc;
+            }
+
+            return 0;
+        }
+
         internal static string GetUsedSkillName(int spellid)
         {
             int div = (MaxSpellCount * 3) >> 3;

--- a/src/ClassicUO.Client/Game/UI/Gumps/SpellbookGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/SpellbookGump.cs
@@ -398,13 +398,13 @@ namespace ClassicUO.Game.UI.Gumps
 
                                 _dataBox.Add(text, page);
 
-                                int toolTipCliloc = id >= 0 && id < 6 ? 1115689 : 1155938 - 6;
+                                int toolTipCliloc = SpellsMastery.GetSpellTooltipCliloc(id);
 
                                 if (toolTipCliloc > 0)
                                 {
                                     string tooltip =
                                         Client.Game.UO.FileManager.Clilocs.GetString(
-                                            toolTipCliloc + id
+                                            toolTipCliloc
                                         );
 
                                     icon.SetTooltip(tooltip, 250);

--- a/src/ClassicUO.Client/Game/UI/Gumps/SpellbookGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/SpellbookGump.cs
@@ -397,6 +397,18 @@ namespace ClassicUO.Game.UI.Gumps
                                 };
 
                                 _dataBox.Add(text, page);
+
+                                int toolTipCliloc = id >= 0 && id < 6 ? 1115689 : 1155938 - 6;
+
+                                if (toolTipCliloc > 0)
+                                {
+                                    string tooltip =
+                                        Client.Game.UO.FileManager.Clilocs.GetString(
+                                            toolTipCliloc + id
+                                        );
+
+                                    icon.SetTooltip(tooltip, 250);
+                                }
                             }
                         }
 


### PR DESCRIPTION
The mastery spellbook rework in #605 dropped the tooltip that was set on each ability icon. Re-add it using the same cliloc lookup so hovering a mastery ability shows its description again.