### PR TITLE
Add option to hide macro target message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ All notable changes to TazUO will be recorded here.
 * Converted the world map "Go to location" window to a Myra window with a clear button and live decoding that shows the resolved map coordinates (from map or sextant input) as you type - [P.R 682](https://github.com/PlayTazUO/TazUO/pull/682) ([bittiez](https://github.com/bittiez))
 * Added a "Radar Map" entry to the top bar More menu that opens the radar/mini map - [P.R 686](https://github.com/PlayTazUO/TazUO/pull/686) ([bittiez](https://github.com/bittiez))
 * Added a "Button Editor" button to the new options window's Macros tab, giving access to the macro button editor (label, scale, color, graphic) - [P.R 685](https://github.com/PlayTazUO/TazUO/pull/685) ([bittiez](https://github.com/bittiez))
+* Added an option to hide the "Target: name" overhead message shown when a macro sets a target - [P.R 687](https://github.com/PlayTazUO/TazUO/pull/687) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
 * Fixed client crash ("pointer being freed was not allocated") when deleting map markers in the marker manager, caused by leaked marker list controls whose graphics textures were freed off the render thread by the GC finalizer - [P.R 678](https://github.com/PlayTazUO/TazUO/pull/678) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.43</AssemblyVersion>
-    <FileVersion>5.3.43</FileVersion>
+    <AssemblyVersion>5.3.44</AssemblyVersion>
+    <FileVersion>5.3.44</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Configuration/Language.cs
+++ b/src/ClassicUO.Client/Configuration/Language.cs
@@ -1348,8 +1348,6 @@ namespace ClassicUO.Configuration
             public string DamageToLastAttack { get; set; } = "Damage to last attack";
             public string DisplayPartyChatOverPlayerHeads { get; set; } = "Display party chat over player heads";
             public string TooltipPartyChat { get; set; } = "If a party member uses party chat their text will also show above their head to you";
-            public string HideMacroTargetMessage { get; set; } = "Hide macro target message";
-            public string TooltipHideMacroTargetMessage { get; set; } = "Hide the \"Target: name\" message shown overhead when a macro sets a target";
             public string OverheadTextWidth { get; set; } = "Overhead text width";
             public string TooltipOverheadText { get; set; } = "This adjusts the maximum width for text over players, setting to 0 will allow it to use any width needed to stay one line";
             public string BelowMobileHealthBarScale { get; set; } = "Below mobile health bar scale";

--- a/src/ClassicUO.Client/Configuration/Language.cs
+++ b/src/ClassicUO.Client/Configuration/Language.cs
@@ -1348,6 +1348,8 @@ namespace ClassicUO.Configuration
             public string DamageToLastAttack { get; set; } = "Damage to last attack";
             public string DisplayPartyChatOverPlayerHeads { get; set; } = "Display party chat over player heads";
             public string TooltipPartyChat { get; set; } = "If a party member uses party chat their text will also show above their head to you";
+            public string HideMacroTargetMessage { get; set; } = "Hide macro target message";
+            public string TooltipHideMacroTargetMessage { get; set; } = "Hide the \"Target: name\" message shown overhead when a macro sets a target";
             public string OverheadTextWidth { get; set; } = "Overhead text width";
             public string TooltipOverheadText { get; set; } = "This adjusts the maximum width for text over players, setting to 0 will allow it to use any width needed to stay one line";
             public string BelowMobileHealthBarScale { get; set; } = "Below mobile health bar scale";

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -633,6 +633,8 @@ namespace ClassicUO.Configuration
 
         public bool DisplayPartyChatOverhead { get; set => SetProperty(ref field, value); } = true;
 
+        public bool HideMacroTargetMessage { get; set => SetProperty(ref field, value); } = false;
+
         public string SelectedTTFJournalFont { get; set => SetProperty(ref field, value); } = "avadonian";
         public int SelectedJournalFontSize { get; set => SetProperty(ref field, value); } = 20;
 

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -5,7 +5,7 @@
 ; Missing keys are auto-appended with English defaults when
 ; this file's version is newer than the user's copy.
 ; -------------------------------------------------------
-_version=38
+_version=39
 accountname=Account Name
 accountcontextmenutooltip=Right click to select another account.
 music=Music
@@ -523,6 +523,8 @@ macrocontrol_hotkey=HotKey:
 ; Misc
 disablesystemchat_journalopen=Disable system chat while Resizable Journal is open
 journal_transparencywheninactive=Journal transparency when not active
+hidemacrotargetmessage=Hide macro target message
+hidemacrotargetmessage_tooltip=Hide the "Target: name" message shown overhead when a macro sets a target
 
 ; Bandage agent
 bandageagent_profilenotloaded=Profile not loaded

--- a/src/ClassicUO.Client/Game/Managers/MacroManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/MacroManager.cs
@@ -2587,7 +2587,8 @@ namespace ClassicUO.Game.Managers
                 {
                     if (ent != null)
                     {
-                        GameActions.MessageOverhead(_world, string.Format(ResGeneral.Target0, ent.Name), Notoriety.GetHue(((Mobile)ent).NotorietyFlag), _world.Player);
+                        if (!ProfileManager.CurrentProfile.HideMacroTargetMessage)
+                            GameActions.MessageOverhead(_world, string.Format(ResGeneral.Target0, ent.Name), Notoriety.GetHue(((Mobile)ent).NotorietyFlag), _world.Player);
 
                         _world.TargetManager.NewTargetSystemSerial = serial;
                         _world.TargetManager.SelectedTarget = serial;
@@ -2600,7 +2601,8 @@ namespace ClassicUO.Game.Managers
                 {
                     if (ent != null)
                     {
-                        GameActions.MessageOverhead(_world, string.Format(ResGeneral.Target0, ent.Name), 992, _world.Player);
+                        if (!ProfileManager.CurrentProfile.HideMacroTargetMessage)
+                            GameActions.MessageOverhead(_world, string.Format(ResGeneral.Target0, ent.Name), 992, _world.Player);
                         _world.TargetManager.SelectedTarget = serial;
                         _world.TargetManager.LastTargetInfo.SetEntity(serial);
 

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/SpeechTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/SpeechTab.cs
@@ -151,6 +151,12 @@ internal static class SpeechTab
                 tuoLang.DisableMouseInteractionsForOverheadText,
                 new Accessor<bool>(() => profile.DisableMouseInteractionOverheadText),
                 search: new SearchMetadata(tuoLang.DisableMouseInteractionsForOverheadText, Keywords: [kw.Mouse])
+            ),
+            Option.Checkbox(
+                tuoLang.HideMacroTargetMessage,
+                new Accessor<bool>(() => profile.HideMacroTargetMessage),
+                tuoLang.TooltipHideMacroTargetMessage,
+                new SearchMetadata(tuoLang.HideMacroTargetMessage, Keywords: [kw.Target])
             )
         ).AsSearchGroup()
          .WithSearch(new SearchMetadata(Keywords: [kw.Overhead]));

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/SpeechTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/SpeechTab.cs
@@ -133,6 +133,9 @@ internal static class SpeechTab
         ModernOptionsGumpLanguage.TazUO tuoLang = lang.GetTazUO;
         ModernOptionsGumpLanguage.KeywordsLang kw = lang.Kw;
 
+        string hideMacroTargetMessage = TazLang.Get("hidemacrotargetmessage", "Hide macro target message");
+        string hideMacroTargetMessageTooltip = TazLang.Get("hidemacrotargetmessage_tooltip", "Hide the \"Target: name\" message shown overhead when a macro sets a target");
+
         return OptionsUi.VisualContainer(
             new VisualContainerProps { LabelText = speechLang.OverheadText },
             Option.Checkbox(
@@ -153,10 +156,10 @@ internal static class SpeechTab
                 search: new SearchMetadata(tuoLang.DisableMouseInteractionsForOverheadText, Keywords: [kw.Mouse])
             ),
             Option.Checkbox(
-                tuoLang.HideMacroTargetMessage,
+                hideMacroTargetMessage,
                 new Accessor<bool>(() => profile.HideMacroTargetMessage),
-                tuoLang.TooltipHideMacroTargetMessage,
-                new SearchMetadata(tuoLang.HideMacroTargetMessage, Keywords: [kw.Target])
+                hideMacroTargetMessageTooltip,
+                new SearchMetadata(hideMacroTargetMessage, Keywords: [kw.Target])
             )
         ).AsSearchGroup()
          .WithSearch(new SearchMetadata(Keywords: [kw.Overhead]));


### PR DESCRIPTION
Adds a HideMacroTargetMessage profile option (Chat > Speech > Overhead Text section) that suppresses the "Target: name" overhead message shown when a macro sets the last target.