### PR TITLE
Add scaling support to the trade gump

### DIFF
--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -788,6 +788,8 @@ namespace ClassicUO.Configuration
 
         public double ContextMenuScale { get; set => SetProperty(ref field, Math.Clamp(value, 0.5d, 3.0d)); } = 1f;
 
+        public double TradeGumpScale { get; set => SetProperty(ref field, Math.Clamp(value, 0.5d, 3.0d)); } = 1f;
+
         /// <summary>
         /// Scale applied to every server created gump (and all of its controls).
         /// </summary>

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -5,7 +5,7 @@
 ; Missing keys are auto-appended with English defaults when
 ; this file's version is newer than the user's copy.
 ; -------------------------------------------------------
-_version=31
+_version=32
 accountname=Account Name
 accountcontextmenutooltip=Right click to select another account.
 music=Music
@@ -705,3 +705,5 @@ gumpscaling_statusgump=Status Gump
 gumpscaling_statusgumpscaling=Status gump scaling
 gumpscaling_contextmenu=Context Menus
 gumpscaling_contextmenuscaling=Context menu scaling
+gumpscaling_tradegump=Trade Gump
+gumpscaling_tradegumpscaling=Trade gump scaling

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
@@ -4869,6 +4869,20 @@ namespace ClassicUO.Game.UI.Gumps
             (
                 new SliderWithLabel
                 (
+                    TazLang.Get("gumpscaling_tradegump", "Trade Gump"), 0, ThemeSettings.SLIDER_WIDTH, 50, 300,
+                    (int)(profile.TradeGumpScale * 100), (i) =>
+                    {
+                        //Must be cast even though VS thinks it's redundant.
+                        double v = (double)i / (double)100;
+                        profile.TradeGumpScale = v > 0 ? v : 1f;
+                    }
+                ), true, page
+            );
+
+            content.AddToRight
+            (
+                new SliderWithLabel
+                (
                     TazLang.Get("gumpscaling_servergump", "Server Gumps"), 0, ThemeSettings.SLIDER_WIDTH, 50, 300,
                     (int)(profile.ServerGumpScale * 100), (i) =>
                     {

--- a/src/ClassicUO.Client/Game/UI/Gumps/TradingGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/TradingGump.cs
@@ -292,8 +292,8 @@ namespace ClassicUO.Game.UI.Gumps
 
                         if (GumpScale != 1.0)
                         {
-                            x = (int)(x / GumpScale);
-                            y = (int)(y / GumpScale);
+                            x = ScaleHelper.Unscaled(x, GumpScale);
+                            y = ScaleHelper.Unscaled(y, GumpScale);
                         }
 
                         if (artInfo.Texture != null)

--- a/src/ClassicUO.Client/Game/UI/Gumps/TradingGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/TradingGump.cs
@@ -1,6 +1,7 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
 using System;
+using ClassicUO.Configuration;
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.UI.Controls;
@@ -13,8 +14,11 @@ using Microsoft.Xna.Framework;
 
 namespace ClassicUO.Game.UI.Gumps
 {
-    public sealed class TradingGump : TextContainerGump
+    public sealed class TradingGump : ScalableTextContainerGump
     {
+        private const int BOX_WIDTH = 110;
+        private const int BOX_HEIGHT = 80;
+
         private uint _gold,
             _platinum,
             _hisGold,
@@ -42,6 +46,9 @@ namespace ClassicUO.Game.UI.Gumps
 
             ID1 = id1;
             ID2 = id2;
+
+            if (ProfileManager.CurrentProfile != null)
+                GumpScale = ProfileManager.CurrentProfile.TradeGumpScale;
 
             BuildGump();
         }
@@ -175,14 +182,14 @@ namespace ClassicUO.Game.UI.Gumps
 
                 if (artInfo.Texture != null)
                 {
-                    if (x + artInfo.UV.Width > _myBox.Width)
+                    if (x + artInfo.UV.Width > BOX_WIDTH)
                     {
-                        x = _myBox.Width - artInfo.UV.Width;
+                        x = BOX_WIDTH - artInfo.UV.Width;
                     }
 
-                    if (y + artInfo.UV.Height > _myBox.Height)
+                    if (y + artInfo.UV.Height > BOX_HEIGHT)
                     {
-                        y = _myBox.Height - artInfo.UV.Height;
+                        y = BOX_HEIGHT - artInfo.UV.Height;
                     }
                 }
 
@@ -198,6 +205,11 @@ namespace ClassicUO.Game.UI.Gumps
 
                 g.X = x;
                 g.Y = y;
+
+                if (GumpScale != 1.0)
+                {
+                    g.ApplyScale(GumpScale);
+                }
 
                 _myBox.Add(g);
             }
@@ -230,14 +242,14 @@ namespace ClassicUO.Game.UI.Gumps
 
                 if (artInfo.Texture != null)
                 {
-                    if (x + artInfo.UV.Width > _myBox.Width)
+                    if (x + artInfo.UV.Width > BOX_WIDTH)
                     {
-                        x = _myBox.Width - artInfo.UV.Width;
+                        x = BOX_WIDTH - artInfo.UV.Width;
                     }
 
-                    if (y + artInfo.UV.Height > _myBox.Height)
+                    if (y + artInfo.UV.Height > BOX_HEIGHT)
                     {
-                        y = _myBox.Height - artInfo.UV.Height;
+                        y = BOX_HEIGHT - artInfo.UV.Height;
                     }
                 }
 
@@ -253,6 +265,11 @@ namespace ClassicUO.Game.UI.Gumps
 
                 g.X = x;
                 g.Y = y;
+
+                if (GumpScale != 1.0)
+                {
+                    g.ApplyScale(GumpScale);
+                }
 
                 _hisBox.Add(g);
             }
@@ -273,19 +290,25 @@ namespace ClassicUO.Game.UI.Gumps
                         x -= _myBox.X;
                         y -= _myBox.Y;
 
+                        if (GumpScale != 1.0)
+                        {
+                            x = (int)(x / GumpScale);
+                            y = (int)(y / GumpScale);
+                        }
+
                         if (artInfo.Texture != null)
                         {
                             x -= artInfo.UV.Width >> 1;
                             y -= artInfo.UV.Height >> 1;
 
-                            if (x + artInfo.UV.Width > _myBox.Width)
+                            if (x + artInfo.UV.Width > BOX_WIDTH)
                             {
-                                x = _myBox.Width - artInfo.UV.Width;
+                                x = BOX_WIDTH - artInfo.UV.Width;
                             }
 
-                            if (y + artInfo.UV.Height > _myBox.Height)
+                            if (y + artInfo.UV.Height > BOX_HEIGHT)
                             {
-                                y = _myBox.Height - artInfo.UV.Height;
+                                y = BOX_HEIGHT - artInfo.UV.Height;
                             }
                         }
 

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/VideoTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/VideoTab.cs
@@ -292,6 +292,16 @@ public static class VideoTab
                 search: new SearchMetadata(TazLang.Get("gumpscaling_contextmenuscaling", "Context menu scaling"), Keywords: [kw.Scale])
             ),
             Option.Slider(
+                TazLang.Get("gumpscaling_tradegumpscaling", "Trade gump scaling"),
+                50,
+                300,
+                new Accessor<float>(() => (int)(profile.TradeGumpScale * 100), newValue =>
+                {
+                    profile.TradeGumpScale = Math.Clamp(newValue / 100, 0.5f, 3.0f);
+                }),
+                search: new SearchMetadata(TazLang.Get("gumpscaling_tradegumpscaling", "Trade gump scaling"), Keywords: [kw.Scale])
+            ),
+            Option.Slider(
                 TazLang.Get("gumpscaling_servergumpscaling", "Server gump scaling"),
                 50,
                 300,

--- a/src/ClassicUO.Client/Game/UI/ScaleHelper.cs
+++ b/src/ClassicUO.Client/Game/UI/ScaleHelper.cs
@@ -39,6 +39,12 @@ namespace ClassicUO.Game.UI
         /// </summary>
         public static Point Scaled(Point p, double scale) => new Point((int)(p.X * scale), (int)(p.Y * scale));
 
+        /// <summary>
+        /// Remove a gump/context-menu scale from a logical-space value to get its design-space value.
+        /// The inverse of <see cref="Scaled(int, double)"/>.
+        /// </summary>
+        public static int Unscaled(int value, double scale) => scale == 0 ? value : (int)(value / scale);
+
         // --- Physical window -> Logical space (the live "game scale" divide) ---------------------
 
         /// <summary>The global game/render scale that maps logical UI space onto the physical window.</summary>


### PR DESCRIPTION
Mirror the paperdoll and status bar gump scaling: the TradingGump now derives from ScalableTextContainerGump and applies a configurable GumpScale from the new profile setting TradeGumpScale. Direct children scale automatically on Add, and trade-box items are scaled and their drop coordinates converted back to unscaled container space so drops land correctly. Scale sliders added to both the modern options gump and the Myra video options tab.