### PR TITLE
Add OPL name and data references to Item class

### DIFF
--- a/src/ClassicUO.Client/Game/GameObjects/Item.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Item.cs
@@ -228,6 +228,8 @@ namespace ClassicUO.Game.GameObjects
             if (string.IsNullOrEmpty(name))
                 return string.Empty;
 
+            name = name.Trim();
+
             // OPL names (and some fallbacks) may already include a leading stack size,
             // e.g. "5 Gold Coins". Strip it so amount display is controlled consistently.
             string amountStr = $"{Amount.ToString(CultureInfo.InvariantCulture)} ";

--- a/src/ClassicUO.Client/Game/GameObjects/Item.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Item.cs
@@ -218,10 +218,11 @@ namespace ClassicUO.Game.GameObjects
 
             if (string.IsNullOrEmpty(name))
             {
-                // Fall back to the item data name, adjusted for plurality, then the entity name.
-                name = !string.IsNullOrEmpty(ItemData.Name)
-                    ? StringHelper.CapitalizeAllWords(StringHelper.GetPluralAdjustedString(ItemData.Name, Amount > 1))
-                    : Name;
+                // Fall back to the server-assigned entity name, then the item data name
+                // (adjusted for plurality).
+                name = !string.IsNullOrEmpty(Name)
+                    ? Name
+                    : StringHelper.CapitalizeAllWords(StringHelper.GetPluralAdjustedString(ItemData.Name, Amount > 1));
             }
 
             if (string.IsNullOrEmpty(name))

--- a/src/ClassicUO.Client/Game/GameObjects/Item.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Item.cs
@@ -1,12 +1,14 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
 using System;
+using System.Globalization;
 using System.Threading.Tasks;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.Scenes;
 using ClassicUO.Game.UI.Gumps;
 using ClassicUO.Assets;
+using ClassicUO.Utility;
 using ClassicUO.Utility.Logging;
 using Microsoft.Xna.Framework;
 using MathHelper = ClassicUO.Utility.MathHelper;
@@ -198,6 +200,43 @@ namespace ClassicUO.Game.GameObjects
         {
             string name = await ItemDatabaseManager.Instance.GetItemCustomName(Serial);
             CustomName = name ?? "";
+        }
+
+        /// <summary>
+        /// Gets a display friendly name for this item, preferring the cached OPL name
+        /// (received from the server) and falling back to the item data name.
+        /// </summary>
+        /// <param name="showAmount">
+        /// When true, the stack size is prefixed to the name (e.g. "5 Gold Coins") for stacks
+        /// greater than one. When false, any leading stack size is stripped so only the name remains.
+        /// </param>
+        /// <returns>The normalized item name, or an empty string if no name is available.</returns>
+        public string GetNormalizedName(bool showAmount)
+        {
+            // Prefer the OPL name cached when OPL data was received (easier/faster lookup).
+            string name = OPLName;
+
+            if (string.IsNullOrEmpty(name))
+            {
+                // Fall back to the item data name, adjusted for plurality, then the entity name.
+                name = !string.IsNullOrEmpty(ItemData.Name)
+                    ? StringHelper.CapitalizeAllWords(StringHelper.GetPluralAdjustedString(ItemData.Name, Amount > 1))
+                    : Name;
+            }
+
+            if (string.IsNullOrEmpty(name))
+                return string.Empty;
+
+            // OPL names (and some fallbacks) may already include a leading stack size,
+            // e.g. "5 Gold Coins". Strip it so amount display is controlled consistently.
+            string amountStr = $"{Amount.ToString(CultureInfo.InvariantCulture)} ";
+            if (name.StartsWith(amountStr, StringComparison.Ordinal))
+                name = name[amountStr.Length..];
+
+            if (showAmount && Amount > 1)
+                name = amountStr + name;
+
+            return name;
         }
 
         public override void OnGraphicSet(ushort newGraphic)

--- a/src/ClassicUO.Client/Game/GameObjects/Item.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Item.cs
@@ -36,6 +36,18 @@ namespace ClassicUO.Game.GameObjects
         public bool HighlightChecked;
         public string CustomName { get; set; }
 
+        /// <summary>
+        /// The OPL (Object Property List) name for this item, cached when OPL data is received.
+        /// May be null if OPL data has not yet been received.
+        /// </summary>
+        public string OPLName { get; set; }
+
+        /// <summary>
+        /// The OPL (Object Property List) data (tooltip body) for this item, cached when OPL data is received.
+        /// May be null if OPL data has not yet been received.
+        /// </summary>
+        public string OPLData { get; set; }
+
         public ushort DisplayedGraphic
         {
             get
@@ -171,6 +183,14 @@ namespace ClassicUO.Game.GameObjects
             var i = new Item(world); // _pool.GetOne();
             i.Serial = serial;
             i.TryGetCustomName();
+
+            // If OPL data was already received before this item existed, cache it now.
+            if (world.OPL.TryGetNameAndData(serial, out string oplName, out string oplData))
+            {
+                i.OPLName = oplName;
+                i.OPLData = oplData;
+            }
+
             return i;
         }
 

--- a/src/ClassicUO.Client/Game/Managers/ObjectPropertiesListManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/ObjectPropertiesListManager.cs
@@ -41,8 +41,12 @@ namespace ClassicUO.Game.Managers
             EventSink.InvokeOPLOnReceive(null, new OPLEventArgs(serial, name, data));
 
             Item item = _world.Items.Get(serial);
-            if(item != null)
+            if (item != null)
+            {
+                item.OPLName = name;
+                item.OPLData = data;
                 ItemDatabaseManager.Instance.AddOrUpdateItem(item, _world);
+            }
         }
 
         public bool Contains(uint serial)

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
@@ -2520,21 +2520,7 @@ namespace ClassicUO.Game.UI.Gumps
                 return contents;
             }
 
-            private static string GetItemName(Item item)
-            {
-                if (World.Instance?.OPL?.TryGetNameAndData(item.Serial, out string name, out string _) != true)
-                    return !string.IsNullOrEmpty(item.Name) ? item.Name : item.ItemData.Name;
-
-                // OPL has a cached name for the item
-                if (string.IsNullOrEmpty(name))
-                    return item.ItemData.Name;
-
-                // The stack-size, including a space
-                string itemAmountStr = $"{item.Amount.ToString(CultureInfo.InvariantCulture)} ";
-                return name.StartsWith(itemAmountStr, StringComparison.Ordinal)
-                    ? name[itemAmountStr.Length..] // Trim the stack-size and trailing space
-                    : name;
-            }
+            private static string GetItemName(Item item) => item.GetNormalizedName(false);
 
             private void SetupGridItemControls()
             {

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
@@ -44,7 +44,6 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Xml;
 using ClassicUO.Game.UI.Gumps.GridHighLight;
@@ -1246,26 +1245,6 @@ public partial class GridContainer : ResizableGump
             Spotlight
         }
 
-/// <summary>
-/// Resolves the base item name from OPL tooltip data, falling back to the item's own name.
-/// When <paramref name="fromOPL" /> is true the returned value is the raw (untrimmed) OPL
-/// name; callers apply their own trimming and formatting.
-/// </summary>
-private static string ResolveItemBaseName(World world, Item item, out bool fromOPL)
-{
-    fromOPL = false;
-
-    if (world?.OPL?.TryGetNameAndData(item.Serial, out string oplName, out string _) == true
-        && !string.IsNullOrWhiteSpace(oplName))
-    {
-        fromOPL = true;
-        return oplName;
-    }
-
-    return item.Name;
-}
-
-
         public class GridItem : Control
         {
             private bool _mousePressedWhenEntered;
@@ -1381,82 +1360,11 @@ private static string ResolveItemBaseName(World world, Item item, out bool fromO
                 if (!_isListLayout || _item == null)
                     return;
 
-                string name = GetDisplayName(_world, _item);
+                string name = _item.GetNormalizedName(_item.ItemData.IsStackable && _item.Amount > 1);
                 int widthChars = Math.Max(8, (Width - LIST_ICON_SIZE - 8) / 7);
                 _listLabel.Text = name.Truncate(Math.Min(LIST_NAME_MAX_CHARS, widthChars));
                 _listLabel.Y = Math.Max(0, (Height - _listLabel.Height) >> 1);
                 _listLabel.IsVisible = true;
-            }
-
-private static string GetDisplayName(World world, Item item)
-{
-    bool showAmount = item.ItemData.IsStackable && item.Amount > 1;
-
-    string name = ResolveItemBaseName(world, item, out bool fromOPL);
-
-    // OPL hit: return trimmed tooltip name directly (no further normalization).
-    if (fromOPL)
-        return name.Trim();
-
-    name = NormalizeFallbackDisplayName(name, item, showAmount);
-
-    if (string.IsNullOrWhiteSpace(name))
-    {
-        name = StringHelper.CapitalizeAllWords(
-            StringHelper.GetPluralAdjustedString(item.ItemData.Name, showAmount)
-        );
-    }
-
-    if (showAmount && !HasAmountPrefix(name, item.Amount))
-        return $"{item.Amount} {name}";
-
-    return name;
-}
-
-            private static string NormalizeFallbackDisplayName(string name, Item item, bool showAmount)
-            {
-                if (string.IsNullOrWhiteSpace(name))
-                    return name;
-
-                name = name.Trim();
-
-                if (showAmount)
-                    return StripAmountPrefix(name, item.Amount);
-
-                return item.ItemData.IsStackable ? name : StripLeadingNumberPrefix(name);
-            }
-
-            private static string StripAmountPrefix(string name, int amount)
-            {
-                if (string.IsNullOrWhiteSpace(name) || amount <= 1)
-                    return name;
-
-                string amountPrefix = $"{amount} ";
-                return HasAmountPrefix(name, amount) ? name[amountPrefix.Length..] : name;
-            }
-
-            private static bool HasAmountPrefix(string name, int amount)
-            {
-                if (string.IsNullOrWhiteSpace(name) || amount <= 1)
-                    return false;
-
-                return name.StartsWith($"{amount} ", StringComparison.Ordinal);
-            }
-
-            private static string StripLeadingNumberPrefix(string name)
-            {
-                int separatorIndex = name.IndexOf(' ');
-
-                if (separatorIndex <= 0 || separatorIndex >= name.Length - 1)
-                    return name;
-
-                for (int i = 0; i < separatorIndex; i++)
-                {
-                    if (!char.IsDigit(name[i]))
-                        return name;
-                }
-
-                return name[(separatorIndex + 1)..];
             }
 
             /// <summary>
@@ -2708,19 +2616,7 @@ private static string GetDisplayName(World world, Item item)
                 return contents;
             }
 
-            private static string GetItemName(Item item)
-            {
-                string name = ResolveItemBaseName(World.Instance, item, out bool fromOPL);
-
-                if (!fromOPL)
-                    return !string.IsNullOrEmpty(name) ? name : item.ItemData.Name;
-
-                // stack-size, including space
-                string itemAmountStr = $"{item.Amount.ToString(CultureInfo.InvariantCulture)} ";
-                return name.StartsWith(itemAmountStr, StringComparison.Ordinal)
-                    ? name[itemAmountStr.Length..] // Trim stack-size trailing space
-                    : name;
-            }
+            private static string GetItemName(Item item) => item.GetNormalizedName(false);
 
             private void SetupGridItemControls()
             {

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainer.cs
@@ -44,7 +44,6 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Xml;
 using ClassicUO.Game.UI.Gumps.GridHighLight;


### PR DESCRIPTION
Cache the OPL (Object Property List) name and data directly on the Item when OPL data is received in ObjectPropertiesListManager.Add, and also populate them at item creation if OPL data was already received before the item existed. This allows easier/faster OPL lookup without going through the OPL manager dictionary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Item names now use cached object property information when available, improving consistency and responsiveness in item labels.

* **Bug Fixes**
  * Fixed item naming so stack counts are handled more reliably, including cases where names arrive before the item appears.
  * Improved fallback behavior for items with missing or empty names, reducing odd or blank display text.
  * Sorting and search-related item name handling now uses the same normalized naming behavior as the rest of the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->