### PR TITLE
WebMap: serve marker icons by file path instead of streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ All notable changes to TazUO will be recorded here.
 * Add option to disable the party-style health bar for party members - [P.R 620](https://github.com/PlayTazUO/TazUO/pull/620) ([bittiez](https://github.com/bittiez))
 * Added a clear (X) button to the nameplate manager search field - [P.R 621](https://github.com/PlayTazUO/TazUO/pull/621) ([bittiez](https://github.com/bittiez))
 * Added a scaling option for context menus - [P.R 623](https://github.com/PlayTazUO/TazUO/pull/623) ([bittiez](https://github.com/bittiez))
+* Added marker icons to the web map, served from their source file on disk instead of streaming rendered textures, with a toggle to switch between icons and circles - [P.R 637](https://github.com/PlayTazUO/TazUO/pull/637) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
 * Fixed simultaneous drag and resize occurring on resizable windows - [P.R #](https://github.com/PlayTazUO/TazUO/pull/#) ([yuval-po](https://github.com/yuval-po))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.19</AssemblyVersion>
-    <FileVersion>5.3.19</FileVersion>
+    <AssemblyVersion>5.3.20</AssemblyVersion>
+    <FileVersion>5.3.20</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/Managers/MapWebServer.cs
+++ b/src/ClassicUO.Client/Game/Managers/MapWebServer.cs
@@ -134,6 +134,9 @@ namespace ClassicUO.Game.Managers
                     case "/api/maptexture":
                         ServeMapTexture(context.Response);
                         break;
+                    case "/api/markericon":
+                        ServeMarkerIcon(context.Request, context.Response);
+                        break;
                     case "/api/events":
                         ServeEventStream(context.Response);
                         break;
@@ -282,6 +285,65 @@ namespace ClassicUO.Game.Managers
             {
                 _cachedMapPng = null;
                 _lastMapIndex = -1;
+            }
+        }
+
+        // Serves a marker icon by name. Rather than streaming a rendered GPU texture, we look up the
+        // original icon file's path on disk and send the file bytes directly. The browser references
+        // the icon via a stable URL (/api/markericon?name=...) which it can cache between requests.
+        private void ServeMarkerIcon(HttpListenerRequest request, HttpListenerResponse response)
+        {
+            try
+            {
+                string name = request.QueryString["name"];
+
+                if (string.IsNullOrEmpty(name))
+                {
+                    response.StatusCode = 400;
+                    response.Close();
+                    return;
+                }
+
+                string iconPath = null;
+                UI.Gumps.WorldMapGump._markerIconPaths.TryGetValue(name.ToLower(), out iconPath);
+
+                if (string.IsNullOrEmpty(iconPath) || !File.Exists(iconPath))
+                {
+                    response.StatusCode = 404;
+                    response.Close();
+                    return;
+                }
+
+                byte[] iconData = File.ReadAllBytes(iconPath);
+
+                response.ContentType = GetIconContentType(iconPath);
+                response.Headers.Add("Cache-Control", "public, max-age=86400");
+                response.ContentLength64 = iconData.Length;
+                response.OutputStream.Write(iconData, 0, iconData.Length);
+                response.Close();
+            }
+            catch (Exception ex)
+            {
+                Log.Error($"Error serving marker icon: {ex.Message}");
+                try
+                {
+                    response.StatusCode = 500;
+                    response.Close();
+                }
+                catch { }
+            }
+        }
+
+        private static string GetIconContentType(string path)
+        {
+            switch (Path.GetExtension(path).ToLowerInvariant())
+            {
+                case ".png": return "image/png";
+                case ".jpg":
+                case ".jpeg": return "image/jpeg";
+                case ".ico":
+                case ".cur": return "image/x-icon";
+                default: return "application/octet-stream";
             }
         }
 
@@ -1060,6 +1122,7 @@ namespace ClassicUO.Game.Managers
             <label><input type=""checkbox"" id=""showParty"" checked> Show Party</label>
             <label><input type=""checkbox"" id=""showGuild"" checked> Show Guild</label>
             <label><input type=""checkbox"" id=""showMarkers"" checked> Show Markers</label>
+            <label style=""margin-left: 20px;""><input type=""checkbox"" id=""showMarkerIcons"" checked> Icons</label>
             <input type=""text"" id=""markerSearch"" class=""marker-search"" placeholder=""Search markers..."" autocomplete=""off"" />
             <label><input type=""checkbox"" id=""showMobiles"" checked> Show Mobiles</label>
             <label style=""margin-left: 20px;""><input type=""checkbox"" id=""showEnemies"" checked> Enemies</label>
@@ -1614,6 +1677,30 @@ namespace ClassicUO.Game.Managers
             ctx.fillText(text, labelX, labelY);
         }
 
+        // Cache of marker icon images keyed by icon name. Icons are fetched once from the server by
+        // their file (via /api/markericon?name=...) and reused; the browser also caches the HTTP
+        // response so switching maps/markers doesn't re-download them.
+        const markerIconCache = {};
+
+        function getMarkerIcon(name) {
+            if (!name) return null;
+
+            const key = name.toLowerCase();
+            let entry = markerIconCache[key];
+
+            if (entry === undefined) {
+                const img = new Image();
+                entry = { img: img, loaded: false, failed: false };
+                markerIconCache[key] = entry;
+
+                img.onload = () => { entry.loaded = true; draw(); };
+                img.onerror = () => { entry.failed = true; };
+                img.src = '/api/markericon?name=' + encodeURIComponent(name);
+            }
+
+            return (entry.loaded && !entry.failed) ? entry.img : null;
+        }
+
         function draw() {
             ctx.fillStyle = '#000';
             ctx.fillRect(0, 0, canvas.width, canvas.height);
@@ -1691,14 +1778,24 @@ namespace ClassicUO.Game.Managers
                     // Scale for proper sizing
                     ctx.scale(1 / zoom, 1 / zoom);
 
-                    // Draw marker circle
-                    ctx.fillStyle = markerColor;
-                    ctx.strokeStyle = '#ffffff';
-                    ctx.lineWidth = 1;
-                    ctx.beginPath();
-                    ctx.arc(0, 0, 3, 0, Math.PI * 2);
-                    ctx.fill();
-                    ctx.stroke();
+                    // Prefer the marker's icon (served from its file on disk) when available;
+                    // fall back to a colored circle when there's no icon or it hasn't loaded yet.
+                    const markerIcon = document.getElementById('showMarkerIcons').checked
+                        ? getMarkerIcon(marker.iconName)
+                        : null;
+
+                    if (markerIcon) {
+                        ctx.drawImage(markerIcon, -markerIcon.width / 2, -markerIcon.height / 2);
+                    } else {
+                        // Draw marker circle
+                        ctx.fillStyle = markerColor;
+                        ctx.strokeStyle = '#ffffff';
+                        ctx.lineWidth = 1;
+                        ctx.beginPath();
+                        ctx.arc(0, 0, 3, 0, Math.PI * 2);
+                        ctx.fill();
+                        ctx.stroke();
+                    }
 
                     // Draw label
                     if (marker.name) {

--- a/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
@@ -57,6 +57,10 @@ public class WorldMapGump : ResizableGump
     private static readonly string UserMarkersFilePath = Path.Combine(CUOEnviroment.ExecutablePath, "Data", "Client", $"{USER_MARKERS_FILE}.usr");
     public static readonly List<WMapMarkerFile> _markerFiles = new List<WMapMarkerFile>();
     public static readonly Dictionary<string, Texture2D> _markerIcons = new Dictionary<string, Texture2D>();
+    // Maps a marker icon name (file name without extension, lowercased) to the full path of the
+    // source icon file on disk. Used by the web map so it can serve the original icon file by its
+    // path instead of streaming rendered GPU textures.
+    public static readonly Dictionary<string, string> _markerIconPaths = new Dictionary<string, string>();
     private static readonly float[] _zooms = new float[10] { 0.125f, 0.25f, 0.5f, 0.75f, 1f, 1.5f, 2f, 4f, 6f, 8f };
     private static readonly Color _semiTransparentWhiteForGrid = new Color(255, 255, 255, 56);
     private static Point _last_position = new Point(100, 100);
@@ -1582,6 +1586,7 @@ public class WorldMapGump : ResizableGump
                 }
 
                 _markerIcons.Clear();
+                _markerIconPaths.Clear();
 
                     List<string> mapIconPaths = new();
                     List<string> mapIconPathsPngJpg = new();
@@ -1616,7 +1621,9 @@ public class WorldMapGump : ResizableGump
                     {
                         Texture2D texture = CurLoader.CreateTextureFromICO_Cur(ms);
 
-                        _markerIcons.Add(Path.GetFileNameWithoutExtension(icon).ToLower(), texture);
+                        string iconKey = Path.GetFileNameWithoutExtension(icon).ToLower();
+                        _markerIcons.Add(iconKey, texture);
+                        _markerIconPaths[iconKey] = icon;
                     }
                     catch (Exception ee)
                     {
@@ -1640,7 +1647,9 @@ public class WorldMapGump : ResizableGump
                     {
                         var texture = Texture2D.FromStream(Client.Game.GraphicsDevice, ms);
 
-                        _markerIcons.Add(Path.GetFileNameWithoutExtension(icon).ToLower(), texture);
+                        string iconKey = Path.GetFileNameWithoutExtension(icon).ToLower();
+                        _markerIcons.Add(iconKey, texture);
+                        _markerIconPaths[iconKey] = icon;
                     }
                     catch (Exception ee)
                     {


### PR DESCRIPTION
Add marker icon support to the web map. Instead of rendering GPU textures and streaming pixel data, the client tracks each icon's source file path (WorldMapGump._markerIconPaths) and the web server exposes an /api/markericon?name=... endpoint that serves the original icon file from disk with an appropriate content type and cache header.

The web page loads each marker's icon once via that cacheable URL, caches the Image, and draws it centered on the marker (falling back to the colored circle when there is no icon or it fails to load). A new "Icons" toggle lets users switch between icons and circles.