### PR TITLE
Migrate more raw strings to TazLang

### DIFF
--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -5,7 +5,7 @@
 ; Missing keys are auto-appended with English defaults when
 ; this file's version is newer than the user's copy.
 ; -------------------------------------------------------
-_version=32
+_version=33
 accountname=Account Name
 accountcontextmenutooltip=Right click to select another account.
 music=Music
@@ -738,3 +738,55 @@ healthbarcollector_filter=Filter
 healthbarcollector_sort=Sort
 healthbarcollector_party=Party
 healthbarcollector_pets=Pets
+
+; Top bar gump buttons & menu
+topbargump_assistant=Assistant
+topbargump_legionscript=Legion Script
+topbargump_more=More +
+topbargump_togglenameplates=Toggle nameplates
+topbargump_tools=Tools
+topbargump_spellquickcast=Spell quick cast
+topbargump_openboatcontrol=Open boat control
+topbargump_nearbyloot=Nearby loot
+topbargump_retrievegumps=Retrieve gumps
+topbargump_developer=Developer
+topbargump_tinkerer=Tinkerer
+topbargump_profiler=Profiler
+topbargump_xmlgumps=Xml Gumps
+topbargump_reload=Reload
+
+; Assistant window tabs
+assistantwindow_title=Legion Assistant
+assistantwindow_tab_general=General
+assistantwindow_tab_agents=Agents
+assistantwindow_tab_filters=Filters
+assistantwindow_tab_itemdatabase=Item Database
+assistantwindow_tab_macros=Macros
+assistantwindow_tab_hotkeys=Hotkeys
+assistantwindow_tab_skills=Skills
+
+; Assistant general sub-tabs
+assistant_general_tab_options=Options
+assistant_general_tab_hud=HUD
+assistant_general_tab_spellbar=Spell Bar
+assistant_general_tab_titlebar=Title Bar
+assistant_general_tab_spellindicators=Spell Indicators
+assistant_general_tab_friends=Friends
+assistant_general_tab_pathfinding=Pathfinding
+
+; Assistant agent sub-tabs
+assistant_agent_tab_autoloot=Auto Loot
+assistant_agent_tab_dress=Dress Agent
+assistant_agent_tab_autobuy=Auto Buy
+assistant_agent_tab_autosell=Auto Sell
+assistant_agent_tab_bandage=Bandage
+assistant_agent_tab_selfheal=Self Heal
+assistant_agent_tab_organizer=Organizer
+assistant_agent_tab_statlock=Stat Lock
+
+; Assistant filter sub-tabs
+assistant_filter_tab_graphics=Graphics
+assistant_filter_tab_journal=Journal Filter
+assistant_filter_tab_sound=Sound Filter
+assistant_filter_tab_music=Music Filter
+assistant_filter_tab_season=Season Filter

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -5,7 +5,7 @@
 ; Missing keys are auto-appended with English defaults when
 ; this file's version is newer than the user's copy.
 ; -------------------------------------------------------
-_version=31
+_version=32
 accountname=Account Name
 accountcontextmenutooltip=Right click to select another account.
 music=Music
@@ -705,3 +705,36 @@ gumpscaling_statusgump=Status Gump
 gumpscaling_statusgumpscaling=Status gump scaling
 gumpscaling_contextmenu=Context Menus
 gumpscaling_contextmenuscaling=Context menu scaling
+
+; Multi item move gump
+multimove_header_moving=Moving {0} items.
+multimove_header_selected=Selected {0} items.
+multimove_objectdelay=Object delay:
+multimove_movetobackpack=Move to backpack
+multimove_movetobackpack_tooltip=Move selected items to your backpack.
+multimove_setfavoritebag=Set favorite bag
+multimove_setfavoritebag_tooltip=Set your preferred destination container for future item moves.
+multimove_tofavorite=To favorite
+multimove_tofavorite_tooltip=Move selected items to your favorite container.
+multimove_cancel=Cancel
+multimove_moveto=Move to
+multimove_moveto_tooltip=Select a container, a mobile (or its name plate), or a ground tile to move these items to.
+multimove_targetfavorite=Target a container to set as your favorite.
+multimove_nofavorite=No favorite container set. Please target one.
+multimove_favoriteunavailable=Favorite container is not available.
+multimove_wheremove=Where should we move these items?
+multimove_invalidmobile=That does not appear to be a valid mobile...
+multimove_movingtomobile=Moving items to the selected mobile..
+multimove_notcontainer=That does not appear to be a container...
+multimove_movingtocontainer=Moving items to the selected container..
+
+; Nearby items gump
+nearbyitems_loot=Loot
+nearbyitems_use=Use
+
+; Healthbar collector gump
+healthbarcollector_title=Healthbar Collector
+healthbarcollector_filter=Filter
+healthbarcollector_sort=Sort
+healthbarcollector_party=Party
+healthbarcollector_pets=Pets

--- a/src/ClassicUO.Client/Game/UI/Gumps/HealthbarCollectorGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/HealthbarCollectorGump.cs
@@ -87,7 +87,7 @@ namespace ClassicUO.Game.UI.Gumps
             Add(_background);
 
             // Title label
-            var titleLabel = new Label("Healthbar Collector", true, 0x0481, font: 1)
+            var titleLabel = new Label(TazLang.Get("healthbarcollector_title", "Healthbar Collector"), true, 0x0481, font: 1)
             {
                 X = 5,
                 Y = 8
@@ -95,7 +95,7 @@ namespace ClassicUO.Game.UI.Gumps
             Add(titleLabel);
 
             // Notorieties button
-            _notorietiesButton = new NiceButton(5, 28, 55, 20, ButtonAction.Activate, "Filter")
+            _notorietiesButton = new NiceButton(5, 28, 55, 20, ButtonAction.Activate, TazLang.Get("healthbarcollector_filter", "Filter"))
             {
                 IsSelectable = false,
                 ButtonParameter = 0
@@ -104,7 +104,7 @@ namespace ClassicUO.Game.UI.Gumps
             Add(_notorietiesButton);
 
             // Sort button
-            _sortButton = new NiceButton(62, 28, 40, 20, ButtonAction.Activate, "Sort")
+            _sortButton = new NiceButton(62, 28, 40, 20, ButtonAction.Activate, TazLang.Get("healthbarcollector_sort", "Sort"))
             {
                 IsSelectable = true,
                 ButtonParameter = 1
@@ -154,7 +154,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             // Add Party filter option
             contextMenu.Add(
-                "Party",
+                TazLang.Get("healthbarcollector_party", "Party"),
                 () => TogglePartyFilter(),
                 canBeSelected: true,
                 defaultValue: _filterParty
@@ -162,7 +162,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             // Add Pets filter option
             contextMenu.Add(
-                "Pets",
+                TazLang.Get("healthbarcollector_pets", "Pets"),
                 () => TogglePetsFilter(),
                 canBeSelected: true,
                 defaultValue: _filterPets

--- a/src/ClassicUO.Client/Game/UI/Gumps/MultiItemMoveGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/MultiItemMoveGump.cs
@@ -107,7 +107,7 @@ namespace ClassicUO.Game.UI.Gumps
             // "Object delay" + numeric input (right-aligned)
             int delayRowY = cy + _header.Height + 5;
 
-            Add(new Label("Object delay:", true, 0xFFFF, 150)
+            Add(new Label(TazLang.Get("multimove_objectdelay", "Object delay:"), true, 0xFFFF, 150)
             {
                 X = cx,
                 Y = delayRowY
@@ -144,8 +144,8 @@ namespace ClassicUO.Game.UI.Gumps
             NiceButton b;
 
             // Move to backpack (full width)
-            Add(b = new NiceButton(cx, rowY1, cw, 20, ButtonAction.Activate, "Move to backpack", align: TEXT_ALIGN_TYPE.TS_CENTER));
-            b.SetTooltip("Move selected items to your backpack.");
+            Add(b = new NiceButton(cx, rowY1, cw, 20, ButtonAction.Activate, TazLang.Get("multimove_movetobackpack", "Move to backpack"), align: TEXT_ALIGN_TYPE.TS_CENTER));
+            b.SetTooltip(TazLang.Get("multimove_movetobackpack_tooltip", "Move selected items to your backpack."));
             b.MouseUp += (s, e) =>
             {
                 if (e.Button == MouseButtonType.Left)
@@ -158,20 +158,20 @@ namespace ClassicUO.Game.UI.Gumps
             };
 
             // Set favorite (left)
-            Add(b = new NiceButton(cx, rowY2, halfW, 20, ButtonAction.Activate, "Set favorite bag", align: TEXT_ALIGN_TYPE.TS_CENTER));
-            b.SetTooltip("Set your preferred destination container for future item moves.");
+            Add(b = new NiceButton(cx, rowY2, halfW, 20, ButtonAction.Activate, TazLang.Get("multimove_setfavoritebag", "Set favorite bag"), align: TEXT_ALIGN_TYPE.TS_CENTER));
+            b.SetTooltip(TazLang.Get("multimove_setfavoritebag_tooltip", "Set your preferred destination container for future item moves."));
             b.MouseUp += (s, e) =>
             {
                 if (e.Button == MouseButtonType.Left)
                 {
-                    GameActions.Print(World, "Target a container to set as your favorite.");
+                    GameActions.Print(World, TazLang.Get("multimove_targetfavorite", "Target a container to set as your favorite."));
                     World.TargetManager.SetTargeting(CursorTarget.SetFavoriteMoveBag, CursorType.Target, TargetType.Neutral);
                 }
             };
 
             // To favorite (right)
-            Add(b = new NiceButton(cx + halfW + GAP, rowY2, halfW, 20, ButtonAction.Activate, "To favorite", align: TEXT_ALIGN_TYPE.TS_CENTER));
-            b.SetTooltip("Move selected items to your favorite container.");
+            Add(b = new NiceButton(cx + halfW + GAP, rowY2, halfW, 20, ButtonAction.Activate, TazLang.Get("multimove_tofavorite", "To favorite"), align: TEXT_ALIGN_TYPE.TS_CENTER));
+            b.SetTooltip(TazLang.Get("multimove_tofavorite_tooltip", "Move selected items to your favorite container."));
             b.MouseUp += (s, e) =>
             {
                 if (e.Button == MouseButtonType.Left)
@@ -179,19 +179,19 @@ namespace ClassicUO.Game.UI.Gumps
                     uint fav = ProfileManager.CurrentProfile.SetFavoriteMoveBagSerial;
                     if (fav == 0)
                     {
-                        GameActions.Print(World, "No favorite container set. Please target one.");
+                        GameActions.Print(World, TazLang.Get("multimove_nofavorite", "No favorite container set. Please target one."));
                         World.TargetManager.SetTargeting(CursorTarget.SetFavoriteMoveBag, CursorType.Target, TargetType.Neutral);
                         return;
                     }
 
                     Item cont = World.Items.Get(fav);
                     if (cont != null) ProcessItemMoves(World, cont);
-                    else GameActions.Print(World, "Favorite container is not available.");
+                    else GameActions.Print(World, TazLang.Get("multimove_favoriteunavailable", "Favorite container is not available."));
                 }
             };
 
             // Cancel (left)
-            Add(b = new NiceButton(cx, rowY3, halfW, 20, ButtonAction.Activate, "Cancel", align: TEXT_ALIGN_TYPE.TS_CENTER));
+            Add(b = new NiceButton(cx, rowY3, halfW, 20, ButtonAction.Activate, TazLang.Get("multimove_cancel", "Cancel"), align: TEXT_ALIGN_TYPE.TS_CENTER));
             b.MouseUp += (s, e) =>
             {
                 if (e.Button == MouseButtonType.Left)
@@ -202,13 +202,13 @@ namespace ClassicUO.Game.UI.Gumps
             };
 
             // Move to (right)
-            Add(b = new NiceButton(cx + halfW + GAP, rowY3, halfW, 20, ButtonAction.Activate, "Move to", align: TEXT_ALIGN_TYPE.TS_CENTER));
-            b.SetTooltip("Select a container, a mobile (or its name plate), or a ground tile to move these items to.");
+            Add(b = new NiceButton(cx + halfW + GAP, rowY3, halfW, 20, ButtonAction.Activate, TazLang.Get("multimove_moveto", "Move to"), align: TEXT_ALIGN_TYPE.TS_CENTER));
+            b.SetTooltip(TazLang.Get("multimove_moveto_tooltip", "Select a container, a mobile (or its name plate), or a ground tile to move these items to."));
             b.MouseUp += (s, e) =>
             {
                 if (e.Button == MouseButtonType.Left)
                 {
-                    GameActions.Print(World, "Where should we move these items?");
+                    GameActions.Print(World, TazLang.Get("multimove_wheremove", "Where should we move these items?"));
                     World.TargetManager.SetTargeting(CursorTarget.MoveItemContainer, CursorType.Target, TargetType.Neutral);
                 }
             };
@@ -261,10 +261,10 @@ namespace ClassicUO.Game.UI.Gumps
                 Mobile mobile = world.Mobiles.Get(serial);
                 if (mobile == null)
                 {
-                    GameActions.Print(world, "That does not appear to be a valid mobile...");
+                    GameActions.Print(world, TazLang.Get("multimove_invalidmobile", "That does not appear to be a valid mobile..."));
                     return;
                 }
-                GameActions.Print(world, "Moving items to the selected mobile..");
+                GameActions.Print(world, TazLang.Get("multimove_movingtomobile", "Moving items to the selected mobile.."));
                 ProcessItemMovesToMobile(world, mobile.Serial);
                 return;
             }
@@ -274,10 +274,10 @@ namespace ClassicUO.Game.UI.Gumps
                 Item moveToContainer = world.Items.Get(serial);
                 if (moveToContainer == null || !moveToContainer.ItemData.IsContainer)
                 {
-                    GameActions.Print(world, "That does not appear to be a container...");
+                    GameActions.Print(world, TazLang.Get("multimove_notcontainer", "That does not appear to be a container..."));
                     return;
                 }
-                GameActions.Print(world, "Moving items to the selected container..");
+                GameActions.Print(world, TazLang.Get("multimove_movingtocontainer", "Moving items to the selected container.."));
                 ProcessItemMoves(world, moveToContainer);
             }
         }
@@ -416,7 +416,9 @@ namespace ClassicUO.Game.UI.Gumps
         private static string TextForHeader()
         {
             int count = SelectedCount;
-            return processing ? $"Moving {count} items." : $"Selected {count} items.";
+            return processing
+                ? TazLang.Get("multimove_header_moving", new[] { count.ToString() })
+                : TazLang.Get("multimove_header_selected", new[] { count.ToString() });
         }
 
         private static void ClearAll()

--- a/src/ClassicUO.Client/Game/UI/Gumps/NearbyItems.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/NearbyItems.cs
@@ -125,7 +125,7 @@ namespace ClassicUO.Game.UI.Gumps
             itemSpriteInfo = Client.Game.UO.Arts.GetArt((uint)(item.DisplayedGraphic));
 
             var loot = new HitBox(0, 0, Width, Height / 2);
-            loot.Add(TextBox.GetOne("Loot", TrueTypeLoader.EMBEDDED_FONT, 16, Color.White, TextBox.RTLOptions.DefaultCentered(Width)));
+            loot.Add(TextBox.GetOne(TazLang.Get("nearbyitems_loot", "Loot"), TrueTypeLoader.EMBEDDED_FONT, 16, Color.White, TextBox.RTLOptions.DefaultCentered(Width)));
             loot.MouseUp += (s, e) =>
             {
                 if(e.Button != MouseButtonType.Left) return;
@@ -136,7 +136,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             var use = new HitBox(0, Height / 2, Width, Height / 2);
             TextBox tb;
-            use.Add(tb = TextBox.GetOne("Use", TrueTypeLoader.EMBEDDED_FONT, 16, Color.White, TextBox.RTLOptions.DefaultCentered(Width)));
+            use.Add(tb = TextBox.GetOne(TazLang.Get("nearbyitems_use", "Use"), TrueTypeLoader.EMBEDDED_FONT, 16, Color.White, TextBox.RTLOptions.DefaultCentered(Width)));
             tb.Y = use.Height - tb.MeasuredSize.Y;
             use.MouseUp += (s, e) =>
             {

--- a/src/ClassicUO.Client/Game/UI/Gumps/TopBarGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/TopBarGump.cs
@@ -135,7 +135,7 @@ namespace ClassicUO.Game.UI.Gumps
                 0x098D,
                 0x098D,
                 0x098D,
-                "Assistant",
+                TazLang.Get("topbargump_assistant", "Assistant"),
                 1,
                 true,
                 0,
@@ -158,7 +158,7 @@ namespace ClassicUO.Game.UI.Gumps
                 0x098D,
                 0x098D,
                 0x098D,
-                "Legion Script",
+                TazLang.Get("topbargump_legionscript", "Legion Script"),
                 1,
                 true,
                 0,
@@ -184,7 +184,7 @@ namespace ClassicUO.Game.UI.Gumps
                     0x098D,
                     0x098D,
                     0x098D,
-                    "More +",
+                    TazLang.Get("topbargump_more", "More +"),
                     1,
                     true,
                     0,
@@ -246,14 +246,14 @@ namespace ClassicUO.Game.UI.Gumps
             }));
             moreMenu.ContextMenu.Add(new ContextMenuItemEntry(cliloc.GetString(3000134, ResGumps.Help), () => { GameActions.RequestHelp(); }));
 
-            moreMenu.ContextMenu.Add(new ContextMenuItemEntry("Toggle nameplates", () => { World.NameOverHeadManager.ToggleOverheads(); }));
+            moreMenu.ContextMenu.Add(new ContextMenuItemEntry(TazLang.Get("topbargump_togglenameplates", "Toggle nameplates"), () => { World.NameOverHeadManager.ToggleOverheads(); }));
 
-            var submenu = new ContextMenuItemEntry("Tools");
-            submenu.Add(new ContextMenuItemEntry("Spell quick cast", () => { UIManager.Add(new SpellQuickSearch(World, 200, 200, (sp) => {if (sp != null) GameActions.CastSpell(sp.ID);})); }));
-            submenu.Add(new ContextMenuItemEntry("Open boat control", () => { UIManager.Add(new BoatControl(World) { X = 200, Y = 200 }); }));
-            submenu.Add(new ContextMenuItemEntry("Nearby loot", () => { UIManager.Add(new NearbyLootGump(World)); }));
-            submenu.Add(new ContextMenuItemEntry("Healthbar Collector", () => { UIManager.Add(new HealthbarCollectorGump(World) { X = 100, Y = 100 }); }));
-            submenu.Add(new ContextMenuItemEntry("Retrieve gumps", () =>
+            var submenu = new ContextMenuItemEntry(TazLang.Get("topbargump_tools", "Tools"));
+            submenu.Add(new ContextMenuItemEntry(TazLang.Get("topbargump_spellquickcast", "Spell quick cast"), () => { UIManager.Add(new SpellQuickSearch(World, 200, 200, (sp) => {if (sp != null) GameActions.CastSpell(sp.ID);})); }));
+            submenu.Add(new ContextMenuItemEntry(TazLang.Get("topbargump_openboatcontrol", "Open boat control"), () => { UIManager.Add(new BoatControl(World) { X = 200, Y = 200 }); }));
+            submenu.Add(new ContextMenuItemEntry(TazLang.Get("topbargump_nearbyloot", "Nearby loot"), () => { UIManager.Add(new NearbyLootGump(World)); }));
+            submenu.Add(new ContextMenuItemEntry(TazLang.Get("healthbarcollector_title", "Healthbar Collector"), () => { UIManager.Add(new HealthbarCollectorGump(World) { X = 100, Y = 100 }); }));
+            submenu.Add(new ContextMenuItemEntry(TazLang.Get("topbargump_retrievegumps", "Retrieve gumps"), () =>
             {
                 for (LinkedListNode<IGui> last = UIManager.Gumps.Last; last != null; last = last.Previous)
                 {
@@ -275,9 +275,9 @@ namespace ClassicUO.Game.UI.Gumps
             }));
             moreMenu.ContextMenu.Add(submenu);
 
-            var devSubmenu = new ContextMenuItemEntry("Developer");
-            devSubmenu.Add(new ContextMenuItemEntry("Tinkerer", TinkererWindow.Show));
-            devSubmenu.Add(new ContextMenuItemEntry("Profiler", MyraWindows.ProfilerWindow.Show));
+            var devSubmenu = new ContextMenuItemEntry(TazLang.Get("topbargump_developer", "Developer"));
+            devSubmenu.Add(new ContextMenuItemEntry(TazLang.Get("topbargump_tinkerer", "Tinkerer"), TinkererWindow.Show));
+            devSubmenu.Add(new ContextMenuItemEntry(TazLang.Get("topbargump_profiler", "Profiler"), MyraWindows.ProfilerWindow.Show));
             moreMenu.ContextMenu.Add(devSubmenu);
 
             startX += largeWidth + 1;
@@ -293,7 +293,7 @@ namespace ClassicUO.Game.UI.Gumps
                         0x098D,
                         0x098D,
                         0x098D,
-                        "Xml Gumps",
+                        TazLang.Get("topbargump_xmlgumps", "Xml Gumps"),
                         1,
                         true,
                         0,
@@ -357,7 +357,7 @@ namespace ClassicUO.Game.UI.Gumps
                 }, false, ProfileManager.CurrentProfile.AutoOpenXmlGumps.Contains(xml)));
             }
 
-            var reload = new ContextMenuItemEntry("Reload", RefreshXmlGumps);
+            var reload = new ContextMenuItemEntry(TazLang.Get("topbargump_reload", "Reload"), RefreshXmlGumps);
             XmlGumps.ContextMenu.Add(reload);
         }
 

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/AssistantWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/AssistantWindow.cs
@@ -1,3 +1,4 @@
+using ClassicUO.Configuration;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.UI;
 using ClassicUO.Game.UI.Controls;
@@ -29,7 +30,7 @@ public class AssistantWindow : MyraControl
 
     private SkillsTabContent _skillsTabContent;
 
-    public AssistantWindow() : base("Legion Assistant")
+    public AssistantWindow() : base(TazLang.Get("assistantwindow_title", "Legion Assistant"))
     {
         CanBeSaved = true;
         Build();
@@ -57,13 +58,13 @@ public class AssistantWindow : MyraControl
     private void Build()
     {
         var tabs = new MyraTabControl();
-        tabs.AddTab("General", GeneralTab.Build);
-        tabs.AddTab("Agents", AgentTab.Build);
-        tabs.AddTab("Filters", FiltersTab.Build);
-        tabs.AddTab("Item Database", ItemDatabaseTabContent.Build);
-        tabs.AddTab("Macros", () => MacrosTabContent.Build(this));
-        tabs.AddTab("Hotkeys", HotkeysTabContent.Build);
-        tabs.AddTab("Skills", () => _skillsTabContent = new());
+        tabs.AddTab(TazLang.Get("assistantwindow_tab_general", "General"), GeneralTab.Build);
+        tabs.AddTab(TazLang.Get("assistantwindow_tab_agents", "Agents"), AgentTab.Build);
+        tabs.AddTab(TazLang.Get("assistantwindow_tab_filters", "Filters"), FiltersTab.Build);
+        tabs.AddTab(TazLang.Get("assistantwindow_tab_itemdatabase", "Item Database"), ItemDatabaseTabContent.Build);
+        tabs.AddTab(TazLang.Get("assistantwindow_tab_macros", "Macros"), () => MacrosTabContent.Build(this));
+        tabs.AddTab(TazLang.Get("assistantwindow_tab_hotkeys", "Hotkeys"), HotkeysTabContent.Build);
+        tabs.AddTab(TazLang.Get("assistantwindow_tab_skills", "Skills"), () => _skillsTabContent = new());
         tabs.SelectFirst();
         SetRootContent(tabs);
     }

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/AgentTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/AgentTab.cs
@@ -1,3 +1,4 @@
+using ClassicUO.Configuration;
 using Myra.Graphics2D.UI;
 
 namespace ClassicUO.Game.UI.MyraWindows.Widgets.Assistant.Agents;
@@ -7,14 +8,14 @@ public static class AgentTab
     public static Widget Build()
     {
         var tabs = new MyraTabControl();
-        tabs.AddTab("Auto Loot", AutoLootAgentTabContent.Build);
-        tabs.AddTab("Dress Agent", DressAgentTabContent.Build);
-        tabs.AddTab("Auto Buy", AutoBuyAgentTabContent.Build);
-        tabs.AddTab("Auto Sell", AutoSellAgentTabContent.Build);
-        tabs.AddTab("Bandage", BandageAgentTabContent.Build);
-        tabs.AddTab("Self Heal", SelfHealTabContent.Build);
-        tabs.AddTab("Organizer", OrganizerAgentTabContent.Build);
-        tabs.AddTab("Stat Lock", AutoStatLockAgentTabContent.Build);
+        tabs.AddTab(TazLang.Get("assistant_agent_tab_autoloot", "Auto Loot"), AutoLootAgentTabContent.Build);
+        tabs.AddTab(TazLang.Get("assistant_agent_tab_dress", "Dress Agent"), DressAgentTabContent.Build);
+        tabs.AddTab(TazLang.Get("assistant_agent_tab_autobuy", "Auto Buy"), AutoBuyAgentTabContent.Build);
+        tabs.AddTab(TazLang.Get("assistant_agent_tab_autosell", "Auto Sell"), AutoSellAgentTabContent.Build);
+        tabs.AddTab(TazLang.Get("assistant_agent_tab_bandage", "Bandage"), BandageAgentTabContent.Build);
+        tabs.AddTab(TazLang.Get("assistant_agent_tab_selfheal", "Self Heal"), SelfHealTabContent.Build);
+        tabs.AddTab(TazLang.Get("assistant_agent_tab_organizer", "Organizer"), OrganizerAgentTabContent.Build);
+        tabs.AddTab(TazLang.Get("assistant_agent_tab_statlock", "Stat Lock"), AutoStatLockAgentTabContent.Build);
         tabs.SelectFirst();
         return tabs;
     }

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Filters/FiltersTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Filters/FiltersTab.cs
@@ -1,3 +1,4 @@
+using ClassicUO.Configuration;
 using Myra.Graphics2D.UI;
 
 namespace ClassicUO.Game.UI.MyraWindows.Widgets.Assistant.Filters;
@@ -7,11 +8,11 @@ public static class FiltersTab
     public static Widget Build()
     {
         var tabs = new MyraTabControl();
-        tabs.AddTab("Graphics", GraphicReplacementTabContent.Build);
-        tabs.AddTab("Journal Filter", JournalFilterTabContent.Build);
-        tabs.AddTab("Sound Filter", SoundFilterTabContent.Build);
-        tabs.AddTab("Music Filter", MusicFilterTabContent.Build);
-        tabs.AddTab("Season Filter", SeasonFilterTabContent.Build);
+        tabs.AddTab(TazLang.Get("assistant_filter_tab_graphics", "Graphics"), GraphicReplacementTabContent.Build);
+        tabs.AddTab(TazLang.Get("assistant_filter_tab_journal", "Journal Filter"), JournalFilterTabContent.Build);
+        tabs.AddTab(TazLang.Get("assistant_filter_tab_sound", "Sound Filter"), SoundFilterTabContent.Build);
+        tabs.AddTab(TazLang.Get("assistant_filter_tab_music", "Music Filter"), MusicFilterTabContent.Build);
+        tabs.AddTab(TazLang.Get("assistant_filter_tab_season", "Season Filter"), SeasonFilterTabContent.Build);
         tabs.SelectFirst();
         return tabs;
     }

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/GeneralTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/GeneralTab.cs
@@ -1,3 +1,4 @@
+using ClassicUO.Configuration;
 using Myra.Graphics2D.UI;
 
 namespace ClassicUO.Game.UI.MyraWindows.Widgets.Assistant;
@@ -7,13 +8,13 @@ public static class GeneralTab
     public static Widget Build()
     {
         var tabs = new MyraTabControl();
-        tabs.AddTab("Options", GeneralTabContent.Build);
-        tabs.AddTab("HUD", HudTabContent.Build);
-        tabs.AddTab("Spell Bar", SpellBarTabContent.Build);
-        tabs.AddTab("Title Bar", TitleBarTabContent.Build);
-        tabs.AddTab("Spell Indicators", SpellIndicatorTabContent.Build);
-        tabs.AddTab("Friends", FriendsListTabContent.Build);
-        tabs.AddTab("Pathfinding", PathfindingTabContent.Build);
+        tabs.AddTab(TazLang.Get("assistant_general_tab_options", "Options"), GeneralTabContent.Build);
+        tabs.AddTab(TazLang.Get("assistant_general_tab_hud", "HUD"), HudTabContent.Build);
+        tabs.AddTab(TazLang.Get("assistant_general_tab_spellbar", "Spell Bar"), SpellBarTabContent.Build);
+        tabs.AddTab(TazLang.Get("assistant_general_tab_titlebar", "Title Bar"), TitleBarTabContent.Build);
+        tabs.AddTab(TazLang.Get("assistant_general_tab_spellindicators", "Spell Indicators"), SpellIndicatorTabContent.Build);
+        tabs.AddTab(TazLang.Get("assistant_general_tab_friends", "Friends"), FriendsListTabContent.Build);
+        tabs.AddTab(TazLang.Get("assistant_general_tab_pathfinding", "Pathfinding"), PathfindingTabContent.Build);
         tabs.SelectFirst();
         return tabs;
     }


### PR DESCRIPTION
Convert user-facing raw strings in various places to TazLang lookups, and add the matching language.ini entries (bumping _version to 32 so existing user language files pick up the new keys).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded localization support across several UI windows and menus, including assistant tabs, top bar options, nearby items, healthbar controls, and item-moving dialogs.
  * Added English text entries for new interface areas such as multi-item move, nearby items, healthbar collector, and assistant sub-tabs.

* **Bug Fixes**
  * Replaced remaining hardcoded English labels with localized text so more interface elements now display consistently based on language settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->