### PR TITLE
Add Shift+Ctrl multi-segment pathfinding to WorldMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ All notable changes to TazUO will be recorded here.
 * Added a clear (X) button to the nameplate manager search field - [P.R 621](https://github.com/PlayTazUO/TazUO/pull/621) ([bittiez](https://github.com/bittiez))
 * Added a scaling option for context menus - [P.R 623](https://github.com/PlayTazUO/TazUO/pull/623) ([bittiez](https://github.com/bittiez))
 * Added marker icons to the web map, served from their source file on disk instead of streaming rendered textures, with a toggle to switch between icons and circles - [P.R 637](https://github.com/PlayTazUO/TazUO/pull/637) ([bittiez](https://github.com/bittiez))
-* World map pathfinding now supports multi-segment routes — hold the append modifier (Shift by default, rebindable) while Ctrl right-clicking to chain a new path segment onto the current route (A→B→C) instead of restarting - [P.R #](https://github.com/PlayTazUO/TazUO/pull/#) ([bittiez](https://github.com/bittiez))
+* World map pathfinding now supports multi-segment routes — hold the append modifier (Shift by default, rebindable) while Ctrl right-clicking to chain a new path segment onto the current route (A→B→C) instead of restarting - [P.R 638](https://github.com/PlayTazUO/TazUO/pull/638) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
 * Fixed simultaneous drag and resize occurring on resizable windows - [P.R #](https://github.com/PlayTazUO/TazUO/pull/#) ([yuval-po](https://github.com/yuval-po))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable changes to TazUO will be recorded here.
 * Added a clear (X) button to the nameplate manager search field - [P.R 621](https://github.com/PlayTazUO/TazUO/pull/621) ([bittiez](https://github.com/bittiez))
 * Added a scaling option for context menus - [P.R 623](https://github.com/PlayTazUO/TazUO/pull/623) ([bittiez](https://github.com/bittiez))
 * Added marker icons to the web map, served from their source file on disk instead of streaming rendered textures, with a toggle to switch between icons and circles - [P.R 637](https://github.com/PlayTazUO/TazUO/pull/637) ([bittiez](https://github.com/bittiez))
+* World map pathfinding now supports multi-segment routes — hold the append modifier (Shift by default, rebindable) while Ctrl right-clicking to chain a new path segment onto the current route (A→B→C) instead of restarting - [P.R #](https://github.com/PlayTazUO/TazUO/pull/#) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
 * Fixed simultaneous drag and resize occurring on resizable windows - [P.R #](https://github.com/PlayTazUO/TazUO/pull/#) ([yuval-po](https://github.com/yuval-po))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.20</AssemblyVersion>
-    <FileVersion>5.3.20</FileVersion>
+    <AssemblyVersion>5.3.21</AssemblyVersion>
+    <FileVersion>5.3.21</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/Managers/Hotkeys/HotKeyRegistrar.cs
+++ b/src/ClassicUO.Client/Game/Managers/Hotkeys/HotKeyRegistrar.cs
@@ -34,6 +34,7 @@ namespace ClassicUO.Game.Managers.Hotkeys
         #region World map
         public const string WorldMapMarkerId = "worldmap.addmarker";
         public const string WorldMapPathfindId = "worldmap.pathfind";
+        public const string WorldMapPathfindAppendId = "worldmap.pathfind.append";
         #endregion
 
         #region World interaction
@@ -76,6 +77,8 @@ namespace ClassicUO.Game.Managers.Hotkeys
             const string category = "World Map";
             ContextModifier(WorldMapMarkerId, "Add marker", Modifier(ctrl: true), category);
             ContextModifier(WorldMapPathfindId, "Pathfind to point", Modifier(ctrl: true), category);
+            // Held together with the pathfind modifier to append a new segment onto the current route.
+            ContextModifier(WorldMapPathfindAppendId, "Append to current path (with pathfind)", Modifier(shift: true), category);
         }
 
         private static void RegisterGlobal()

--- a/src/ClassicUO.Client/Game/Pathfinder.cs
+++ b/src/ClassicUO.Client/Game/Pathfinder.cs
@@ -1016,6 +1016,40 @@ namespace ClassicUO.Game
             }
         }
 
+        /// <summary>
+        /// Appends additional pre-computed steps onto the path currently being walked by
+        /// <see cref="StartComputedPath"/>, without restarting the walk. Used by the WorldMap
+        /// to chain pathfinding segments (A-&gt;B-&gt;C). Must be called on the main thread.
+        /// Returns <c>false</c> when there is no active computed path to extend (the caller
+        /// should then start a fresh path instead).
+        /// </summary>
+        public bool AppendComputedPath(IReadOnlyList<(int X, int Y, int Z, int Direction)> points)
+        {
+            if (!_computedPathActive || !AutoWalking || points == null || points.Count == 0)
+                return false;
+
+            foreach (var p in points)
+            {
+                var node = PathNode.Get();
+                node.X = p.X;
+                node.Y = p.Y;
+                node.Z = p.Z;
+                node.Direction = p.Direction;
+                node.IsValid = true;
+                _path.Add(node);
+            }
+
+            // The appended nodes are owned by _path just like the originals (StartComputedPath
+            // already set _ownsPathNodes), so CleanupPathfinding will return them to the pool.
+            _endPoint.X = _path[_path.Count - 1].X;
+            _endPoint.Y = _path[_path.Count - 1].Y;
+            _endPointZ = _path[_path.Count - 1].Z;
+
+            // Nudge the walker in case it had already caught up to the previous end and idled.
+            ProcessAutoWalk();
+            return true;
+        }
+
         public List<(int X, int Y, int Z)> GetPathTo(int x, int y, int z, int distance)
         {
             _zLevelDiff = ProfileManager.CurrentProfile.PathfindingZLevelDiff;

--- a/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
@@ -113,6 +113,13 @@ public class WorldMapGump : ResizableGump
     private List<Point> _navPath;
     private Action<int, int> _navStepFailedHandler;
 
+    // End of the currently planned route (world coords + Z). Shift+Ctrl right-click extends
+    // the path by searching from here to the new point, so multi-segment routes chain
+    // A->B->C. _navSegments tracks how many segments make up the active route.
+    private Point _navPlannedEnd;
+    private sbyte _navPlannedEndZ;
+    private int _navSegments;
+
     private const int MAX_NAV_REPLANS = 3;
     private int _navReplansLeft;
 
@@ -877,6 +884,7 @@ public class WorldMapGump : ResizableGump
         _navStepFailedHandler = null;
         _navDest = null;
         _navPath = null;
+        _navSegments = 0;
 
         base.Dispose();
     }
@@ -3429,9 +3437,28 @@ public class WorldMapGump : ResizableGump
             if (button == MouseButtonType.Right && HotKeys.IsPressed(HotKeyRegistrar.WorldMapPathfindId) && !Keyboard.Alt)
             {
                 CanvasToWorld(x, y, out int wX, out int wY);
+                int mapIndex = _world.Map.Index;
+
+                // Shift extends the active route: search from the end of the current path to the
+                // new point and append the result (A->B->C) instead of restarting from the player.
+                bool append = Keyboard.Shift
+                              && _navDest.HasValue
+                              && _world.Player?.Pathfinder != null
+                              && _world.Player.Pathfinder.AutoWalking;
+
+                if (append)
+                {
+                    StartNavPath(mapIndex, _navPlannedEnd.X, _navPlannedEnd.Y, _navPlannedEndZ, wX, wY,
+                                 firstAttempt: true, append: true);
+                    return;
+                }
+
                 _navDest = new Point(wX, wY);
                 _navDestSetTime = Environment.TickCount64;
                 _navPath = null;
+                _navPlannedEnd = new Point(wX, wY);
+                _navPlannedEndZ = _world.Player.Z;
+                _navSegments = 1;
                 ClearGoToMarker();
 
                 // Fresh nav session: clear any dynamic-block memory from a previous run,
@@ -3447,8 +3474,8 @@ public class WorldMapGump : ResizableGump
                 }
                 _navReplansLeft = MaxNavReplans;
 
-                int mapIndex = _world.Map.Index;
-                StartNavPath(mapIndex, _world.Player.X, _world.Player.Y, _world.Player.Z, wX, wY, firstAttempt: true);
+                StartNavPath(mapIndex, _world.Player.X, _world.Player.Y, _world.Player.Z, wX, wY,
+                             firstAttempt: true, append: false);
                 return;
             }
 
@@ -3480,10 +3507,12 @@ public class WorldMapGump : ResizableGump
 
     /// <summary>
     /// Dispatches a WorldMapPathfinder search and hands the result to the walker.
-    /// Registers an on-step-failed hook so dynamic obstacles get added to the dynamic-block
-    /// set and the search retried up to MAX_NAV_REPLANS times.
+    /// When <paramref name="append"/> is set the result is chained onto the route currently
+    /// being walked (multi-segment A-&gt;B-&gt;C) instead of replacing it. For fresh (non-append)
+    /// paths it registers an on-step-failed hook so dynamic obstacles get added to the
+    /// dynamic-block set and the search retried up to MAX_NAV_REPLANS times.
     /// </summary>
-    private void StartNavPath(int mapIndex, int startX, int startY, sbyte startZ, int destX, int destY, bool firstAttempt)
+    private void StartNavPath(int mapIndex, int startX, int startY, sbyte startZ, int destX, int destY, bool firstAttempt, bool append)
     {
         var houseMultis = BuildHouseMultiSnapshot();
 
@@ -3491,10 +3520,18 @@ public class WorldMapGump : ResizableGump
         {
             if (path == null || path.Count == 0)
             {
+                if (append)
+                {
+                    // Couldn't extend the route — leave the existing path intact.
+                    GameActions.Print("Can't extend the path there.");
+                    return;
+                }
+
                 if (firstAttempt)
                     GameActions.Print("Can't find a path there.");
                 _navDest = null;
                 _navPath = null;
+                _navSegments = 0;
                 return;
             }
 
@@ -3505,7 +3542,33 @@ public class WorldMapGump : ResizableGump
                 pathPoints.Add((p.X, p.Y, p.Z, p.Direction));
                 navRender.Add(new Point(p.X, p.Y));
             }
+
+            var last = path[path.Count - 1];
+
+            // Extend the active route without restarting the walk.
+            if (append && _world.Player.Pathfinder.AppendComputedPath(pathPoints))
+            {
+                if (_navPath == null)
+                    _navPath = navRender;
+                else
+                    _navPath.AddRange(navRender);
+
+                _navDest = new Point(last.X, last.Y);
+                _navDestSetTime = Environment.TickCount64;
+                _navPlannedEnd = new Point(last.X, last.Y);
+                _navPlannedEndZ = (sbyte)last.Z;
+                _navSegments++;
+                return;
+            }
+
+            // Fresh path (or an append that found nothing to attach to because the previous
+            // route had already finished): replace whatever was there.
             _navPath = navRender;
+            _navDest = new Point(last.X, last.Y);
+            _navDestSetTime = Environment.TickCount64;
+            _navPlannedEnd = new Point(last.X, last.Y);
+            _navPlannedEndZ = (sbyte)last.Z;
+            _navSegments = 1;
 
             // Unsubscribe any stale handler from a previous plan before registering the new one.
             if (_navStepFailedHandler != null)
@@ -3513,10 +3576,24 @@ public class WorldMapGump : ResizableGump
 
             _navStepFailedHandler = (blockX, blockY) =>
             {
+                // Multi-segment routes can't be locally replanned around a block without
+                // skipping waypoints, so a blocked step clears the entire route.
+                if (_navSegments > 1)
+                {
+                    if (_navStepFailedHandler != null)
+                        _world.Player.Pathfinder.OnComputedPathStepFailed -= _navStepFailedHandler;
+                    _navStepFailedHandler = null;
+                    _navDest = null;
+                    _navPath = null;
+                    _navSegments = 0;
+                    return;
+                }
+
                 if (_navReplansLeft <= 0 || !_navDest.HasValue)
                 {
                     _navDest = null;
                     _navPath = null;
+                    _navSegments = 0;
                     return;
                 }
 
@@ -3525,7 +3602,7 @@ public class WorldMapGump : ResizableGump
 
                 var dest = _navDest.Value;
                 StartNavPath(_world.Map.Index, _world.Player.X, _world.Player.Y, _world.Player.Z,
-                             dest.X, dest.Y, firstAttempt: false);
+                             dest.X, dest.Y, firstAttempt: false, append: false);
             };
             _world.Player.Pathfinder.OnComputedPathStepFailed += _navStepFailedHandler;
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
@@ -3439,9 +3439,10 @@ public class WorldMapGump : ResizableGump
                 CanvasToWorld(x, y, out int wX, out int wY);
                 int mapIndex = _world.Map.Index;
 
-                // Shift extends the active route: search from the end of the current path to the
-                // new point and append the result (A->B->C) instead of restarting from the player.
-                bool append = Keyboard.Shift
+                // The append modifier (Shift by default, rebindable) extends the active route:
+                // search from the end of the current path to the new point and append the result
+                // (A->B->C) instead of restarting from the player.
+                bool append = HotKeys.IsPressed(HotKeyRegistrar.WorldMapPathfindAppendId)
                               && _navDest.HasValue
                               && _world.Player?.Pathfinder != null
                               && _world.Player.Pathfinder.AutoWalking;


### PR DESCRIPTION
Shift+Ctrl right-click on the WorldMap now extends the active route instead of restarting it. Ctrl-click B starts pathfinding A->B; a subsequent Shift+Ctrl-click C searches from the end of the current path (B) to C and, if a path is found, appends it so the player walks A->B->C. If no path to C is found the existing route is left intact.

- Pathfinder.AppendComputedPath chains new steps onto the path being walked without restarting, updating the end point.
- WorldMapGump tracks the planned route end and segment count; a blocked step on a multi-segment route clears the whole route (single-segment routes keep the existing dynamic-block replan behavior).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a world-map hotkey to extend an active auto-walk route with another path segment.
  * Multi-segment world-map navigation now supports appending new destination points without restarting the current route.

* **Bug Fixes**
  * Improved route handling so failed multi-segment paths clear correctly and avoid leaving navigation in an inconsistent state.
  * Better preserves the current path when an appended search cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->