### PR TITLE
feat: Remember size for OptionsWindow

### DIFF
--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.25</AssemblyVersion>
-    <FileVersion>5.3.25</FileVersion>
+    <AssemblyVersion>5.3.26</AssemblyVersion>
+    <FileVersion>5.3.26</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -476,7 +476,7 @@ namespace ClassicUO.Configuration
         public int AutoFollowDistance { get; set => SetProperty(ref field, value); } = 1;
         public bool DisableAutoFollowAlt { get; set => SetProperty(ref field, value); } = false;
         [JsonConverter(typeof(Point2Converter))] public Point ResizeJournalSize { get; set => SetProperty(ref field, value); } = new(410, 350);
-        [JsonConverter(typeof(Point2Converter))] public Point? OptionsWindowsSize { get; set => SetProperty(ref field, value); }
+        [JsonConverter(typeof(NullablePoint2Converter))] public Point? OptionsWindowsSize { get; set => SetProperty(ref field, value); }
         public bool FollowingMode { get; set => SetProperty(ref field, value); } = false;
         public uint FollowingTarget { get; set => SetProperty(ref field, value); }
         public bool NamePlateHealthBar { get; set => SetProperty(ref field, value); } = true;

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -475,7 +475,8 @@ namespace ClassicUO.Configuration
 
         public int AutoFollowDistance { get; set => SetProperty(ref field, value); } = 1;
         public bool DisableAutoFollowAlt { get; set => SetProperty(ref field, value); } = false;
-        [JsonConverter(typeof(Point2Converter))] public Point ResizeJournalSize { get; set => SetProperty(ref field, value); } = new Point(410, 350);
+        [JsonConverter(typeof(Point2Converter))] public Point ResizeJournalSize { get; set => SetProperty(ref field, value); } = new(410, 350);
+        [JsonConverter(typeof(Point2Converter))] public Point? OptionsWindowsSize { get; set => SetProperty(ref field, value); }
         public bool FollowingMode { get; set => SetProperty(ref field, value); } = false;
         public uint FollowingTarget { get; set => SetProperty(ref field, value); }
         public bool NamePlateHealthBar { get; set => SetProperty(ref field, value); } = true;

--- a/src/ClassicUO.Client/Game/UI/Controls/ResizableComponents/ResizableWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ResizableComponents/ResizableWindow.cs
@@ -16,10 +16,17 @@ using Myra.Graphics2D.UI;
 
 namespace ClassicUO.Game.UI.Controls.ResizableComponents;
 
+/// <summary>
+///     A Myra <see cref="Window" /> that supports edge/corner drag-resizing, minimizing to its title bar,
+///     and persisting its size, based on the behavior configured via <see cref="Props" />.
+/// </summary>
 public class ResizableWindow : Window, IDisposable
 {
     #region Events
 
+    /// <summary>
+    ///     Raised after the window's size has changed as a result of a drag-resize operation.
+    /// </summary>
     public event EventHandler<ResizeEventArgs> Resized;
 
     #endregion
@@ -68,14 +75,23 @@ public class ResizableWindow : Window, IDisposable
         }
     }
 
+    /// <summary>
+    ///     Gets or sets the horizontal alignment of the title label within the title panel.
+    /// </summary>
     public HorizontalAlignment TitleLabelAlignment
     {
         get => _titleLabel.HorizontalAlignment;
         set => _titleLabel.HorizontalAlignment = value;
     }
 
+    /// <summary>
+    ///     Gets the glyph displayed on the minimize/maximize button for the current <see cref="IsMinimized" /> state.
+    /// </summary>
     private string MinMaxButtonText => IsMinimized ? "□" : "−";
 
+    /// <summary>
+    ///     Gets the font used to render the minimize/maximize button glyph for the current <see cref="IsMinimized" /> state.
+    /// </summary>
     private SpriteFontBase MinMaxButtonFont => IsMinimized
         ? TrueTypeLoader.Instance.GetFont(EmbeddedFontNames.NOTO_SANS_2_SYMBOLS, 24)
         : TrueTypeLoader.Instance.GetFont(EmbeddedFontNames.NOTO_SANS_2_SYMBOLS, 32);
@@ -371,6 +387,8 @@ public class ResizableWindow : Window, IDisposable
     ///     Event handler for the minimize/maximize button click.
     ///     Minimizes or maximizes the window
     /// </summary>
+    /// <param name="_">Unused event sender.</param>
+    /// <param name="_1">Unused event arguments.</param>
     private void OnMinMaxButtonClick(object _, EventArgs _1)
     {
         if (IsMinimized)
@@ -383,8 +401,8 @@ public class ResizableWindow : Window, IDisposable
     ///     Event handler for the reset-window-size button click.
     ///     Resets the window's width/height which causes the window to size itself to fit its current content.
     /// </summary>
-    /// <param name="_"></param>
-    /// <param name="_1"></param>
+    /// <param name="_">Unused event sender.</param>
+    /// <param name="_1">Unused event arguments.</param>
     private void OnResetSizeButtonClick(object _, EventArgs _1)
     {
         Width = null;
@@ -397,6 +415,7 @@ public class ResizableWindow : Window, IDisposable
     /// <summary>
     ///     Initializes and adds the minimize/maximize button to the title panel.
     /// </summary>
+    /// <param name="index">The position within the title panel's widget list at which to insert the button.</param>
     private void ConfigureMinMaxButton(int index = 0)
     {
         if (_minMaxButton != null)
@@ -429,6 +448,9 @@ public class ResizableWindow : Window, IDisposable
         TitlePanel.TouchDoubleClick += OnMinMaxButtonClick;
     }
 
+    /// <summary>
+    ///     Removes the minimize/maximize button from the title panel, if present.
+    /// </summary>
     private void RemoveMinMaxButton()
     {
         if (_minMaxButton == null)
@@ -444,6 +466,7 @@ public class ResizableWindow : Window, IDisposable
     /// <summary>
     ///     Initializes and adds the reset-window-size button to the title panel.
     /// </summary>
+    /// <param name="index">The position within the title panel's widget list at which to insert the button.</param>
     private void ConfigureResizeResetButton(int index = 1)
     {
         if (_resetSizeButton != null)
@@ -474,6 +497,9 @@ public class ResizableWindow : Window, IDisposable
         TitlePanel.Widgets.Insert(index, _resetSizeButton);
     }
 
+    /// <summary>
+    ///     Removes the reset-window-size button from the title panel, if present.
+    /// </summary>
     private void RemoveResizeResetButton()
     {
         if (_resetSizeButton == null)
@@ -673,6 +699,8 @@ public class ResizableWindow : Window, IDisposable
     /// <summary>
     ///     Updates the cursor style as it moves within the window based on whether it is over a resize handle.
     /// </summary>
+    /// <param name="_">Unused event sender.</param>
+    /// <param name="e">Unused mouse-moved event data.</param>
     private void OnMouseMovedWhileInWindow(object _, MouseMovedEventArgs e)
     {
         // Resize is disabled when the window is minimized, so no need to even check the cursor position.
@@ -695,6 +723,8 @@ public class ResizableWindow : Window, IDisposable
     /// <summary>
     ///     Processes window resizing as the mouse moves.
     /// </summary>
+    /// <param name="_">Unused event sender.</param>
+    /// <param name="e">Unused mouse-moved event data.</param>
     private void OnMouseMovedWhileResizing(object _, MouseMovedEventArgs e)
     {
         if (!_activeResizeEdge.HasValue || !Mouse.LButtonPressed)
@@ -723,6 +753,10 @@ public class ResizableWindow : Window, IDisposable
         Resized?.Invoke(this, new ResizeEventArgs { NewWidth = newBounds.Width, NewHeight = newBounds.Height });
     }
 
+    /// <summary>
+    ///     Shows or hides the title label based on whether it would overflow the space available
+    ///     next to the close button at the window's current width.
+    /// </summary>
     private void UpdateTitleLabelVisibility()
     {
         if (!Width.HasValue && Bounds.Width <= 0)
@@ -788,6 +822,8 @@ public class ResizableWindow : Window, IDisposable
     /// <summary>
     ///     Handles left mouse button click state changes during a drag/resize operation.
     /// </summary>
+    /// <param name="_">Unused event sender.</param>
+    /// <param name="e">Event data indicating the new left-button press state.</param>
     private void LeftClickChangedHandler(object _, MouseLeftButtonClickStateChangedEventArgs e)
     {
         if (!e.Current && _activeResizeEdge.HasValue)
@@ -797,6 +833,8 @@ public class ResizableWindow : Window, IDisposable
     /// <summary>
     ///     Stops the current drag/resize operation.
     /// </summary>
+    /// <param name="_">Unused event sender.</param>
+    /// <param name="_1">Unused event arguments.</param>
     private void OnDragStop(object _, EventArgs _1)
     {
         _activeResizeEdge = null;
@@ -825,6 +863,11 @@ public class ResizableWindow : Window, IDisposable
         _isOverridingCursorStyle = false;
     }
 
+    /// <summary>
+    ///     Reconfigures the window's UI components when a property on <see cref="Props" /> changes.
+    /// </summary>
+    /// <param name="sender">Unused event sender.</param>
+    /// <param name="e">Event data identifying which property changed.</param>
     private void OnPropsChanged(object sender, PropertyChangedEventArgs e) => Configure(e);
 
     #endregion

--- a/src/ClassicUO.Client/Game/UI/Controls/ResizableComponents/ResizableWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ResizableComponents/ResizableWindow.cs
@@ -109,6 +109,8 @@ public class ResizableWindow : Window, IDisposable
     private int _resizeStartWidth;
     private int _resizeStartHeight;
 
+    private int? _restoreMinWidth;
+    private int? _restoreMinHeight;
     private int? _restoreWidth;
     private int? _restoreHeight;
     private bool _restoreAutoWidth;
@@ -157,10 +159,18 @@ public class ResizableWindow : Window, IDisposable
         if (IsMinimized)
             return;
 
+        // Store the min width/height - we'll need to reset them
+        // to make sure the window does indeed shrink properly
+        _restoreMinWidth = MinWidth;
+        _restoreMinHeight = MinHeight;
+
         _restoreAutoWidth = !Width.HasValue;
         _restoreAutoHeight = !Height.HasValue;
         _restoreWidth = Width ?? Bounds.Width;
         _restoreHeight = Height ?? Bounds.Height;
+
+        MinWidth = null;
+        MinHeight = null;
         Width = null;
         Height = null;
 
@@ -181,6 +191,8 @@ public class ResizableWindow : Window, IDisposable
             return;
 
         IsMinimized = false;
+        MinWidth = _restoreMinWidth;
+        MinHeight = _restoreMinHeight;
         Width = _restoreAutoWidth ? null : _restoreWidth;
         Height = _restoreAutoHeight ? null : _restoreHeight;
 

--- a/src/ClassicUO.Client/Game/UI/Controls/ResizableComponents/ResizableWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ResizableComponents/ResizableWindow.cs
@@ -16,35 +16,6 @@ using Myra.Graphics2D.UI;
 
 namespace ClassicUO.Game.UI.Controls.ResizableComponents;
 
-#region Auxiliary Classes
-
-public class ResizableWindowProps : MyraCommonProps
-{
-    public ResizeBehavior Resize
-    {
-        get;
-        set
-        {
-            ResizeBehavior oldValue = field;
-            if (SetField(ref field, value))
-            {
-                oldValue?.PropertyChanged -= OnResizePropertyChanged;
-                field?.PropertyChanged += OnResizePropertyChanged;
-            }
-        }
-    } = new();
-    public bool Minimizable { get; set => SetField(ref field, value); } = true;
-
-    public ResizableWindowProps()
-    {
-        Resize?.PropertyChanged += OnResizePropertyChanged;
-    }
-
-    private void OnResizePropertyChanged(object sender, PropertyChangedEventArgs e) => OnPropertyChanged(nameof(Resize));
-}
-
-#endregion
-
 public class ResizableWindow : Window, IDisposable
 {
     #region Events
@@ -77,7 +48,7 @@ public class ResizableWindow : Window, IDisposable
     /// </summary>
     /// <remarks>
     ///     A window is considered resizable if resizing is enabled via the configuration
-    ///     properties and the window is not minimized.
+    ///     properties, and the window is not minimized.
     /// </remarks>
     public bool IsCurrentlyResizable => Props.Resize.Enabled && !IsMinimized;
 
@@ -154,7 +125,8 @@ public class ResizableWindow : Window, IDisposable
     {
         Props = props ?? new ResizableWindowProps();
         Props.PropertyChanged += OnPropsChanged;
-        Configure();
+
+        Configure(null);
     }
 
     #endregion
@@ -357,8 +329,19 @@ public class ResizableWindow : Window, IDisposable
     /// <summary>
     ///     Configures the window UI components.
     /// </summary>
-    private void Configure()
+    /// <param name="e">An optional property changed event arguments, if the call was triggered by property changes</param>
+    private void Configure(PropertyChangedEventArgs e)
     {
+        if (e == null || e.PropertyName == nameof(Props.InitialSizeStore))
+        {
+            Point? initialSize = Props.InitialSizeStore?.Get();
+            if (initialSize.HasValue)
+            {
+                Width = initialSize.Value.X;
+                Height = initialSize.Value.Y;
+            }
+        }
+
         // The close button is kinda ugly, so we center it manually during construction.
         CloseButton?.VerticalAlignment = VerticalAlignment.Center;
         CloseButton?.Margin = new Thickness(2, 0);
@@ -406,6 +389,9 @@ public class ResizableWindow : Window, IDisposable
     {
         Width = null;
         Height = null;
+
+        // Reset stored size, if one is defined
+        Props?.InitialSizeStore?.Set(null);
     }
 
     /// <summary>
@@ -733,6 +719,7 @@ public class ResizableWindow : Window, IDisposable
 
         UpdateTitleLabelVisibility();
 
+        Props?.InitialSizeStore?.Set(new Point(newBounds.Width, newBounds.Height));
         Resized?.Invoke(this, new ResizeEventArgs { NewWidth = newBounds.Width, NewHeight = newBounds.Height });
     }
 
@@ -838,7 +825,7 @@ public class ResizableWindow : Window, IDisposable
         _isOverridingCursorStyle = false;
     }
 
-    private void OnPropsChanged(object sender, PropertyChangedEventArgs e) => Configure();
+    private void OnPropsChanged(object sender, PropertyChangedEventArgs e) => Configure(e);
 
     #endregion
 }

--- a/src/ClassicUO.Client/Game/UI/Controls/ResizableComponents/ResizableWindowProps.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ResizableComponents/ResizableWindowProps.cs
@@ -1,0 +1,32 @@
+using System.ComponentModel;
+using ClassicUO.Common;
+using Microsoft.Xna.Framework;
+
+namespace ClassicUO.Game.UI.Controls.ResizableComponents;
+
+public class ResizableWindowProps : MyraCommonProps
+{
+    public ResizeBehavior Resize
+    {
+        get;
+        set
+        {
+            ResizeBehavior oldValue = field;
+            if (SetField(ref field, value))
+            {
+                oldValue?.PropertyChanged -= OnResizePropertyChanged;
+                field?.PropertyChanged += OnResizePropertyChanged;
+            }
+        }
+    } = new();
+    public bool Minimizable { get; set => SetField(ref field, value); } = true;
+
+    public Accessor<Point?> InitialSizeStore { get; set => SetField(ref field, value); }
+
+    public ResizableWindowProps()
+    {
+        Resize?.PropertyChanged += OnResizePropertyChanged;
+    }
+
+    private void OnResizePropertyChanged(object sender, PropertyChangedEventArgs e) => OnPropertyChanged(nameof(Resize));
+}

--- a/src/ClassicUO.Client/Game/UI/Controls/ResizableComponents/ResizableWindowProps.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ResizableComponents/ResizableWindowProps.cs
@@ -4,8 +4,15 @@ using Microsoft.Xna.Framework;
 
 namespace ClassicUO.Game.UI.Controls.ResizableComponents;
 
+/// <summary>
+///     Defines the configurable properties of a <see cref="ResizableWindow" />, such as its
+///     resize behavior, whether it can be minimized, and where its size is persisted.
+/// </summary>
 public class ResizableWindowProps : MyraCommonProps
 {
+    /// <summary>
+    ///     Gets or sets the resize behavior (enabled edges, size limits, and scrollbar mode) of the window.
+    /// </summary>
     public ResizeBehavior Resize
     {
         get;
@@ -19,14 +26,29 @@ public class ResizableWindowProps : MyraCommonProps
             }
         }
     } = new();
+
+    /// <summary>
+    ///     Gets or sets a value indicating whether the window can be minimized to its title bar.
+    /// </summary>
     public bool Minimizable { get; set => SetField(ref field, value); } = true;
 
+    /// <summary>
+    ///     Gets or sets the accessor used to persist and restore the window's size across sessions.
+    /// </summary>
     public Accessor<Point?> InitialSizeStore { get; set => SetField(ref field, value); }
 
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="ResizableWindowProps" /> class.
+    /// </summary>
     public ResizableWindowProps()
     {
         Resize?.PropertyChanged += OnResizePropertyChanged;
     }
 
+    /// <summary>
+    ///     Re-raises property change notifications from <see cref="Resize" /> as a change of the <see cref="Resize" /> property itself.
+    /// </summary>
+    /// <param name="sender">The <see cref="ResizeBehavior" /> instance that changed.</param>
+    /// <param name="e">Event data describing which property of <see cref="Resize" /> changed.</param>
     private void OnResizePropertyChanged(object sender, PropertyChangedEventArgs e) => OnPropertyChanged(nameof(Resize));
 }

--- a/src/ClassicUO.Client/Game/UI/Controls/ResizableComponents/ResizerStructs.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ResizableComponents/ResizerStructs.cs
@@ -2,41 +2,123 @@ using System;
 
 namespace ClassicUO.Game.UI.Controls.ResizableComponents;
 
+/// <summary>
+///     Identifies the edges of a window that can be used as resize handles.
+/// </summary>
 [Flags]
 public enum ResizeEdges
 {
+    /// <summary>
+    ///     No resize edges enabled.
+    /// </summary>
     None = 0,
+
+    /// <summary>
+    ///     The left edge.
+    /// </summary>
     Left = 1,
+
+    /// <summary>
+    ///     The top edge.
+    /// </summary>
     Top = 1 << 2,
+
+    /// <summary>
+    ///     The right edge.
+    /// </summary>
     Right = 1 << 3,
+
+    /// <summary>
+    ///     The bottom edge.
+    /// </summary>
     Bottom = 1 << 4,
+
+    /// <summary>
+    ///     All edges (left, top, right, and bottom).
+    /// </summary>
     All = Left | Top | Right | Bottom
 }
 
+/// <summary>
+///     Provides data for the <see cref="ResizableWindow.Resized" /> event.
+/// </summary>
 public class ResizeEventArgs : EventArgs
 {
+    /// <summary>
+    ///     Gets or sets the window's new width, in pixels.
+    /// </summary>
     public int NewWidth { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the window's new height, in pixels.
+    /// </summary>
     public int NewHeight { get; set; }
 }
 
+/// <summary>
+///     Defines the configurable properties of a resize handle, such as which edges are active
+///     and the pixel radii used to detect the cursor over them.
+/// </summary>
 public class ResizerProperties : MyraCommonProps
 {
-    public ResizeEdges Placements { get; set => SetField(ref field, value);} = ResizeEdges.All;
-    public uint CornerTriggerRadiusPx { get; set => SetField(ref field, value);} = 18;
-    public uint EdgeTriggerBandWidthPx { get; set => SetField(ref field, value);} = 8;
+    /// <summary>
+    ///     Gets or sets which edges of the window act as resize handles.
+    /// </summary>
+    public ResizeEdges Placements { get; set => SetField(ref field, value); } = ResizeEdges.All;
+
+    /// <summary>
+    ///     Gets or sets the radius, in pixels, of the circular hit area used to detect the cursor
+    ///     over a corner resize handle.
+    /// </summary>
+    public uint CornerTriggerRadiusPx { get; set => SetField(ref field, value); } = 18;
+
+    /// <summary>
+    ///     Gets or sets the thickness, in pixels, of the hit area strip used to detect the cursor
+    ///     over an edge (non-corner) resize handle.
+    /// </summary>
+    public uint EdgeTriggerBandWidthPx { get; set => SetField(ref field, value); } = 8;
 }
 
+/// <summary>
+///     Specifies which scrollbars a resizable window's content wrapper may display.
+/// </summary>
 [Flags]
 public enum ScrollViewerMode
 {
+    /// <summary>
+    ///     No scrollbars; the content is not wrapped in a scroll viewer.
+    /// </summary>
     None = 0,
+
+    /// <summary>
+    ///     A horizontal scrollbar is shown when needed.
+    /// </summary>
     Horizontal = 1,
+
+    /// <summary>
+    ///     A vertical scrollbar is shown when needed.
+    /// </summary>
     Vertical = 1 << 1,
+
+    /// <summary>
+    ///     Both horizontal and vertical scrollbars are shown when needed.
+    /// </summary>
     Both = Horizontal | Vertical
 }
 
+/// <summary>
+///     Defines the resize behavior of a <see cref="ResizableWindow" />, including whether
+///     resizing is enabled, which edges are active, size limits, and how content is scrolled.
+/// </summary>
 public class ResizeBehavior : ResizerProperties
 {
+    /// <summary>
+    ///     Gets or sets a value indicating whether resizing is enabled.
+    /// </summary>
     public bool Enabled { get; set => SetField(ref field, value); } = true;
+
+    /// <summary>
+    ///     Gets or sets which scrollbars are displayed when the window's content overflows its bounds.
+    /// </summary>
     public ScrollViewerMode ScrollerMode { get; set => SetField(ref field, value); } = ScrollViewerMode.Both;
 }

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Options/OptionsWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Options/OptionsWindow.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using ClassicUO.Common;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.UI.Controls;
@@ -28,8 +29,12 @@ public class OptionsWindow : MyraControl
 
     #region Consts/Readonly
 
+    private const int MIN_HEIGHT = 250;
+    private const int MIN_WIDTH = 350;
+
     private const int MAX_HEIGHT = 850;
     private const int MAX_WIDTH = 1200;
+
     private const int SEARCH_DEBOUNCE_MS = 500;
 
     private readonly Dictionary<string, List<IOptionSource>> _optionSources = new();
@@ -105,7 +110,8 @@ public class OptionsWindow : MyraControl
     {
         UIManager.ForEach<OptionsWindow>(w =>
         {
-            if (w != this) w.Dispose();
+            if (w != this)
+                w.Dispose();
         });
 
         SetupOptions();
@@ -113,10 +119,19 @@ public class OptionsWindow : MyraControl
 
         CenterInViewPort();
 
+        _rootWindow.Props.Resize.MinHeight = MIN_HEIGHT;
+        _rootWindow.Props.Resize.MinWidth = MIN_WIDTH;
+
         _rootWindow.Props.Resize.MaxHeight = MAX_HEIGHT;
         _rootWindow.Props.Resize.MaxWidth = MAX_WIDTH;
+
+        _rootWindow.MinHeight = MIN_HEIGHT;
+        _rootWindow.MinWidth = MIN_WIDTH;
+
         _rootWindow.MaxHeight = MAX_HEIGHT;
         _rootWindow.MaxWidth = MAX_WIDTH;
+
+        _rootWindow.Props.InitialSizeStore = new Accessor<Point?>(() => ProfileManager.CurrentProfile.OptionsWindowsSize);
 
         _rootWindow.SizeChanged += (_, _) => _resultsBudget = null;
     }

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Options/OptionsWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Options/OptionsWindow.cs
@@ -131,7 +131,13 @@ public class OptionsWindow : MyraControl
         _rootWindow.MaxHeight = MAX_HEIGHT;
         _rootWindow.MaxWidth = MAX_WIDTH;
 
-        _rootWindow.Props.InitialSizeStore = new Accessor<Point?>(() => ProfileManager.CurrentProfile.OptionsWindowsSize);
+        // The accessor cannot verify whether the underlying singleton has a value so we provide
+        // explicit getter/setter which use conditional logic to make sure we don't throw in the incredibly unlikely case
+        // the profile is not ready.
+        _rootWindow.Props.InitialSizeStore = new Accessor<Point?>(
+            () => ProfileManager.CurrentProfile?.OptionsWindowsSize,
+            (newValue) => ProfileManager.CurrentProfile?.OptionsWindowsSize = newValue
+            );
 
         _rootWindow.SizeChanged += (_, _) => _resultsBudget = null;
     }


### PR DESCRIPTION
## Description
The `OptionsWindow` will now remember its last size as set by the user.
Note that this does not impact autosizing.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Documentation update

## Testing
Local

## Additional Notes
* Raised at [Discord](https://discord.com/channels/1344851225538986064/1522456643000991905/1522488412823621643)
* `ResizableWindow` now supports provision of an `InitialSizeStore` `Accessor<Point?>`. Said accessor will be used to store the window size set by the user upon resize.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Options windows now remember their last size and restore it when reopened.
  * Resizable windows better preserve their size limits when minimized, maximized, or resized.

* **Bug Fixes**
  * Improved window sizing constraints so resize behavior stays consistent and respects minimum dimensions.

* **Chores**
  * Updated the client version metadata to **5.3.26**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->