### PR TITLE
Fix client crash from unpaired UTF-16 surrogates in journal/text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ All notable changes to TazUO will be recorded here.
 * Fixed context menu submenus being unreachable when they open to the left (or upward) near the screen edge, where moving the mouse onto them closed the whole menu - [P.R 642](https://github.com/PlayTazUO/TazUO/pull/642) ([bittiez](https://github.com/bittiez))
 * Fixed nested context menu submenus extending past the bottom of the window; the overflow guard now clamps against absolute screen coordinates and the live logical window height so it stays correct at any nesting depth and honors both context menu and game scaling - [P.R 646](https://github.com/PlayTazUO/TazUO/pull/646) ([bittiez](https://github.com/bittiez))
 * Fixed OverflowException crash in MultiMapLoader when a DisplayMap packet supplies out-of-range or inverted map bounds; the pixel buffer allocation is now validated to guard against negative or overflowing dimensions - [P.R 658](https://github.com/PlayTazUO/TazUO/pull/658) ([bittiez](https://github.com/bittiez))
+* Fixed client crash (IndexOutOfRangeException) from unpaired UTF-16 surrogates in journal/text; malformed text (e.g. a truncated emoji from the server) is now sanitized before measuring instead of crashing - [P.R 659](https://github.com/PlayTazUO/TazUO/pull/659) ([bittiez](https://github.com/bittiez))
 
 ### Legion
 * Added ModernNineSliceGump.SetLegionTexture to go along with zip files and custom png's - Use your own png for a 9-slice texture - ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.30</AssemblyVersion>
-    <FileVersion>5.3.30</FileVersion>
+    <AssemblyVersion>5.3.31</AssemblyVersion>
+    <FileVersion>5.3.31</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Controls/TextBox.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/TextBox.cs
@@ -114,6 +114,7 @@ namespace ClassicUO.Game.UI.Controls
         private void CreateRichTextLayout(string text)
         {
             text ??= string.Empty;  //Prevent null ref error while still updating everything else
+            text = StringHelper.RemoveUnpairedSurrogates(text); //Lone surrogates crash FontStashSharp's text measuring
             _dirty = false;         //Reset these because we're creating a new text object
             WantUpdateSize = false; //Not resetting them causes this to happen twice from the constructor setting _font and what not.
 
@@ -232,6 +233,8 @@ namespace ClassicUO.Game.UI.Controls
             {
                 if (_rtl.Text != value)
                 {
+                    value = StringHelper.RemoveUnpairedSurrogates(value); //Lone surrogates crash FontStashSharp's text measuring
+
                     if (Options.ConvertHtmlColors)
                     {
                         _rtl.Text = ConvertHTMLColorsToFSS(value);

--- a/src/ClassicUO.Utility/StringHelper.cs
+++ b/src/ClassicUO.Utility/StringHelper.cs
@@ -203,6 +203,63 @@ namespace ClassicUO.Utility
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsSafeChar(int c) => c >= 0x20 && c < 0xFFFE;
 
+        /// <summary>
+        /// Removes unpaired UTF-16 surrogate characters from a string.
+        /// A lone high surrogate (one not followed by a low surrogate) makes
+        /// FontStashSharp read past the end of its internal buffer and throws an
+        /// <see cref="IndexOutOfRangeException"/> while measuring text, so any
+        /// surrogate that is not part of a valid pair must be stripped before the
+        /// text reaches the renderer. Well-formed surrogate pairs are preserved.
+        /// </summary>
+        public static string RemoveUnpairedSurrogates(string str)
+        {
+            if (string.IsNullOrEmpty(str))
+                return str;
+
+            bool hasSurrogate = false;
+
+            for (int i = 0; i < str.Length; i++)
+            {
+                if (char.IsSurrogate(str[i]))
+                {
+                    hasSurrogate = true;
+
+                    break;
+                }
+            }
+
+            if (!hasSurrogate) //Fast path: nothing to sanitize, keep the original reference
+                return str;
+
+            var sb = new ValueStringBuilder(str.Length);
+
+            for (int i = 0; i < str.Length; i++)
+            {
+                char c = str[i];
+
+                if (char.IsHighSurrogate(c))
+                {
+                    if (i + 1 < str.Length && char.IsLowSurrogate(str[i + 1]))
+                    {
+                        sb.Append(c);
+                        sb.Append(str[i + 1]);
+                        i++;
+                    }
+                    //else: unpaired high surrogate -> drop it
+                }
+                else if (!char.IsLowSurrogate(c)) //Drop unpaired low surrogates, keep everything else
+                {
+                    sb.Append(c);
+                }
+            }
+
+            string result = sb.ToString();
+
+            sb.Dispose();
+
+            return result;
+        }
+
         public static void AddSpaceBeforeCapital(string[] str, bool checkAcronyms = true)
         {
             for (int i = 0; i < str.Length; i++)

--- a/src/ClassicUO.Utility/StringHelper.cs
+++ b/src/ClassicUO.Utility/StringHelper.cs
@@ -1,6 +1,7 @@
 ﻿// SPDX-License-Identifier: BSD-2-Clause
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Runtime.CompilerServices;
@@ -216,48 +217,56 @@ namespace ClassicUO.Utility
             if (string.IsNullOrEmpty(str))
                 return str;
 
-            bool hasSurrogate = false;
+            ReadOnlySpan<char> span = str.AsSpan();
 
-            for (int i = 0; i < str.Length; i++)
-            {
-                if (char.IsSurrogate(str[i]))
-                {
-                    hasSurrogate = true;
+            //Fast path: vectorized scan for the first surrogate. If there are none, keep the original reference.
+            int firstSurrogate = span.IndexOfAnyInRange('\uD800', '\uDFFF');
 
-                    break;
-                }
-            }
-
-            if (!hasSurrogate) //Fast path: nothing to sanitize, keep the original reference
+            if (firstSurrogate < 0)
                 return str;
 
-            var sb = new ValueStringBuilder(str.Length);
+            //Output can never be longer than the input. Stackalloc for small strings, rent for larger ones.
+            char[] rented = null;
+            Span<char> destination = str.Length <= 512
+                ? stackalloc char[512]
+                : (rented = ArrayPool<char>.Shared.Rent(str.Length));
 
-            for (int i = 0; i < str.Length; i++)
+            try
             {
-                char c = str[i];
+                //Bulk copy the clean prefix up to the first surrogate, then process the remainder char by char.
+                span.Slice(0, firstSurrogate).CopyTo(destination);
+                int d = firstSurrogate;
 
-                if (char.IsHighSurrogate(c))
+                for (int i = firstSurrogate; i < span.Length; i++)
                 {
-                    if (i + 1 < str.Length && char.IsLowSurrogate(str[i + 1]))
+                    char c = span[i];
+
+                    if (char.IsHighSurrogate(c))
                     {
-                        sb.Append(c);
-                        sb.Append(str[i + 1]);
-                        i++;
+                        if (i + 1 < span.Length && char.IsLowSurrogate(span[i + 1]))
+                        {
+                            destination[d++] = c;
+                            destination[d++] = span[i + 1];
+                            i++;
+                        }
+                        //else: unpaired high surrogate -> drop it
                     }
-                    //else: unpaired high surrogate -> drop it
+                    else if (!char.IsLowSurrogate(c)) //Drop unpaired low surrogates, keep everything else
+                    {
+                        destination[d++] = c;
+                    }
                 }
-                else if (!char.IsLowSurrogate(c)) //Drop unpaired low surrogates, keep everything else
-                {
-                    sb.Append(c);
-                }
+
+                if (d == str.Length) //Every surrogate was part of a valid pair; nothing removed
+                    return str;
+
+                return new string(destination.Slice(0, d));
             }
-
-            string result = sb.ToString();
-
-            sb.Dispose();
-
-            return result;
+            finally
+            {
+                if (rented != null)
+                    ArrayPool<char>.Shared.Return(rented);
+            }
         }
 
         public static void AddSpaceBeforeCapital(string[] str, bool checkAcronyms = true)


### PR DESCRIPTION
FontStashSharp's StringBuilderConvertToUtf32 reads sb[index + 1] whenever sb[index] is a high surrogate, without checking that index + 1 is within bounds. Any text whose measured chunk ends with a lone high surrogate (a truncated emoji or otherwise malformed UTF-16 from the server) therefore throws IndexOutOfRangeException while measuring, crashing the whole client from the journal Update loop.

Strip unpaired surrogates before handing text to the renderer via a new StringHelper.RemoveUnpairedSurrogates helper, applied at the TextBox text entry points (CreateRichTextLayout and the Text setter). Valid surrogate pairs are preserved.