### PR TITLE
Clamp nested context submenus to window using absolute screen coords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ All notable changes to TazUO will be recorded here.
 * Fixed context menus rendering outside the window bounds when global or context menu scaling was active, and fixed submenu arrows being clipped out of view at higher scales - [P.R 640](https://github.com/PlayTazUO/TazUO/pull/640) ([bittiez](https://github.com/bittiez))
 * Retrieve Gumps now also brings Myra (iGui) windows such as the Script Manager back on screen, and accounts for game scale - [P.R 641](https://github.com/PlayTazUO/TazUO/pull/641) ([bittiez](https://github.com/bittiez))
 * Fixed context menu submenus being unreachable when they open to the left (or upward) near the screen edge, where moving the mouse onto them closed the whole menu - [P.R 642](https://github.com/PlayTazUO/TazUO/pull/642) ([bittiez](https://github.com/bittiez))
+* Fixed nested context menu submenus extending past the bottom of the window; the overflow guard now clamps against absolute screen coordinates and the live logical window height so it stays correct at any nesting depth and honors both context menu and game scaling - [P.R 646](https://github.com/PlayTazUO/TazUO/pull/646) ([bittiez](https://github.com/bittiez))
 
 ### Legion
 * Added ModernNineSliceGump.SetLegionTexture to go along with zip files and custom png's - Use your own png for a 9-slice texture - ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.24</AssemblyVersion>
-    <FileVersion>5.3.24</FileVersion>
+    <AssemblyVersion>5.3.25</AssemblyVersion>
+    <FileVersion>5.3.25</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Controls/ContextMenuControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ContextMenuControl.cs
@@ -375,9 +375,19 @@ namespace ClassicUO.Game.UI.Controls
                     int windowWidth = (int)(Client.Game.Window.ClientBounds.Width / Client.Game.RenderScale);
                     int windowHeight = (int)(Client.Game.Window.ClientBounds.Height / Client.Game.RenderScale);
 
+                    // The submenu is a child of _gump, so its X/Y are relative to _gump.
+                    // Clamp against the parent menu's absolute on-screen position instead
+                    // of its raw X/Y: for the root menu these are identical, but for a
+                    // nested submenu (a submenu opened from another submenu) _gump.X/Y are
+                    // only relative to that submenu's own parent, so using them would
+                    // under-count the real offset and let deep submenus spill off the
+                    // window edges. ScreenCoordinate* accumulates every ancestor offset.
+                    int parentScreenX = _gump.ScreenCoordinateX;
+                    int parentScreenY = _gump.ScreenCoordinateY;
+
                     // Open to the right by default, but flip to the left of the parent
                     // menu if the submenu would run off the right edge of the window.
-                    if (_gump.X + Width + _subMenu.MenuWidth > windowWidth && _gump.X - _subMenu.MenuWidth >= 0)
+                    if (parentScreenX + Width + _subMenu.MenuWidth > windowWidth && parentScreenX - _subMenu.MenuWidth >= 0)
                     {
                         _subMenu.X = -_subMenu.MenuWidth;
                     }
@@ -389,14 +399,14 @@ namespace ClassicUO.Game.UI.Controls
                     // Keep the submenu inside the window vertically.
                     int subMenuY = Y;
 
-                    if (_gump.Y + subMenuY + _subMenu.MenuHeight > windowHeight)
+                    if (parentScreenY + subMenuY + _subMenu.MenuHeight > windowHeight)
                     {
-                        subMenuY = windowHeight - _subMenu.MenuHeight - _gump.Y;
+                        subMenuY = windowHeight - _subMenu.MenuHeight - parentScreenY;
                     }
 
-                    if (_gump.Y + subMenuY < 0)
+                    if (parentScreenY + subMenuY < 0)
                     {
-                        subMenuY = -_gump.Y;
+                        subMenuY = -parentScreenY;
                     }
 
                     _subMenu.Y = subMenuY;

--- a/src/ClassicUO.Client/Game/UI/Controls/ContextMenuControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ContextMenuControl.cs
@@ -79,6 +79,7 @@ namespace ClassicUO.Game.UI.Controls
     public class ContextMenuShowMenu : Gump
     {
         private readonly AlphaBlendControl _background;
+        private readonly ScrollArea _scroll;
         private List<ContextMenuShowMenu> _subMenus;
         private readonly double _scale;
 
@@ -102,7 +103,7 @@ namespace ClassicUO.Game.UI.Controls
             _background = new AlphaBlendControl(0.7f);
             Add(_background);
 
-            var _scroll = new ScrollArea(0, 0, 0, 0, true);
+            _scroll = new ScrollArea(0, 0, 0, 0, true);
             Add(_scroll);
 
             int y = 0;
@@ -177,6 +178,26 @@ namespace ClassicUO.Game.UI.Controls
             }
         }
 
+
+        // The height cap applied in the constructor is frozen against the window
+        // size at that moment. If the game scale (RenderScale) or the window is
+        // changed while the menu is open, that stale cap can be taller than the
+        // current logical window and the menu spills off screen. Re-clamp against
+        // the live logical window height so it can only ever shrink to fit; the
+        // context menu scale is already baked into these heights, so both scales
+        // are accounted for. Only shrinks, never grows past the constructor cap.
+        internal void ClampHeightToWindow(int windowHeight)
+        {
+            if (windowHeight < 0)
+            {
+                windowHeight = 0;
+            }
+
+            if (_background.Height > windowHeight)
+            {
+                _scroll.Height = Height = _background.Height = windowHeight;
+            }
+        }
 
         public override void Update()
         {
@@ -384,6 +405,11 @@ namespace ClassicUO.Game.UI.Controls
                     // window edges. ScreenCoordinate* accumulates every ancestor offset.
                     int parentScreenX = _gump.ScreenCoordinateX;
                     int parentScreenY = _gump.ScreenCoordinateY;
+
+                    // Keep the submenu no taller than the current logical window so a
+                    // game-scale or window-size change after it was built cannot leave
+                    // it overflowing. MenuHeight below then reflects the clamped size.
+                    _subMenu.ClampHeightToWindow(windowHeight);
 
                     // Open to the right by default, but flip to the left of the parent
                     // menu if the submenu would run off the right edge of the window.


### PR DESCRIPTION
The submenu vertical/horizontal overflow guards clamped against the parent menu's raw X/Y. That is the absolute on-screen position only for the root menu; for a submenu opened from another submenu (e.g. the CounterBar spell picker: root -> "Set spell" -> "Magery" -> spells) the parent's X/Y are relative to its own parent, so the clamp under-counts the real offset and lets deep submenus spill past the window edges, most visibly extending down past the bottom.

Clamp against ScreenCoordinateX/Y instead, which equals X/Y for the root menu but accumulates every ancestor offset for nested submenus, keeping submenus inside the window at any nesting depth.