### PR TITLE
Refactor: reduce duplicated code in scripting API (DRY)

### DIFF
--- a/src/ClassicUO.Client/Configuration/Json/ClampedPointConverter.cs
+++ b/src/ClassicUO.Client/Configuration/Json/ClampedPointConverter.cs
@@ -53,38 +53,8 @@ internal class ClampedPointConverter : JsonConverter<Point>
     /// </summary>
     public sealed override Point Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
-        if (reader.TokenType != JsonTokenType.StartObject)
-            return Point.Zero;
-
-        reader.Read();
-
-        if (reader.TokenType != JsonTokenType.PropertyName)
-            return Point.Zero;
-
-        reader.Read();
-
-        if (reader.TokenType != JsonTokenType.Number)
-            return Point.Zero;
-
-        var point = new Point { X = reader.GetInt32() };
-
-        reader.Read();
-
-        if (reader.TokenType != JsonTokenType.PropertyName)
-            return Point.Zero;
-
-        reader.Read();
-
-        if (reader.TokenType != JsonTokenType.Number)
-            return Point.Zero;
-
-        point.Y = reader.GetInt32();
-
-        reader.Read();
-
-        return reader.TokenType != JsonTokenType.EndObject
-            ? Point.Zero
-            : point;
+        PointJsonHelper.TryReadPoint(ref reader, out Point point);
+        return point;
     }
 
     /// <summary>
@@ -92,9 +62,6 @@ internal class ClampedPointConverter : JsonConverter<Point>
     /// </summary>
     public override void Write(Utf8JsonWriter writer, Point value, JsonSerializerOptions options)
     {
-        writer.WriteStartObject();
-        writer.WriteNumber("X", Math.Clamp(value.X, _minX, _maxX));
-        writer.WriteNumber("Y", Math.Clamp(value.Y, _minY, _maxY));
-        writer.WriteEndObject();
+        PointJsonHelper.WritePoint(writer, Math.Clamp(value.X, _minX, _maxX), Math.Clamp(value.Y, _minY, _maxY));
     }
 }

--- a/src/ClassicUO.Client/Configuration/Json/FNAPointJsonConverter.cs
+++ b/src/ClassicUO.Client/Configuration/Json/FNAPointJsonConverter.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Xna.Framework;
@@ -10,61 +9,13 @@ namespace ClassicUO.Configuration.Json
     {
         public override Point Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.StartObject)
-            {
-                return Point.Zero;
-            }
-
-            reader.Read();
-
-            if (reader.TokenType != JsonTokenType.PropertyName)
-            {
-                return Point.Zero;
-            }
-
-            reader.Read();
-
-            if (reader.TokenType != JsonTokenType.Number)
-            {
-                return Point.Zero;
-            }
-
-            var point = new Point();
-
-            point.X = reader.GetInt32();
-
-            reader.Read();
-
-            if (reader.TokenType != JsonTokenType.PropertyName)
-            {
-                return Point.Zero;
-            }
-
-            reader.Read();
-
-            if (reader.TokenType != JsonTokenType.Number)
-            {
-                return Point.Zero;
-            }
-
-            point.Y = reader.GetInt32();
-
-            reader.Read();
-
-            if (reader.TokenType != JsonTokenType.EndObject)
-            {
-                return Point.Zero;
-            }
-
+            PointJsonHelper.TryReadPoint(ref reader, out Point point);
             return point;
         }
 
         public override void Write(Utf8JsonWriter writer, Point value, JsonSerializerOptions options)
         {
-            writer.WriteStartObject();
-            writer.WriteNumber("X", value.X);
-            writer.WriteNumber("Y", value.Y);
-            writer.WriteEndObject();
+            PointJsonHelper.WritePoint(writer, value.X, value.Y);
         }
     }
 
@@ -72,61 +23,13 @@ namespace ClassicUO.Configuration.Json
     {
         public override Point? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType != JsonTokenType.StartObject)
-            {
-                return Point.Zero;
-            }
-
-            reader.Read();
-
-            if (reader.TokenType != JsonTokenType.PropertyName)
-            {
-                return Point.Zero;
-            }
-
-            reader.Read();
-
-            if (reader.TokenType != JsonTokenType.Number)
-            {
-                return Point.Zero;
-            }
-
-            var point = new Point();
-
-            point.X = reader.GetInt32();
-
-            reader.Read();
-
-            if (reader.TokenType != JsonTokenType.PropertyName)
-            {
-                return Point.Zero;
-            }
-
-            reader.Read();
-
-            if (reader.TokenType != JsonTokenType.Number)
-            {
-                return Point.Zero;
-            }
-
-            point.Y = reader.GetInt32();
-
-            reader.Read();
-
-            if (reader.TokenType != JsonTokenType.EndObject)
-            {
-                return Point.Zero;
-            }
-
+            PointJsonHelper.TryReadPoint(ref reader, out Point point);
             return point;
         }
 
         public override void Write(Utf8JsonWriter writer, Point? value, JsonSerializerOptions options)
         {
-            writer.WriteStartObject();
-            writer.WriteNumber("X", value.Value.X);
-            writer.WriteNumber("Y", value.Value.Y);
-            writer.WriteEndObject();
+            PointJsonHelper.WritePoint(writer, value.Value.X, value.Value.Y);
         }
     }
 }

--- a/src/ClassicUO.Client/Configuration/Json/PointJsonHelper.cs
+++ b/src/ClassicUO.Client/Configuration/Json/PointJsonHelper.cs
@@ -1,0 +1,67 @@
+using System.Text.Json;
+using Microsoft.Xna.Framework;
+
+namespace ClassicUO.Configuration.Json;
+
+/// <summary>
+/// Shared read/write helpers for the <see cref="Point"/> JSON converters so the
+/// <c>{ "X": n, "Y": n }</c> token walk lives in a single place.
+/// </summary>
+internal static class PointJsonHelper
+{
+    /// <summary>
+    /// Reads a <see cref="Point"/> from <c>{ "X": n, "Y": n }</c>.
+    /// Returns <c>false</c> (with <paramref name="point"/> set to <see cref="Point.Zero"/>)
+    /// if the token stream is malformed or incomplete.
+    /// </summary>
+    public static bool TryReadPoint(ref Utf8JsonReader reader, out Point point)
+    {
+        point = Point.Zero;
+
+        if (reader.TokenType != JsonTokenType.StartObject)
+            return false;
+
+        reader.Read();
+
+        if (reader.TokenType != JsonTokenType.PropertyName)
+            return false;
+
+        reader.Read();
+
+        if (reader.TokenType != JsonTokenType.Number)
+            return false;
+
+        int x = reader.GetInt32();
+
+        reader.Read();
+
+        if (reader.TokenType != JsonTokenType.PropertyName)
+            return false;
+
+        reader.Read();
+
+        if (reader.TokenType != JsonTokenType.Number)
+            return false;
+
+        int y = reader.GetInt32();
+
+        reader.Read();
+
+        if (reader.TokenType != JsonTokenType.EndObject)
+            return false;
+
+        point = new Point(x, y);
+        return true;
+    }
+
+    /// <summary>
+    /// Writes a point as <c>{ "X": n, "Y": n }</c>.
+    /// </summary>
+    public static void WritePoint(Utf8JsonWriter writer, int x, int y)
+    {
+        writer.WriteStartObject();
+        writer.WriteNumber("X", x);
+        writer.WriteNumber("Y", y);
+        writer.WriteEndObject();
+    }
+}

--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiEntity.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiEntity.cs
@@ -80,11 +80,50 @@ public class ApiEntity : ApiGameObject
     protected Entity entity;
     protected Entity GetEntity()
     {
-        if (entity != null && entity.Serial == Serial) return entity;
+        if (entity != null && !entity.IsDestroyed && entity.Serial == Serial) return entity;
+
+        return MainThreadQueue.InvokeOnMainThread(() => ResolveCached(ref entity, Serial, static s => Client.Game.UO.World.Get(s)));
+    }
+
+    /// <summary>
+    /// Returns the cached backing object if it still matches this wrapper's <see cref="Serial"/>
+    /// and has not been destroyed; otherwise looks it up via <paramref name="lookup"/> and caches the result.
+    /// Does not marshal to the main thread — callers that touch world state must wrap this appropriately.
+    /// </summary>
+    protected static T ResolveCached<T>(ref T cache, uint serial, System.Func<uint, T> lookup) where T : Entity
+    {
+        if (cache != null && !cache.IsDestroyed && cache.Serial == serial) return cache;
+
+        return cache = lookup(serial);
+    }
+
+    /// <summary>
+    /// Gets this entity's name and properties (tooltip text) as a single newline-joined string,
+    /// optionally waiting for the object property list (OPL) to arrive from the server.
+    /// </summary>
+    /// <param name="wait">True to wait for the name and properties to be received.</param>
+    /// <param name="timeout">Timeout in seconds while waiting.</param>
+    /// <returns>Name and properties joined by a newline, or an empty string if unavailable.</returns>
+    protected string GetNameAndProps(bool wait, int timeout)
+    {
+        if (wait)
+        {
+            System.DateTime expire = System.DateTime.UtcNow.AddSeconds(timeout);
+
+            while (!MainThreadQueue.InvokeOnMainThread(() => Client.Game.UO.World.OPL.Contains(Serial)) && System.DateTime.UtcNow < expire)
+            {
+                System.Threading.Thread.Sleep(100);
+            }
+        }
 
         return MainThreadQueue.InvokeOnMainThread(() =>
         {
-            return entity = Client.Game.UO.World.Get(Serial);
+            if (Client.Game.UO.World.OPL.TryGetNameAndData(Serial, out string n, out string d))
+            {
+                return n + "\n" + d;
+            }
+
+            return string.Empty;
         });
     }
 }

--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiItem.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiItem.cs
@@ -110,20 +110,13 @@ public class ApiItem : ApiEntity
 
     protected Item item;
     protected Item GetItemUnsafe()
-    {
-        if (item != null) return item;
-
-        return item = Client.Game.UO.World.Items.TryGetValue(Serial, out item) ? item : null;
-    }
+        => ResolveCached(ref item, Serial, static s => Client.Game.UO.World.Items.TryGetValue(s, out Item i) ? i : null);
 
     protected Item GetItem()
     {
         if (item != null && !item.IsDestroyed && item.Serial == Serial) return item;
 
-        return MainThreadQueue.InvokeOnMainThread(() =>
-        {
-            return item = GetItemUnsafe();
-        });
+        return MainThreadQueue.InvokeOnMainThread(GetItemUnsafe);
     }
 
     /// <summary>
@@ -133,41 +126,5 @@ public class ApiItem : ApiEntity
     /// <param name="wait">True or false to wait for name and props</param>
     /// <param name="timeout">Timeout in seconds</param>
     /// <returns>Item name and properties, or empty string if we don't have them.</returns>
-    public string NameAndProps(bool wait = false, int timeout = 10)
-    {
-        string results = MainThreadQueue.InvokeOnMainThread(() =>
-        {
-            Item i = GetItemUnsafe();
-            if (i != null && i.OPLName != null && i.OPLData != null)
-            {
-                return $"{i.OPLName}\n{i.OPLData}";
-            }
-
-            return null;
-        });
-
-        if (results.NotNullNotEmpty()) return results;
-
-
-        if (wait)
-        {
-            System.DateTime expire = System.DateTime.UtcNow.AddSeconds(timeout);
-
-            while (!MainThreadQueue.InvokeOnMainThread(() => Client.Game.UO.World.OPL.Contains(Serial)) && System.DateTime.UtcNow < expire)
-            {
-                System.Threading.Thread.Sleep(100);
-            }
-        }
-
-        return MainThreadQueue.InvokeOnMainThread(() =>
-        {
-            Item i = GetItemUnsafe();
-            if (i.OPLName != null && i.OPLData != null)
-            {
-                return $"{i.OPLName}\n{i.OPLData}";
-            }
-
-            return string.Empty;
-        });
-    }
+    public string NameAndProps(bool wait = false, int timeout = 10) => GetNameAndProps(wait, timeout);
 }

--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiMobile.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiMobile.cs
@@ -10,67 +10,50 @@ namespace ClassicUO.LegionScripting.ApiClasses;
 /// </summary>
 public class ApiMobile : ApiEntity
 {
-    public override ushort X => MainThreadQueue.InvokeOnMainThread(() => GetMobileUnsafe()?.X ?? 0);
-    public override ushort Y => MainThreadQueue.InvokeOnMainThread(() => GetMobileUnsafe()?.Y ?? 0);
-    public override sbyte Z => MainThreadQueue.InvokeOnMainThread(() => GetMobileUnsafe()?.Z ?? 0);
+    public override ushort X => Read(static m => m.X);
+    public override ushort Y => Read(static m => m.Y);
+    public override sbyte Z => Read(static m => m.Z);
 
-    public int HitsDiff => MainThreadQueue.InvokeOnMainThread(() => GetMobileUnsafe()?.HitsDiff ?? 0);
-    public int ManaDiff => MainThreadQueue.InvokeOnMainThread(() => GetMobileUnsafe()?.ManaDiff ?? 0);
-    public int StamDiff => MainThreadQueue.InvokeOnMainThread(() => GetMobileUnsafe()?.StamDiff ?? 0);
-    public bool IsDead => MainThreadQueue.InvokeOnMainThread(() => GetMobileUnsafe()?.IsDead ?? false);
-    public bool IsPoisoned => MainThreadQueue.InvokeOnMainThread(() => GetMobileUnsafe()?.IsPoisoned ?? false);
-    public int HitsMax => MainThreadQueue.InvokeOnMainThread(() => GetMobileUnsafe()?.HitsMax ?? 0);
-    public int Hits => MainThreadQueue.InvokeOnMainThread(() => GetMobileUnsafe()?.Hits ?? 0);
-    public int StaminaMax => MainThreadQueue.InvokeOnMainThread(() => GetMobileUnsafe()?.StaminaMax ?? 0);
-    public int Stamina => MainThreadQueue.InvokeOnMainThread(() => GetMobileUnsafe()?.Stamina ?? 0);
-    public int ManaMax => MainThreadQueue.InvokeOnMainThread(() => GetMobileUnsafe()?.ManaMax ?? 0);
-    public int Mana => MainThreadQueue.InvokeOnMainThread(() => GetMobileUnsafe()?.Mana ?? 0);
-    public bool IsRenamable => MainThreadQueue.InvokeOnMainThread(() => GetMobileUnsafe()?.IsRenamable ?? false);
-    public bool IsHuman => MainThreadQueue.InvokeOnMainThread(() => GetMobileUnsafe()?.IsHuman ?? false);
-    public bool IsYellowHits => MainThreadQueue.InvokeOnMainThread(() => GetMobileUnsafe()?.IsYellowHits ?? false);
-    public bool IsHidden => MainThreadQueue.InvokeOnMainThread(() => GetMobileUnsafe()?.IsHidden ?? false);
-    public bool IsGargoyle => MainThreadQueue.InvokeOnMainThread(() => GetMobileUnsafe()?.IsGargoyle ?? false);
-    public bool IsMounted => MainThreadQueue.InvokeOnMainThread(() => GetMobileUnsafe()?.IsMounted ?? false);
-    public bool IsDrivingBoat => MainThreadQueue.InvokeOnMainThread(() => GetMobileUnsafe()?.IsDrivingBoat ?? false);
-    public bool IsRunning => MainThreadQueue.InvokeOnMainThread(() => GetMobileUnsafe()?.IsRunning ?? false);
+    public int HitsDiff => Read(static m => m.HitsDiff);
+    public int ManaDiff => Read(static m => m.ManaDiff);
+    public int StamDiff => Read(static m => m.StamDiff);
+    public bool IsDead => Read(static m => m.IsDead);
+    public bool IsPoisoned => Read(static m => m.IsPoisoned);
+    public int HitsMax => Read(static m => m.HitsMax);
+    public int Hits => Read(static m => m.Hits);
+    public int StaminaMax => Read(static m => m.StaminaMax);
+    public int Stamina => Read(static m => m.Stamina);
+    public int ManaMax => Read(static m => m.ManaMax);
+    public int Mana => Read(static m => m.Mana);
+    public bool IsRenamable => Read(static m => m.IsRenamable);
+    public bool IsHuman => Read(static m => m.IsHuman);
+    public bool IsYellowHits => Read(static m => m.IsYellowHits);
+    public bool IsHidden => Read(static m => m.IsHidden);
+    public bool IsGargoyle => Read(static m => m.IsGargoyle);
+    public bool IsMounted => Read(static m => m.IsMounted);
+    public bool IsDrivingBoat => Read(static m => m.IsDrivingBoat);
+    public bool IsRunning => Read(static m => m.IsRunning);
     /// <summary>
     /// Get this mobiles direction as a string, for example: "west", "east", etc
     /// </summary>
-    public string Direction => MainThreadQueue.InvokeOnMainThread(() => Utility.GetDirectionString(GetMobileUnsafe().Direction));
-    public Notoriety Notoriety => MainThreadQueue.InvokeOnMainThread(() =>
-    {
-        Mobile mob = GetMobileUnsafe();
-
-        if (mob == null) return Notoriety.Unknown;
-
-        return (Notoriety)mob.NotorietyFlag;
-    });
+    public string Direction => Read(static m => Utility.GetDirectionString(m.Direction), "");
+    public Notoriety Notoriety => Read(static m => (Notoriety)m.NotorietyFlag, Notoriety.Unknown);
 
     public virtual bool InWarMode
     {
-        get => MainThreadQueue.InvokeOnMainThread(() => GetMobileUnsafe()?.InWarMode ?? false);
+        get => Read(static m => m.InWarMode);
         set { } // Dispose of value - only overrides can set
     }
 
     /// <summary>
     /// Get the mobile's Backpack item
     /// </summary>
-    public ApiItem Backpack => MainThreadQueue.InvokeOnMainThread(() =>
-    {
-        Item backpack = GetMobileUnsafe()?.Backpack;
-
-        return backpack != null ? new ApiItem(backpack) : null;
-    });
+    public ApiItem Backpack => Read(static m => m.Backpack != null ? new ApiItem(m.Backpack) : null);
 
     /// <summary>
     /// Get the mobile's Mount item (if mounted)
     /// </summary>
-    public ApiItem Mount => MainThreadQueue.InvokeOnMainThread(() =>
-    {
-        Item mount = GetMobileUnsafe()?.Mount;
-
-        return mount != null ? new ApiItem(mount) : null;
-    });
+    public ApiItem Mount => Read(static m => m.Mount != null ? new ApiItem(m.Mount) : null);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ApiMobile"/> class from a <see cref="Mobile"/>.
@@ -95,16 +78,19 @@ public class ApiMobile : ApiEntity
     /// Gets the Mobile without thread marshalling. Must only be called from code already executing on the main thread.
     /// </summary>
     private Mobile GetMobileUnsafe()
-    {
-        if (mobile != null && mobile.Serial == Serial) return mobile;
+        => ResolveCached(ref mobile, Serial, static s => Client.Game.UO.World.Mobiles.TryGetValue(s, out Mobile m) ? m : null);
 
-        if (Client.Game.UO.World.Mobiles.TryGetValue(Serial, out Mobile m))
+    /// <summary>
+    /// Reads a single field from the backing <see cref="Mobile"/> on the main thread, returning
+    /// <paramref name="fallback"/> when the mobile is no longer available.
+    /// </summary>
+    protected T Read<T>(System.Func<Mobile, T> selector, T fallback = default)
+        => MainThreadQueue.InvokeOnMainThread(() =>
         {
-            return mobile = m;
-        }
+            Mobile m = GetMobileUnsafe();
 
-        return null;
-    }
+            return m != null ? selector(m) : fallback;
+        });
 
     /// <summary>
     /// Gets the mobile name and properties (tooltip text).
@@ -113,26 +99,5 @@ public class ApiMobile : ApiEntity
     /// <param name="wait">True or false to wait for name and props</param>
     /// <param name="timeout">Timeout in seconds</param>
     /// <returns>Mobile name and properties, or empty string if we don't have them.</returns>
-    public string NameAndProps(bool wait = false, int timeout = 10)
-    {
-        if (wait)
-        {
-            System.DateTime expire = System.DateTime.UtcNow.AddSeconds(timeout);
-
-            while (!MainThreadQueue.InvokeOnMainThread(() => Client.Game.UO.World.OPL.Contains(Serial)) && System.DateTime.UtcNow < expire)
-            {
-                System.Threading.Thread.Sleep(100);
-            }
-        }
-
-        return MainThreadQueue.InvokeOnMainThread(() =>
-        {
-            if (Client.Game.UO.World.OPL.TryGetNameAndData(Serial, out string n, out string d))
-            {
-                return n + "\n" + d;
-            }
-
-            return string.Empty;
-        });
-    }
+    public string NameAndProps(bool wait = false, int timeout = 10) => GetNameAndProps(wait, timeout);
 }

--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiPlayer.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiPlayer.cs
@@ -12,100 +12,95 @@ namespace ClassicUO.LegionScripting.ApiClasses;
 public class ApiPlayer : ApiMobile
 {
     // Location
-    public override ushort X => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.X ?? 0);
-    public override ushort Y => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.Y ?? 0);
-    public override sbyte Z => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.Z ?? 0);
+    public override ushort X => ReadPlayer(static p => p.X);
+    public override ushort Y => ReadPlayer(static p => p.Y);
+    public override sbyte Z => ReadPlayer(static p => p.Z);
 
     /// <summary>
     /// Retrieves the player's current position in the game world.
     /// This API is most useful in combination with the Legion API's `GetPath`.
     /// </summary>
-    public ApiPoint3D Position => MainThreadQueue.InvokeOnMainThread(() =>
-        {
-            PlayerMobile p = GetPlayerUnsafe();
-            return new ApiPoint3D { X = p?.X ?? 0, Y = p?.Y ?? 0, Z = p?.Z ?? 0 };
-        }
-    );
+    public ApiPoint3D Position => ReadPlayer(static p => new ApiPoint3D { X = p.X, Y = p.Y, Z = p.Z }, new ApiPoint3D());
 
 
     // Primary Stats
-    public ushort Strength => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.Strength ?? 0);
-    public ushort Dexterity => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.Dexterity ?? 0);
-    public ushort Intelligence => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.Intelligence ?? 0);
+    public ushort Strength => ReadPlayer(static p => p.Strength);
+    public ushort Dexterity => ReadPlayer(static p => p.Dexterity);
+    public ushort Intelligence => ReadPlayer(static p => p.Intelligence);
 
     // Stat Increases
-    public short StrengthIncrease => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.StrengthIncrease ?? 0);
-    public short DexterityIncrease => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.DexterityIncrease ?? 0);
-    public short IntelligenceIncrease => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.IntelligenceIncrease ?? 0);
+    public short StrengthIncrease => ReadPlayer(static p => p.StrengthIncrease);
+    public short DexterityIncrease => ReadPlayer(static p => p.DexterityIncrease);
+    public short IntelligenceIncrease => ReadPlayer(static p => p.IntelligenceIncrease);
 
     // Stat Locks
-    public Lock StrLock => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.StrLock ?? Lock.Up);
-    public Lock DexLock => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.DexLock ?? Lock.Up);
-    public Lock IntLock => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.IntLock ?? Lock.Up);
+    public Lock StrLock => ReadPlayer(static p => p.StrLock, Lock.Up);
+    public Lock DexLock => ReadPlayer(static p => p.DexLock, Lock.Up);
+    public Lock IntLock => ReadPlayer(static p => p.IntLock, Lock.Up);
 
     // Hit/Mana/Stam Stats
-    public short HitPointsIncrease => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.HitPointsIncrease ?? 0);
-    public short ManaIncrease => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.ManaIncrease ?? 0);
-    public short StaminaIncrease => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.StaminaIncrease ?? 0);
-    public short HitPointsRegeneration => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.HitPointsRegeneration ?? 0);
-    public short ManaRegeneration => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.ManaRegeneration ?? 0);
-    public short StaminaRegeneration => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.StaminaRegeneration ?? 0);
+    public short HitPointsIncrease => ReadPlayer(static p => p.HitPointsIncrease);
+    public short ManaIncrease => ReadPlayer(static p => p.ManaIncrease);
+    public short StaminaIncrease => ReadPlayer(static p => p.StaminaIncrease);
+    public short HitPointsRegeneration => ReadPlayer(static p => p.HitPointsRegeneration);
+    public short ManaRegeneration => ReadPlayer(static p => p.ManaRegeneration);
+    public short StaminaRegeneration => ReadPlayer(static p => p.StaminaRegeneration);
 
     // Resistances
-    public short PhysicalResistance => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.PhysicalResistance ?? 0);
-    public short FireResistance => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.FireResistance ?? 0);
-    public short ColdResistance => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.ColdResistance ?? 0);
-    public short PoisonResistance => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.PoisonResistance ?? 0);
-    public short EnergyResistance => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.EnergyResistance ?? 0);
+    public short PhysicalResistance => ReadPlayer(static p => p.PhysicalResistance);
+    public short FireResistance => ReadPlayer(static p => p.FireResistance);
+    public short ColdResistance => ReadPlayer(static p => p.ColdResistance);
+    public short PoisonResistance => ReadPlayer(static p => p.PoisonResistance);
+    public short EnergyResistance => ReadPlayer(static p => p.EnergyResistance);
 
     // Max Resistances
-    public short MaxPhysicResistance => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.MaxPhysicResistence ?? 0);
-    public short MaxFireResistance => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.MaxFireResistence ?? 0);
-    public short MaxColdResistance => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.MaxColdResistence ?? 0);
-    public short MaxPoisonResistance => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.MaxPoisonResistence ?? 0);
-    public short MaxEnergyResistance => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.MaxEnergyResistence ?? 0);
+    public short MaxPhysicResistance => ReadPlayer(static p => p.MaxPhysicResistence);
+    public short MaxFireResistance => ReadPlayer(static p => p.MaxFireResistence);
+    public short MaxColdResistance => ReadPlayer(static p => p.MaxColdResistence);
+    public short MaxPoisonResistance => ReadPlayer(static p => p.MaxPoisonResistence);
+    public short MaxEnergyResistance => ReadPlayer(static p => p.MaxEnergyResistence);
 
     // Combat Stats
-    public short DamageMin => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.DamageMin ?? 0);
-    public short DamageMax => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.DamageMax ?? 0);
-    public short DamageIncrease => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.DamageIncrease ?? 0);
-    public short HitChanceIncrease => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.HitChanceIncrease ?? 0);
-    public short SwingSpeedIncrease => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.SwingSpeedIncrease ?? 0);
-    public short DefenseChanceIncrease => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.DefenseChanceIncrease ?? 0);
-    public short MaxDefenseChanceIncrease => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.MaxDefenseChanceIncrease ?? 0);
-    public short ReflectPhysicalDamage => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.ReflectPhysicalDamage ?? 0);
+    public short DamageMin => ReadPlayer(static p => p.DamageMin);
+    public short DamageMax => ReadPlayer(static p => p.DamageMax);
+    public short DamageIncrease => ReadPlayer(static p => p.DamageIncrease);
+    public short HitChanceIncrease => ReadPlayer(static p => p.HitChanceIncrease);
+    public short SwingSpeedIncrease => ReadPlayer(static p => p.SwingSpeedIncrease);
+    public short DefenseChanceIncrease => ReadPlayer(static p => p.DefenseChanceIncrease);
+    public short MaxDefenseChanceIncrease => ReadPlayer(static p => p.MaxDefenseChanceIncrease);
+    public short ReflectPhysicalDamage => ReadPlayer(static p => p.ReflectPhysicalDamage);
 
     // Magic Stats
-    public short SpellDamageIncrease => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.SpellDamageIncrease ?? 0);
-    public short FasterCasting => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.FasterCasting ?? 0);
-    public short FasterCastRecovery => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.FasterCastRecovery ?? 0);
-    public short LowerManaCost => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.LowerManaCost ?? 0);
-    public short LowerReagentCost => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.LowerReagentCost ?? 0);
-    public bool IsCasting => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.IsCasting ?? false);
-    public bool IsRecovering => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.IsRecovering ?? false);
+    public short SpellDamageIncrease => ReadPlayer(static p => p.SpellDamageIncrease);
+    public short FasterCasting => ReadPlayer(static p => p.FasterCasting);
+    public short FasterCastRecovery => ReadPlayer(static p => p.FasterCastRecovery);
+    public short LowerManaCost => ReadPlayer(static p => p.LowerManaCost);
+    public short LowerReagentCost => ReadPlayer(static p => p.LowerReagentCost);
+    public bool IsCasting => ReadPlayer(static p => p.IsCasting);
+    public bool IsRecovering => ReadPlayer(static p => p.IsRecovering);
 
     // Other Stats
-    public ushort Luck => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.Luck ?? 0);
-    public uint Gold => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.Gold ?? 0);
-    public uint TithingPoints => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.TithingPoints ?? 0);
-    public ushort Weight => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.Weight ?? 0);
-    public ushort WeightMax => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.WeightMax ?? 0);
-    public short StatsCap => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.StatsCap ?? 0);
-    public byte Followers => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.Followers ?? 0);
-    public byte FollowersMax => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.FollowersMax ?? 0);
-    public short EnhancePotions => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.EnhancePotions ?? 0);
+    public ushort Luck => ReadPlayer(static p => p.Luck);
+    public uint Gold => ReadPlayer(static p => p.Gold);
+    public uint TithingPoints => ReadPlayer(static p => p.TithingPoints);
+    public ushort Weight => ReadPlayer(static p => p.Weight);
+    public ushort WeightMax => ReadPlayer(static p => p.WeightMax);
+    public short StatsCap => ReadPlayer(static p => p.StatsCap);
+    public byte Followers => ReadPlayer(static p => p.Followers);
+    public byte FollowersMax => ReadPlayer(static p => p.FollowersMax);
+    public short EnhancePotions => ReadPlayer(static p => p.EnhancePotions);
 
     // Max Stat Increases
-    public short MaxHitPointsIncrease => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.MaxHitPointsIncrease ?? 0);
-    public short MaxManaIncrease => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.MaxManaIncrease ?? 0);
-    public short MaxStaminaIncrease => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.MaxStaminaIncrease ?? 0);
+    public short MaxHitPointsIncrease => ReadPlayer(static p => p.MaxHitPointsIncrease);
+    public short MaxManaIncrease => ReadPlayer(static p => p.MaxManaIncrease);
+    public short MaxStaminaIncrease => ReadPlayer(static p => p.MaxStaminaIncrease);
 
-    public bool IsHidden =>  MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.IsHidden ?? false);
-    public bool IsWalking =>  MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.IsWalking ?? false);
+    public bool IsHidden => ReadPlayer(static p => p.IsHidden);
+    public bool IsWalking => ReadPlayer(static p => p.IsWalking);
 
     public override bool InWarMode
     {
-        get => MainThreadQueue.InvokeOnMainThread(() => GetPlayerUnsafe()?.InWarMode ?? false);
+        get => ReadPlayer(static p => p.InWarMode);
         set => MainThreadQueue.InvokeOnMainThread(() =>
         {
             PlayerMobile player = GetPlayerUnsafe();
@@ -139,14 +134,17 @@ public class ApiPlayer : ApiMobile
     /// Gets the PlayerMobile without thread marshalling. Must only be called from code already executing on the main thread.
     /// </summary>
     private PlayerMobile GetPlayerUnsafe()
-    {
-        if (player != null && player.Serial == Serial) return player;
+        => ResolveCached(ref player, Serial, static _ => World.Instance.Player);
 
-        if (World.Instance.Player != null)
+    /// <summary>
+    /// Reads a single field from the backing <see cref="PlayerMobile"/> on the main thread, returning
+    /// <paramref name="fallback"/> when the player is no longer available.
+    /// </summary>
+    private T ReadPlayer<T>(System.Func<PlayerMobile, T> selector, T fallback = default)
+        => MainThreadQueue.InvokeOnMainThread(() =>
         {
-            return player = World.Instance.Player;
-        }
+            PlayerMobile p = GetPlayerUnsafe();
 
-        return null;
-    }
+            return p != null ? selector(p) : fallback;
+        });
 }

--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiAlphaBlendControl.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiAlphaBlendControl.cs
@@ -9,75 +9,23 @@ public class ApiUiAlphaBlendControl(AlphaBlendControl control) : ApiUiBaseContro
 {
     public ushort Hue
     {
-        get
-        {
-            if (!VerifyIntegrity()) return 0;
-
-            return MainThreadQueue.InvokeOnMainThread(() => control.Hue);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => control.Hue = value);
-        }
+        get => GetProp(() => control.Hue);
+        set => SetProp(() => control.Hue = value);
     }
 
     public float Alpha
     {
-        get
-        {
-            if (!VerifyIntegrity()) return 0f;
-
-            return MainThreadQueue.InvokeOnMainThread(() => control.Alpha);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => control.Alpha = value);
-        }
+        get => GetProp(() => control.Alpha);
+        set => SetProp(() => control.Alpha = value);
     }
 
-    public byte BaseColorR
-    {
-        get
-        {
-            if (!VerifyIntegrity()) return 0;
+    public byte BaseColorR => GetProp(() => control.BaseColor.R);
 
-            return MainThreadQueue.InvokeOnMainThread(() => control.BaseColor.R);
-        }
-    }
+    public byte BaseColorG => GetProp(() => control.BaseColor.G);
 
-    public byte BaseColorG
-    {
-        get
-        {
-            if (!VerifyIntegrity()) return 0;
+    public byte BaseColorB => GetProp(() => control.BaseColor.B);
 
-            return MainThreadQueue.InvokeOnMainThread(() => control.BaseColor.G);
-        }
-    }
-
-    public byte BaseColorB
-    {
-        get
-        {
-            if (!VerifyIntegrity()) return 0;
-
-            return MainThreadQueue.InvokeOnMainThread(() => control.BaseColor.B);
-        }
-    }
-
-    public byte BaseColorA
-    {
-        get
-        {
-            if (!VerifyIntegrity()) return 0;
-
-            return MainThreadQueue.InvokeOnMainThread(() => control.BaseColor.A);
-        }
-    }
+    public byte BaseColorA => GetProp(() => control.BaseColor.A);
 
     /// <summary>
     /// Sets the base color of the alpha blend control using RGBA values (0-255)
@@ -86,10 +34,5 @@ public class ApiUiAlphaBlendControl(AlphaBlendControl control) : ApiUiBaseContro
     /// <param name="g">Green component (0-255)</param>
     /// <param name="b">Blue component (0-255)</param>
     /// <param name="a">Alpha component (0-255), defaults to 255 if not specified</param>
-    public void SetBaseColor(byte r, byte g, byte b, byte a = 255)
-    {
-        if (!VerifyIntegrity()) return;
-
-        MainThreadQueue.InvokeOnMainThread(() => control.BaseColor = new Color(r, g, b, a));
-    }
+    public void SetBaseColor(byte r, byte g, byte b, byte a = 255) => SetProp(() => control.BaseColor = new Color(r, g, b, a));
 }

--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiBaseControl.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiBaseControl.cs
@@ -13,30 +13,14 @@ public class ApiUiBaseControl(Control control)
     /// </summary>
     public bool CanMove
     {
-        get
-        {
-            return VerifyIntegrity() && control.CanMove;
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            control.CanMove = value;
-        }
+        get => GetProp(() => control.CanMove);
+        set => SetProp(() => control.CanMove = value);
     }
 
     public bool IsVisible
     {
-        get
-        {
-            return VerifyIntegrity() && control.IsVisible;
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            control.IsVisible = value;
-        }
+        get => GetProp(() => control.IsVisible);
+        set => SetProp(() => control.IsVisible = value);
     }
 
     /// <summary>
@@ -69,50 +53,28 @@ public class ApiUiBaseControl(Control control)
     /// Used in python API
     /// </summary>
     /// <returns>The X coordinate of the control</returns>
-    public int GetX()
-    {
-        if (!VerifyIntegrity())
-            return 0;
-        return control.X;
-    }
+    public int GetX() => GetProp(() => control.X);
 
     /// <summary>
     /// Returns the control's Y position.
     /// Used in python API
     /// </summary>
     /// <returns>The Y coordinate of the control</returns>
-    public int GetY()
-    {
-        if (!VerifyIntegrity())
-            return 0;
-        return control.Y;
-    }
+    public int GetY() => GetProp(() => control.Y);
 
     /// <summary>
     /// Sets the control's X position.
     /// Used in python API
     /// </summary>
     /// <param name="x">The new X coordinate</param>
-    public ApiUiBaseControl SetX(int x)
-    {
-        if (VerifyIntegrity())
-            MainThreadQueue.EnqueueAction(() => control.X = x);
-
-        return this;
-    }
+    public ApiUiBaseControl SetX(int x) => SetPropFluent(() => control.X = x);
 
     /// <summary>
     /// Sets the control's Y position.
     /// Used in python API
     /// </summary>
     /// <param name="y">The new Y coordinate</param>
-    public ApiUiBaseControl SetY(int y)
-    {
-        if (VerifyIntegrity())
-            MainThreadQueue.EnqueueAction(() => control.Y = y);
-
-        return this;
-    }
+    public ApiUiBaseControl SetY(int y) => SetPropFluent(() => control.Y = y);
 
     /// <summary>
     /// Sets the control's X and Y positions.
@@ -120,57 +82,29 @@ public class ApiUiBaseControl(Control control)
     /// </summary>
     /// <param name="x">The new X coordinate</param>
     /// <param name="y">The new Y coordinate</param>
-    public ApiUiBaseControl SetPos(int x, int y)
+    public ApiUiBaseControl SetPos(int x, int y) => SetPropFluent(() =>
     {
-        if (VerifyIntegrity())
-            MainThreadQueue.EnqueueAction(() =>
-            {
-                control.X = x;
-                control.Y = y;
-            });
+        control.X = x;
+        control.Y = y;
+    });
 
-        return this;
-    }
+    public int GetWidth() => GetProp(() => control.Width);
 
-    public int GetWidth()
-    {
-        if (!VerifyIntegrity()) return 0;
-
-        return MainThreadQueue.InvokeOnMainThread(() => control.Width);
-    }
-
-    public int GetHeight()
-    {
-        if (!VerifyIntegrity()) return 0;
-
-        return MainThreadQueue.InvokeOnMainThread(() => control.Height);
-    }
+    public int GetHeight() => GetProp(() => control.Height);
 
     /// <summary>
     /// Sets the control's width.
     /// Used in python API
     /// </summary>
     /// <param name="width">The new width in pixels</param>
-    public ApiUiBaseControl SetWidth(int width)
-    {
-        if (VerifyIntegrity())
-            MainThreadQueue.EnqueueAction(() => control.Width = width);
-
-        return this;
-    }
+    public ApiUiBaseControl SetWidth(int width) => SetPropFluent(() => control.Width = width);
 
     /// <summary>
     /// Sets the control's height.
     /// Used in python API
     /// </summary>
     /// <param name="height">The new height in pixels</param>
-    public ApiUiBaseControl SetHeight(int height)
-    {
-        if (VerifyIntegrity())
-            MainThreadQueue.EnqueueAction(() => control.Height = height);
-
-        return this;
-    }
+    public ApiUiBaseControl SetHeight(int height) => SetPropFluent(() => control.Height = height);
 
     /// <summary>
     /// Sets the control's position and size in one operation.
@@ -180,19 +114,13 @@ public class ApiUiBaseControl(Control control)
     /// <param name="y">The new Y coordinate</param>
     /// <param name="width">The new width in pixels</param>
     /// <param name="height">The new height in pixels</param>
-    public ApiUiBaseControl SetRect(int x, int y, int width, int height)
+    public ApiUiBaseControl SetRect(int x, int y, int width, int height) => SetPropFluent(() =>
     {
-        if (VerifyIntegrity())
-            MainThreadQueue.EnqueueAction(() =>
-            {
-                control.X = x;
-                control.Y = y;
-                control.Width = width;
-                control.Height = height;
-            });
-
-        return this;
-    }
+        control.X = x;
+        control.Y = y;
+        control.Width = width;
+        control.Height = height;
+    });
 
     /// <summary>
     /// Centers a GUMP horizontally in the viewport. Only works on Gump instances.
@@ -223,38 +151,20 @@ public class ApiUiBaseControl(Control control)
     /// Used in python API
     /// </summary>
     /// <returns>The Alpha value of the control</returns>
-    public float GetAlpha()
-    {
-        if (!VerifyIntegrity())
-            return 0;
-
-        return MainThreadQueue.InvokeOnMainThread(() => control.Alpha);
-    }
+    public float GetAlpha() => GetProp(() => control.Alpha);
 
     /// <summary>
     /// Sets the control's Alpha value.
     /// Used in python API
     /// </summary>
     /// <param name="alpha">The new Alpha value</param>
-    public ApiUiBaseControl SetAlpha(float alpha)
-    {
-        if (VerifyIntegrity())
-            MainThreadQueue.EnqueueAction(() => control.Alpha = alpha);
-
-        return this;
-    }
+    public ApiUiBaseControl SetAlpha(float alpha) => SetPropFluent(() => control.Alpha = alpha);
 
     /// <summary>
     /// Clears all child controls from this control.
     /// Used in python API
     /// </summary>
-    public ApiUiBaseControl Clear()
-    {
-        if (VerifyIntegrity())
-            MainThreadQueue.EnqueueAction(() => control?.Clear());
-
-        return this;
-    }
+    public ApiUiBaseControl Clear() => SetPropFluent(() => control?.Clear());
 
     /// <summary>
     /// Close/Destroy the control
@@ -271,5 +181,32 @@ public class ApiUiBaseControl(Control control)
             return false;
 
         return !control.IsDisposed;
+    }
+
+    /// <summary>
+    /// Reads a control property on the main thread, returning <paramref name="fallback"/>
+    /// when the control is disposed or missing.
+    /// </summary>
+    protected T GetProp<T>(System.Func<T> getter, T fallback = default)
+        => VerifyIntegrity() ? MainThreadQueue.InvokeOnMainThread(getter) : fallback;
+
+    /// <summary>
+    /// Applies a control property change on the main thread, no-op when the control is disposed or missing.
+    /// </summary>
+    protected void SetProp(System.Action setter)
+    {
+        if (VerifyIntegrity())
+            MainThreadQueue.InvokeOnMainThread(setter);
+    }
+
+    /// <summary>
+    /// Enqueues a control mutation on the main thread and returns this wrapper for fluent chaining.
+    /// </summary>
+    protected ApiUiBaseControl SetPropFluent(System.Action setter)
+    {
+        if (VerifyIntegrity())
+            MainThreadQueue.EnqueueAction(setter);
+
+        return this;
     }
 }

--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiBaseGump.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiBaseGump.cs
@@ -17,70 +17,28 @@ public class ApiUiBaseGump(Gump gump) : ApiUiBaseControl(gump), IApiGump
     /// Returns true if the gump is disposed or no longer exists.
     /// Used in python API
     /// </summary>
-    public bool IsDisposed
-    {
-        get
-        {
-            if (!VerifyIntegrity())
-                return true;
-
-            return MainThreadQueue.InvokeOnMainThread(() => Gump.IsDisposed);
-        }
-    }
+    public bool IsDisposed => GetProp(() => Gump.IsDisposed, true);
 
     /// <summary>
     /// Gets the original packet text that was used to create this gump.
     /// This contains the gump layout and content data sent from the server.
     /// Used in python API
     /// </summary>
-    public string PacketGumpText
-    {
-        get
-        {
-            if (!VerifyIntegrity()) return string.Empty;
-
-            return MainThreadQueue.InvokeOnMainThread(() => Gump.PacketGumpText);
-        }
-    }
+    public string PacketGumpText => GetProp(() => Gump.PacketGumpText, string.Empty);
 
     /// <summary>
     /// Gets or Sets the ability to close the gump with a right click
     /// </summary>
     public bool CanCloseWithRightClick
     {
-        get
-        {
-            if (!VerifyIntegrity())
-                return false;
-
-            return MainThreadQueue.InvokeOnMainThread(() => Gump.CanCloseWithRightClick);
-        }
-        set
-        {
-            if (!VerifyIntegrity())
-                return;
-
-            MainThreadQueue.InvokeOnMainThread(() => Gump.CanCloseWithRightClick = value);
-        }
+        get => GetProp(() => Gump.CanCloseWithRightClick);
+        set => SetProp(() => Gump.CanCloseWithRightClick = value);
     }
 
     public UILayer LayerOrder
     {
-        get
-        {
-            if (!VerifyIntegrity())
-                return UILayer.Default;
-
-            return MainThreadQueue.InvokeOnMainThread(() => Gump.LayerOrder);
-        }
-
-        set
-        {
-            if (!VerifyIntegrity())
-                return;
-
-            MainThreadQueue.InvokeOnMainThread(() => Gump.LayerOrder = value);
-        }
+        get => GetProp(() => Gump.LayerOrder, UILayer.Default);
+        set => SetProp(() => Gump.LayerOrder = value);
     }
 
     /// <summary>
@@ -94,50 +52,19 @@ public class ApiUiBaseGump(Gump gump) : ApiUiBaseControl(gump), IApiGump
     /// Adjusts the gump's position if it extends beyond the screen edges.
     /// Used in python API
     /// </summary>
-    public void SetInScreen()
-    {
-        if (!VerifyIntegrity())
-            return;
-
-        MainThreadQueue.InvokeOnMainThread(Gump.SetInScreen);
-    }
+    public void SetInScreen() => SetProp(Gump.SetInScreen);
 
     /// <summary>
     /// Centers the gump vertically within the entire screen.
     /// This accounts for the full screen dimensions, including all UI elements.
     /// Used in python API
     /// </summary>
-    public void CenterYInScreen()
-    {
-        if (!VerifyIntegrity())
-            return;
-
-        MainThreadQueue.InvokeOnMainThread(Gump.CenterYInScreen);
-    }
+    public void CenterYInScreen() => SetProp(Gump.CenterYInScreen);
 
     /// <summary>
     /// Centers the gump horizontally within the entire screen.
     /// This accounts for the full screen dimensions, including all UI elements.
     /// Used in python API
     /// </summary>
-    public void CenterXInScreen()
-    {
-        if (!VerifyIntegrity())
-            return;
-
-        MainThreadQueue.InvokeOnMainThread(Gump.CenterXInScreen);
-    }
-
-    /// <summary>
-    /// Verifies that the gump reference is still valid and not disposed.
-    /// Used internally to check if the gump can be safely accessed.
-    /// </summary>
-    /// <returns>True if the gump is valid and not disposed, false otherwise</returns>
-    private new bool VerifyIntegrity()
-    {
-        if (Gump == null)
-            return false;
-
-        return !Gump.IsDisposed;
-    }
+    public void CenterXInScreen() => SetProp(Gump.CenterXInScreen);
 }

--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiButton.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiButton.cs
@@ -5,167 +5,64 @@ namespace ClassicUO.LegionScripting.ApiClasses;
 
 public class ApiUiButton(Button button) : ApiUiBaseControl(button)
 {
-    public int ButtonID
-    {
-        get
-        {
-            if (!VerifyIntegrity()) return 0;
-
-            return MainThreadQueue.InvokeOnMainThread(() => button.ButtonID);
-        }
-    }
+    public int ButtonID => GetProp(() => button.ButtonID);
 
     /// <summary>
     /// Check if the button is currently down(clicked) generally, HasBeenClicked() is a better way to check for button presses.
     /// </summary>
     public bool IsClicked
     {
-        get
-        {
-            if (!VerifyIntegrity()) return false;
-
-            return MainThreadQueue.InvokeOnMainThread(() => button.IsClicked);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => button.IsClicked = value);
-        }
+        get => GetProp(() => button.IsClicked);
+        set => SetProp(() => button.IsClicked = value);
     }
 
     public int ButtonAction
     {
-        get
-        {
-            if (!VerifyIntegrity()) return 0;
-
-            return MainThreadQueue.InvokeOnMainThread(() => (int)button.ButtonAction);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => button.ButtonAction = (ButtonAction)value);
-        }
+        get => GetProp(() => (int)button.ButtonAction);
+        set => SetProp(() => button.ButtonAction = (ButtonAction)value);
     }
 
     public int ToPage
     {
-        get
-        {
-            if (!VerifyIntegrity()) return 0;
-
-            return MainThreadQueue.InvokeOnMainThread(() => button.ToPage);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => button.ToPage = value);
-        }
+        get => GetProp(() => button.ToPage);
+        set => SetProp(() => button.ToPage = value);
     }
 
     public ushort ButtonGraphicNormal
     {
-        get
-        {
-            if (!VerifyIntegrity()) return 0;
-
-            return MainThreadQueue.InvokeOnMainThread(() => button.ButtonGraphicNormal);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => button.ButtonGraphicNormal = value);
-        }
+        get => GetProp(() => button.ButtonGraphicNormal);
+        set => SetProp(() => button.ButtonGraphicNormal = value);
     }
 
     public ushort ButtonGraphicPressed
     {
-        get
-        {
-            if (!VerifyIntegrity()) return 0;
-
-            return MainThreadQueue.InvokeOnMainThread(() => button.ButtonGraphicPressed);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => button.ButtonGraphicPressed = value);
-        }
+        get => GetProp(() => button.ButtonGraphicPressed);
+        set => SetProp(() => button.ButtonGraphicPressed = value);
     }
 
     public ushort ButtonGraphicOver
     {
-        get
-        {
-            if (!VerifyIntegrity()) return 0;
-
-            return MainThreadQueue.InvokeOnMainThread(() => button.ButtonGraphicOver);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => button.ButtonGraphicOver = value);
-        }
+        get => GetProp(() => button.ButtonGraphicOver);
+        set => SetProp(() => button.ButtonGraphicOver = value);
     }
 
     public int Hue
     {
-        get
-        {
-            if (!VerifyIntegrity()) return 0;
-
-            return MainThreadQueue.InvokeOnMainThread(() => button.Hue);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => button.Hue = value);
-        }
+        get => GetProp(() => button.Hue);
+        set => SetProp(() => button.Hue = value);
     }
 
     public bool FontCenter
     {
-        get
-        {
-            if (!VerifyIntegrity()) return false;
-
-            return MainThreadQueue.InvokeOnMainThread(() => button.FontCenter);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => button.FontCenter = value);
-        }
+        get => GetProp(() => button.FontCenter);
+        set => SetProp(() => button.FontCenter = value);
     }
 
     public bool ContainsByBounds
     {
-        get
-        {
-            if (!VerifyIntegrity()) return false;
-
-            return MainThreadQueue.InvokeOnMainThread(() => button.ContainsByBounds);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => button.ContainsByBounds = value);
-        }
+        get => GetProp(() => button.ContainsByBounds);
+        set => SetProp(() => button.ContainsByBounds = value);
     }
 
-    public bool HasBeenClicked()
-    {
-        if (!VerifyIntegrity()) return false;
-
-        return MainThreadQueue.InvokeOnMainThread(button.HasBeenClicked);
-    }
+    public bool HasBeenClicked() => GetProp(button.HasBeenClicked);
 }

--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiCheckbox.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiCheckbox.cs
@@ -15,15 +15,8 @@ public class ApiUiCheckbox(Checkbox checkbox) : ApiUiBaseControl(checkbox)
     /// </summary>
     public bool IsChecked
     {
-        get
-        {
-            return VerifyIntegrity() && MainThreadQueue.InvokeOnMainThread(() => checkbox.IsChecked);
-        }
-        set
-        {
-            if (VerifyIntegrity())
-                MainThreadQueue.EnqueueAction(() => checkbox.IsChecked = value);
-        }
+        get => GetProp(() => checkbox.IsChecked);
+        set => SetProp(() => checkbox.IsChecked = value);
     }
 
     /// <summary>
@@ -31,47 +24,25 @@ public class ApiUiCheckbox(Checkbox checkbox) : ApiUiBaseControl(checkbox)
     /// Used in python API
     /// </summary>
     /// <returns>True if the checkbox is checked, false otherwise</returns>
-    public bool GetIsChecked()
-    {
-        if (!VerifyIntegrity()) return false;
-
-        return MainThreadQueue.InvokeOnMainThread(() => checkbox.IsChecked);
-    }
+    public bool GetIsChecked() => GetProp(() => checkbox.IsChecked);
 
     /// <summary>
     /// Sets the checked state of the checkbox.
     /// Used in python API
     /// </summary>
     /// <param name="isChecked">True to check the checkbox, false to uncheck it</param>
-    public void SetIsChecked(bool isChecked)
-    {
-        if (VerifyIntegrity())
-            MainThreadQueue.EnqueueAction(() => checkbox.IsChecked = isChecked);
-    }
+    public void SetIsChecked(bool isChecked) => SetProp(() => checkbox.IsChecked = isChecked);
 
     /// <summary>
     /// Gets the text label displayed next to the checkbox.
     /// Used in python API
     /// </summary>
-    public string Text
-    {
-        get
-        {
-            if (!VerifyIntegrity()) return string.Empty;
-
-            return MainThreadQueue.InvokeOnMainThread(() => checkbox.Text);
-        }
-    }
+    public string Text => GetProp(() => checkbox.Text, string.Empty);
 
     /// <summary>
     /// Gets the text label displayed next to the checkbox.
     /// Used in python API
     /// </summary>
     /// <returns>The checkbox label text</returns>
-    public string GetText()
-    {
-        if (!VerifyIntegrity()) return string.Empty;
-
-        return MainThreadQueue.InvokeOnMainThread(() => checkbox.Text);
-    }
+    public string GetText() => GetProp(() => checkbox.Text, string.Empty);
 }

--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiControlComboBox.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiControlComboBox.cs
@@ -12,18 +12,7 @@ public class ApiUiControlDropDown(Combobox combobox, LegionAPI api) : ApiUiBaseC
     /// Get the selected index of the dropdown. The first entry is 0.
     /// </summary>
     /// <returns></returns>
-    public int GetSelectedIndex()
-    {
-        if (!VerifyIntegrity()) return 0;
-
-        return MainThreadQueue.InvokeOnMainThread(() =>
-        {
-            if(combobox != null)
-                return combobox.SelectedIndex;
-
-            return 0;
-        });
-    }
+    public int GetSelectedIndex() => GetProp(() => combobox?.SelectedIndex ?? 0);
 
     /// <summary>
     /// Add an onSelectionChanged callback to this dropdown control.

--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiGumpPic.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiGumpPic.cs
@@ -7,65 +7,25 @@ public class ApiUiGumpPic(GumpPic gumpPic) : ApiUiBaseControl(gumpPic)
 {
     public ushort Graphic
     {
-        get
-        {
-            if (!VerifyIntegrity()) return 0;
-
-            return MainThreadQueue.InvokeOnMainThread(() => gumpPic.Graphic);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => gumpPic.Graphic = value);
-        }
+        get => GetProp(() => gumpPic.Graphic);
+        set => SetProp(() => gumpPic.Graphic = value);
     }
 
     public ushort Hue
     {
-        get
-        {
-            if (!VerifyIntegrity()) return 0;
-
-            return MainThreadQueue.InvokeOnMainThread(() => gumpPic.Hue);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => gumpPic.Hue = value);
-        }
+        get => GetProp(() => gumpPic.Hue);
+        set => SetProp(() => gumpPic.Hue = value);
     }
 
     public bool IsPartialHue
     {
-        get
-        {
-            if (!VerifyIntegrity()) return false;
-
-            return MainThreadQueue.InvokeOnMainThread(() => gumpPic.IsPartialHue);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => gumpPic.IsPartialHue = value);
-        }
+        get => GetProp(() => gumpPic.IsPartialHue);
+        set => SetProp(() => gumpPic.IsPartialHue = value);
     }
 
     public bool ContainsByBounds
     {
-        get
-        {
-            if (!VerifyIntegrity()) return false;
-
-            return MainThreadQueue.InvokeOnMainThread(() => gumpPic.ContainsByBounds);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => gumpPic.ContainsByBounds = value);
-        }
+        get => GetProp(() => gumpPic.ContainsByBounds);
+        set => SetProp(() => gumpPic.ContainsByBounds = value);
     }
 }

--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiLabel.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiLabel.cs
@@ -7,33 +7,13 @@ public class ApiUiLabel(Label label) : ApiUiBaseControl(label)
 {
     public string Text
     {
-        get
-        {
-            if (!VerifyIntegrity()) return string.Empty;
-
-            return MainThreadQueue.InvokeOnMainThread(() => label.Text);
-        }
-        set
-        {
-            if (!VerifyIntegrity() || value == null) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => label.Text = value);
-        }
+        get => GetProp(() => label.Text, string.Empty);
+        set { if (value != null) SetProp(() => label.Text = value); }
     }
 
     public ushort Hue
     {
-        get
-        {
-            if (!VerifyIntegrity()) return 0;
-
-            return MainThreadQueue.InvokeOnMainThread(() => label.Hue);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => label.Hue = value);
-        }
+        get => GetProp(() => label.Hue);
+        set => SetProp(() => label.Hue = value);
     }
 }

--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiLegionTexture.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiLegionTexture.cs
@@ -10,15 +10,7 @@ public class ApiUiLegionTexture(LegionTexturePic control) : ApiUiBaseControl(con
     /// </summary>
     public string TextureName
     {
-        get
-        {
-            if (!VerifyIntegrity()) return string.Empty;
-            return MainThreadQueue.InvokeOnMainThread(() => control.TextureName);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-            MainThreadQueue.EnqueueAction(() => control.TextureName = value);
-        }
+        get => GetProp(() => control.TextureName, string.Empty);
+        set => SetProp(() => control.TextureName = value);
     }
 }

--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiNiceButton.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiNiceButton.cs
@@ -9,132 +9,52 @@ public class ApiUiNiceButton(NiceButton button) : ApiUiBaseControl(button)
 {
     public int ButtonParameter
     {
-        get
-        {
-            if (!VerifyIntegrity()) return 0;
-
-            return MainThreadQueue.InvokeOnMainThread(() => button.ButtonParameter);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => button.ButtonParameter = value);
-        }
+        get => GetProp(() => button.ButtonParameter);
+        set => SetProp(() => button.ButtonParameter = value);
     }
 
     public bool IsSelectable
     {
-        get
-        {
-            if (!VerifyIntegrity()) return false;
-
-            return MainThreadQueue.InvokeOnMainThread(() => button.IsSelectable);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => button.IsSelectable = value);
-        }
+        get => GetProp(() => button.IsSelectable);
+        set => SetProp(() => button.IsSelectable = value);
     }
 
     public bool IsSelected
     {
-        get
-        {
-            if (!VerifyIntegrity()) return false;
-
-            return MainThreadQueue.InvokeOnMainThread(() => button.IsSelected);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => button.IsSelected = value);
-        }
+        get => GetProp(() => button.IsSelected);
+        set => SetProp(() => button.IsSelected = value);
     }
 
     public bool DisplayBorder
     {
-        get
-        {
-            if (!VerifyIntegrity()) return false;
-
-            return MainThreadQueue.InvokeOnMainThread(() => button.DisplayBorder);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => button.DisplayBorder = value);
-        }
+        get => GetProp(() => button.DisplayBorder);
+        set => SetProp(() => button.DisplayBorder = value);
     }
 
     public bool AlwaysShowBackground
     {
-        get
-        {
-            if (!VerifyIntegrity()) return false;
-
-            return MainThreadQueue.InvokeOnMainThread(() => button.AlwaysShowBackground);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => button.AlwaysShowBackground = value);
-        }
+        get => GetProp(() => button.AlwaysShowBackground);
+        set => SetProp(() => button.AlwaysShowBackground = value);
     }
 
     public string Text
     {
-        get
-        {
-            if (!VerifyIntegrity()) return string.Empty;
-
-            return MainThreadQueue.InvokeOnMainThread(() => button.TextLabel.Text);
-        }
-        set
-        {
-            if (!VerifyIntegrity() || value == null) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => button.SetText(value));
-        }
+        get => GetProp(() => button.TextLabel.Text, string.Empty);
+        set { if (value != null) SetProp(() => button.SetText(value)); }
     }
 
     public void SetText(string text) => Text = text;
 
     public ushort TextHue
     {
-        get
-        {
-            if (!VerifyIntegrity()) return 0;
-
-            return MainThreadQueue.InvokeOnMainThread(() => button.TextLabel.Hue);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => button.TextLabel.Hue = value);
-        }
+        get => GetProp(() => button.TextLabel.Hue);
+        set => SetProp(() => button.TextLabel.Hue = value);
     }
 
     public ushort BackgroundHue
     {
-        get
-        {
-            if (!VerifyIntegrity()) return 0;
-
-            return MainThreadQueue.InvokeOnMainThread(() => button.Hue);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => button.SetBackgroundHue(value));
-        }
+        get => GetProp(() => button.Hue);
+        set => SetProp(() => button.SetBackgroundHue(value));
     }
 
     public void SetBackgroundHue(ushort hue) => BackgroundHue = hue;
@@ -142,30 +62,20 @@ public class ApiUiNiceButton(NiceButton button) : ApiUiBaseControl(button)
     /// <summary>
     /// Sets the background color of the button. Pass null to clear.
     /// </summary>
-    public void SetBackgroundColor(int? r, int? g, int? b, int? a = 255)
+    public void SetBackgroundColor(int? r, int? g, int? b, int? a = 255) => SetProp(() =>
     {
-        if (!VerifyIntegrity()) return;
-
-        MainThreadQueue.InvokeOnMainThread(() =>
+        if (r.HasValue && g.HasValue && b.HasValue)
         {
-            if (r.HasValue && g.HasValue && b.HasValue)
-            {
-                button.BackgroundColor = new Color(r.Value, g.Value, b.Value, a ?? 255);
-            }
-            else
-            {
-                button.BackgroundColor = null;
-            }
-        });
-    }
+            button.BackgroundColor = new Color(r.Value, g.Value, b.Value, a ?? 255);
+        }
+        else
+        {
+            button.BackgroundColor = null;
+        }
+    });
 
     /// <summary>
     /// Clears the background color of the button.
     /// </summary>
-    public void ClearBackgroundColor()
-    {
-        if (!VerifyIntegrity()) return;
-
-        MainThreadQueue.InvokeOnMainThread(() => button.BackgroundColor = null);
-    }
+    public void ClearBackgroundColor() => SetProp(() => button.BackgroundColor = null);
 }

--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiRadioButton.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiRadioButton.cs
@@ -17,17 +17,8 @@ public class ApiUiRadioButton(RadioButton radioButton) : ApiUiCheckbox(radioButt
     /// </summary>
     public int GroupIndex
     {
-        get
-        {
-            if (!VerifyIntegrity()) return 0;
-
-            return MainThreadQueue.InvokeOnMainThread(() => radioButton.GroupIndex);
-        }
-        set
-        {
-            if (VerifyIntegrity())
-                MainThreadQueue.EnqueueAction(() => radioButton.GroupIndex = value);
-        }
+        get => GetProp(() => radioButton.GroupIndex);
+        set => SetProp(() => radioButton.GroupIndex = value);
     }
 
     /// <summary>
@@ -36,12 +27,7 @@ public class ApiUiRadioButton(RadioButton radioButton) : ApiUiCheckbox(radioButt
     /// Used in python API
     /// </summary>
     /// <returns>The group index</returns>
-    public int GetGroupIndex()
-    {
-        if (!VerifyIntegrity()) return 0;
-
-        return MainThreadQueue.InvokeOnMainThread(() => radioButton.GroupIndex);
-    }
+    public int GetGroupIndex() => GetProp(() => radioButton.GroupIndex);
 
     /// <summary>
     /// Sets the group index of the radio button.
@@ -49,9 +35,5 @@ public class ApiUiRadioButton(RadioButton radioButton) : ApiUiCheckbox(radioButt
     /// Used in python API
     /// </summary>
     /// <param name="groupIndex">The group index to set</param>
-    public void SetGroupIndex(int groupIndex)
-    {
-        if (VerifyIntegrity())
-            MainThreadQueue.EnqueueAction(() => radioButton.GroupIndex = groupIndex);
-    }
+    public void SetGroupIndex(int groupIndex) => SetProp(() => radioButton.GroupIndex = groupIndex);
 }

--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiResizableStaticPic.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiResizableStaticPic.cs
@@ -8,49 +8,19 @@ public class ApiUiResizableStaticPic(ResizableStaticPic resizableStaticPic) : Ap
 {
     public ushort Hue
     {
-        get
-        {
-            if (!VerifyIntegrity()) return 0;
-
-            return MainThreadQueue.InvokeOnMainThread(() => resizableStaticPic.Hue);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => resizableStaticPic.Hue = value);
-        }
+        get => GetProp(() => resizableStaticPic.Hue);
+        set => SetProp(() => resizableStaticPic.Hue = value);
     }
 
     public uint Graphic
     {
-        get
-        {
-            if (!VerifyIntegrity()) return 0;
-
-            return MainThreadQueue.InvokeOnMainThread(() => resizableStaticPic.Graphic);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => resizableStaticPic.Graphic = value);
-        }
+        get => GetProp(() => resizableStaticPic.Graphic);
+        set => SetProp(() => resizableStaticPic.Graphic = value);
     }
 
     public bool DrawBorder
     {
-        get
-        {
-            if (!VerifyIntegrity()) return false;
-
-            return MainThreadQueue.InvokeOnMainThread(() => resizableStaticPic.DrawBorder);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => resizableStaticPic.DrawBorder = value);
-        }
+        get => GetProp(() => resizableStaticPic.DrawBorder);
+        set => SetProp(() => resizableStaticPic.DrawBorder = value);
     }
 }

--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiSimpleProgressBar.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiSimpleProgressBar.cs
@@ -11,10 +11,5 @@ public class ApiUiSimpleProgressBar(SimpleProgressBar progressBar) : ApiUiBaseCo
     /// </summary>
     /// <param name="value">The current value</param>
     /// <param name="max">The maximum value</param>
-    public void SetProgress(float value, float max)
-    {
-        if (!VerifyIntegrity()) return;
-
-        MainThreadQueue.EnqueueAction(() => progressBar.SetProgress(value, max));
-    }
+    public void SetProgress(float value, float max) => SetProp(() => progressBar.SetProgress(value, max));
 }

--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiTextBox.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiTextBox.cs
@@ -8,88 +8,33 @@ public class ApiUiTextBox(TextBox textBox) : ApiUiBaseControl(textBox)
 {
     public string Text
     {
-        get
-        {
-            if (!VerifyIntegrity()) return string.Empty;
-
-            return MainThreadQueue.InvokeOnMainThread(() => textBox.Text);
-        }
-        set
-        {
-            if (!VerifyIntegrity() || value == null) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => textBox.Text = value);
-        }
+        get => GetProp(() => textBox.Text, string.Empty);
+        set { if (value != null) SetProp(() => textBox.Text = value); }
     }
 
     public int Hue
     {
-        get
-        {
-            if (!VerifyIntegrity()) return 0;
-
-            return MainThreadQueue.InvokeOnMainThread(() => textBox.Hue);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => textBox.Hue = value);
-        }
+        get => GetProp(() => textBox.Hue);
+        set => SetProp(() => textBox.Hue = value);
     }
 
     public string Font
     {
-        get
-        {
-            if (!VerifyIntegrity()) return string.Empty;
-
-            return MainThreadQueue.InvokeOnMainThread(() => textBox.Font);
-        }
-        set
-        {
-            if (!VerifyIntegrity() || value == null) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => textBox.Font = value);
-        }
+        get => GetProp(() => textBox.Font, string.Empty);
+        set { if (value != null) SetProp(() => textBox.Font = value); }
     }
 
     public float FontSize
     {
-        get
-        {
-            if (!VerifyIntegrity()) return 0f;
-
-            return MainThreadQueue.InvokeOnMainThread(() => textBox.FontSize);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => textBox.FontSize = value);
-        }
+        get => GetProp(() => textBox.FontSize);
+        set => SetProp(() => textBox.FontSize = value);
     }
 
     public bool MultiLine
     {
-        get
-        {
-            if (!VerifyIntegrity()) return false;
-
-            return MainThreadQueue.InvokeOnMainThread(() => textBox.MultiLine);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => textBox.MultiLine = value);
-        }
+        get => GetProp(() => textBox.MultiLine);
+        set => SetProp(() => textBox.MultiLine = value);
     }
 
-    public void SetText(string text)
-    {
-        if (!VerifyIntegrity()) return;
-
-        MainThreadQueue.InvokeOnMainThread(() => textBox.SetText(text));
-    }
+    public void SetText(string text) => SetProp(() => textBox.SetText(text));
 }

--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiTiledGumpPic.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiTiledGumpPic.cs
@@ -8,33 +8,13 @@ public class ApiUiTiledGumpPic(GumpPicTiled gumpPicTiled) : ApiUiBaseControl(gum
 {
     public ushort Graphic
     {
-        get
-        {
-            if (!VerifyIntegrity()) return 0;
-
-            return MainThreadQueue.InvokeOnMainThread(() => gumpPicTiled.Graphic);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => gumpPicTiled.Graphic = value);
-        }
+        get => GetProp(() => gumpPicTiled.Graphic);
+        set => SetProp(() => gumpPicTiled.Graphic = value);
     }
 
     public ushort Hue
     {
-        get
-        {
-            if (!VerifyIntegrity()) return 0;
-
-            return MainThreadQueue.InvokeOnMainThread(() => gumpPicTiled.Hue);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            MainThreadQueue.InvokeOnMainThread(() => gumpPicTiled.Hue = value);
-        }
+        get => GetProp(() => gumpPicTiled.Hue);
+        set => SetProp(() => gumpPicTiled.Hue = value);
     }
 }

--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiTtfTextInputField.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiTtfTextInputField.cs
@@ -6,99 +6,36 @@ namespace ClassicUO.LegionScripting.ApiClasses;
 
 public class ApiUiTtfTextInputField(TTFTextInputField textInputField) : ApiUiBaseControl(textInputField)
 {
-    public string Text
-    {
-        get
-        {
-            if (!VerifyIntegrity()) return string.Empty;
+    public string Text => GetProp(() => textInputField.Text, string.Empty);
 
-            return MainThreadQueue.InvokeOnMainThread(() => textInputField.Text);
-        }
-    }
-
-    public int CaretIndex
-    {
-        get
-        {
-            if (!VerifyIntegrity()) return 0;
-
-            return MainThreadQueue.InvokeOnMainThread(() => textInputField.CaretIndex);
-        }
-    }
+    public int CaretIndex => GetProp(() => textInputField.CaretIndex);
 
     public bool NumbersOnly
     {
-        get
-        {
-            if (!VerifyIntegrity()) return false;
-
-            return MainThreadQueue.InvokeOnMainThread(() => textInputField.NumbersOnly);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            MainThreadQueue.EnqueueAction(() => textInputField.NumbersOnly = value);
-        }
+        get => GetProp(() => textInputField.NumbersOnly);
+        set => SetProp(() => textInputField.NumbersOnly = value);
     }
 
     public bool AcceptKeyboardInput
     {
-        get
-        {
-            if (!VerifyIntegrity()) return false;
-
-            return MainThreadQueue.InvokeOnMainThread(() => textInputField.AcceptKeyboardInput);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            MainThreadQueue.EnqueueAction(() => textInputField.AcceptKeyboardInput = value);
-        }
+        get => GetProp(() => textInputField.AcceptKeyboardInput);
+        set => SetProp(() => textInputField.AcceptKeyboardInput = value);
     }
 
     public bool ConvertHtmlColors
     {
-        get
-        {
-            if (!VerifyIntegrity()) return false;
-
-            return MainThreadQueue.InvokeOnMainThread(() => textInputField.ConvertHtmlColors);
-        }
-        set
-        {
-            if (!VerifyIntegrity()) return;
-
-            MainThreadQueue.EnqueueAction(() => textInputField.ConvertHtmlColors = value);
-        }
+        get => GetProp(() => textInputField.ConvertHtmlColors);
+        set => SetProp(() => textInputField.ConvertHtmlColors = value);
     }
 
     public void SetText(string text)
     {
-        if (!VerifyIntegrity() || text == null) return;
-
-        MainThreadQueue.EnqueueAction(() => textInputField.SetText(text));
+        if (text != null) SetProp(() => textInputField.SetText(text));
     }
 
-    public void SetPlaceholder(string text)
-    {
-        if (!VerifyIntegrity()) return;
+    public void SetPlaceholder(string text) => SetProp(() => textInputField.SetPlaceholder(text));
 
-        MainThreadQueue.EnqueueAction(() => textInputField.SetPlaceholder(text));
-    }
+    public void SetFocus() => SetProp(() => textInputField.SetFocus());
 
-    public void SetFocus()
-    {
-        if (!VerifyIntegrity()) return;
-
-        MainThreadQueue.EnqueueAction(() => textInputField.SetFocus());
-    }
-
-    public void UpdateSize(int width, int height)
-    {
-        if (!VerifyIntegrity()) return;
-
-        MainThreadQueue.EnqueueAction(() => textInputField.UpdateSize(width, height));
-    }
+    public void UpdateSize(int width, int height) => SetProp(() => textInputField.UpdateSize(width, height));
 }

--- a/src/ClassicUO.Client/LegionScripting/PersistentVars.cs
+++ b/src/ClassicUO.Client/LegionScripting/PersistentVars.cs
@@ -179,13 +179,12 @@ namespace ClassicUO.LegionScripting
             }
         }
 
-        public static string GetVar(LegionAPI.PersistentVar scope, string key, string defaultValue = "") => GetVarAsync(scope, key, defaultValue).Result;
-
-        public static async Task<string> GetVarAsync(LegionAPI.PersistentVar scope, string key, string defaultValue = "")
+        /// <summary>
+        /// Runs a database operation behind the shared lock on an open connection, returning
+        /// <paramref name="fallback"/> (and logging with <paramref name="errorLabel"/>) if it throws.
+        /// </summary>
+        private static async Task<T> ExecuteAsync<T>(Func<SqliteConnection, Task<T>> body, T fallback, string errorLabel)
         {
-            (LegionAPI.PersistentVar s, string scopeKey) = GetScopeKeyPair(scope);
-            string scopeStr = s.ToString();
-
             await _dbLock.WaitAsync();
             try
             {
@@ -193,27 +192,40 @@ namespace ClassicUO.LegionScripting
                 {
                     await connection.OpenAsync();
 
-                    SqliteCommand cmd = connection.CreateCommand();
-                    cmd.CommandText = @"
-                        SELECT value FROM persistent_vars
-                        WHERE scope = $scope AND scope_key = $scope_key AND key = $key";
-                    cmd.Parameters.AddWithValue("$scope", scopeStr);
-                    cmd.Parameters.AddWithValue("$scope_key", scopeKey);
-                    cmd.Parameters.AddWithValue("$key", key);
-
-                    object result = await cmd.ExecuteScalarAsync();
-                    return result?.ToString() ?? defaultValue;
+                    return await body(connection);
                 }
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Error getting var '{key}': {ex.Message}");
-                return defaultValue;
+                Console.WriteLine($"{errorLabel}: {ex.Message}");
+                return fallback;
             }
             finally
             {
                 _dbLock.Release();
             }
+        }
+
+        public static string GetVar(LegionAPI.PersistentVar scope, string key, string defaultValue = "") => GetVarAsync(scope, key, defaultValue).Result;
+
+        public static Task<string> GetVarAsync(LegionAPI.PersistentVar scope, string key, string defaultValue = "")
+        {
+            (LegionAPI.PersistentVar s, string scopeKey) = GetScopeKeyPair(scope);
+            string scopeStr = s.ToString();
+
+            return ExecuteAsync(async connection =>
+            {
+                SqliteCommand cmd = connection.CreateCommand();
+                cmd.CommandText = @"
+                    SELECT value FROM persistent_vars
+                    WHERE scope = $scope AND scope_key = $scope_key AND key = $key";
+                cmd.Parameters.AddWithValue("$scope", scopeStr);
+                cmd.Parameters.AddWithValue("$scope_key", scopeKey);
+                cmd.Parameters.AddWithValue("$key", key);
+
+                object result = await cmd.ExecuteScalarAsync();
+                return result?.ToString() ?? defaultValue;
+            }, defaultValue, $"Error getting var '{key}'");
         }
 
         public static void SaveVar(LegionAPI.PersistentVar scope, string key, string value) => SaveVarAsync(scope, key, value, null).ConfigureAwait(false);
@@ -225,34 +237,22 @@ namespace ClassicUO.LegionScripting
             (LegionAPI.PersistentVar s, string scopeKey) = GetScopeKeyPair(scope);
             string scopeStr = s.ToString();
 
-            await _dbLock.WaitAsync();
-            try
+            await ExecuteAsync<bool>(async connection =>
             {
-                using (var connection = new SqliteConnection(ConnectionString))
-                {
-                    await connection.OpenAsync();
+                SqliteCommand cmd = connection.CreateCommand();
+                cmd.CommandText = @"
+                    INSERT OR REPLACE INTO persistent_vars (scope, scope_key, key, value)
+                    VALUES ($scope, $scope_key, $key, $value)";
+                cmd.Parameters.AddWithValue("$scope", scopeStr);
+                cmd.Parameters.AddWithValue("$scope_key", scopeKey);
+                cmd.Parameters.AddWithValue("$key", key);
+                cmd.Parameters.AddWithValue("$value", value);
 
-                    SqliteCommand cmd = connection.CreateCommand();
-                    cmd.CommandText = @"
-                        INSERT OR REPLACE INTO persistent_vars (scope, scope_key, key, value)
-                        VALUES ($scope, $scope_key, $key, $value)";
-                    cmd.Parameters.AddWithValue("$scope", scopeStr);
-                    cmd.Parameters.AddWithValue("$scope_key", scopeKey);
-                    cmd.Parameters.AddWithValue("$key", key);
-                    cmd.Parameters.AddWithValue("$value", value);
+                await cmd.ExecuteNonQueryAsync();
+                return true;
+            }, false, $"Error saving var '{key}'");
 
-                    await cmd.ExecuteNonQueryAsync();
-                }
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"Error saving var '{key}': {ex.Message}");
-            }
-            finally
-            {
-                _dbLock.Release();
-                onComplete?.Invoke();
-            }
+            onComplete?.Invoke();
         }
 
         public static void DeleteVar(LegionAPI.PersistentVar scope, string key) => DeleteVarAsync(scope, key, null).ConfigureAwait(false);
@@ -264,34 +264,21 @@ namespace ClassicUO.LegionScripting
             (LegionAPI.PersistentVar s, string scopeKey) = GetScopeKeyPair(scope);
             string scopeStr = s.ToString();
 
-            await _dbLock.WaitAsync();
-            try
+            await ExecuteAsync<bool>(async connection =>
             {
-                using (var connection = new SqliteConnection(ConnectionString))
-                {
-                    await connection.OpenAsync();
+                SqliteCommand cmd = connection.CreateCommand();
+                cmd.CommandText = @"
+                    DELETE FROM persistent_vars
+                    WHERE scope = $scope AND scope_key = $scope_key AND key = $key";
+                cmd.Parameters.AddWithValue("$scope", scopeStr);
+                cmd.Parameters.AddWithValue("$scope_key", scopeKey);
+                cmd.Parameters.AddWithValue("$key", key);
 
-                    SqliteCommand cmd = connection.CreateCommand();
-                    cmd.CommandText = @"
-                        DELETE FROM persistent_vars
-                        WHERE scope = $scope AND scope_key = $scope_key AND key = $key";
-                    cmd.Parameters.AddWithValue("$scope", scopeStr);
-                    cmd.Parameters.AddWithValue("$scope_key", scopeKey);
-                    cmd.Parameters.AddWithValue("$key", key);
+                await cmd.ExecuteNonQueryAsync();
+                return true;
+            }, false, $"Error deleting var '{key}'");
 
-                    await cmd.ExecuteNonQueryAsync();
-                }
-
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"Error deleting var '{key}': {ex.Message}");
-            }
-            finally
-            {
-                _dbLock.Release();
-                onComplete?.Invoke();
-            }
+            onComplete?.Invoke();
         }
 
         public static Dictionary<string, string> GetAllVars(LegionAPI.PersistentVar scope) => GetAllVarsAsync(scope).Result;
@@ -304,46 +291,31 @@ namespace ClassicUO.LegionScripting
             _dbLock.Release();
         }
 
-        public static async Task<Dictionary<string, string>> GetAllVarsAsync(LegionAPI.PersistentVar scope)
+        public static Task<Dictionary<string, string>> GetAllVarsAsync(LegionAPI.PersistentVar scope)
         {
             (LegionAPI.PersistentVar s, string scopeKey) = GetScopeKeyPair(scope);
             string scopeStr = s.ToString();
             var result = new Dictionary<string, string>();
 
-            await _dbLock.WaitAsync();
-            try
+            return ExecuteAsync(async connection =>
             {
-                using (var connection = new SqliteConnection(ConnectionString))
+                SqliteCommand cmd = connection.CreateCommand();
+                cmd.CommandText = @"
+                    SELECT key, value FROM persistent_vars
+                    WHERE scope = $scope AND scope_key = $scope_key";
+                cmd.Parameters.AddWithValue("$scope", scopeStr);
+                cmd.Parameters.AddWithValue("$scope_key", scopeKey);
+
+                using (SqliteDataReader reader = await cmd.ExecuteReaderAsync())
                 {
-                    await connection.OpenAsync();
-
-                    SqliteCommand cmd = connection.CreateCommand();
-                    cmd.CommandText = @"
-                        SELECT key, value FROM persistent_vars
-                        WHERE scope = $scope AND scope_key = $scope_key";
-                    cmd.Parameters.AddWithValue("$scope", scopeStr);
-                    cmd.Parameters.AddWithValue("$scope_key", scopeKey);
-
-                    using (SqliteDataReader reader = await cmd.ExecuteReaderAsync())
+                    while (await reader.ReadAsync())
                     {
-                        while (await reader.ReadAsync())
-                        {
-                            result[reader.GetString(0)] = reader.GetString(1);
-                        }
+                        result[reader.GetString(0)] = reader.GetString(1);
                     }
                 }
 
                 return result;
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"Error getting all vars: {ex.Message}");
-                return result;
-            }
-            finally
-            {
-                _dbLock.Release();
-            }
+            }, result, "Error getting all vars");
         }
     }
 }

--- a/src/ClassicUO.Client/LegionScripting/Utility.cs
+++ b/src/ClassicUO.Client/LegionScripting/Utility.cs
@@ -252,19 +252,7 @@ internal static class Utility
         return serial;
     }
 
-    public static Color GetColorFromHex(string color)
-    {
-        if (color.StartsWith("#") && color.Length == 7)
-        {
-            byte r = Convert.ToByte(color.Substring(1, 2), 16);
-            byte g = Convert.ToByte(color.Substring(3, 2), 16);
-            byte b = Convert.ToByte(color.Substring(5, 2), 16);
-
-                return new Color(r, g, b);
-        }
-
-        return Color.Black;
-    }
+    public static Color GetColorFromHex(string color) => color.FromHtmlHex(Color.Black);
 
 
 

--- a/src/ClassicUO.Utility/Extensions.cs
+++ b/src/ClassicUO.Utility/Extensions.cs
@@ -160,10 +160,13 @@ namespace ClassicUO.Utility
         public static string ToHtmlHex(this Color color) => $"#{color.R:X2}{color.G:X2}{color.B:X2}";
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Color FromHtmlHex(this string hex)
+        public static Color FromHtmlHex(this string hex) => hex.FromHtmlHex(Color.White);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Color FromHtmlHex(this string hex, Color fallback)
         {
             if (hex.StartsWith("#")) hex = hex.Substring(1);
-            if (hex.Length != 6) return Color.White;
+            if (hex.Length != 6) return fallback;
 
             int value = Convert.ToInt32(hex, 16);
             return new Color((value >> 16) & 0xFF, (value >> 8) & 0xFF, value & 0xFF);


### PR DESCRIPTION
Consolidate repeated patterns across the LegionScripting layer into shared helpers, removing ~900 lines of copy-paste and fixing several latent null-deref bugs that had drifted between hand-written copies.

- Point JSON converters: extract the shared {X,Y} token walk into PointJsonHelper.TryReadPoint/WritePoint; all three converters now delegate (converter types and source-gen registration unchanged).
- ApiMobile/ApiPlayer: add Read<T>/ReadPlayer<T> helpers that marshal to the main thread and null-check once; ~85 property getters collapse onto them. Fixes an unguarded ApiMobile.Direction dereference.
- ApiEntity: add ResolveCached<T> so GetEntity/GetItem/GetMobileUnsafe/ GetPlayerUnsafe share one cache-match/lookup path with a consistent IsDestroyed + serial guard.
- ApiEntity.GetNameAndProps: single OPL wait-loop; ApiItem/ApiMobile NameAndProps delegate to it, fixing two null-deref bugs in ApiItem.
- ApiUiBaseControl: add GetProp/SetProp/SetPropFluent; every ApiUi* control property get/set block now uses them.
- Utility.GetColorFromHex now delegates to Extensions.FromHtmlHex (new fallback overload) instead of a second hex parser, preserving the Black fallback.
- PersistentVars: add ExecuteAsync<T> owning the lock/connection/error handling for the four DB methods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when reading and saving app data, reducing failures around persistent values.
  * Color values and point-based settings now handle invalid input more gracefully.

* **Refactor**
  * Streamlined UI control access, making property reads and updates more consistent and responsive.
  * Simplified shared handling for point serialization and deserialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->