### PR TITLE
Fixed potential issue with parsing mobtypes.txt 

### DIFF
--- a/src/ClassicUO.Assets/AnimationsLoader.cs
+++ b/src/ClassicUO.Assets/AnimationsLoader.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: BSD-2-Clause
+// SPDX-License-Identifier: BSD-2-Clause
 
 using ClassicUO.IO;
 using ClassicUO.Utility;
@@ -174,7 +174,7 @@ namespace ClassicUO.Assets
 
                             //uint number = uint.Parse(parts[2], NumberStyles.HexNumber);
 
-                            if (!uint.TryParse(parts[2], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out uint number))
+                            if (!uint.TryParse(parts[2].Trim(), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out uint number))
                             {
                                 Log.Error("Failed to parse expected number.");
                                 continue;


### PR DESCRIPTION
when there are more extras spaces than expected. This was noticed in UOAlive's latest version of 7.0.116.0

Example bad input:

1698 EQUIPMENT 10000  # Tanto_G- NO ANIMATION - PLACEHOLDER FOR PAPERDOLL
1699 EQUIPMENT 10000   # Otsuchi_G- NO ANIMATION - PLACEHOLDER FOR PAPERDOLL
1700 EQUIPMENT 10000   # Bokuto_G- NO ANIMATION - PLACEHOLDER FOR PAPERDOLL

there are multiple spaces before # comment instead of one tab space

## Description
Added trim during parsing. This matches behavior with CUO fix here: https://github.com/ClassicUO/ClassicUO/commit/d4a188976e3d139ce31f46ab99d3681fc762a6c6

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of animation data by handling extra whitespace in hexadecimal values.
  * Corrected the file header formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->