### PR TITLE
Add macro button editor access to the new options window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ All notable changes to TazUO will be recorded here.
 * Rebuilt the world map Markers Manager as a Myra window with real tabs (full-path tooltips), map/zoom columns, editable map and zoom fields, and — on editable .usr/.csv files — checkbox bulk delete and bulk move of markers between files - [P.R 679](https://github.com/PlayTazUO/TazUO/pull/679) ([bittiez](https://github.com/bittiez))
 * Converted the world map "Go to location" window to a Myra window with a clear button and live decoding that shows the resolved map coordinates (from map or sextant input) as you type - [P.R 682](https://github.com/PlayTazUO/TazUO/pull/682) ([bittiez](https://github.com/bittiez))
 * Added a "Radar Map" entry to the top bar More menu that opens the radar/mini map - [P.R 686](https://github.com/PlayTazUO/TazUO/pull/686) ([bittiez](https://github.com/bittiez))
+* Added a "Button Editor" button to the new options window's Macros tab, giving access to the macro button editor (label, scale, color, graphic) - [P.R 685](https://github.com/PlayTazUO/TazUO/pull/685) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
 * Fixed client crash ("pointer being freed was not allocated") when deleting map markers in the marker manager, caused by leaked marker list controls whose graphics textures were freed off the render thread by the GC finalizer - [P.R 678](https://github.com/PlayTazUO/TazUO/pull/678) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.42</AssemblyVersion>
-    <FileVersion>5.3.42</FileVersion>
+    <AssemblyVersion>5.3.43</AssemblyVersion>
+    <FileVersion>5.3.43</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Gumps/MacroButtonEditorGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/MacroButtonEditorGump.cs
@@ -76,6 +76,9 @@ namespace ClassicUO.Game.UI.Gumps
 
         private void BuildGump()
         {
+            Width = WIDTH;
+            Height = HEIGHT;
+
             Add
             (
                 new AlphaBlendControl(0.95f)

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Macros/MacrosTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Macros/MacrosTabContent.cs
@@ -734,10 +734,9 @@ public static class MacrosTabContent
         MacroButtonEditorGump? existing = UIManager.Gumps.OfType<MacroButtonEditorGump>().FirstOrDefault();
         existing?.Dispose();
 
-        int posX = (Client.Game.Window.ClientBounds.Width >> 1) - 300;
-        int posY = (Client.Game.Window.ClientBounds.Height >> 1) - 250;
-
-        var btnEditorGump = new MacroButtonEditorGump(World.Instance, macro, posX, posY);
+        var btnEditorGump = new MacroButtonEditorGump(World.Instance, macro, 0, 0);
+        btnEditorGump.CenterXInViewPort();
+        btnEditorGump.CenterYInViewPort();
         UIManager.Add(btnEditorGump);
         btnEditorGump.SetInScreen();
         btnEditorGump.BringOnTop();

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Macros/MacrosTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Macros/MacrosTabContent.cs
@@ -205,8 +205,9 @@ public static class MacrosTabContent
             editorPanel.Widgets.Add(hotkeyRow);
             editorPanel.Widgets.Add(new MyraSpacer(10, 2));
 
-            // Create Macro Button
-            editorPanel.Widgets.Add(new MyraButton("Create Macro Button", () =>
+            // Create Macro Button / Button Editor
+            var macroButtonRow = new HorizontalStackPanel { Spacing = 2 };
+            macroButtonRow.Widgets.Add(new MyraButton("Create Macro Button", () =>
             {
                 foreach (IGui? gump in UIManager.Gumps)
                     if (gump is MacroButtonGump mbg && mbg.TheMacro == macro)
@@ -219,6 +220,13 @@ public static class MacrosTabContent
                 macroButtonGump.CenterYInViewPort();
                 UIManager.Add(macroButtonGump);
             }) { Tooltip = "Create a draggable macro button for this macro" });
+
+            macroButtonRow.Widgets.Add(new MyraButton("Button Editor", () =>
+            {
+                OpenMacroButtonEditor(macro);
+            }) { Tooltip = "Edit the appearance of this macro's button (label, scale, color, graphic)" });
+
+            editorPanel.Widgets.Add(macroButtonRow);
 
             editorPanel.Widgets.Add(new MyraSpacer(10, 2));
 
@@ -718,5 +726,20 @@ public static class MacrosTabContent
         root.Widgets.Add(toolbar);
         root.Widgets.Add(mainArea);
         return root;
+    }
+
+    /// <summary>Opens (or brings to front) the macro button editor for the given macro.</summary>
+    private static void OpenMacroButtonEditor(Macro macro)
+    {
+        MacroButtonEditorGump? existing = UIManager.Gumps.OfType<MacroButtonEditorGump>().FirstOrDefault();
+        existing?.Dispose();
+
+        int posX = (Client.Game.Window.ClientBounds.Width >> 1) - 300;
+        int posY = (Client.Game.Window.ClientBounds.Height >> 1) - 250;
+
+        var btnEditorGump = new MacroButtonEditorGump(World.Instance, macro, posX, posY);
+        UIManager.Add(btnEditorGump);
+        btnEditorGump.SetInScreen();
+        btnEditorGump.BringOnTop();
     }
 }


### PR DESCRIPTION
The new options window's Macros tab could create a macro button but had no way to open the button editor to customize its appearance. Add a "Button Editor" button next to "Create Macro Button" that opens the MacroButtonEditorGump for the selected macro, matching the capability already present in the ModernOptions gump's MacroControl.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a **Button Editor** option to the Macros tab.
  - Users can open or bring forward the macro button editor for the macro currently being edited.
  - The editor now opens centered on the screen for easier access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->