### PR TITLE
Sort and space the Open macro gump sub-type list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ All notable changes to TazUO will be recorded here.
 * Added a "Button Editor" button to the new options window's Macros tab, giving access to the macro button editor (label, scale, color, graphic) - [P.R 685](https://github.com/PlayTazUO/TazUO/pull/685) ([bittiez](https://github.com/bittiez))
 * Added an option to hide the "Target: name" overhead message shown when a macro sets a target - [P.R 687](https://github.com/PlayTazUO/TazUO/pull/687) ([bittiez](https://github.com/bittiez))
 * Added a "Borderless window (no title bar)" video option that removes the window border while keeping a normal windowed size, separate from fullscreen-borderless - [P.R 680](https://github.com/PlayTazUO/TazUO/pull/680) ([bittiez](https://github.com/bittiez))
+* The Open macro type's gump list in the Macros tab is now sorted alphabetically and spaced after capitals for legibility, matching the main macro list - [P.R 688](https://github.com/PlayTazUO/TazUO/pull/688) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
 * Fixed client crash ("pointer being freed was not allocated") when deleting map markers in the marker manager, caused by leaked marker list controls whose graphics textures were freed off the render thread by the GC finalizer - [P.R 678](https://github.com/PlayTazUO/TazUO/pull/678) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.46</AssemblyVersion>
-    <FileVersion>5.3.46</FileVersion>
+    <AssemblyVersion>5.3.47</AssemblyVersion>
+    <FileVersion>5.3.47</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Macros/MacrosTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Macros/MacrosTabContent.cs
@@ -17,6 +17,12 @@ namespace ClassicUO.Game.UI.MyraWindows.Widgets.Assistant.Macros;
 public static class MacrosTabContent
 {
     private static readonly HashSet<MacroType> _filteredMacroTypes = new() { MacroType.INVALID };
+
+    /// <summary>Macro types whose sub-type dropdown is a list of available gumps (shared sub-type range).</summary>
+    private static readonly HashSet<MacroType> _gumpListMacroTypes = new()
+    {
+        MacroType.Open, MacroType.Close, MacroType.Minimize, MacroType.Maximize, MacroType.ToggleGump
+    };
     private static readonly string[] _sortedMacroTypeNames;
     private static readonly MacroType[] _sortedMacroTypeValues;
     private static readonly Dictionary<MacroType, int> _macroTypeToDisplayIndex;
@@ -493,12 +499,28 @@ public static class MacrosTabContent
                 int subCount = 0, subOffset = 0;
                 Macro.GetBoundByCode(capturedAction.Code, ref subCount, ref subOffset);
 
+                var subValues = new MacroSubType[subCount];
                 string[] subNames = new string[subCount];
                 for (int si = 0; si < subCount; si++)
-                    subNames[si] = ((MacroSubType)(si + subOffset)).ToString();
+                {
+                    subValues[si] = (MacroSubType)(si + subOffset);
+                    subNames[si] = subValues[si].ToString();
+                }
 
-                int curSubIdx = (int)capturedAction.SubCode - subOffset;
-                if (curSubIdx < 0 || curSubIdx >= subCount) curSubIdx = 0;
+                // The gump-list macro types (Open/Close/Minimize/Maximize/ToggleGump) show a list
+                // of available gumps. Sort that list the same way as the main macro list and add
+                // spacing after capitals for legibility; other sub-type lists keep their natural order.
+                if (_gumpListMacroTypes.Contains(capturedAction.Code))
+                {
+                    int[] order = Enumerable.Range(0, subCount)
+                        .OrderBy(i => subNames[i], StringComparer.OrdinalIgnoreCase)
+                        .ToArray();
+                    subValues = order.Select(i => subValues[i]).ToArray();
+                    subNames = order.Select(i => StringHelper.AddSpaceBeforeCapital(subNames[i])).ToArray();
+                }
+
+                int curSubIdx = Array.IndexOf(subValues, capturedAction.SubCode);
+                if (curSubIdx < 0) curSubIdx = 0;
 
 #pragma warning disable CS0612, CS0618
                 var subCombo = new ComboBox
@@ -514,7 +536,7 @@ public static class MacrosTabContent
                 subCombo.SelectedIndexChanged += (_, _) =>
                 {
                     if (subCombo.SelectedIndex == null) return;
-                    capturedAction.SubCode = (MacroSubType)(subCombo.SelectedIndex.Value + subOffset);
+                    capturedAction.SubCode = subValues[subCombo.SelectedIndex.Value];
                     MarkDirty();
                 };
 #pragma warning restore CS0612, CS0618


### PR DESCRIPTION
The gump-list macro types (Open/Close/Minimize/Maximize/ToggleGump) show a list of available gumps in their sub-type dropdown. Sort that list the same way as the main macro list (alphabetical, ordinal-ignore-case) and add spacing after capitals for legibility, matching the type dropdown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the ordering and display of macro sub-type options in relevant dropdown menus.
  - Macro entries are now sorted consistently by name, with clearer word spacing.
  - Selections correctly map to their corresponding macro actions after sorting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->