### PR TITLE
Fix Windows PR build: force bash shell for Checkout PR step

### DIFF
--- a/.github/workflows/tuo-pr-build.yml
+++ b/.github/workflows/tuo-pr-build.yml
@@ -44,6 +44,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout PR
+        shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}


### PR DESCRIPTION
The Checkout PR step ran "gh pr checkout $PR_NUMBER" without an explicit shell, so it used each runner's default: bash on Linux/macOS but PowerShell on Windows. In PowerShell $PR_NUMBER does not reference an environment variable, so the argument expanded to an empty string and gh fell back to detecting the PR from the current branch. Because actions/checkout leaves the repo in detached HEAD, that detection failed with "could not determine current branch: not on any branch" and only the Windows job failed.

Pinning the step to bash makes $PR_NUMBER expand correctly on all runners.