### PR TITLE
Fix grid container stack-count position and optimize item rebuild

### DIFF
--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -520,7 +520,7 @@ namespace ClassicUO.Configuration
         public bool UseGridLayoutContainerGumps { get; set => SetProperty(ref field, value); } = true;
         public bool GridContainersDefaultToOldStyleView { get; set => SetProperty(ref field, value); } = false;
         public int GridContainerViewMode { get; set => SetProperty(ref field, value); } = 0; // 0 = Grid, 1 = List
-        public int GridContainerSearchMode { get; set => SetProperty(ref field, value); } = 1;
+        public int GridContainerSearchMode { get; set => SetProperty(ref field, value); } = 0;
         public bool EnableGridContainerAnchor { get; set => SetProperty(ref field, value); } = false;
         public byte GridBorderAlpha { get; set => SetProperty(ref field, value); } = 75;
         public ushort GridBorderHue { get; set => SetProperty(ref field, value); } = 0;

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainerListView.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainerListView.cs
@@ -1,3 +1,4 @@
+using System;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Managers;
 
@@ -55,17 +56,13 @@ namespace ClassicUO.Game.UI.Gumps
             SlotManager?.FindItem(e.Serial)?.RefreshListName();
         }
 
-        private GridContainerViewModeOverride GetContainerViewModeOverride()
-        {
-            int mode = _gridContainerEntry?.ViewModeOverride ?? (int)GridContainerViewModeOverride.Default;
+        private static GridContainerViewModeOverride ToViewModeOverride(int value) =>
+            Enum.IsDefined((GridContainerViewModeOverride)value)
+                ? (GridContainerViewModeOverride)value
+                : GridContainerViewModeOverride.Default;
 
-            return mode switch
-            {
-                (int)GridContainerViewModeOverride.Grid => GridContainerViewModeOverride.Grid,
-                (int)GridContainerViewModeOverride.List => GridContainerViewModeOverride.List,
-                _ => GridContainerViewModeOverride.Default
-            };
-        }
+        private GridContainerViewModeOverride GetContainerViewModeOverride() =>
+            ToViewModeOverride(_gridContainerEntry?.ViewModeOverride ?? (int)GridContainerViewModeOverride.Default);
 
         private void SetContainerViewModeOverride(GridContainerViewModeOverride mode)
         {
@@ -77,14 +74,6 @@ namespace ClassicUO.Game.UI.Gumps
 
         private int GetContainerViewModeOverrideIndex() => (int)GetContainerViewModeOverride();
 
-        private void SetContainerViewModeOverrideIndex(int index)
-        {
-            SetContainerViewModeOverride(index switch
-            {
-                (int)GridContainerViewModeOverride.Grid => GridContainerViewModeOverride.Grid,
-                (int)GridContainerViewModeOverride.List => GridContainerViewModeOverride.List,
-                _ => GridContainerViewModeOverride.Default
-            });
-        }
+        private void SetContainerViewModeOverrideIndex(int index) => SetContainerViewModeOverride(ToViewModeOverride(index));
     }
 }

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/Controls/GridItem.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/Controls/GridItem.cs
@@ -112,6 +112,7 @@ public class GridItem : Control
         _background.Width = GridItemSize;
         _background.Height = GridItemSize;
         _listLabel.IsVisible = false;
+        RepositionCount();
     }
 
     public void ResizeList(int width)
@@ -124,6 +125,13 @@ public class GridItem : Control
         _listLabel.X = GridContainer.LIST_ICON_SIZE + 4;
         _listLabel.IsVisible = _item != null;
         RefreshListName();
+        RepositionCount();
+    }
+
+    private void RepositionCount()
+    {
+        if (_count != null)
+            _count.Y = Height - _count.Height;
     }
 
     public void RefreshListName()
@@ -182,7 +190,7 @@ public class GridItem : Control
             {
                 X = 1
             };
-            Y = Height - _count.Height;
+            RepositionCount();
         }
 
         RefreshListName();

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/Controls/GridItem.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/Controls/GridItem.cs
@@ -256,95 +256,110 @@ public class GridItem : Control
     {
         base.OnMouseUp(x, y, e);
 
-        if (e == MouseButtonType.Left)
+        if (e != MouseButtonType.Left)
+            return;
+
+        // Modes are mutually exclusive and checked in priority order.
+        if (Client.Game.UO.GameCursor.ItemHold.Enabled)
+            DropHeldItem();
+        else if (_world.TargetManager.IsTargeting)
+            HandleTargetingClick();
+        else if (_gridContainer.IsLockSlot)
+            HandleLockSlotClick();
+        else if (_gridContainer.IsMultiMove && _item != null)
+            HandleMultiMoveClick();
+        else if (_gridContainer.IsAutoLoot && _item != null && _profile.EnableAutoLoot && !_profile.HoldShiftForContext && !_profile.HoldShiftToSplitStack)
+            AddToAutoLoot();
+        else if (_item != null)
+            HandlePlainClick();
+    }
+
+    // Drops the item currently held by the cursor: into this slot's item if it's a container,
+    // stacked onto a matching stackable, or into this grid slot otherwise.
+    private void DropHeldItem()
+    {
+        if (_item != null && _item.ItemData.IsContainer)
         {
-            if (Client.Game.UO.GameCursor.ItemHold.Enabled)
-            {
-                if (_item != null && _item.ItemData.IsContainer)
-                {
-                    GameActions.DropItem(Client.Game.UO.GameCursor.ItemHold.Serial, 0xFFFF, 0xFFFF, 0, _item.Serial);
-                    Mouse.CancelDoubleClick = true;
-                    _mousePressedWhenEntered = false; //Fix for not needing to move mouse out of grid box to re-drag item
-                }
-                else if (_item != null && _item.ItemData.IsStackable && _item.Graphic == Client.Game.UO.GameCursor.ItemHold.Graphic)
-                {
-                    GameActions.DropItem(Client.Game.UO.GameCursor.ItemHold.Serial, _item.X, _item.Y, 0, _item.Serial);
-                    Mouse.CancelDoubleClick = true;
-                    _mousePressedWhenEntered = false; //Fix for not needing to move mouse out of grid box to re-drag item
-                }
-                else
-                {
-                    Rectangle containerBounds = _world.ContainerManager.Get(_container.Graphic).Bounds;
-                    _gridContainer.SlotManager.AddItemSlot(Client.Game.UO.GameCursor.ItemHold.Serial, _slot);
-                    (int X, int Y) pos = GetBoxPosition(_slot, Client.Game.UO.GameCursor.ItemHold.Graphic, containerBounds.Width, containerBounds.Height);
-                    GameActions.DropItem(Client.Game.UO.GameCursor.ItemHold.Serial, pos.X, pos.Y, 0, _container.Serial);
-                    Mouse.CancelDoubleClick = true;
-                    _mousePressedWhenEntered = false; //Fix for not needing to move mouse out of grid box to re-drag item
-                }
-            }
-            else if (_world.TargetManager.IsTargeting)
-            {
-                if (_item != null)
-                {
-                    _world.TargetManager.Target(_item);
-                    if (_world.TargetManager.TargetingState == CursorTarget.SetTargetClientSide)
-                    {
-                        UIManager.Add(new InspectorGump(_world, _item));
-                    }
-                }
-                else if (!_profile.DisableTargetingGridContainers)
-                    _world.TargetManager.Target(_container);
-                Mouse.CancelDoubleClick = true;
-            }
-            else if (_gridContainer.IsLockSlot)
-            {
-                if (_item != null)
-                    _gridContainer.SlotManager.SetLockedSlot(_slot, !ItemGridLocked, _gridContainer.GridContainerEntry.GetSlot(_item.Serial));
-                Mouse.CancelDoubleClick = true;
-            }
-            else if (_gridContainer.IsMultiMove && _item != null)
-            {
-                // If no drag occurred, toggle on click to prevent missed quick taps.
-                if (!_altDragActive)
-                {
-                    _selectHighlight = MultiItemMoveGump.ToggleItem(_item);
-                }
-                else
-                {
-                    _selectHighlight = MultiItemMoveGump.IsSelected(_item.Serial);
-                }
+            GameActions.DropItem(Client.Game.UO.GameCursor.ItemHold.Serial, 0xFFFF, 0xFFFF, 0, _item.Serial);
+        }
+        else if (_item != null && _item.ItemData.IsStackable && _item.Graphic == Client.Game.UO.GameCursor.ItemHold.Graphic)
+        {
+            GameActions.DropItem(Client.Game.UO.GameCursor.ItemHold.Serial, _item.X, _item.Y, 0, _item.Serial);
+        }
+        else
+        {
+            Rectangle containerBounds = _world.ContainerManager.Get(_container.Graphic).Bounds;
+            _gridContainer.SlotManager.AddItemSlot(Client.Game.UO.GameCursor.ItemHold.Serial, _slot);
+            (int X, int Y) pos = GetBoxPosition(_slot, Client.Game.UO.GameCursor.ItemHold.Graphic, containerBounds.Width, containerBounds.Height);
+            GameActions.DropItem(Client.Game.UO.GameCursor.ItemHold.Serial, pos.X, pos.Y, 0, _container.Serial);
+        }
 
-                if (_selectHighlight)
-                    MultiItemMoveGump.ShowNextTo(_gridContainer);
+        Mouse.CancelDoubleClick = true;
+        _mousePressedWhenEntered = false; //Fix for not needing to move mouse out of grid box to re-drag item
+    }
 
-                Mouse.CancelDoubleClick = true;
-            }
-            else if (_gridContainer.IsAutoLoot && _item != null && _profile.EnableAutoLoot && !_profile.HoldShiftForContext && !_profile.HoldShiftToSplitStack)
+    private void HandleTargetingClick()
+    {
+        if (_item != null)
+        {
+            _world.TargetManager.Target(_item);
+            if (_world.TargetManager.TargetingState == CursorTarget.SetTargetClientSide)
             {
-                AutoLootManager.Instance.AddAutoLootEntry(_item.Graphic, _item.Hue, _item.Name);
-                GameActions.Print(_world, $"Added this item to auto loot.");
+                UIManager.Add(new InspectorGump(_world, _item));
             }
-            else if (_item != null)
-            {
-                Point offset = Mouse.LDragOffset;
-                if (Math.Abs(offset.X) < Constants.MIN_PICKUP_DRAG_DISTANCE_PIXELS && Math.Abs(offset.Y) < Constants.MIN_PICKUP_DRAG_DISTANCE_PIXELS)
-                {
-                    if ((_gridContainer.IsCorpse && _profile.CorpseSingleClickLoot) || _gridContainer.QuickLootThisContainer)
-                    {
-                        ObjectActionQueue.Instance.Enqueue(ObjectActionQueueItem.QuickLoot(_item), ActionPriority.MoveItem);
-                        Mouse.CancelDoubleClick = true;
-                    }
-                    else
-                    {
-                        if (_world.ClientFeatures.TooltipsEnabled)
-                            _world.DelayedObjectClickManager.Set(_item.Serial, _gridContainer.X, _gridContainer.Y - 80, Time.Ticks + Mouse.MOUSE_DELAY_DOUBLE_CLICK);
-                        else
-                        {
-                            GameActions.SingleClick(_world, _item.Serial);
-                        }
-                    }
-                }
-            }
+        }
+        else if (!_profile.DisableTargetingGridContainers)
+            _world.TargetManager.Target(_container);
+
+        Mouse.CancelDoubleClick = true;
+    }
+
+    private void HandleLockSlotClick()
+    {
+        if (_item != null)
+            _gridContainer.SlotManager.SetLockedSlot(_slot, !ItemGridLocked, _gridContainer.GridContainerEntry.GetSlot(_item.Serial));
+
+        Mouse.CancelDoubleClick = true;
+    }
+
+    private void HandleMultiMoveClick()
+    {
+        // If no drag occurred, toggle on click to prevent missed quick taps.
+        _selectHighlight = !_altDragActive
+            ? MultiItemMoveGump.ToggleItem(_item)
+            : MultiItemMoveGump.IsSelected(_item.Serial);
+
+        if (_selectHighlight)
+            MultiItemMoveGump.ShowNextTo(_gridContainer);
+
+        Mouse.CancelDoubleClick = true;
+    }
+
+    private void AddToAutoLoot()
+    {
+        AutoLootManager.Instance.AddAutoLootEntry(_item.Graphic, _item.Hue, _item.Name);
+        GameActions.Print(_world, $"Added this item to auto loot.");
+    }
+
+    // A plain left click on an item: quick-loot it if enabled, otherwise show its tooltip/single-click.
+    private void HandlePlainClick()
+    {
+        Point offset = Mouse.LDragOffset;
+        if (Math.Abs(offset.X) >= Constants.MIN_PICKUP_DRAG_DISTANCE_PIXELS || Math.Abs(offset.Y) >= Constants.MIN_PICKUP_DRAG_DISTANCE_PIXELS)
+            return;
+
+        if ((_gridContainer.IsCorpse && _profile.CorpseSingleClickLoot) || _gridContainer.QuickLootThisContainer)
+        {
+            ObjectActionQueue.Instance.Enqueue(ObjectActionQueueItem.QuickLoot(_item), ActionPriority.MoveItem);
+            Mouse.CancelDoubleClick = true;
+        }
+        else if (_world.ClientFeatures.TooltipsEnabled)
+        {
+            _world.DelayedObjectClickManager.Set(_item.Serial, _gridContainer.X, _gridContainer.Y - 80, Time.Ticks + Mouse.MOUSE_DELAY_DOUBLE_CLICK);
+        }
+        else
+        {
+            GameActions.SingleClick(_world, _item.Serial);
         }
     }
 
@@ -862,53 +877,68 @@ public class GridItem : Control
         );
     }
 
+    /// <summary>
+    /// When compare mode is active and the cursor is over an equippable item, builds the
+    /// side-by-side comparison tooltip against the currently equipped item(s).
+    /// </summary>
+    private void TryShowComparisonTooltip()
+    {
+        if (!_hasItem || !_gridContainer.IsCompare || _item.ItemData.Layer <= 0 || !MouseIsOver)
+            return;
+
+        // Bail if a comparison tooltip is already showing.
+        if ((_toolTipThis != null && !_toolTipThis.IsDisposed) ||
+            (_toolTipitem1 != null && !_toolTipitem1.IsDisposed) ||
+            (_toolTipitem2 != null && !_toolTipitem2.IsDisposed))
+            return;
+
+        var itemLayer = (Layer)_item.ItemData.Layer;
+        Item compItem = _world.Player.FindItemByLayer(itemLayer);
+        Item compItem2 = null;
+
+        // For weapons, get both possible comparison items (one-handed and two-handed)
+        (Item weaponPrimary, Item weaponSecondary) = GetWeaponComparisonItems(itemLayer);
+        if (weaponPrimary != null)
+        {
+            compItem = weaponPrimary;
+            compItem2 = weaponSecondary;
+        }
+
+        if (compItem == null || itemLayer == Layer.Backpack)
+            return;
+
+        ClearTooltip();
+        var toolTipList = new List<CustomToolTip>();
+        _toolTipThis = new CustomToolTip(_world, _item, Mouse.Position.X + 5, Mouse.Position.Y + 5, this, compareTo: compItem);
+        toolTipList.Add(_toolTipThis);
+        _toolTipitem1 = new CustomToolTip(_world, compItem, _toolTipThis.X + _toolTipThis.Width + 10, _toolTipThis.Y, this, "<basefont color=\"orange\">Equipped Item<br>");
+        toolTipList.Add(_toolTipitem1);
+
+        if (CUOEnviroment.Debug)
+        {
+            var i1 = new ItemPropertiesData(_world, _item);
+            var i2 = new ItemPropertiesData(_world, compItem);
+
+            if (i1.GenerateComparisonTooltip(i2, out string compileToolTip))
+                GameActions.Print(_world, compileToolTip);
+        }
+
+        // Add second weapon comparison if both hands have weapons
+        if (compItem2 != null)
+        {
+            _toolTipitem2 = new CustomToolTip(_world, compItem2, _toolTipitem1.X + _toolTipitem1.Width + 10, _toolTipitem1.Y, this, "<basefont color=\"orange\">Equipped Item<br>");
+            toolTipList.Add(_toolTipitem2);
+        }
+
+        var multipleToolTipGump = new MultipleToolTipGump(_world, Mouse.Position.X + 10, Mouse.Position.Y + 10, toolTipList.ToArray(), this);
+        UIManager.Add(multipleToolTipGump);
+    }
+
     public override bool Draw(UltimaBatcher2D batcher, int x, int y)
     {
         if (!_shouldDraw || IsDisposed) return false;
 
-        if (_hasItem && _gridContainer.IsCompare && _item.ItemData.Layer > 0 && MouseIsOver && (_toolTipThis == null || _toolTipThis.IsDisposed) && (_toolTipitem1 == null || _toolTipitem1.IsDisposed) && (_toolTipitem2 == null || _toolTipitem2.IsDisposed))
-        {
-            var itemLayer = (Layer)_item.ItemData.Layer;
-            Item compItem = _world.Player.FindItemByLayer(itemLayer);
-            Item compItem2 = null;
-
-            // For weapons, get both possible comparison items (one-handed and two-handed)
-            (Item weaponPrimary, Item weaponSecondary) = GetWeaponComparisonItems(itemLayer);
-            if (weaponPrimary != null)
-            {
-                compItem = weaponPrimary;
-                compItem2 = weaponSecondary;
-            }
-
-            if (compItem != null && itemLayer != Layer.Backpack)
-            {
-                ClearTooltip();
-                var toolTipList = new List<CustomToolTip>();
-                _toolTipThis = new CustomToolTip(_world, _item, Mouse.Position.X + 5, Mouse.Position.Y + 5, this, compareTo: compItem);
-                toolTipList.Add(_toolTipThis);
-                _toolTipitem1 = new CustomToolTip(_world, compItem, _toolTipThis.X + _toolTipThis.Width + 10, _toolTipThis.Y, this, "<basefont color=\"orange\">Equipped Item<br>");
-                toolTipList.Add(_toolTipitem1);
-
-                if (CUOEnviroment.Debug)
-                {
-                    var i1 = new ItemPropertiesData(_world, _item);
-                    var i2 = new ItemPropertiesData(_world, compItem);
-
-                    if (i1.GenerateComparisonTooltip(i2, out string compileToolTip))
-                        GameActions.Print(_world, compileToolTip);
-                }
-
-                // Add second weapon comparison if both hands have weapons
-                if (compItem2 != null)
-                {
-                    _toolTipitem2 = new CustomToolTip(_world, compItem2, _toolTipitem1.X + _toolTipitem1.Width + 10, _toolTipitem1.Y, this, "<basefont color=\"orange\">Equipped Item<br>");
-                    toolTipList.Add(_toolTipitem2);
-                }
-
-                var multipleToolTipGump = new MultipleToolTipGump(_world, Mouse.Position.X + 10, Mouse.Position.Y + 10, toolTipList.ToArray(), this);
-                UIManager.Add(multipleToolTipGump);
-            }
-        }
+        TryShowComparisonTooltip();
 
         if (_selectHighlight && _hasItem)
             if (!MultiItemMoveGump.IsSelected(_item.Serial))

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/Controls/GridScrollArea.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/Controls/GridScrollArea.cs
@@ -6,6 +6,13 @@ namespace ClassicUO.Game.UI.Controls;
 
 public class GridScrollArea : Control
 {
+    /// <summary>Width reserved on the right edge for the scroll bar.</summary>
+    public const int SCROLLBAR_WIDTH = 14;
+
+    // The scroll bar is always Children[0]; content controls start at index 1. The loops
+    // below iterate from index 1 to skip the scroll bar itself.
+    private const int FIRST_CONTENT_CHILD = 1;
+
     private readonly ScrollBarBase _scrollBar;
     private int _lastWidth;
     private int _lastHeight;
@@ -26,7 +33,7 @@ public class GridScrollArea : Control
         _lastWidth = w;
         _lastHeight = h;
 
-        _scrollBar = new ScrollBar(Width - 14, 0, Height);
+        _scrollBar = new ScrollBar(Width - SCROLLBAR_WIDTH, 0, Height);
 
 
         ScrollMaxHeight = scrollMaxHeight;
@@ -56,7 +63,7 @@ public class GridScrollArea : Control
 
         if (Width != _lastWidth || Height != _lastHeight)
         {
-            _scrollBar.X = Width - 14;
+            _scrollBar.X = Width - SCROLLBAR_WIDTH;
             _scrollBar.Height = Height;
             _lastWidth = Width;
             _lastHeight = Height;
@@ -88,9 +95,9 @@ public class GridScrollArea : Control
     {
         _scrollBar.Draw(batcher, x + _scrollBar.X, y + _scrollBar.Y);
 
-        if (batcher.ClipBegin(x, y, Width - 14, Height))
+        if (batcher.ClipBegin(x, y, Width - SCROLLBAR_WIDTH, Height))
         {
-            for (int i = 1; i < Children.Count; i++)
+            for (int i = FIRST_CONTENT_CHILD; i < Children.Count; i++)
             {
                 IGui child = Children[i];
 
@@ -128,7 +135,7 @@ public class GridScrollArea : Control
 
     public override void Clear()
     {
-        for (int i = 1; i < Children.Count; i++)
+        for (int i = FIRST_CONTENT_CHILD; i < Children.Count; i++)
         {
             Children[i].Dispose();
         }
@@ -141,7 +148,7 @@ public class GridScrollArea : Control
 
         int startX = 0, startY = 0, endX = 0, endY = 0;
 
-        for (int i = 1; i < Children.Count; i++)
+        for (int i = FIRST_CONTENT_CHILD; i < Children.Count; i++)
         {
             IGui c = Children[i];
 
@@ -189,7 +196,7 @@ public class GridScrollArea : Control
 
         _scrollBar.UpdateOffset(0, Offset.Y);
 
-        for (int i = 1; i < Children.Count; i++)
+        for (int i = FIRST_CONTENT_CHILD; i < Children.Count; i++)
         {
             Children[i].UpdateOffset(0, -_scrollBar.Value);
         }

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/GridContainer.cs
@@ -708,11 +708,16 @@ public partial class GridContainer : ResizableGump
             if (columns < 0)
                 columns = ProfileManager.CurrentProfile.Grid_DefaultColumns;
 
-            // Calculate the total width of the grid container
+            // Calculate the total width of the grid container.
+            // The layout (see GridSlotManager.SetGridPositions) starts each row at x = X_SPACING
+            // and advances by GridItemSize + X_SPACING per column, so N columns need a leading
+            // gap plus one trailing gap per column: X_SPACING * (columns + 1). Budgeting only
+            // X_SPACING * columns leaves the last column landing exactly on the wrap boundary,
+            // pushing it to the next row (e.g. asking for 5 columns only fits 4).
             return (GetCurrentBorderWidth() * 2)          // Borders on the left and right
                     + GridScrollArea.SCROLLBAR_WIDTH      // Width of the scroll bar
                     + (GridItemSize * columns)            // Total width of grid items
-                    + (X_SPACING * columns);              // Spacing between grid items
+                    + (X_SPACING * (columns + 1));        // Leading gap + spacing after each column
         }
         private static int GetHeight(int rows = -1)
         {

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/GridContainer.cs
@@ -29,7 +29,10 @@ public partial class GridContainer : ResizableGump
         #region private static vars
         private static int _lastX = 100, _lastY = 100, _lastCorpseX = 100, _lastCorpseY = 100;
         public static int GridItemSize => (int)Math.Round(50 * (ProfileManager.CurrentProfile.GridContainersScale / 100f));
-        private static int _borderWidth = 4;
+        private const int DEFAULT_BORDER_WIDTH = 4;
+        // Per-instance so containers can't stomp each other's border width; the static size
+        // helpers derive the current width from the profile via GetCurrentBorderWidth().
+        private int _borderWidth = DEFAULT_BORDER_WIDTH;
 
         private static readonly Dictionary<BorderStyle, (int graphic, int borderSize)> _borderStyleConfig = new()
         {
@@ -44,14 +47,17 @@ public partial class GridContainer : ResizableGump
         #endregion
 
         #region private readonly vars
-        private readonly AlphaBlendControl _background;
-        private readonly AlphaBlendControl _searchBoxBackground;
-        private readonly Label _containerNameLabel;
-        private readonly StbTextBox _searchBox;
-        private readonly GumpPic _openRegularGump, _sortContents;
-        private readonly ResizableStaticPic _quickDropBackpack;
-        private readonly GumpPicTiled _backgroundTexture;
-        private readonly NiceButton _setLootBag, _searchClearButton;
+        // These UI controls are created once (in the Build* helpers invoked from the constructor)
+        // and never reassigned; they are non-readonly only because they are assigned from helper
+        // methods rather than inline in the constructor body.
+        private AlphaBlendControl _background;
+        private AlphaBlendControl _searchBoxBackground;
+        private Label _containerNameLabel;
+        private StbTextBox _searchBox;
+        private GumpPic _openRegularGump, _sortContents;
+        private ResizableStaticPic _quickDropBackpack;
+        private GumpPicTiled _backgroundTexture;
+        private NiceButton _setLootBag, _searchClearButton;
         private readonly bool _isCorpse;
         #endregion
 
@@ -72,7 +78,7 @@ public partial class GridContainer : ResizableGump
 
         #region private vars
         private Item Container => World.Items.Get(LocalSerial);
-        private float _lastGridItemScale = (ProfileManager.CurrentProfile.GridContainersScale / 100f);
+        private int _lastGridItemSize = GridItemSize;
         private int _lastWidth = GetWidth(), _lastHeight = GetHeight();
         private bool _quickLootThisContainer;
         public bool? UseOldContainerStyle;
@@ -82,7 +88,7 @@ public partial class GridContainer : ResizableGump
         private readonly bool _skipSave;
         private readonly ushort _originalContainerItemGraphic;
 
-        private readonly GridScrollArea _scrollArea;
+        private GridScrollArea _scrollArea;
         private bool _isMinimized;
         private int _heightBeforeMinimize;
         #endregion
@@ -152,15 +158,20 @@ public partial class GridContainer : ResizableGump
             if (_scrollArea != null) _scrollArea.IsVisible = visible;
             if (_setLootBag != null) _setLootBag.IsVisible = visible && _isCorpse;
 
-            // Find and toggle resize button
-            foreach (Control child in Children)
-            {
-                if (child is Button)
-                {
-                    child.IsVisible = visible;
-                    break;
-                }
-            }
+            if (ResizeButton != null) ResizeButton.IsVisible = visible;
+        }
+
+        /// <summary>
+        /// Repositions the resize handle into the bottom-right corner. Used when we bypass
+        /// <see cref="ResizableGump.ResizeWindow"/> (e.g. maintaining the minimized height).
+        /// </summary>
+        private void RepositionResizeButton()
+        {
+            Button btn = ResizeButton;
+            if (btn == null) return;
+
+            btn.X = Width - btn.Width + 2;
+            btn.Y = Height - btn.Height + 2;
         }
 
         /// <summary>
@@ -281,7 +292,42 @@ public partial class GridContainer : ResizableGump
             AcceptMouseInput = true;
             #endregion
 
-            #region background
+            BuildBackground();
+            BuildTopBar();
+            BuildScrollArea();
+            BuildLootBag();
+            AddControls();
+
+            SlotManager = new GridSlotManager(world, LocalSerial, this, _scrollArea); //Must come after scroll area
+            InitializeListView();
+
+            UpdateContainerNameLabel();
+
+            if (ShouldUseOldContainerStyle())
+            {
+                _skipSave = true; //Avoid unsaving item slots because they have not be set up yet
+                OpenOldContainer(local);
+                return;
+            }
+
+            BuildBorder();
+            ResizeWindow(savedSize);
+
+            // Apply minimized state after all controls are created
+            if (loadMinimized)
+            {
+                // Store the current (full) height from savedSize before minimizing
+                _heightBeforeMinimize = savedSize.Y > 0 ? savedSize.Y : Height;
+                _isMinimized = true;
+                // Don't call UpdateMinimizedState here - just apply the minimized dimensions directly
+                // to avoid overwriting _heightBeforeMinimize
+                ApplyMinimizedDimensions();
+            }
+        }
+
+        #region Control construction
+        private void BuildBackground()
+        {
             _background = new AlphaBlendControl()
             {
                 Width = Width - (_borderWidth * 2),
@@ -298,9 +344,10 @@ public partial class GridContainer : ResizableGump
 
             _backgroundTexture = new GumpPicTiled(0) { CanMove = true };
             _backgroundTexture.MouseDoubleClick += OnMinimizeToggleDoubleClick;
-            #endregion
+        }
 
-            #region TOP BAR AREA
+        private void BuildTopBar()
+        {
             _containerNameLabel = new Label(GetContainerName(), true, 0x0481, 0, ishtml: true)
             {
                 X = _borderWidth,
@@ -403,9 +450,10 @@ public partial class GridContainer : ResizableGump
             _sortContents.MouseEnter += (sender, e) => { _sortContents.Graphic = 1209; };
             _sortContents.MouseExit += (sender, e) => { _sortContents.Graphic = 1210; };
             _sortContents.SetTooltip(SortButtonTooltip);
-            #endregion
+        }
 
-            #region Scroll Area
+        private void BuildScrollArea()
+        {
             _scrollArea = new GridScrollArea(
                 _background.X,
                 LABEL_HEIGHT + TOP_BAR_HEIGHT + _background.Y,
@@ -426,20 +474,22 @@ public partial class GridContainer : ResizableGump
                     }
                 }
             };
-            #endregion
+        }
 
-            #region Set loot bag
+        private void BuildLootBag()
+        {
             _setLootBag = new NiceButton(0, Height - 20, 100, 20, ButtonAction.Default, TazLang.Get("gridcontainer_setlootbag", "Set loot bag")) { IsSelectable = false };
             _setLootBag.IsVisible = _isCorpse;
             _setLootBag.SetTooltip(TazLang.Get("gridcontainer_setlootbag_tooltip", "For double click looting only"));
             _setLootBag.MouseUp += (s, e) =>
             {
-                GameActions.Print(world, Resources.ResGumps.TargetContainerToGrabItemsInto);
-                world.TargetManager.SetTargeting(CursorTarget.SetGrabBag, 0, TargetType.Neutral);
+                GameActions.Print(World, Resources.ResGumps.TargetContainerToGrabItemsInto);
+                World.TargetManager.SetTargeting(CursorTarget.SetGrabBag, 0, TargetType.Neutral);
             };
-            #endregion
+        }
 
-            #region Add controls
+        private void AddControls()
+        {
             Add(_background);
             Add(_backgroundTexture);
             Add(_containerNameLabel);
@@ -457,34 +507,8 @@ public partial class GridContainer : ResizableGump
             Add(_sortContents);
             Add(_scrollArea);
             Add(_setLootBag);
-            #endregion
-
-            SlotManager = new GridSlotManager(world, LocalSerial, this, _scrollArea); //Must come after scroll area
-            InitializeListView();
-
-            UpdateContainerNameLabel();
-
-            if (ShouldUseOldContainerStyle())
-            {
-                _skipSave = true; //Avoid unsaving item slots because they have not be set up yet
-                OpenOldContainer(local);
-                return;
-            }
-
-            BuildBorder();
-            ResizeWindow(savedSize);
-
-            // Apply minimized state after all controls are created
-            if (loadMinimized)
-            {
-                // Store the current (full) height from savedSize before minimizing
-                _heightBeforeMinimize = savedSize.Y > 0 ? savedSize.Y : Height;
-                _isMinimized = true;
-                // Don't call UpdateMinimizedState here - just apply the minimized dimensions directly
-                // to avoid overwriting _heightBeforeMinimize
-                ApplyMinimizedDimensions();
-            }
         }
+        #endregion
 
         /// <summary>
         ///     Checks whether the container should be opened in the 'old' style.
@@ -510,6 +534,24 @@ public partial class GridContainer : ResizableGump
 
         public override GumpType GumpType => GumpType.GridContainer;
 
+        /// <summary>Height of the container when minimized (just the label area plus borders).</summary>
+        private int MinimizedHeight => LABEL_HEIGHT + (_borderWidth * 2);
+
+        /// <summary>
+        /// Collapses the window to <see cref="MinimizedHeight"/> and shrinks the background to the
+        /// label strip. Shared by the runtime minimize toggle and the initial-load path.
+        /// </summary>
+        private void ApplyMinimizedHeight()
+        {
+            ResizeWindow(new Point(Width, MinimizedHeight));
+            Height = MinimizedHeight;
+
+            if (_background != null) _background.Height = LABEL_HEIGHT;
+            if (_backgroundTexture != null) _backgroundTexture.Height = LABEL_HEIGHT;
+
+            OnResize();
+        }
+
         private void UpdateMinimizedState()
         {
             if (_isMinimized)
@@ -519,31 +561,15 @@ public partial class GridContainer : ResizableGump
 
                 SwitchPositionState(false);
                 SetControlsVisibility(false);
-
-                // Resize to minimal height (just the label area + border)
-                int minimizedHeight = LABEL_HEIGHT + (_borderWidth * 2);
-                ResizeWindow(new Point(Width, minimizedHeight));
-                Height = minimizedHeight;
-
-                // Update border and background dimensions
-                if (_background != null) _background.Height = LABEL_HEIGHT;
-                if (_backgroundTexture != null) _backgroundTexture.Height = LABEL_HEIGHT;
-
-                OnResize();
+                ApplyMinimizedHeight();
             }
             else
             {
                 SwitchPositionState(true);
-
                 SetControlsVisibility(true);
 
-                // Restore original height (fallback to default if not set)
-                int restoredHeight;
-                if (_heightBeforeMinimize > 0)
-                    restoredHeight = _heightBeforeMinimize;
-                else
-                    // Fallback to a reasonable default height
-                    restoredHeight = GetHeight();
+                // Restore original height (fallback to a reasonable default if not set)
+                int restoredHeight = _heightBeforeMinimize > 0 ? _heightBeforeMinimize : GetHeight();
 
                 ResizeWindow(new Point(Width, restoredHeight));
                 Height = restoredHeight;
@@ -566,19 +592,7 @@ public partial class GridContainer : ResizableGump
         {
             // Hide all controls except container name, background, and border
             SetControlsVisibility(false);
-
-            // Resize to minimal height (just the label area + border)
-            int minimizedHeight = LABEL_HEIGHT + (_borderWidth * 2);
-            ResizeWindow(new Point(Width, minimizedHeight));
-            Height = minimizedHeight;
-
-            // Update border and background dimensions
-            if (_background != null) _background.Height = LABEL_HEIGHT;
-            if (_backgroundTexture != null) _backgroundTexture.Height = LABEL_HEIGHT;
-
-            // Update the border control to match new dimensions
-            OnResize();
-
+            ApplyMinimizedHeight();
             WantUpdateSize = true;
         }
 
@@ -674,6 +688,20 @@ public partial class GridContainer : ResizableGump
 
             return control;
         }
+        /// <summary>
+        /// Border width implied by the profile's current border style. Used by the static size
+        /// helpers, which run before an instance exists and so can't read <see cref="_borderWidth"/>.
+        /// </summary>
+        private static int GetCurrentBorderWidth()
+        {
+            var style = (BorderStyle)ProfileManager.CurrentProfile.Grid_BorderStyle;
+
+            if (style != BorderStyle.Default && _borderStyleConfig.TryGetValue(style, out (int graphic, int borderSize) config))
+                return config.borderSize;
+
+            return DEFAULT_BORDER_WIDTH;
+        }
+
         private static int GetWidth(int columns = -1)
         {
             // Use default columns if none are specified
@@ -681,10 +709,10 @@ public partial class GridContainer : ResizableGump
                 columns = ProfileManager.CurrentProfile.Grid_DefaultColumns;
 
             // Calculate the total width of the grid container
-            return (_borderWidth * 2)           // Borders on the left and right
-                    + 15                       // Width of the scroll bar
-                    + (GridItemSize * columns) // Total width of grid items
-                    + (X_SPACING * columns);   // Spacing between grid items
+            return (GetCurrentBorderWidth() * 2)          // Borders on the left and right
+                    + GridScrollArea.SCROLLBAR_WIDTH      // Width of the scroll bar
+                    + (GridItemSize * columns)            // Total width of grid items
+                    + (X_SPACING * columns);              // Spacing between grid items
         }
         private static int GetHeight(int rows = -1)
         {
@@ -695,7 +723,7 @@ public partial class GridContainer : ResizableGump
             // Calculate the total height of the grid container
             return LABEL_HEIGHT                 // Height of the container name label
                    + TOP_BAR_HEIGHT             // Height of the top bar
-                   + (_borderWidth * 2)          // Borders on the top and bottom
+                   + (GetCurrentBorderWidth() * 2)  // Borders on the top and bottom
                    + ((GridItemSize + Y_SPACING) * rows); // Total height of grid items with spacing
         }
 
@@ -964,46 +992,26 @@ public partial class GridContainer : ResizableGump
             }
 
             // Maintain minimized height when minimized
-            if (_isMinimized && Height != LABEL_HEIGHT + (_borderWidth * 2))
+            if (_isMinimized && Height != MinimizedHeight)
             {
-                Height = LABEL_HEIGHT + (_borderWidth * 2);
+                Height = MinimizedHeight;
                 _background.Height = LABEL_HEIGHT;
                 _backgroundTexture.Height = LABEL_HEIGHT;
                 BorderControl.Width = Width;
                 BorderControl.Height = Height;
 
                 // Manually reposition the resize button since we're bypassing ResizeWindow's min height
-                foreach (Control child in Children)
-                {
-                    if (child is Button btn)
-                    {
-                        btn.X = Width - btn.Width + 2;
-                        btn.Y = Height - btn.Height + 2;
-                        break;
-                    }
-                }
+                RepositionResizeButton();
 
                 WantUpdateSize = true;
             }
 
-            if (!_isMinimized && (_lastWidth != Width || _lastHeight != Height || _lastGridItemScale != GridItemSize))
+            if (!_isMinimized && (_lastWidth != Width || _lastHeight != Height || _lastGridItemSize != GridItemSize))
             {
-                _lastGridItemScale = GridItemSize;
-                int adjustedWidth = Width - (_borderWidth * 2);
-                int adjustedHeight = Height - (_borderWidth * 2);
-                UpdateBackgroundDimensions(adjustedWidth, adjustedHeight);
-                _scrollArea.Width = adjustedWidth;
-                _scrollArea.Height = adjustedHeight - LABEL_HEIGHT - TOP_BAR_HEIGHT;
-                _openRegularGump.X = Width - _openRegularGump.Width - _borderWidth;
-                _quickDropBackpack.X = _openRegularGump.X - _quickDropBackpack.Width;
-                _sortContents.X = _quickDropBackpack.X - _sortContents.Width;
+                _lastGridItemSize = GridItemSize;
+                LayoutControls();
                 _lastHeight = Height;
                 _lastWidth = Width;
-                _searchBox.Width = adjustedWidth - 18;
-                _searchBoxBackground.Width = _searchBox.Width;
-                _searchClearButton.X = _borderWidth + adjustedWidth - 16;
-                UpdateBackgroundStyle(_background.Hue, _background.Alpha);
-                _setLootBag.Y = Height - 20;
 
                 if (IsPlayerBackpack)
                     ProfileManager.CurrentProfile.BackpackGridSize = new Point(Width, Height);
@@ -1025,11 +1033,17 @@ public partial class GridContainer : ResizableGump
             }
         }
 
+        /// <summary>
+        /// Resolves the container's display name: custom name if set, otherwise the item's name,
+        /// falling back to "a container".
+        /// </summary>
+        private string ResolveRawName() =>
+            GridContainerEntry?.CustomName.NotNullNotEmpty() == true ? GridContainerEntry.CustomName :
+            !string.IsNullOrEmpty(Container.Name) ? Container.Name : "a container";
+
         private void UpdateContainerNameLabel()
         {
-            string rawName = GridContainerEntry?.CustomName.NotNullNotEmpty() == true
-                ? GridContainerEntry.CustomName
-                : !string.IsNullOrEmpty(Container.Name) ? Container.Name : "a container";
+            string rawName = ResolveRawName();
 
             string countSuffix = SlotManager != null ? $" ({SlotManager.ContainerContents.Count})" : "";
 
@@ -1057,9 +1071,7 @@ public partial class GridContainer : ResizableGump
 
         private string GetContainerName(bool skipCount = false, bool truncate = true)
         {
-            string containerName =
-                GridContainerEntry?.CustomName.NotNullNotEmpty() == true ? GridContainerEntry.CustomName :
-                !string.IsNullOrEmpty(Container.Name) ? Container.Name : "a container";
+            string containerName = ResolveRawName();
 
             if (truncate)
                 containerName = containerName.Truncate(21);
@@ -1138,35 +1150,52 @@ public partial class GridContainer : ResizableGump
                 BorderControl.BorderSize = borderSize;
                 _borderWidth = borderSize;
             }
-            UpdateUiPositions();
+            LayoutControls();
             OnResize();
 
             BorderControl.IsVisible = !ProfileManager.CurrentProfile.Grid_HideBorder;
         }
 
-        private void UpdateUiPositions()
+        /// <summary>
+        /// Positions and sizes every child control from the current <see cref="Control.Width"/>,
+        /// <see cref="Control.Height"/>, and <see cref="_borderWidth"/>. Shared by initial layout
+        /// (via <see cref="BuildBorder"/>) and the resize path in <see cref="PreDraw"/>; every
+        /// assignment is idempotent so calling it repeatedly is safe.
+        /// </summary>
+        private void LayoutControls()
         {
-            _background.X = _background.Y = _borderWidth;
-            _scrollArea.X = _background.X;
-            _scrollArea.Y = LABEL_HEIGHT + TOP_BAR_HEIGHT + _background.Y;
-            _searchBox.X = _borderWidth;
-            _searchBox.Y = _borderWidth + LABEL_HEIGHT;
-            _quickDropBackpack.Y = _sortContents.Y = _openRegularGump.Y = _borderWidth;
-            _backgroundTexture.X = _background.X;
-            _backgroundTexture.Y = _background.Y;
-
             int adjustedWidth = Width - (_borderWidth * 2);
             int adjustedHeight = Height - (_borderWidth * 2);
 
+            // Background + tiled texture
+            _background.X = _background.Y = _borderWidth;
+            _backgroundTexture.X = _background.X;
+            _backgroundTexture.Y = _background.Y;
             UpdateBackgroundDimensions(adjustedWidth, adjustedHeight);
+            UpdateBackgroundStyle(_background.Hue, _background.Alpha);
 
+            // Top-bar buttons (right-aligned, in from the right edge)
+            _openRegularGump.X = Width - _openRegularGump.Width - _borderWidth;
+            _quickDropBackpack.X = _openRegularGump.X - _quickDropBackpack.Width;
+            _sortContents.X = _quickDropBackpack.X - _sortContents.Width;
+            _quickDropBackpack.Y = _sortContents.Y = _openRegularGump.Y = _borderWidth;
+
+            // Search box + clear button
+            _searchBox.X = _borderWidth;
+            _searchBox.Y = _borderWidth + LABEL_HEIGHT;
             _searchBox.Width = adjustedWidth - 18;
             _searchBoxBackground.Width = _searchBox.Width;
             _searchClearButton.X = _borderWidth + adjustedWidth - 16;
             _searchClearButton.Y = _borderWidth + LABEL_HEIGHT;
 
+            // Scroll area (below the top bar)
+            _scrollArea.X = _background.X;
+            _scrollArea.Y = LABEL_HEIGHT + TOP_BAR_HEIGHT + _background.Y;
             _scrollArea.Width = adjustedWidth;
             _scrollArea.Height = adjustedHeight - LABEL_HEIGHT - TOP_BAR_HEIGHT;
+
+            // Set-loot-bag button (corpses only, pinned to the bottom)
+            _setLootBag.Y = Height - 20;
         }
 
         public override bool Draw(UltimaBatcher2D batcher, int x, int y)

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/GridContainer.cs
@@ -977,8 +977,8 @@ public partial class GridContainer : ResizableGump
                 {
                     if (child is Button btn)
                     {
-                        btn.X = Width - (btn.Width >> 0) + 2;
-                        btn.Y = Height - (btn.Height >> 0) + 2;
+                        btn.X = Width - btn.Width + 2;
+                        btn.Y = Height - btn.Height + 2;
                         break;
                     }
                 }

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/GridSlotManager.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/GridSlotManager.cs
@@ -124,44 +124,61 @@ namespace ClassicUO.Game.UI.Gumps.GridContainers;
                 slot.Value.SetGridItem(null);
             }
 
+            // Serials of everything we're allowed to display, for O(1) membership checks.
+            var filteredSerials = new HashSet<uint>(filteredItems.Count);
+            foreach (Item i in filteredItems)
+                filteredSerials.Add(i.Serial);
+
+            // Tracks which items have already been placed so the second pass can skip them
+            // without mutating the caller's list (which may be a shared/cached collection).
+            var placed = new HashSet<uint>();
+
             // First pass: Place items that have saved positions (and locked items if sorting)
             // This maintains user-customized item positions unless auto-sort is overriding
             foreach (KeyValuePair<int, uint> spot in _itemPositions)
             {
-                Item i = _world.Items.Get(spot.Value);
-                if (i != null)
-                    // Place item if it's in the filtered list AND (not sorting OR item is locked)
-                    if (filteredItems.Contains(i) && (!overrideSort || _itemLocks.Contains(spot.Value)))
-                    {
-                        if (spot.Key < _gridSlots.Count)
-                        {
-                            // Place the item at its saved slot position
-                            _gridSlots[spot.Key].SetGridItem(i);
+                uint serial = spot.Value;
 
-                            // Mark the slot as locked if the item is locked in place
-                            if (_itemLocks.Contains(spot.Value))
-                                _gridSlots[spot.Key].ItemGridLocked = true;
+                if (spot.Key >= _gridSlots.Count || placed.Contains(serial))
+                    continue;
 
-                            // Remove from the list so it won't be placed again
-                            filteredItems.Remove(i);
-                        }
-                    }
+                // Place item if it's in the filtered list AND (not sorting OR item is locked)
+                if (!filteredSerials.Contains(serial) || (overrideSort && !_itemLocks.Contains(serial)))
+                    continue;
+
+                Item i = _world.Items.Get(serial);
+                if (i == null)
+                    continue;
+
+                // Place the item at its saved slot position
+                _gridSlots[spot.Key].SetGridItem(i);
+
+                // Mark the slot as locked if the item is locked in place
+                if (_itemLocks.Contains(serial))
+                    _gridSlots[spot.Key].ItemGridLocked = true;
+
+                placed.Add(serial);
             }
 
             // Second pass: Fill remaining empty slots with items that don't have saved positions
             // This includes new items or items being auto-sorted
+            int nextFreeSlot = 0;
             foreach (Item i in filteredItems)
             {
-                foreach (KeyValuePair<int, GridItem> slot in _gridSlots)
-                {
-                    // Skip slots that already have items
-                    if (slot.Value.SlotItem != null)
-                        continue;
-                    // Place item in first available empty slot
-                    slot.Value.SetGridItem(i);
-                    AddItemSlot(i, slot.Key);
+                if (placed.Contains(i.Serial))
+                    continue;
+
+                // Advance to the next empty slot (slots fill front-to-back, so we never need
+                // to re-scan from the beginning).
+                while (nextFreeSlot < _gridSlots.Count && _gridSlots[nextFreeSlot].SlotItem != null)
+                    nextFreeSlot++;
+
+                if (nextFreeSlot >= _gridSlots.Count)
                     break;
-                }
+
+                _gridSlots[nextFreeSlot].SetGridItem(i);
+                AddItemSlot(i, nextFreeSlot);
+                placed.Add(i.Serial);
             }
 
             // Rebuild the GridItems lookup dictionary for quick serial-to-GridItem access

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/GridSlotManager.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/GridSlotManager.cs
@@ -247,7 +247,7 @@ namespace ClassicUO.Game.UI.Gumps.GridContainers;
         {
             if (_gridContainer.IsListView)
             {
-                int rowWidth = Math.Max(0, _area.Width - 14);
+                int rowWidth = Math.Max(0, _area.Width - GridScrollArea.SCROLLBAR_WIDTH);
                 int columns = Math.Max(1, rowWidth / LIST_COLUMN_WIDTH);
                 int columnWidth = columns > 1 ? rowWidth / columns : rowWidth;
                 int itemWidth = Math.Max(0, columnWidth - (columns > 1 ? LIST_COLUMN_GAP : 0));
@@ -276,7 +276,7 @@ namespace ClassicUO.Game.UI.Gumps.GridContainers;
                 {
                     continue;
                 }
-                if (x + GridItemSize >= _area.Width - 14) //14 is the scroll bar width
+                if (x + GridItemSize >= _area.Width - GridScrollArea.SCROLLBAR_WIDTH)
                 {
                     x = X_SPACING;
                     y += GridItemSize + Y_SPACING;

--- a/src/ClassicUO.Client/Game/UI/Gumps/ResizableGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ResizableGump.cs
@@ -23,6 +23,9 @@ namespace ClassicUO.Game.UI.Gumps
 
         public BorderControl BorderControl => _borderControl;
 
+        /// <summary>The drag handle in the bottom-right corner used to resize the gump.</summary>
+        protected Button ResizeButton => _button;
+
         protected ResizableGump
         (
             World world,int width,


### PR DESCRIPTION
- GridItem: stack-count label was positioned via `Y = Height - _count.Height`, which mutated the slot's own Y (immediately overwritten by SetGridPositions) instead of the label's Y. The count consequently rendered at the cell's top-left rather than the bottom. Assign _count.Y instead and reposition it on grid/list layout changes.
- GridSlotManager.RebuildContainer: replaced the O(n^2) List.Contains/Remove scans with HashSet membership plus a monotonic free-slot pointer, and stopped mutating the caller-supplied list (which can be a shared/cached collection).
- GridContainer: removed no-op `>> 0` shifts when repositioning the resize button.