### PR TITLE
Fix grid container empty layout and old-style switch showing empty

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/GridContainer.cs
@@ -313,6 +313,13 @@ public partial class GridContainer : ResizableGump
             BuildBorder();
             ResizeWindow(savedSize);
 
+            // Populate and lay out the grid immediately. Content updates are otherwise only
+            // triggered when the server sends item packets (see ItemHelpers), so without this
+            // an empty container would leave its empty slots stacked at (0,0), and switching
+            // from the old container style back to the grid (where the items already exist in
+            // the world and no packet arrives) would render an empty grid.
+            RequestUpdateContents();
+
             // Apply minimized state after all controls are created
             if (loadMinimized)
             {


### PR DESCRIPTION
The grid container constructor never triggered an initial content population. Population relied entirely on the item-added packet handler (ItemHelpers) calling RequestUpdateContents. This caused two issues:

- Opening an empty container left its empty slots stacked at (0,0) in the top-left, since RebuildContainer/SetGridPositions never ran.
- Switching from the old container style back to the grid rendered an empty grid, since the items already existed in the world and no packet arrived to trigger a content update.

Request a content update at the end of the grid-style constructor path so the grid populates and lays out immediately on open.
