### PR TITLE
Apply Retrieve Gumps to Myra (iGui) windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ All notable changes to TazUO will be recorded here.
 * Fixed the Show Target Indicator option not hiding the target bracket graphics while the new target system was enabled; the option now solely controls the brackets - [P.R #](https://github.com/PlayTazUO/TazUO/pull/#) ([bittiez](https://github.com/bittiez))
 * Restored tooltips for mastery spell abilities that were dropped in the mastery spellbook rework - [P.R 635](https://github.com/PlayTazUO/TazUO/pull/635) ([bittiez](https://github.com/bittiez))
 * Fixed context menus rendering outside the window bounds when global or context menu scaling was active, and fixed submenu arrows being clipped out of view at higher scales - [P.R 640](https://github.com/PlayTazUO/TazUO/pull/640) ([bittiez](https://github.com/bittiez))
+* Retrieve Gumps now also brings Myra (iGui) windows such as the Script Manager back on screen, and accounts for game scale - [P.R 641](https://github.com/PlayTazUO/TazUO/pull/641) ([bittiez](https://github.com/bittiez))
 
 ### Legion
 * Added ModernNineSliceGump.SetLegionTexture to go along with zip files and custom png's - Use your own png for a 9-slice texture - ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.22</AssemblyVersion>
-    <FileVersion>5.3.22</FileVersion>
+    <AssemblyVersion>5.3.23</AssemblyVersion>
+    <FileVersion>5.3.23</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Controls/MyraControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/MyraControl.cs
@@ -222,13 +222,19 @@ public class MyraControl : IGui
     /// </summary>
     public void SetInScreen()
     {
-        Rectangle windowBounds = Client.Game.Window.ClientBounds;
+        // The window's client bounds are in physical pixels, but this window's
+        // coordinates and size live in logical UI space, which the global
+        // RenderScale maps onto the screen. Convert the bounds into that same
+        // logical space so clamping stays correct at any game scale.
+        float scale = Client.Game.RenderScale;
+        int windowWidth = (int)(Client.Game.Window.ClientBounds.Width / scale);
+        int windowHeight = (int)(Client.Game.Window.ClientBounds.Height / scale);
 
         int halfWidth = Width / 2;
         int halfHeight = Height / 2;
 
-        int newX = (int)MathHelper.Clamp(X, -halfWidth, windowBounds.Width - halfWidth);
-        int newY = (int)MathHelper.Clamp(Y, -halfHeight, windowBounds.Height - halfHeight);
+        int newX = (int)MathHelper.Clamp(X, -halfWidth, windowWidth - halfWidth);
+        int newY = (int)MathHelper.Clamp(Y, -halfHeight, windowHeight - halfHeight);
 
         SetPosition(newX, newY);
     }

--- a/src/ClassicUO.Client/Game/UI/Controls/MyraControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/MyraControl.cs
@@ -216,6 +216,23 @@ public class MyraControl : IGui
         UpdateBoundsToContents();
     }
 
+    /// <summary>
+    /// Ensure this window is at least partially within the game window bounds,
+    /// clamping its position so it can be retrieved when it ends up off-screen.
+    /// </summary>
+    public void SetInScreen()
+    {
+        Rectangle windowBounds = Client.Game.Window.ClientBounds;
+
+        int halfWidth = Width / 2;
+        int halfHeight = Height / 2;
+
+        int newX = (int)MathHelper.Clamp(X, -halfWidth, windowBounds.Width - halfWidth);
+        int newY = (int)MathHelper.Clamp(Y, -halfHeight, windowBounds.Height - halfHeight);
+
+        SetPosition(newX, newY);
+    }
+
     public virtual void Update()
     {
         if (IsDisposed)

--- a/src/ClassicUO.Client/Game/UI/Gumps/TopBarGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/TopBarGump.cs
@@ -259,9 +259,17 @@ namespace ClassicUO.Game.UI.Gumps
                 {
                     IGui c = last.Value;
 
-                    if (!c.IsDisposed && c is Gump g)
+                    if (c.IsDisposed)
+                        continue;
+
+                    switch (c)
                     {
-                        g.SetInScreen();
+                        case Gump g:
+                            g.SetInScreen();
+                            break;
+                        case MyraControl m:
+                            m.SetInScreen();
+                            break;
                     }
                 }
             }));


### PR DESCRIPTION
The Retrieve Gumps top-bar option only called SetInScreen() on Gump instances, so Myra-based windows (e.g. Script Manager) that were dragged off-screen could not be retrieved. Add a SetInScreen() to MyraControl and handle both Gump and MyraControl in the retrieve loop.