### PR TITLE
Add optional API.OnStop() callback to LegionScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ All notable changes to TazUO will be recorded here.
 * Added `API.GetClilocString(cliloc, englishOnly=False)` to retrieve cliloc strings from scripts - [P.R 546](https://github.com/PlayTazUO/TazUO/pull/546) ([bittiez](https://github.com/bittiez))
 * Added `API.PlaySound(index)` to play a sound effect locally, `API.LastSpellIndex` to get the index of the last spell cast, and `API.LastSpellName` to get the name of the last spell cast - [P.R 561](https://github.com/PlayTazUO/TazUO/pull/561) ([bittiez](https://github.com/bittiez))
 * Added the ability to bind a hotkey (keyboard, mouse, or controller) to a Legion script from the script manager to toggle it on/off - [P.R 609](https://github.com/PlayTazUO/TazUO/pull/609) ([bittiez](https://github.com/bittiez))
+* Added an optional `API.OnStop(callback)` hook — when set, stopping a script is delayed until the callback is processed via `API.ProcessCallbacks` or a maximum of 5 seconds has elapsed - [P.R 652](https://github.com/PlayTazUO/TazUO/pull/652) ([bittiez](https://github.com/bittiez))
 
 ### Misc
 * Remove tab completion and command history tracking - [P.R 489](https://github.com/PlayTazUO/TazUO/pull/489) ([Jascen](https://github.com/Jascen))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.27</AssemblyVersion>
-    <FileVersion>5.3.27</FileVersion>
+    <AssemblyVersion>5.3.28</AssemblyVersion>
+    <FileVersion>5.3.28</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
@@ -44,7 +44,7 @@ namespace ClassicUO.LegionScripting
         private uint _timedCallbackCurrentId;
         private readonly ConcurrentDictionary<uint, TimedCallback> _timedCallbacks = new();
 
-        private object _onStopCallback;
+        private volatile object _onStopCallback;
         private volatile bool _onStopScheduled;
         private volatile bool _onStopCompleted;
         private readonly ConcurrentDictionary<string, bool> _pressedKeys = new();
@@ -3321,7 +3321,7 @@ namespace ClassicUO.LegionScripting
         /// When set, stopping the script will be delayed until this callback has been
         /// processed, or until a maximum of 5 seconds have passed.
         ///
-        /// Callbacks only run while the script is calling <see cref="ProcessCallbacks"/>,
+        /// Callbacks only run while the script is calling `API.ProcessCallbacks`,
         /// so make sure your script keeps calling it (for example in its main loop) for
         /// the OnStop callback to actually run before the timeout elapses.
         ///

--- a/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
@@ -43,6 +43,10 @@ namespace ClassicUO.LegionScripting
 
         private uint _timedCallbackCurrentId;
         private readonly ConcurrentDictionary<uint, TimedCallback> _timedCallbacks = new();
+
+        private object _onStopCallback;
+        private volatile bool _onStopScheduled;
+        private volatile bool _onStopCompleted;
         private readonly ConcurrentDictionary<string, bool> _pressedKeys = new();
         private readonly ConcurrentDictionary<string, string> _keyToHotkeyMap = new();
 
@@ -164,6 +168,60 @@ namespace ClassicUO.LegionScripting
                     break;
             }
         }
+
+        #endregion
+
+        #region OnStop Callback
+
+        /// <summary>
+        /// Returns true if an OnStop callback is registered that still needs to run.
+        /// </summary>
+        internal bool HasPendingStopCallback => !_disposed && _onStopCallback != null && !_onStopCompleted;
+
+        /// <summary>
+        /// Returns true once a registered OnStop callback has finished running (or no callback was set).
+        /// </summary>
+        internal bool OnStopCompleted => _onStopCompleted;
+
+        /// <summary>
+        /// Schedules the registered OnStop callback so it will run on the next call to
+        /// <see cref="ProcessCallbacks"/>. This is idempotent: it only schedules once and
+        /// returns true only on the first call so callers can start a single wait/timeout.
+        /// </summary>
+        internal bool BeginStopCallback()
+        {
+            if (_onStopScheduled)
+                return false;
+
+            _onStopScheduled = true;
+
+            object callback = _onStopCallback;
+            if (callback == null)
+            {
+                _onStopCompleted = true;
+                return true;
+            }
+
+            ScheduleCallbackActions([WrapStopCallback(callback)]);
+            return true;
+        }
+
+        private Action WrapStopCallback(object callback) =>
+            () =>
+            {
+                try
+                {
+                    CallbackChannel.Invoke(callback);
+                }
+                catch (Exception ex)
+                {
+                    Log.Warn($"OnStop callback error: {ex}");
+                }
+                finally
+                {
+                    _onStopCompleted = true;
+                }
+            };
 
         #endregion
 
@@ -3257,6 +3315,32 @@ namespace ClassicUO.LegionScripting
         /// </summary>
         public void Stop() =>
             MainThreadQueue.InvokeOnMainThread(() => { LegionScripting.StopScript(_scriptFile); });
+
+        /// <summary>
+        /// Register an optional callback to run when this script is being stopped.
+        /// When set, stopping the script will be delayed until this callback has been
+        /// processed, or until a maximum of 5 seconds have passed.
+        ///
+        /// Callbacks only run while the script is calling <see cref="ProcessCallbacks"/>,
+        /// so make sure your script keeps calling it (for example in its main loop) for
+        /// the OnStop callback to actually run before the timeout elapses.
+        ///
+        /// Example:
+        /// ```py
+        /// def on_stop():
+        ///   API.SysMsg("Cleaning up before stopping...")
+        /// API.OnStop(on_stop)
+        /// while True:
+        ///   API.ProcessCallbacks()
+        ///   API.Pause(0.1)
+        /// ```
+        /// To unregister, call with no callback:
+        /// ```py
+        /// API.OnStop()
+        /// ```
+        /// </summary>
+        /// <param name="callback">The function to invoke when the script is stopping, or `null` to unregister.</param>
+        public void OnStop(object callback = null) => _onStopCallback = callback;
 
         /// <summary>
         /// Toggle autolooting on or off.

--- a/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
@@ -431,7 +431,7 @@ namespace ClassicUO.LegionScripting
         public static void Unload()
         {
             while (RunningScripts.Count > 0)
-                StopScript(RunningScripts[0]);
+                StopScript(RunningScripts[0], force: true);
 
             PyThreads.Clear();
 
@@ -707,18 +707,33 @@ namespace ClassicUO.LegionScripting
             }
         }
 
-        public static void StopScript(ScriptFile script)
+        public static void StopScript(ScriptFile script, bool force = false)
         {
             if (script == null) return;
+
+            LegionAPI api = script.ScopedApi;
+
+            // If the script registered an OnStop callback, give it a chance to run before we
+            // tear everything down. The callback only runs while the script keeps calling
+            // API.ProcessCallbacks, so we can't force it - we wait for it to complete or for a
+            // maximum of 5 seconds, whichever comes first. Skipped when force is requested
+            // (e.g. during client shutdown).
+            if (!force && script.ScriptThread is { IsAlive: true } && api is { StopRequested: false } && api.HasPendingStopCallback)
+            {
+                if (api.BeginStopCallback())
+                    WaitForStopCallbackThenStop(script);
+
+                return;
+            }
 
             RunningScripts.Remove(script);
 
             if (script.ScriptThread is { IsAlive: true })
             {
-                if (script.ScopedApi != null)
+                if (api != null)
                 {
-                    script.ScopedApi.StopRequested = true;
-                    script.ScopedApi.CancellationToken.Cancel();
+                    api.StopRequested = true;
+                    api.CancellationToken.Cancel();
                 }
 
                 if (script.PythonEngine != null)
@@ -740,6 +755,45 @@ namespace ClassicUO.LegionScripting
                 script.ScriptThread = null;
                 ScriptStopped?.Invoke(null, script);
             }
+        }
+
+        /// <summary>
+        /// Waits (without blocking the main thread) for a script's OnStop callback to finish,
+        /// or for a maximum of 5 seconds, then performs the actual stop.
+        /// </summary>
+        private static void WaitForStopCallbackThenStop(ScriptFile script)
+        {
+            LegionAPI api = script.ScopedApi;
+            DateTime start = DateTime.UtcNow;
+
+            var timer = new System.Timers.Timer(100) { AutoReset = true };
+
+            timer.Elapsed += (_, _) =>
+            {
+                bool completed = api == null || api.OnStopCompleted;
+                bool timedOut = (DateTime.UtcNow - start).TotalSeconds >= 5;
+
+                if (!completed && !timedOut)
+                    return;
+
+                timer.Stop();
+                timer.Dispose();
+
+                MainThreadQueue.EnqueueAction(() =>
+                {
+                    // The script may have already stopped on its own during the grace period.
+                    if (!RunningScripts.Contains(script))
+                        return;
+
+                    // Ensure the delayed path is not taken again on the follow-up stop.
+                    if (script.ScopedApi != null)
+                        script.ScopedApi.StopRequested = true;
+
+                    StopScript(script);
+                });
+            };
+
+            timer.Start();
         }
 
         /// <summary>

--- a/src/ClassicUO.Client/LegionScripting/docs/API.py
+++ b/src/ClassicUO.Client/LegionScripting/docs/API.py
@@ -2613,6 +2613,33 @@ def Stop() -> None:
     """
     pass
 
+def OnStop(callback: "Any" = None) -> None:
+    """
+     Register an optional callback to run when this script is being stopped.
+     When set, stopping the script will be delayed until this callback has been
+     processed, or until a maximum of 5 seconds have passed.
+    
+     Callbacks only run while the script is calling <see cref="ProcessCallbacks"/> ,
+     so make sure your script keeps calling it (for example in its main loop) for
+     the OnStop callback to actually run before the timeout elapses.
+    
+     Example:
+     ```py
+     def on_stop():
+       API.SysMsg("Cleaning up before stopping...")
+     API.OnStop(on_stop)
+     while True:
+       API.ProcessCallbacks()
+       API.Pause(0.1)
+     ```
+     To unregister, call with no callback:
+     ```py
+     API.OnStop()
+     ```
+    
+    """
+    pass
+
 def ToggleAutoLoot() -> None:
     """
      Toggle autolooting on or off.

--- a/src/ClassicUO.Client/LegionScripting/docs/API.py
+++ b/src/ClassicUO.Client/LegionScripting/docs/API.py
@@ -2619,7 +2619,7 @@ def OnStop(callback: "Any" = None) -> None:
      When set, stopping the script will be delayed until this callback has been
      processed, or until a maximum of 5 seconds have passed.
     
-     Callbacks only run while the script is calling <see cref="ProcessCallbacks"/> ,
+     Callbacks only run while the script is calling `API.ProcessCallbacks`,
      so make sure your script keeps calling it (for example in its main loop) for
      the OnStop callback to actually run before the timeout elapses.
     

--- a/src/ClassicUO.Client/LegionScripting/docs/LegionAPI.md
+++ b/src/ClassicUO.Client/LegionScripting/docs/LegionAPI.md
@@ -21,7 +21,7 @@ You can now type `-updateapi` in game to download the latest API.py file.
 
 [Additional notes](../notes/)  
 
-*This was generated on `7/1/26`.*
+*This was generated on `7/5/26`.*
 
 ## Properties
 ### `Events`
@@ -2558,6 +2558,41 @@ You can now type `-updateapi` in game to download the latest API.py file.
  API.Stop()
  ```
 
+
+**Return Type:** `void` *(Does not return anything)*
+
+---
+
+### OnStop
+`(callback)`
+ Register an optional callback to run when this script is being stopped.
+ When set, stopping the script will be delayed until this callback has been
+ processed, or until a maximum of 5 seconds have passed.
+
+ Callbacks only run while the script is calling <see cref="ProcessCallbacks"/> ,
+ so make sure your script keeps calling it (for example in its main loop) for
+ the OnStop callback to actually run before the timeout elapses.
+
+ Example:
+ ```py
+ def on_stop():
+   API.SysMsg("Cleaning up before stopping...")
+ API.OnStop(on_stop)
+ while True:
+   API.ProcessCallbacks()
+   API.Pause(0.1)
+ ```
+ To unregister, call with no callback:
+ ```py
+ API.OnStop()
+ ```
+
+
+**Parameters:**
+
+| Name | Type | Optional | Description |
+| --- | --- | --- | --- |
+| `callback` | `object` | ✅ Yes | The function to invoke when the script is stopping, or `null` to unregister. |
 
 **Return Type:** `void` *(Does not return anything)*
 

--- a/src/ClassicUO.Client/LegionScripting/docs/LegionAPI.md
+++ b/src/ClassicUO.Client/LegionScripting/docs/LegionAPI.md
@@ -2569,7 +2569,7 @@ You can now type `-updateapi` in game to download the latest API.py file.
  When set, stopping the script will be delayed until this callback has been
  processed, or until a maximum of 5 seconds have passed.
 
- Callbacks only run while the script is calling <see cref="ProcessCallbacks"/> ,
+ Callbacks only run while the script is calling `API.ProcessCallbacks`,
  so make sure your script keeps calling it (for example in its main loop) for
  the OnStop callback to actually run before the timeout elapses.
 


### PR DESCRIPTION
Scripts can register an OnStop callback via API.OnStop(cb). When set, stopping the script is delayed until the callback has been processed (run via API.ProcessCallbacks) or a maximum of 5 seconds has elapsed, whichever comes first. Since callbacks only run when the script calls ProcessCallbacks, the wait is best-effort with a hard 5s cap.

The wait is performed off the main thread via a timer so the client does not freeze, and client shutdown force-stops scripts to avoid waiting on callbacks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional stop-callback hook for scripts, allowing custom actions to run when a script is stopping.
  * Script shutdown now gives registered stop callbacks a short grace period to complete before fully stopping.

* **Bug Fixes**
  * Improved shutdown behavior so running scripts are force-stopped cleanly during app unload.

* **Documentation**
  * Updated API reference and examples to include the new stop-callback behavior and registration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->