### PR TITLE
Fix context menu submenus being unreachable when they open to the left

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ All notable changes to TazUO will be recorded here.
 * Restored tooltips for mastery spell abilities that were dropped in the mastery spellbook rework - [P.R 635](https://github.com/PlayTazUO/TazUO/pull/635) ([bittiez](https://github.com/bittiez))
 * Fixed context menus rendering outside the window bounds when global or context menu scaling was active, and fixed submenu arrows being clipped out of view at higher scales - [P.R 640](https://github.com/PlayTazUO/TazUO/pull/640) ([bittiez](https://github.com/bittiez))
 * Retrieve Gumps now also brings Myra (iGui) windows such as the Script Manager back on screen, and accounts for game scale - [P.R 641](https://github.com/PlayTazUO/TazUO/pull/641) ([bittiez](https://github.com/bittiez))
+* Fixed context menu submenus being unreachable when they open to the left (or upward) near the screen edge, where moving the mouse onto them closed the whole menu - [P.R 642](https://github.com/PlayTazUO/TazUO/pull/642) ([bittiez](https://github.com/bittiez))
 
 ### Legion
 * Added ModernNineSliceGump.SetLegionTexture to go along with zip files and custom png's - Use your own png for a 9-slice texture - ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.23</AssemblyVersion>
-    <FileVersion>5.3.23</FileVersion>
+    <AssemblyVersion>5.3.24</AssemblyVersion>
+    <FileVersion>5.3.24</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Controls/ContextMenuControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ContextMenuControl.cs
@@ -182,6 +182,51 @@ namespace ClassicUO.Game.UI.Controls
         {
             base.Update();
             WantUpdateSize = true;
+
+            // Submenus that have no room to the right open to the left of this menu and
+            // therefore live at a negative X (and, near the bottom of the screen, can sit
+            // above it at a negative Y). base.Update only ever grows the bounds rectangle
+            // right/down, and Control.HitTest gates on that rectangle before descending
+            // into children, so those left/up regions are unreachable: moving the mouse
+            // onto a left-opening submenu is treated as leaving the menu and closes it.
+            // Extend the hit-test bounds to cover any negative-offset children without
+            // moving anything that is drawn (this gump is drawn at its raw X/Y, so the
+            // offset only affects hit testing).
+            int left = 0, top = 0;
+
+            for (int i = 0; i < Children.Count; i++)
+            {
+                IGui c = Children[i];
+
+                if (c == null || c.IsDisposed || !c.IsVisible)
+                {
+                    continue;
+                }
+
+                if (c.X < left)
+                {
+                    left = c.X;
+                }
+
+                if (c.Y < top)
+                {
+                    top = c.Y;
+                }
+            }
+
+            SetHitTestOffset(left, top);
+
+            // Keep the right/bottom edges where base.Update put them while pushing the
+            // left/top edges out to include the negative-offset children.
+            if (left < 0)
+            {
+                Width -= left;
+            }
+
+            if (top < 0)
+            {
+                Height -= top;
+            }
         }
 
         public override bool Draw(UltimaBatcher2D batcher, int x, int y)

--- a/src/ClassicUO.Client/Game/UI/Controls/Control.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/Control.cs
@@ -258,6 +258,18 @@ namespace ClassicUO.Game.UI.Controls
         }
     }
 
+    /// <summary>
+    /// Sets this control's own hit-test offset without propagating it to children,
+    /// unlike <see cref="UpdateOffset"/>. Used by controls (e.g. context menus) whose
+    /// sub-content is drawn outside the normal bounds rectangle and would otherwise be
+    /// unreachable by the mouse.
+    /// </summary>
+    protected void SetHitTestOffset(int x, int y)
+    {
+        _offset.X = x;
+        _offset.Y = y;
+    }
+
     public virtual bool Draw(UltimaBatcher2D batcher, int x, int y)
     {
         if (IsDisposed)


### PR DESCRIPTION
When a context menu is opened near the right edge of the screen, its submenus flip to open on the left of the parent menu. Those submenus are added as children at a negative X, but Control.HitTest gates on the raw bounds rectangle (which base.Update only ever grows right/down) before descending into children. As a result the left-side submenu region was never hit-tested: moving the mouse onto it registered as leaving the menu and closed the whole thing.

Extend the menu gump's hit-test bounds to cover any negative-offset children by pushing the left/top edges out via a non-propagating hit-test offset while keeping the right/bottom edges base.Update computed. Since the context menu is drawn at its raw X/Y, this affects only hit testing and does not move anything on screen. Also covers submenus that open upward near the bottom of the screen.