### PR TITLE
Fix grid alt+double-click deselecting the clicked item

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/Controls/GridItem.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/Controls/GridItem.cs
@@ -226,8 +226,15 @@ public class GridItem : Control
         }
         else if (_gridContainer.IsMultiMove && _item != null)
         {
-            if (MultiItemMoveGump.TrySelect(_item))
-                _selectHighlight = true;
+            // The second click of this double-click is still a held button press, so the
+            // combo-drag logic in PreDraw would otherwise treat it as a fresh gesture and
+            // toggle the double-clicked item back off. Mark the gesture active and record
+            // this serial as already handled so it stays selected along with its matches.
+            _altDragActive = true;
+            _toggledThisAltDrag.Add(_item.Serial);
+
+            MultiItemMoveGump.TrySelect(_item);
+            _selectHighlight = true;
             ushort graphic = _item.Graphic;
             ushort hue = _item.Hue;
             foreach (GridItem gridItem in _gridContainer.SlotManager.GridSlots.Values)


### PR DESCRIPTION
When Alt + double-clicking an item in a grid container to select all similar items for the quick move system, the double-clicked item itself was left deselected while every matching item was selected.

The second click of the double-click is still a held button press with Alt down, so PreDraw's combo-drag logic treated it as a fresh gesture (the button had been released between the two clicks, resetting the guard) and toggled the already-selected item back off.

Seed the alt-drag guard in the double-click handler so PreDraw skips the double-clicked serial, keeping it selected alongside its matches.