### PR TITLE
Fix IndexOutOfRangeException in item mouse selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to Legacy TazUO will be documented in this file.
 
 ---
+## [4.5.23]
+- Fixed an IndexOutOfRangeException crash when the mouse hovered over items/corpses with a graphic id outside the animation data index bounds
+
 ## [4.5.22]
 - More fixes for EA publish
 

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>ClassicUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>4.5.22</AssemblyVersion>
-    <FileVersion>4.5.22</FileVersion>
+    <AssemblyVersion>4.5.23</AssemblyVersion>
+    <FileVersion>4.5.23</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
   </PropertyGroup>
 

--- a/src/ClassicUO.Renderer/Animations/Animation.cs
+++ b/src/ClassicUO.Renderer/Animations/Animation.cs
@@ -50,7 +50,7 @@ namespace ClassicUO.Renderer.Animations
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public sbyte GetMountedHeightOffset(ushort graphic) =>
-            graphic < _dataIndex.Length ? _dataIndex[graphic]?.MountedHeightOffset ?? 0 : 0;
+            (sbyte)(graphic < _dataIndex.Length ? _dataIndex[graphic]?.MountedHeightOffset ?? 0 : 0);
 
         public bool PixelCheck(
             ushort animID,

--- a/src/ClassicUO.Renderer/Animations/Animation.cs
+++ b/src/ClassicUO.Renderer/Animations/Animation.cs
@@ -41,14 +41,16 @@ namespace ClassicUO.Renderer.Animations
         public int MaxAnimationCount => _dataIndex.Length;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public AnimationGroupsType GetAnimType(ushort graphic) => _dataIndex[graphic]?.Type ?? 0;
+        public AnimationGroupsType GetAnimType(ushort graphic) =>
+            graphic < _dataIndex.Length ? _dataIndex[graphic]?.Type ?? 0 : 0;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public AnimationFlags GetAnimFlags(ushort graphic) => _dataIndex[graphic]?.Flags ?? 0;
+        public AnimationFlags GetAnimFlags(ushort graphic) =>
+            graphic < _dataIndex.Length ? _dataIndex[graphic]?.Flags ?? 0 : 0;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public sbyte GetMountedHeightOffset(ushort graphic) =>
-            _dataIndex[graphic]?.MountedHeightOffset ?? 0;
+            graphic < _dataIndex.Length ? _dataIndex[graphic]?.MountedHeightOffset ?? 0 : 0;
 
         public bool PixelCheck(
             ushort animID,


### PR DESCRIPTION
GetAnimType, GetAnimFlags, and GetMountedHeightOffset indexed the _dataIndex array with a ushort graphic (0-65535) without bounds checking, while _dataIndex is only 2048 entries. In Item.CheckMouseSelection the corpse branch calls GetAnimType/GetAnimFlags before GetAnimationFrames has a chance to resize the array, so a graphic >= 2048 threw IndexOutOfRangeException and crashed the render loop.

Add an upper-bound check to these three inlined accessors, matching the guards already present in ConvertBodyIfNeeded, GetAnimationFrames, and AnimationExists.
