### PR TITLE
Add suggested-fix note for plugin/copilot load crashes

### DIFF
--- a/src/ClassicUO.Client/CrashSuggestedFix.cs
+++ b/src/ClassicUO.Client/CrashSuggestedFix.cs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+using ClassicUO.Utility.Logging;
+using System;
+using System.IO;
+using System.Text;
+
+namespace ClassicUO
+{
+    /// <summary>
+    /// Inspects an unhandled exception and, when the cause is recognized, returns a
+    /// human-friendly explanation and suggested fix that is shown in the crash log.
+    /// Keeping this out of <see cref="Bootstrap"/> lets the list of known crashes grow
+    /// without cluttering Main.cs.
+    /// </summary>
+    internal static class CrashSuggestedFix
+    {
+        /// <summary>
+        /// Returns a suggested fix for the given exception, or <c>null</c> when the crash
+        /// is not one we have specific advice for.
+        /// </summary>
+        public static string Get(object e)
+        {
+            try
+            {
+                if (e is not Exception exception)
+                {
+                    return null;
+                }
+
+                if (exception is ArgumentOutOfRangeException argumentOutOfRangeException &&
+                    argumentOutOfRangeException.StackTrace?.Contains("Microsoft.Xna.Framework.Graphics.GraphicsAdapter.get_DefaultAdapter()") == true)
+                {
+                    return "It appears TazUO was unable to find a suitable graphics adapter to use. " +
+                           "This can sometimes occur if your operating system shuts down your graphics adapter to preserve power.";
+                }
+
+                if (Client.IsShaderCompileFailure(exception))
+                {
+                    return Client.GraphicsShaderHelpMessage;
+                }
+
+                if (exception is Microsoft.Xna.Framework.Graphics.NoSuitableGraphicsDeviceException noSuitableGraphicsDeviceException)
+                {
+                    if (noSuitableGraphicsDeviceException.Message.Contains("OpenGL 2.1 support is required!"))
+                    {
+                        var sb = new StringBuilder();
+                        sb.AppendLine("TazUO was unable to find a graphics device with the required OpenGL 2.1 support.");
+                        sb.AppendLine("This usually means your graphics drivers are missing, out of date, or the client fell back to a software renderer (GDI Generic).");
+                        sb.AppendLine();
+                        sb.AppendLine("Suggested fixes:");
+                        sb.AppendLine("1. Update your graphics card drivers to the latest version.");
+                        sb.AppendLine("2. Try launching TazUO with a different graphics driver by adding one of the following command-line arguments:");
+                        sb.AppendLine("     -force_driver 1   (OpenGL)");
+                        sb.AppendLine("     -force_driver 2   (Vulkan)");
+                        sb.AppendLine("     -force_driver 3   (SDL/FNA auto-select)");
+                        sb.AppendLine("   Try each one in turn until the client starts successfully.");
+                        return sb.ToString();
+                    }
+
+                    if (noSuitableGraphicsDeviceException.Message.Contains("Could not create swapchain!"))
+                    {
+                        string dataPath = Path.Join(CUOEnviroment.ExecutablePath, "Data");
+                        string scriptsPath = Path.Join(CUOEnviroment.ExecutablePath, "LegionScripts");
+                        var sb = new StringBuilder();
+                        sb.AppendLine("Issue analysis indicates a potential conflict with your TazUO installation.");
+                        sb.AppendLine("The client does not support side-by-side installation of both legacy and modern builds.");
+                        sb.AppendLine($"Please backup your data ('{dataPath}') and script ('{scriptsPath}') folders and delete everything else.");
+                        sb.AppendLine("Re-download *only* your selected channel (Legacy or Modern) from the launcher.");
+                        sb.AppendLine("Copy your backed up Data and LegionScripts folders back to where they were.");
+                        return sb.ToString();
+                    }
+                }
+
+                if (TryGetPluginCrashFix(exception, out string pluginFix))
+                {
+                    return pluginFix;
+                }
+            }
+            catch
+            {
+                Log.Error("Failed to obtain a suggested fix for error");
+            }
+
+            return null;
+        }
+
+        private static bool TryGetPluginCrashFix(Exception e, out string fix)
+        {
+            fix = null;
+
+            // ToString() on the top-level exception includes the stack traces of any inner
+            // (and aggregated) exceptions, so we can inspect the whole chain in one string.
+            string details = e.ToString();
+
+            if (string.IsNullOrEmpty(details))
+                return false;
+
+            // These frames only appear when the crash happened while TazUO was loading a
+            // third-party plugin (assistant/copilot, e.g. Razor or a UO "copilot"). Such
+            // plugins run their own initialization code - and often bundle their own copy of
+            // the UO file loaders - so a crash originating here comes from the plugin, not
+            // from TazUO itself.
+            bool crashedInPluginLoad =
+                details.Contains("ClassicUO.Network.Plugin.Load") ||
+                details.Contains("ClassicUO.Network.Plugin.Create") ||
+                details.Contains("GameController.LoadPlugins");
+
+            if (!crashedInPluginLoad)
+                return false;
+
+            var sb = new StringBuilder();
+            sb.AppendLine("A plugin failed to start and crashed TazUO.");
+            sb.AppendLine("The error above was thrown by a third-party plugin's own code while it was being loaded, not by TazUO itself.");
+            sb.AppendLine();
+            sb.AppendLine("Suggested fixes:");
+            sb.AppendLine("1. Update the plugin to its latest version, or temporarily remove/disable it to confirm it is the cause.");
+            sb.AppendLine("2. Make sure the plugin is pointed at the same valid UO data directory that TazUO uses.");
+            sb.AppendLine("   Many assistants load the UO art/map files themselves and will crash if that path is wrong or the files are missing.");
+            sb.AppendLine("3. Verify the plugin supports your client version and this build of TazUO.");
+            sb.AppendLine("4. If it keeps crashing, send this crash log to the plugin's author.");
+
+            fix = sb.ToString();
+            return true;
+        }
+    }
+}

--- a/src/ClassicUO.Client/Main.cs
+++ b/src/ClassicUO.Client/Main.cs
@@ -277,6 +277,11 @@ namespace ClassicUO
                     sb.AppendLine("Copy your backed up Data and LegionScripts folders back to where they were.");
                     return sb.ToString();
                 }
+
+                if (e is Exception pluginException && TryGetPluginCrashFix(pluginException, out string pluginFix))
+                {
+                    return pluginFix;
+                }
             }
             catch
             {
@@ -284,6 +289,45 @@ namespace ClassicUO
             }
 
             return null;
+        }
+
+        private static bool TryGetPluginCrashFix(Exception e, out string fix)
+        {
+            fix = null;
+
+            // ToString() on the top-level exception includes the stack traces of any inner
+            // (and aggregated) exceptions, so we can inspect the whole chain in one string.
+            string details = e.ToString();
+
+            if (string.IsNullOrEmpty(details))
+                return false;
+
+            // These frames only appear when the crash happened while TazUO was loading a
+            // third-party plugin (assistant/copilot, e.g. Razor or a UO "copilot"). Such
+            // plugins run their own initialization code - and often bundle their own copy of
+            // the UO file loaders - so a crash originating here comes from the plugin, not
+            // from TazUO itself.
+            bool crashedInPluginLoad =
+                details.Contains("ClassicUO.Network.Plugin.Load") ||
+                details.Contains("ClassicUO.Network.Plugin.Create") ||
+                details.Contains("GameController.LoadPlugins");
+
+            if (!crashedInPluginLoad)
+                return false;
+
+            var sb = new StringBuilder();
+            sb.AppendLine("A plugin (assistant/copilot) failed to start and crashed TazUO.");
+            sb.AppendLine("The error above was thrown by a third-party plugin's own code while it was being loaded, not by TazUO itself.");
+            sb.AppendLine();
+            sb.AppendLine("Suggested fixes:");
+            sb.AppendLine("1. Update the plugin to its latest version, or temporarily remove/disable it to confirm it is the cause.");
+            sb.AppendLine("2. Make sure the plugin is pointed at the same valid Ultima Online data directory that TazUO uses.");
+            sb.AppendLine("   Many assistants load the UO art/map files themselves and will crash if that path is wrong or the files are missing.");
+            sb.AppendLine("3. Verify the plugin supports your client version and this build of TazUO.");
+            sb.AppendLine("4. If it keeps crashing, send this crash log to the plugin's author.");
+
+            fix = sb.ToString();
+            return true;
         }
 
         private static void ReadSettingsFromArgs(string[] args)

--- a/src/ClassicUO.Client/Main.cs
+++ b/src/ClassicUO.Client/Main.cs
@@ -72,7 +72,7 @@ namespace ClassicUO
                 sb.AppendFormat("Exception:\n{0}\n", e.ExceptionObject);
                 sb.AppendLine();
 
-                string suggestedFix = GetSuggestedFix(e.ExceptionObject);
+                string suggestedFix = CrashSuggestedFix.Get(e.ExceptionObject);
 
                 HtmlCrashLogGen.Generate(sb.ToString(), additional_notes: suggestedFix.NotNullNotEmpty() ? suggestedFix : string.Empty);
 
@@ -229,105 +229,6 @@ namespace ClassicUO
             }
 
             Log.Trace("Closing...");
-        }
-
-        private static string GetSuggestedFix(object e)
-        {
-            try
-            {
-                if (e is ArgumentOutOfRangeException argumentOutOfRangeException &&
-                    argumentOutOfRangeException.StackTrace?.Contains("Microsoft.Xna.Framework.Graphics.GraphicsAdapter.get_DefaultAdapter()") == true)
-                {
-                    return "It appears TazUO was unable to find a suitable graphics adapter to use. " +
-                           "This can sometimes occur if your operating system shuts down your graphics adapter to preserve power.";
-                }
-
-                if (e is Exception shaderException && Client.IsShaderCompileFailure(shaderException))
-                {
-                    return Client.GraphicsShaderHelpMessage;
-                }
-
-                if (e is Microsoft.Xna.Framework.Graphics.NoSuitableGraphicsDeviceException openGlException &&
-                    openGlException.Message.Contains("OpenGL 2.1 support is required!"))
-                {
-                    var sb = new StringBuilder();
-                    sb.AppendLine("TazUO was unable to find a graphics device with the required OpenGL 2.1 support.");
-                    sb.AppendLine("This usually means your graphics drivers are missing, out of date, or the client fell back to a software renderer (GDI Generic).");
-                    sb.AppendLine();
-                    sb.AppendLine("Suggested fixes:");
-                    sb.AppendLine("1. Update your graphics card drivers to the latest version.");
-                    sb.AppendLine("2. Try launching TazUO with a different graphics driver by adding one of the following command-line arguments:");
-                    sb.AppendLine("     -force_driver 1   (OpenGL)");
-                    sb.AppendLine("     -force_driver 2   (Vulkan)");
-                    sb.AppendLine("     -force_driver 3   (SDL/FNA auto-select)");
-                    sb.AppendLine("   Try each one in turn until the client starts successfully.");
-                    return sb.ToString();
-                }
-
-                if (e is Microsoft.Xna.Framework.Graphics.NoSuitableGraphicsDeviceException graphicsException &&
-                    graphicsException.Message.Contains("Could not create swapchain!"))
-                {
-                    string dataPath = Path.Join(CUOEnviroment.ExecutablePath, "Data");
-                    string scriptsPath = Path.Join(CUOEnviroment.ExecutablePath, "LegionScripts");
-                    var sb = new StringBuilder();
-                    sb.AppendLine("Issue analysis indicates a potential conflict with your TazUO installation.");
-                    sb.AppendLine("The client does not support side-by-side installation of both legacy and modern builds.");
-                    sb.AppendLine($"Please backup your data ('{dataPath}') and script ('{scriptsPath}') folders and delete everything else.");
-                    sb.AppendLine("Re-download *only* your selected channel (Legacy or Modern) from the launcher.");
-                    sb.AppendLine("Copy your backed up Data and LegionScripts folders back to where they were.");
-                    return sb.ToString();
-                }
-
-                if (e is Exception pluginException && TryGetPluginCrashFix(pluginException, out string pluginFix))
-                {
-                    return pluginFix;
-                }
-            }
-            catch
-            {
-                Log.Error("Failed to obtain a suggested fix for error");
-            }
-
-            return null;
-        }
-
-        private static bool TryGetPluginCrashFix(Exception e, out string fix)
-        {
-            fix = null;
-
-            // ToString() on the top-level exception includes the stack traces of any inner
-            // (and aggregated) exceptions, so we can inspect the whole chain in one string.
-            string details = e.ToString();
-
-            if (string.IsNullOrEmpty(details))
-                return false;
-
-            // These frames only appear when the crash happened while TazUO was loading a
-            // third-party plugin (assistant/copilot, e.g. Razor or a UO "copilot"). Such
-            // plugins run their own initialization code - and often bundle their own copy of
-            // the UO file loaders - so a crash originating here comes from the plugin, not
-            // from TazUO itself.
-            bool crashedInPluginLoad =
-                details.Contains("ClassicUO.Network.Plugin.Load") ||
-                details.Contains("ClassicUO.Network.Plugin.Create") ||
-                details.Contains("GameController.LoadPlugins");
-
-            if (!crashedInPluginLoad)
-                return false;
-
-            var sb = new StringBuilder();
-            sb.AppendLine("A plugin (assistant/copilot) failed to start and crashed TazUO.");
-            sb.AppendLine("The error above was thrown by a third-party plugin's own code while it was being loaded, not by TazUO itself.");
-            sb.AppendLine();
-            sb.AppendLine("Suggested fixes:");
-            sb.AppendLine("1. Update the plugin to its latest version, or temporarily remove/disable it to confirm it is the cause.");
-            sb.AppendLine("2. Make sure the plugin is pointed at the same valid Ultima Online data directory that TazUO uses.");
-            sb.AppendLine("   Many assistants load the UO art/map files themselves and will crash if that path is wrong or the files are missing.");
-            sb.AppendLine("3. Verify the plugin supports your client version and this build of TazUO.");
-            sb.AppendLine("4. If it keeps crashing, send this crash log to the plugin's author.");
-
-            fix = sb.ToString();
-            return true;
         }
 
         private static void ReadSettingsFromArgs(string[] args)


### PR DESCRIPTION
When a third-party plugin (assistant/copilot) throws during load, the crash originates in the plugin's own code rather than TazUO. Detect plugin-load frames in the exception chain and surface a suggested fix noting that a plugin crashed the client and how to resolve it.