### PR TITLE
Color world map mobile dots by notoriety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@ All notable changes to TazUO will be recorded here.
 * Fixed client crash (IndexOutOfRangeException) from unpaired UTF-16 surrogates in journal/text; malformed text (e.g. a truncated emoji from the server) is now sanitized before measuring instead of crashing - [P.R 659](https://github.com/PlayTazUO/TazUO/pull/659) ([bittiez](https://github.com/bittiez))
 * Show a suggested fix for the ArgumentOutOfRangeException from FetchDisplayAdapter, which happens when connected displays change at runtime (monitor unplugged/slept, dock or KVM switch, laptop lid) - [P.R 660](https://github.com/PlayTazUO/TazUO/pull/660) ([bittiez](https://github.com/bittiez))
 * Fixed container overhead text (item names/speech) being pushed off screen instead of appearing above the item - grid containers now account for the scroll offset when scaled/scrolled, and legacy containers anchor the text over the item's actual slot instead of a stale click coordinate - [P.R 667](https://github.com/PlayTazUO/TazUO/pull/667) ([bittiez](https://github.com/bittiez))
+* World map mobile dots are now colored by notoriety (matching the radar/minimap) instead of always being red - [P.R 684](https://github.com/PlayTazUO/TazUO/pull/684) ([bittiez](https://github.com/bittiez))
 
 ### Legion
 * Added ModernNineSliceGump.SetLegionTexture to go along with zip files and custom png's - Use your own png for a 9-slice texture - ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.40</AssemblyVersion>
-    <FileVersion>5.3.40</FileVersion>
+    <AssemblyVersion>5.3.41</AssemblyVersion>
+    <FileVersion>5.3.41</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
@@ -2488,7 +2488,8 @@ public class WorldMapGump : ResizableGump
                         halfWidth,
                         halfHeight,
                         Zoom,
-                        Color.Red
+                        Color.Red,
+                        useNotorietyHue: true
                     );
                 }
                 else
@@ -2759,7 +2760,8 @@ public class WorldMapGump : ResizableGump
         Color color,
         bool drawName = false,
         bool isparty = false,
-        bool drawHpBar = false
+        bool drawHpBar = false,
+        bool useNotorietyHue = false
     )
     {
         Vector3 hueVector = ShaderHueTranslator.GetHueVector(0);
@@ -2812,6 +2814,12 @@ public class WorldMapGump : ResizableGump
             rot.Y = y + Height - 8 - DOT_SIZE;
         }
 
+        // Color the dot by notoriety (matching the radar/minimap) when requested,
+        // otherwise use the flat color passed in.
+        Vector3 dotHueVector = useNotorietyHue
+            ? ShaderHueTranslator.GetHueVector(Notoriety.GetHue(mobile.NotorietyFlag))
+            : hueVector;
+
         batcher.Draw
         (
             SolidColorTextureCache.GetTexture(color),
@@ -2822,7 +2830,7 @@ public class WorldMapGump : ResizableGump
                 DOT_SIZE,
                 DOT_SIZE
             ),
-            hueVector
+            dotHueVector
         );
 
         if (drawName && !string.IsNullOrEmpty(mobile.Name))


### PR DESCRIPTION
Non-ally mobiles on the world map gump were always drawn as red dots. Match the radar/minimap behavior by tinting each dot with the mobile's notoriety hue (via the same profile-configurable Notoriety.GetHue used by the minimap), so innocents, criminals, enemies, murderers, etc. are visually distinguishable. The red base texture keeps Unknown mobiles red, matching the radar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * World map mobile indicators can now be tinted according to the mobile’s notoriety status, making status distinctions easier to identify at a glance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->