### PR TITLE
Run TUO-PR-Build on PRs labeled release-pr

### DIFF
--- a/.github/workflows/tuo-pr-build.yml
+++ b/.github/workflows/tuo-pr-build.yml
@@ -7,6 +7,8 @@ on:
         description: 'Pull request number to build'
         required: true
         type: string
+  pull_request:
+    types: [labeled, synchronize, reopened]
 
 permissions:
   contents: read
@@ -23,6 +25,9 @@ env:
 
 jobs:
   build:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'release-pr')
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -41,7 +46,7 @@ jobs:
       - name: Checkout PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.inputs.pr_number }}
+          PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
         run: gh pr checkout "$PR_NUMBER"
 
       - name: Get submodules
@@ -94,6 +99,9 @@ jobs:
           retention-days: 3
 
   release:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'release-pr')
     runs-on: ubuntu-latest
     needs: build
     permissions:
@@ -108,7 +116,7 @@ jobs:
         id: pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.inputs.pr_number }}
+          PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
         run: |
           PR_JSON=$(gh pr view "$PR_NUMBER" --json title,state)
           TITLE=$(jq -r .title <<< "$PR_JSON")
@@ -169,7 +177,7 @@ jobs:
           name: ${{ steps.pr.outputs.title }}
           tag: ${{ steps.pr.outputs.tag }}
           body: |
-            Automated pre-release build for PR #${{ github.event.inputs.pr_number }}: ${{ steps.pr.outputs.title }}
+            Automated pre-release build for PR #${{ github.event.inputs.pr_number || github.event.pull_request.number }}: ${{ steps.pr.outputs.title }}
 
             This is a standalone build of the pull request for testing purposes.
             These are modern dotnet builds of TazUO, they do not support plugins. For plugin support see the Legacy releases.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automation so builds and releases can run from pull request updates as well as manual triggers.
  * Updated pull request handling to work more reliably across both manual and PR-based runs.
  * Release notes now use the correct pull request reference in both trigger types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->