### PR TITLE
Unify gump scaling math behind a single ScaleHelper

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Controls/ContextMenuControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ContextMenuControl.cs
@@ -135,8 +135,8 @@ namespace ClassicUO.Game.UI.Controls
             // scale is already baked into _background.Width/Height. Convert the
             // window bounds into that same logical space so the menu stays on
             // screen regardless of global or context menu scaling.
-            int windowWidth = (int)(Client.Game.Window.ClientBounds.Width / Client.Game.RenderScale);
-            int windowHeight = (int)(Client.Game.Window.ClientBounds.Height / Client.Game.RenderScale);
+            int windowWidth = ScaleHelper.LogicalWindowWidth;
+            int windowHeight = ScaleHelper.LogicalWindowHeight;
 
             if (y >= windowHeight >> 1)
             {
@@ -333,7 +333,7 @@ namespace ClassicUO.Game.UI.Controls
 
                 Add(_selectedPic);
 
-                Height = (int)(25 * _scale);
+                Height = ScaleHelper.Scaled(25, _scale);
 
 
                 _label.Y = (Height >> 1) - (_label.Height >> 1);
@@ -344,11 +344,11 @@ namespace ClassicUO.Game.UI.Controls
                     _selectedPic.Y = (Height >> 1) - (_selectedPic.Height >> 1);
                 }
 
-                Width = _label.X + _label.Width + (int)(25 * _scale);
+                Width = _label.X + _label.Width + ScaleHelper.Scaled(25, _scale);
 
-                if (Width < (int)(100 * _scale))
+                if (Width < ScaleHelper.Scaled(100, _scale))
                 {
-                    Width = (int)(100 * _scale);
+                    Width = ScaleHelper.Scaled(100, _scale);
                 }
 
                 // The parent ScrollArea always clips the right edge by its scrollbar
@@ -393,8 +393,8 @@ namespace ClassicUO.Game.UI.Controls
                 {
                     // Bounds are in physical pixels; submenu coordinates live in the
                     // same logical UI space as the parent, so scale by RenderScale.
-                    int windowWidth = (int)(Client.Game.Window.ClientBounds.Width / Client.Game.RenderScale);
-                    int windowHeight = (int)(Client.Game.Window.ClientBounds.Height / Client.Game.RenderScale);
+                    int windowWidth = ScaleHelper.LogicalWindowWidth;
+                    int windowHeight = ScaleHelper.LogicalWindowHeight;
 
                     // The submenu is a child of _gump, so its X/Y are relative to _gump.
                     // Clamp against the parent menu's absolute on-screen position instead
@@ -506,7 +506,7 @@ namespace ClassicUO.Game.UI.Controls
                 {
                     // Keep the arrow left of the ScrollArea's clipped scrollbar gutter
                     // so it stays visible at any global/context menu scale.
-                    _moreMenuLabel.Draw(batcher, x + Width - ScrollArea.SCROLLBAR_WIDTH - (int)((_moreMenuLabel.Width + 5) * _scale), y + (Height >> 1) - ((int)(_moreMenuLabel.Height * _scale) >> 1) - 1, _scale);
+                    _moreMenuLabel.Draw(batcher, x + Width - ScrollArea.SCROLLBAR_WIDTH - ScaleHelper.Scaled(_moreMenuLabel.Width + 5, _scale), y + (Height >> 1) - (ScaleHelper.Scaled(_moreMenuLabel.Height, _scale) >> 1) - 1, _scale);
                 }
 
                 return true;

--- a/src/ClassicUO.Client/Game/UI/Controls/MyraControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/MyraControl.cs
@@ -197,9 +197,11 @@ public class MyraControl : IGui
 
     public MyraControl CenterInScreen()
     {
-        Rectangle bounds = Client.Game.Window.ClientBounds;
-        X = (int)(((bounds.Width / Client.Game.RenderScale) - (Width * Client.Game.RenderScale)) / 2);
-        Y = (int)(((bounds.Height / Client.Game.RenderScale) - (Height * Client.Game.RenderScale)) / 2);
+        // Width/Height are already in logical UI space, so only the window bounds need converting.
+        // (The previous form multiplied Width/Height by RenderScale, double-counting it and
+        // mis-centering whenever the game scale was not 1.0.)
+        X = (ScaleHelper.LogicalWindowWidth - Width) / 2;
+        Y = (ScaleHelper.LogicalWindowHeight - Height) / 2;
 
         if (X < 0)
             X = 0;
@@ -226,9 +228,8 @@ public class MyraControl : IGui
         // coordinates and size live in logical UI space, which the global
         // RenderScale maps onto the screen. Convert the bounds into that same
         // logical space so clamping stays correct at any game scale.
-        float scale = Client.Game.RenderScale;
-        int windowWidth = (int)(Client.Game.Window.ClientBounds.Width / scale);
-        int windowHeight = (int)(Client.Game.Window.ClientBounds.Height / scale);
+        int windowWidth = ScaleHelper.LogicalWindowWidth;
+        int windowHeight = ScaleHelper.LogicalWindowHeight;
 
         int halfWidth = Width / 2;
         int halfHeight = Height / 2;

--- a/src/ClassicUO.Client/Game/UI/Gumps/Gump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/Gump.cs
@@ -143,14 +143,16 @@ namespace ClassicUO.Game.UI.Gumps
 
         public void CenterXInScreen()
         {
-            Rectangle windowBounds = Client.Game.Window.ClientBounds;
-            X = (int)(((windowBounds.Width / Client.Game.RenderScale) - (Width * Client.Game.RenderScale)) / 2);
+            // Width is already in logical UI space, so only the window bounds need converting.
+            // (The previous form multiplied Width by RenderScale, double-counting it and
+            // mis-centering whenever the game scale was not 1.0.)
+            X = (ScaleHelper.LogicalWindowWidth - Width) / 2;
         }
 
         public void CenterYInScreen()
         {
-            Rectangle windowBounds = Client.Game.Window.ClientBounds;
-            Y = (int)(((windowBounds.Height / Client.Game.RenderScale) - (Height * Client.Game.RenderScale)) / 2);
+            // Height is already in logical UI space; see CenterXInScreen for the double-count fix.
+            Y = (ScaleHelper.LogicalWindowHeight - Height) / 2;
         }
 
         public void CenterXInViewPort()

--- a/src/ClassicUO.Client/Game/UI/Gumps/PopupMenuGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/PopupMenuGump.cs
@@ -36,9 +36,9 @@ namespace ClassicUO.Game.UI.Gumps
             };
 
             Add(pic);
-            int offsetY = (int)(10 * scale);
+            int offsetY = ScaleHelper.Scaled(10, scale);
             bool arrowAdded = false;
-            int width = 0, height = (int)(20 * scale);
+            int width = 0, height = ScaleHelper.Scaled(20, scale);
 
             for (int i = 0; i < data.Items.Length; i++)
             {
@@ -57,12 +57,12 @@ namespace ClassicUO.Game.UI.Gumps
 
                 var label = new Label(text, true, hue, font: 1);
                 label.ApplyScale(scale, scalePosition: false);
-                label.X = (int)(10 * scale);
+                label.X = ScaleHelper.Scaled(10, scale);
                 label.Y = offsetY;
 
                 Client.Game.UO.FileManager.Fonts.SetUseHTML(false);
 
-                var box = new HitBox((int)(10 * scale), offsetY, label.Width, label.Height)
+                var box = new HitBox(ScaleHelper.Scaled(10, scale), offsetY, label.Width, label.Height)
                 {
                     Tag = item.Index
                 };
@@ -82,14 +82,14 @@ namespace ClassicUO.Game.UI.Gumps
                     // TODO: wat?
                     var arrow = new Button(0, 0x15E6, 0x15E2, 0x15E2)
                     {
-                        X = (int)(20 * scale),
+                        X = ScaleHelper.Scaled(20, scale),
                         Y = offsetY
                     };
                     arrow.ApplyScale(scale, scalePosition: false);
 
                     Add(arrow);
 
-                    height += (int)(20 * scale);
+                    height += ScaleHelper.Scaled(20, scale);
                 }
 
                 offsetY += label.Height;
@@ -105,9 +105,9 @@ namespace ClassicUO.Game.UI.Gumps
                 }
             }
 
-            width += (int)(20 * scale);
+            width += ScaleHelper.Scaled(20, scale);
 
-            if (height <= (int)(10 * scale) || width <= (int)(20 * scale))
+            if (height <= ScaleHelper.Scaled(10, scale) || width <= ScaleHelper.Scaled(20, scale))
             {
                 Dispose();
             }
@@ -118,7 +118,7 @@ namespace ClassicUO.Game.UI.Gumps
 
                 foreach (HitBox box in FindControls<HitBox>())
                 {
-                    box.Width = width - (int)(20 * scale);
+                    box.Width = width - ScaleHelper.Scaled(20, scale);
                 }
             }
         }

--- a/src/ClassicUO.Client/Game/UI/Gumps/StatusGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/StatusGump.cs
@@ -95,7 +95,7 @@ namespace ClassicUO.Game.UI.Gumps
                     World.TargetManager.Target(World.Player);
                     Mouse.LastLeftButtonClickTime = 0;
                 }
-                else if (x >= _point.X && x <= Width + (int)(16 * GumpScale) && y >= _point.Y && y <= Height + (int)(16 * GumpScale))
+                else if (x >= _point.X && x <= Width + ScaleHelper.Scaled(16, GumpScale) && y >= _point.Y && y <= Height + ScaleHelper.Scaled(16, GumpScale))
                 {
                     Point offset = Mouse.LDragOffset;
 
@@ -516,7 +516,7 @@ namespace ClassicUO.Game.UI.Gumps
                 { CanMove = true }
             );
 
-            _point = new Point((int)(p.X * GumpScale), (int)(p.Y * GumpScale));
+            _point = ScaleHelper.Scaled(p, GumpScale);
         }
 
         public override void Update()
@@ -1381,7 +1381,7 @@ namespace ClassicUO.Game.UI.Gumps
                 { CanMove = true }
             );
 
-            _point = new Point((int)(p.X * GumpScale), (int)(p.Y * GumpScale));
+            _point = ScaleHelper.Scaled(p, GumpScale);
         }
 
         private void AddStatTextLabel

--- a/src/ClassicUO.Client/Game/UI/ScaleHelper.cs
+++ b/src/ClassicUO.Client/Game/UI/ScaleHelper.cs
@@ -1,0 +1,56 @@
+using Microsoft.Xna.Framework;
+
+namespace ClassicUO.Game.UI
+{
+    /// <summary>
+    /// Single source of truth for UI scaling conversions. There are three coordinate spaces in the
+    /// client UI, and this helper makes the conversions between them explicit so callers stop
+    /// re-deriving the math (and stop mixing the two scales up):
+    ///
+    /// <list type="bullet">
+    /// <item><b>Design space</b> - the raw literals authored before any scaling (e.g. a control's
+    /// source size, or hard-coded margins like <c>16</c>/<c>25</c>). Multiply by a gump/context-menu
+    /// scale to reach Logical space.</item>
+    /// <item><b>Logical UI space</b> - what <see cref="Controls.Control"/> coordinates
+    /// (<c>X/Y/Width/Height</c>, <c>ScreenCoordinateX/Y</c>) and <c>Mouse.Position</c> live in. A
+    /// control's gump scale is <i>already baked into</i> these values by
+    /// <see cref="Controls.Control.ApplyScale"/>; the global RenderScale is <i>never</i> applied here.</item>
+    /// <item><b>Physical/screen space</b> - only <c>Client.Game.Window.ClientBounds</c> lives here.
+    /// Logical space is mapped onto it by the global RenderScale at blit time.</item>
+    /// </list>
+    ///
+    /// The one rule this helper exists to protect: <b>never multiply or divide a Control coordinate
+    /// by RenderScale</b> - it is already in logical space, so doing so double-counts. RenderScale is
+    /// only ever used to convert the physical window bounds <i>into</i> logical space (see
+    /// <see cref="LogicalWindowWidth"/>/<see cref="LogicalWindowHeight"/>).
+    /// </summary>
+    public static class ScaleHelper
+    {
+        // --- Design space -> Logical space (the baked "gump scale" multiply) ---------------------
+        // Uses (int)(value * scale) truncation to stay identical with the hand-written math it replaces.
+
+        /// <summary>
+        /// Scale a design-space value by a gump/context-menu scale to get its logical-space value.
+        /// </summary>
+        public static int Scaled(int value, double scale) => (int)(value * scale);
+
+        /// <summary>
+        /// Scale a design-space point by a gump/context-menu scale to get its logical-space point.
+        /// </summary>
+        public static Point Scaled(Point p, double scale) => new Point((int)(p.X * scale), (int)(p.Y * scale));
+
+        // --- Physical window -> Logical space (the live "game scale" divide) ---------------------
+
+        /// <summary>The global game/render scale that maps logical UI space onto the physical window.</summary>
+        public static float RenderScale => Client.Game.RenderScale;
+
+        /// <summary>Convert a physical pixel measurement into logical UI space.</summary>
+        public static int ToLogical(int physical) => (int)(physical / RenderScale);
+
+        /// <summary>The game window width in logical UI space (physical width with RenderScale removed).</summary>
+        public static int LogicalWindowWidth => (int)(Client.Game.Window.ClientBounds.Width / RenderScale);
+
+        /// <summary>The game window height in logical UI space (physical height with RenderScale removed).</summary>
+        public static int LogicalWindowHeight => (int)(Client.Game.Window.ClientBounds.Height / RenderScale);
+    }
+}

--- a/src/ClassicUO.Client/Game/UI/Tooltip.cs
+++ b/src/ClassicUO.Client/Game/UI/Tooltip.cs
@@ -154,18 +154,18 @@ namespace ClassicUO.Game.UI
             {
                 x = 0;
             }
-            else if (x > (Client.Game.Window.ClientBounds.Width / Client.Game.RenderScale)- z_width)
+            else if (x > ScaleHelper.LogicalWindowWidth - z_width)
             {
-                x = (int)((Client.Game.Window.ClientBounds.Width / Client.Game.RenderScale) - z_width);
+                x = ScaleHelper.LogicalWindowWidth - z_width;
             }
 
             if (y < 0)
             {
                 y = 0;
             }
-            else if (y > (Client.Game.Window.ClientBounds.Height / Client.Game.RenderScale) - z_height)
+            else if (y > ScaleHelper.LogicalWindowHeight - z_height)
             {
-                y = (int)((Client.Game.Window.ClientBounds.Height / Client.Game.RenderScale) - z_height);
+                y = ScaleHelper.LogicalWindowHeight - z_height;
             }
 
             X = x - 4;


### PR DESCRIPTION
Paperdoll, the status gump, and the two context-menu implementations each grew their own copies of the same scaling math. Centralize it so there is one source of truth for converting between the client's coordinate spaces.

- Add ScaleHelper with two explicit conversion families:
  - Scaled(value/point, scale): design space -> logical space (the baked gump/context-menu scale multiply)
  - ToLogical / LogicalWindowWidth / LogicalWindowHeight: physical window -> logical space (the live RenderScale divide) The class documents the three coordinate spaces and the rule that a control coordinate must never be multiplied/divided by RenderScale.
- Route the scattered (int)(N * scale) idioms and the duplicated ClientBounds / RenderScale window conversions through the helper in StatusGump, ContextMenuControl, PopupMenuGump, Tooltip, and MyraControl. These rewrites are value-identical.
- Fix a pre-existing centering double-scale bug in Gump.CenterXInScreen/ CenterYInScreen and MyraControl.CenterInScreen: they multiplied the already-logical Width/Height by RenderScale, mis-centering gumps whenever the game scale was not 1.0.