### PR TITLE
Add suggested fix for FetchDisplayAdapter crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ All notable changes to TazUO will be recorded here.
 * Fixed nested context menu submenus extending past the bottom of the window; the overflow guard now clamps against absolute screen coordinates and the live logical window height so it stays correct at any nesting depth and honors both context menu and game scaling - [P.R 646](https://github.com/PlayTazUO/TazUO/pull/646) ([bittiez](https://github.com/bittiez))
 * Fixed OverflowException crash in MultiMapLoader when a DisplayMap packet supplies out-of-range or inverted map bounds; the pixel buffer allocation is now validated to guard against negative or overflowing dimensions - [P.R 658](https://github.com/PlayTazUO/TazUO/pull/658) ([bittiez](https://github.com/bittiez))
 * Fixed client crash (IndexOutOfRangeException) from unpaired UTF-16 surrogates in journal/text; malformed text (e.g. a truncated emoji from the server) is now sanitized before measuring instead of crashing - [P.R 659](https://github.com/PlayTazUO/TazUO/pull/659) ([bittiez](https://github.com/bittiez))
+* Show a suggested fix for the ArgumentOutOfRangeException from FetchDisplayAdapter, which happens when connected displays change at runtime (monitor unplugged/slept, dock or KVM switch, laptop lid) - [P.R 660](https://github.com/PlayTazUO/TazUO/pull/660) ([bittiez](https://github.com/bittiez))
 
 ### Legion
 * Added ModernNineSliceGump.SetLegionTexture to go along with zip files and custom png's - Use your own png for a 9-slice texture - ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.31</AssemblyVersion>
-    <FileVersion>5.3.31</FileVersion>
+    <AssemblyVersion>5.3.32</AssemblyVersion>
+    <FileVersion>5.3.32</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/CrashSuggestedFix.cs
+++ b/src/ClassicUO.Client/CrashSuggestedFix.cs
@@ -35,6 +35,25 @@ namespace ClassicUO
                            "This can sometimes occur if your operating system shuts down your graphics adapter to preserve power.";
                 }
 
+                if (exception is ArgumentOutOfRangeException fetchDisplayAdapterException &&
+                    fetchDisplayAdapterException.StackTrace?.Contains("SDL3_FNAPlatform.FetchDisplayAdapter") == true)
+                {
+                    var sb = new StringBuilder();
+                    sb.AppendLine("TazUO crashed while trying to identify the display it is running on.");
+                    sb.AppendLine("This usually happens when the connected monitors change while the game is running - for example a monitor is unplugged, turned off, put to sleep, or switched to a different input.");
+                    sb.AppendLine("It can also occur when using a docking station, a KVM switch, or a laptop lid that was closed/opened.");
+                    sb.AppendLine();
+                    sb.AppendLine("This is a low-level issue in how the operating system reports displays and is not something TazUO can prevent.");
+                    sb.AppendLine();
+                    sb.AppendLine("Suggested fixes:");
+                    sb.AppendLine("1. Make sure your monitor(s) stay powered on and connected while TazUO is running.");
+                    sb.AppendLine("2. Avoid unplugging monitors, closing your laptop lid, or switching monitor inputs while the game is open.");
+                    sb.AppendLine("3. If you use a docking station or KVM switch, try connecting your monitor directly to test.");
+                    sb.AppendLine("4. Update your graphics card drivers to the latest version.");
+                    sb.AppendLine("5. Simply restart TazUO - it should start normally once your displays are stable.");
+                    return sb.ToString();
+                }
+
                 if (Client.IsShaderCompileFailure(exception))
                 {
                     return Client.GraphicsShaderHelpMessage;


### PR DESCRIPTION
Adds a recognized-crash entry for the ArgumentOutOfRangeException thrown from SDL3_FNAPlatform.FetchDisplayAdapter, which happens when the set of connected displays changes at runtime (monitor unplugged/slept, dock or KVM switch, laptop lid). This can't be prevented by TazUO, so the fix explains the cause and offers practical guidance.