### PR TITLE
Fix client crash when deleting map markers in marker manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ All notable changes to TazUO will be recorded here.
 * Added a journal option to make the journal transparent (hide border, tabs, scroll bar, and background) after 3 seconds when it is not hovered and not the active window - [P.R 670](https://github.com/PlayTazUO/TazUO/pull/670) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
+* Fixed client crash ("pointer being freed was not allocated") when deleting map markers in the marker manager, caused by leaked marker list controls whose graphics textures were freed off the render thread by the GC finalizer - [P.R 678](https://github.com/PlayTazUO/TazUO/pull/678) ([bittiez](https://github.com/bittiez))
 * Auto open doors no longer closes a door that is already open - [P.R 674](https://github.com/PlayTazUO/TazUO/pull/674) ([bittiez](https://github.com/bittiez))
 * Added a Video > Misc option to reduce mobile feet clipping through walls (character depth slice step, default now minimizes clipping) - [P.R 666](https://github.com/PlayTazUO/TazUO/pull/666) ([bittiez](https://github.com/bittiez))
 * Fixed simultaneous drag and resize occurring on resizable windows - [P.R #](https://github.com/PlayTazUO/TazUO/pull/#) ([yuval-po](https://github.com/yuval-po))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.37</AssemblyVersion>
-    <FileVersion>5.3.37</FileVersion>
+    <AssemblyVersion>5.3.38</AssemblyVersion>
+    <FileVersion>5.3.38</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Gumps/MarkersManagerGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/MarkersManagerGump.cs
@@ -246,13 +246,32 @@ namespace ClassicUO.Game.UI.Gumps
             if (sender is int idx)
             {
                 _markers.RemoveAt(idx);
-                // Clear area
-                Remove(_scrollArea);
                 //Redraw List
-                DrawArea(_markerFiles[_categoryId].IsEditable);
+                RebuildScrollArea();
                 //Mark list as Modified
                 _isMarkerListModified = true;
             }
+        }
+
+        /// <summary>
+        /// Disposes the current scroll area (and all of its child controls) on the
+        /// main thread before rebuilding it. Disposing deterministically frees the
+        /// per-label text textures here instead of leaking them and letting the GC
+        /// finalizer thread free the native graphics resources off the render thread,
+        /// which corrupts the native heap ("pointer being freed was not allocated").
+        /// The shared marker icon textures are owned by <see cref="WorldMapGump._markerIcons"/>
+        /// and are not touched by <see cref="DrawTexture"/>, so they survive this.
+        /// </summary>
+        private void RebuildScrollArea()
+        {
+            if (_scrollArea != null)
+            {
+                Remove(_scrollArea);
+                _scrollArea.Dispose();
+                _scrollArea = null;
+            }
+
+            DrawArea(_markerFiles[_categoryId].IsEditable);
         }
 
         public override void OnButtonClick(int buttonID)
@@ -274,8 +293,7 @@ namespace ClassicUO.Game.UI.Gumps
                     break;
             }
 
-            _scrollArea.Clear();
-            DrawArea(_markerFiles[_categoryId].IsEditable);
+            RebuildScrollArea();
         }
 
         public override void OnKeyboardReturn(int textID, string text)
@@ -283,9 +301,8 @@ namespace ClassicUO.Game.UI.Gumps
             if (_searchText.Equals(_searchTextBox.SearchText))
                 return;
 
-            _scrollArea.Clear();
             _searchText = _searchTextBox.SearchText;
-            DrawArea(_markerFiles[_categoryId].IsEditable);
+            RebuildScrollArea();
         }
 
         private void MarkerEditEventHandler(object sender, EventArgs e) => _isMarkerListModified = true;


### PR DESCRIPTION
The marker manager rebuilt its list on every delete/search/category change by calling Control.Remove() (or ScrollArea.Clear()) on the old scroll area. Remove() only detaches the control without disposing it, so the old scroll area and all of its child controls were leaked. Each leaked Label owns a RenderedText Texture2D, so these native graphics resources were never freed deterministically and were instead reclaimed by the GC finalizer thread, freeing GPU/native memory off the render thread. After deleting enough markers this triggered native heap corruption and a hard abort ("pointer being freed was not allocated") with no managed crash log.

Rebuild via a single RebuildScrollArea() helper that removes AND disposes the old scroll area on the main thread before recreating it, so each label's text texture is freed deterministically. The shared marker icon textures live in WorldMapGump._markerIcons and are not disposed by DrawTexture, so they are unaffected.