### PR TITLE
Keep context menus within window bounds when scaling is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ All notable changes to TazUO will be recorded here.
 * Fixed camera smoothly panning across the map on a teleport (dungeon entrance/exit, recall, gate) instead of snapping to the new location when Camera Smoothing is enabled - [P.R 633](https://github.com/PlayTazUO/TazUO/pull/633) ([bittiez](https://github.com/bittiez))
 * Fixed the Show Target Indicator option not hiding the target bracket graphics while the new target system was enabled; the option now solely controls the brackets - [P.R #](https://github.com/PlayTazUO/TazUO/pull/#) ([bittiez](https://github.com/bittiez))
 * Restored tooltips for mastery spell abilities that were dropped in the mastery spellbook rework - [P.R 635](https://github.com/PlayTazUO/TazUO/pull/635) ([bittiez](https://github.com/bittiez))
+* Fixed context menus rendering outside the window bounds when global or context menu scaling was active, and fixed submenu arrows being clipped out of view at higher scales - [P.R 640](https://github.com/PlayTazUO/TazUO/pull/640) ([bittiez](https://github.com/bittiez))
 
 ### Legion
 * Added ModernNineSliceGump.SetLegionTexture to go along with zip files and custom png's - Use your own png for a 9-slice texture - ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.21</AssemblyVersion>
-    <FileVersion>5.3.21</FileVersion>
+    <AssemblyVersion>5.3.22</AssemblyVersion>
+    <FileVersion>5.3.22</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Controls/ContextMenuControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ContextMenuControl.cs
@@ -82,6 +82,9 @@ namespace ClassicUO.Game.UI.Controls
         private List<ContextMenuShowMenu> _subMenus;
         private readonly double _scale;
 
+        internal int MenuWidth => _background.Width;
+        internal int MenuHeight => _background.Height;
+
 
         public ContextMenuShowMenu(World world, List<ContextMenuItemEntry> list) : base(world, 0, 0)
         {
@@ -125,9 +128,18 @@ namespace ClassicUO.Game.UI.Controls
                 y += item.Height;
             }
 
-            if(y >= Client.Game.Window.ClientBounds.Height >> 1)
+            // The window's client bounds are in physical pixels, but the menu's
+            // coordinates and size (and Mouse.Position) live in logical UI space,
+            // which the global RenderScale maps onto the screen. The context menu
+            // scale is already baked into _background.Width/Height. Convert the
+            // window bounds into that same logical space so the menu stays on
+            // screen regardless of global or context menu scaling.
+            int windowWidth = (int)(Client.Game.Window.ClientBounds.Width / Client.Game.RenderScale);
+            int windowHeight = (int)(Client.Game.Window.ClientBounds.Height / Client.Game.RenderScale);
+
+            if (y >= windowHeight >> 1)
             {
-                y = Client.Game.Window.ClientBounds.Height >> 1;
+                y = windowHeight >> 1;
             }
 
             _scroll.Height = Height = _background.Height = y;
@@ -136,14 +148,19 @@ namespace ClassicUO.Game.UI.Controls
             X = Mouse.Position.X + 5;
             Y = Mouse.Position.Y - 20;
 
-            if (X + _background.Width > Client.Game.Window.ClientBounds.Width)
+            if (X + _background.Width > windowWidth)
             {
-                X = Client.Game.Window.ClientBounds.Width - _background.Width;
+                X = windowWidth - _background.Width;
             }
 
-            if (Y + _background.Height > Client.Game.Window.ClientBounds.Height)
+            if (X < 0)
             {
-                Y = Client.Game.Window.ClientBounds.Height - _background.Height;
+                X = 0;
+            }
+
+            if (Y + _background.Height > windowHeight)
+            {
+                Y = windowHeight - _background.Height;
             }
 
             if (Y < 0)
@@ -302,8 +319,36 @@ namespace ClassicUO.Game.UI.Controls
 
                 if (_subMenu != null)
                 {
-                    _subMenu.X = Width;
-                    _subMenu.Y = Y;
+                    // Bounds are in physical pixels; submenu coordinates live in the
+                    // same logical UI space as the parent, so scale by RenderScale.
+                    int windowWidth = (int)(Client.Game.Window.ClientBounds.Width / Client.Game.RenderScale);
+                    int windowHeight = (int)(Client.Game.Window.ClientBounds.Height / Client.Game.RenderScale);
+
+                    // Open to the right by default, but flip to the left of the parent
+                    // menu if the submenu would run off the right edge of the window.
+                    if (_gump.X + Width + _subMenu.MenuWidth > windowWidth && _gump.X - _subMenu.MenuWidth >= 0)
+                    {
+                        _subMenu.X = -_subMenu.MenuWidth;
+                    }
+                    else
+                    {
+                        _subMenu.X = Width;
+                    }
+
+                    // Keep the submenu inside the window vertically.
+                    int subMenuY = Y;
+
+                    if (_gump.Y + subMenuY + _subMenu.MenuHeight > windowHeight)
+                    {
+                        subMenuY = windowHeight - _subMenu.MenuHeight - _gump.Y;
+                    }
+
+                    if (_gump.Y + subMenuY < 0)
+                    {
+                        subMenuY = -_gump.Y;
+                    }
+
+                    _subMenu.Y = subMenuY;
 
                     if (MouseIsOver)
                     {

--- a/src/ClassicUO.Client/Game/UI/Controls/ContextMenuControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ContextMenuControl.cs
@@ -285,6 +285,12 @@ namespace ClassicUO.Game.UI.Controls
                     Width = (int)(100 * _scale);
                 }
 
+                // The parent ScrollArea always clips the right edge by its scrollbar
+                // gutter, so reserve that space here; otherwise the submenu arrow (and
+                // any right-aligned content) gets clipped away - which is especially
+                // visible once global scaling forces the menu to scroll.
+                Width += ScrollArea.SCROLLBAR_WIDTH;
+
                 // it is a bit tricky, but works :D
                 if (_entry.Items != null && _entry.Items.Count != 0)
                 {
@@ -417,7 +423,9 @@ namespace ClassicUO.Game.UI.Controls
 
                 if (_entry.Items != null && _entry.Items.Count != 0)
                 {
-                    _moreMenuLabel.Draw(batcher, x + Width - (int)((_moreMenuLabel.Width + 5) * _scale), y + (Height >> 1) - ((int)(_moreMenuLabel.Height * _scale) >> 1) - 1, _scale);
+                    // Keep the arrow left of the ScrollArea's clipped scrollbar gutter
+                    // so it stays visible at any global/context menu scale.
+                    _moreMenuLabel.Draw(batcher, x + Width - ScrollArea.SCROLLBAR_WIDTH - (int)((_moreMenuLabel.Width + 5) * _scale), y + (Height >> 1) - ((int)(_moreMenuLabel.Height * _scale) >> 1) - 1, _scale);
                 }
 
                 return true;

--- a/src/ClassicUO.Client/Game/UI/Controls/ScrollArea.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ScrollArea.cs
@@ -15,6 +15,13 @@ namespace ClassicUO.Game.UI.Controls
 
     public class ScrollArea : Control
     {
+        /// <summary>
+        /// Width reserved on the right edge for the normal scrollbar. Content is
+        /// always clipped to this gutter, so callers drawing at the right edge must
+        /// account for it or their content will be hidden.
+        /// </summary>
+        public const int SCROLLBAR_WIDTH = 14;
+
         private bool _isNormalScroll;
         private readonly ScrollBarBase _scrollBar;
 
@@ -36,7 +43,7 @@ namespace ClassicUO.Game.UI.Controls
 
             if (normalScrollbar)
             {
-                _scrollBar = new ScrollBar(Width - 14, 0, Height);
+                _scrollBar = new ScrollBar(Width - SCROLLBAR_WIDTH, 0, Height);
             }
             else
             {
@@ -88,7 +95,7 @@ namespace ClassicUO.Game.UI.Controls
         public void UpdateScrollbarPosition()
         {
             if (_isNormalScroll)
-                _scrollBar.X = Width - 14;
+                _scrollBar.X = Width - SCROLLBAR_WIDTH;
             else
                 _scrollBar.X = Width - 19;
         }
@@ -124,7 +131,7 @@ namespace ClassicUO.Game.UI.Controls
             var scrollbar = (ScrollBarBase)Children[0];
             scrollbar.Draw(batcher, x + scrollbar.X, y + scrollbar.Y);
 
-            if (batcher.ClipBegin(x + ScissorRectangle.X, y + ScissorRectangle.Y, Width - 14 + ScissorRectangle.Width, Height + ScissorRectangle.Height))
+            if (batcher.ClipBegin(x + ScissorRectangle.X, y + ScissorRectangle.Y, Width - SCROLLBAR_WIDTH + ScissorRectangle.Width, Height + ScissorRectangle.Height))
             {
                 for (int i = 1; i < Children.Count; i++)
                 {


### PR DESCRIPTION
Context menu coordinates and sizes live in logical UI space, but the on-screen bounds check compared against the physical window ClientBounds. When global RenderScale (or context menu scale) was active, this let menus extend past the visible window edges. Convert the window bounds into logical space (dividing by RenderScale) so the primary menu clamps correctly, and add horizontal-flip / vertical-clamp handling so submenus stay on screen too.