### PR TITLE
Remove CI trigger labels after build so they act as one-time switches

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -61,3 +61,18 @@ jobs:
       with:
         name: build-output
         path: '**/bin/Release/**/*'
+
+  remove-label:
+    # Consume the 'run-ci' label so it acts as a one-time "build this" trigger.
+    # Re-adding the label at any time will queue another build.
+    if: github.event_name == 'pull_request' && contains( github.event.pull_request.labels.*.name, 'run-ci')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+    - name: Remove run-ci label
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
+      run: gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label 'run-ci' || true

--- a/.github/workflows/tuo-pr-build.yml
+++ b/.github/workflows/tuo-pr-build.yml
@@ -24,6 +24,23 @@ env:
   NUGET_XMLDOC_MODE: skip
 
 jobs:
+  remove-label:
+    # Consume the 'release-pr' label so it acts as a one-time "build this"
+    # trigger. Re-adding the label at any time will queue another build.
+    if: >-
+      github.event_name == 'pull_request' &&
+      contains(github.event.pull_request.labels.*.name, 'release-pr')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Remove release-pr label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label 'release-pr' || true
+
   build:
     if: >-
       github.event_name == 'workflow_dispatch' ||


### PR DESCRIPTION
Add a remove-label job to build-test (run-ci) and tuo-pr-build (release-pr) that strips the triggering label once a PR build has been kicked off. Adding the label now behaves as a one-time "build this" request, and re-adding it queues another build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated pull request handling by removing trigger labels after a build or release run starts.
  * This helps prevent repeated re-runs when the same label is added again, making CI behavior more predictable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->