### PR TITLE
Fix OverflowException in MultiMapLoader from malformed DisplayMap pac…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,7 @@ All notable changes to TazUO will be recorded here.
 * Retrieve Gumps now also brings Myra (iGui) windows such as the Script Manager back on screen, and accounts for game scale - [P.R 641](https://github.com/PlayTazUO/TazUO/pull/641) ([bittiez](https://github.com/bittiez))
 * Fixed context menu submenus being unreachable when they open to the left (or upward) near the screen edge, where moving the mouse onto them closed the whole menu - [P.R 642](https://github.com/PlayTazUO/TazUO/pull/642) ([bittiez](https://github.com/bittiez))
 * Fixed nested context menu submenus extending past the bottom of the window; the overflow guard now clamps against absolute screen coordinates and the live logical window height so it stays correct at any nesting depth and honors both context menu and game scaling - [P.R 646](https://github.com/PlayTazUO/TazUO/pull/646) ([bittiez](https://github.com/bittiez))
-* Fixed OverflowException crash in MultiMapLoader when a DisplayMap packet supplies out-of-range or inverted map bounds; the pixel buffer allocation is now validated to guard against negative or overflowing dimensions - [P.R #](https://github.com/PlayTazUO/TazUO/pull/#) ([bittiez](https://github.com/bittiez))
+* Fixed OverflowException crash in MultiMapLoader when a DisplayMap packet supplies out-of-range or inverted map bounds; the pixel buffer allocation is now validated to guard against negative or overflowing dimensions - [P.R 658](https://github.com/PlayTazUO/TazUO/pull/658) ([bittiez](https://github.com/bittiez))
 
 ### Legion
 * Added ModernNineSliceGump.SetLegionTexture to go along with zip files and custom png's - Use your own png for a 9-slice texture - ([bittiez](https://github.com/bittiez))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ All notable changes to TazUO will be recorded here.
 * Retrieve Gumps now also brings Myra (iGui) windows such as the Script Manager back on screen, and accounts for game scale - [P.R 641](https://github.com/PlayTazUO/TazUO/pull/641) ([bittiez](https://github.com/bittiez))
 * Fixed context menu submenus being unreachable when they open to the left (or upward) near the screen edge, where moving the mouse onto them closed the whole menu - [P.R 642](https://github.com/PlayTazUO/TazUO/pull/642) ([bittiez](https://github.com/bittiez))
 * Fixed nested context menu submenus extending past the bottom of the window; the overflow guard now clamps against absolute screen coordinates and the live logical window height so it stays correct at any nesting depth and honors both context menu and game scaling - [P.R 646](https://github.com/PlayTazUO/TazUO/pull/646) ([bittiez](https://github.com/bittiez))
+* Fixed OverflowException crash in MultiMapLoader when a DisplayMap packet supplies out-of-range or inverted map bounds; the pixel buffer allocation is now validated to guard against negative or overflowing dimensions - [P.R #](https://github.com/PlayTazUO/TazUO/pull/#) ([bittiez](https://github.com/bittiez))
 
 ### Legion
 * Added ModernNineSliceGump.SetLegionTexture to go along with zip files and custom png's - Use your own png for a 9-slice texture - ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Assets/MultiMapLoader.cs
+++ b/src/ClassicUO.Assets/MultiMapLoader.cs
@@ -70,6 +70,13 @@ namespace ClassicUO.Assets
                 return default;
             }
 
+            if (width <= 0 || height <= 0 || (long)width * height > int.MaxValue)
+            {
+                Log.Warn("Invalid bounds requested from MultiMap.rle");
+
+                return default;
+            }
+
             int mapSize = width * height;
 
             startx = startx >> 1;
@@ -224,6 +231,11 @@ namespace ClassicUO.Assets
 
             int pwidth = endX - startX;
             int pheight = endY - startY;
+
+            if (pwidth <= 0 || pheight <= 0 || (long)pwidth * pheight > int.MaxValue)
+            {
+                return default;
+            }
 
             uint[] pixels = new uint[pwidth * pheight];
 

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.29</AssemblyVersion>
-    <FileVersion>5.3.29</FileVersion>
+    <AssemblyVersion>5.3.30</AssemblyVersion>
+    <FileVersion>5.3.30</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
…kets

The DisplayMap packet handler passes ushort-derived width/height/start/end coordinates to MultiMapLoader. In LoadFacet, the pixel buffer was allocated as new uint[pwidth * pheight] without validating those dimensions, so a malformed or hostile packet where start > end (negative dimension) or with large bounds (product exceeds Int32) caused new uint[...] to throw OverflowException and crash the client.

Guard both LoadFacet and LoadMap: bail out to default when a computed dimension is non-positive or the allocation size would overflow Int32.