### PR TITLE
Keep context submenus open regardless of mouse bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ All notable changes to TazUO will be recorded here.
 * Show a suggested fix for the ArgumentOutOfRangeException from FetchDisplayAdapter, which happens when connected displays change at runtime (monitor unplugged/slept, dock or KVM switch, laptop lid) - [P.R 660](https://github.com/PlayTazUO/TazUO/pull/660) ([bittiez](https://github.com/bittiez))
 * Fixed container overhead text (item names/speech) being pushed off screen instead of appearing above the item - grid containers now account for the scroll offset when scaled/scrolled, and legacy containers anchor the text over the item's actual slot instead of a stale click coordinate - [P.R 667](https://github.com/PlayTazUO/TazUO/pull/667) ([bittiez](https://github.com/bittiez))
 * World map mobile dots are now colored by notoriety (matching the radar/minimap) instead of always being red - [P.R 684](https://github.com/PlayTazUO/TazUO/pull/684) ([bittiez](https://github.com/bittiez))
+* Context menu submenus now stay open until the menu is closed, an item is clicked, or another submenu is opened, and remain fully clickable when they open above the parent menu instead of closing when the mouse moves toward them - [P.R 689](https://github.com/PlayTazUO/TazUO/pull/689) ([bittiez](https://github.com/bittiez))
 
 ### Legion
 * Added ModernNineSliceGump.SetLegionTexture to go along with zip files and custom png's - Use your own png for a 9-slice texture - ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.45</AssemblyVersion>
-    <FileVersion>5.3.45</FileVersion>
+    <AssemblyVersion>5.3.46</AssemblyVersion>
+    <FileVersion>5.3.46</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Controls/ContextMenuControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ContextMenuControl.cs
@@ -267,6 +267,42 @@ namespace ClassicUO.Game.UI.Controls
             }
         }
 
+        // Union of this menu's own hit area and every currently visible submenu subtree,
+        // expressed in this menu's local coordinate space (submenu positions are relative
+        // to this gump). Submenus can fly out to the left of or above their parent
+        // (negative X/Y) and can be nested several levels deep, so the reachable region
+        // has to be gathered recursively rather than from the direct children alone.
+        private Rectangle GetVisibleTreeBounds()
+        {
+            int minX = 0, minY = 0;
+            int maxX = _background.Width, maxY = _background.Height;
+
+            if (_subMenus != null)
+            {
+                foreach (ContextMenuShowMenu menu in _subMenus)
+                {
+                    if (menu == null || menu.IsDisposed || !menu.IsVisible)
+                    {
+                        continue;
+                    }
+
+                    Rectangle sub = menu.GetVisibleTreeBounds();
+
+                    int left = menu.X + sub.X;
+                    int top = menu.Y + sub.Y;
+                    int right = menu.X + sub.Right;
+                    int bottom = menu.Y + sub.Bottom;
+
+                    if (left < minX) minX = left;
+                    if (top < minY) minY = top;
+                    if (right > maxX) maxX = right;
+                    if (bottom > maxY) maxY = bottom;
+                }
+            }
+
+            return new Rectangle(minX, minY, maxX - minX, maxY - minY);
+        }
+
         public override void Update()
         {
             base.Update();
@@ -276,46 +312,20 @@ namespace ClassicUO.Game.UI.Controls
             // therefore live at a negative X (and, near the bottom of the screen, can sit
             // above it at a negative Y). base.Update only ever grows the bounds rectangle
             // right/down, and Control.HitTest gates on that rectangle before descending
-            // into children, so those left/up regions are unreachable: moving the mouse
-            // onto a left-opening submenu is treated as leaving the menu and closes it.
-            // Extend the hit-test bounds to cover any negative-offset children without
-            // moving anything that is drawn (this gump is drawn at its raw X/Y, so the
-            // offset only affects hit testing).
-            int left = 0, top = 0;
+            // into children, so those left/up regions would be unreachable: the mouse
+            // there resolves to no control, which reads as a click/hover outside the menu
+            // and closes it. Extend the hit-test bounds to cover the whole visible submenu
+            // tree without moving anything that is drawn (this gump is drawn at its raw
+            // X/Y and its border/background use _background's size, so growing the bounds
+            // and shifting the hit-test offset only affects hit testing).
+            Rectangle tree = GetVisibleTreeBounds();
 
-            for (int i = 0; i < Children.Count; i++)
-            {
-                IGui c = Children[i];
-
-                if (c == null || c.IsDisposed || !c.IsVisible)
-                {
-                    continue;
-                }
-
-                if (c.X < left)
-                {
-                    left = c.X;
-                }
-
-                if (c.Y < top)
-                {
-                    top = c.Y;
-                }
-            }
-
-            SetHitTestOffset(left, top);
-
-            // Keep the right/bottom edges where base.Update put them while pushing the
-            // left/top edges out to include the negative-offset children.
-            if (left < 0)
-            {
-                Width -= left;
-            }
-
-            if (top < 0)
-            {
-                Height -= top;
-            }
+            // A negative-offset point p (in this gump's local space) is accepted by
+            // Control.HitTest when tree.X <= p.X < tree.X + Width and likewise for Y, given
+            // the offset below; so size the bounds to the full tree extent.
+            SetHitTestOffset(tree.X, tree.Y);
+            Width = tree.Width;
+            Height = tree.Height;
         }
 
         public override bool Draw(UltimaBatcher2D batcher, int x, int y)
@@ -346,6 +356,11 @@ namespace ClassicUO.Game.UI.Controls
             {
                 foreach (ContextMenuShowMenu menu in _subMenus)
                 {
+                    if (menu == null || menu.IsDisposed || !menu.IsVisible)
+                    {
+                        continue;
+                    }
+
                     if (menu.Contains(x - menu.X, y - menu.Y))
                     {
                         return true;

--- a/src/ClassicUO.Client/Game/UI/Controls/ContextMenuControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ContextMenuControl.cs
@@ -223,6 +223,50 @@ namespace ClassicUO.Game.UI.Controls
             }
         }
 
+        // Show the given submenu and close every other submenu opened from this
+        // menu (along with anything they had open). Called when the mouse hovers the
+        // item that owns <paramref name="sub"/>, so hovering a different item that has
+        // a submenu swaps which one is visible without relying on mouse bounds.
+        internal void OpenSubMenu(ContextMenuShowMenu sub)
+        {
+            if (_subMenus == null)
+            {
+                return;
+            }
+
+            foreach (ContextMenuShowMenu menu in _subMenus)
+            {
+                if (menu == sub)
+                {
+                    menu.IsVisible = true;
+                }
+                else if (menu.IsVisible)
+                {
+                    menu.HideWithChildren();
+                }
+            }
+        }
+
+        // Hide this submenu and recursively hide any submenus it had open, so a
+        // reopened branch does not resurrect a stale nested submenu.
+        internal void HideWithChildren()
+        {
+            IsVisible = false;
+
+            if (_subMenus == null)
+            {
+                return;
+            }
+
+            foreach (ContextMenuShowMenu menu in _subMenus)
+            {
+                if (menu.IsVisible)
+                {
+                    menu.HideWithChildren();
+                }
+            }
+        }
+
         public override void Update()
         {
             base.Update();
@@ -394,6 +438,11 @@ namespace ClassicUO.Game.UI.Controls
                 if (_entry.Items != null && _entry.Items.Count != 0)
                 {
                     _subMenu = new ContextMenuShowMenu(_gump.World, _entry.Items);
+
+                    // Submenus stay hidden until the mouse hovers this item; they are
+                    // no longer toggled by mouse bounds, so start them closed.
+                    _subMenu.IsVisible = false;
+
                     parent.Add(_subMenu);
 
                     if (parent._subMenus == null)
@@ -546,25 +595,15 @@ namespace ClassicUO.Game.UI.Controls
 
                     _subMenu.Y = subMenuY;
 
+                    // Once opened, a submenu stays open until the whole menu is
+                    // disposed (something clicked), or a different sibling submenu is
+                    // opened by hovering its item. It is intentionally NOT closed just
+                    // because the mouse leaves this item's bounds: an upward-opening
+                    // submenu sits above the parent, and closing on mouse-exit made it
+                    // impossible to reach without the menu snapping shut.
                     if (MouseIsOver)
                     {
-                        _subMenu.IsVisible = true;
-                    }
-                    else
-                    {
-                        IGui p = UIManager.MouseOverControl?.Parent;
-
-                        while (p != null)
-                        {
-                            if (p == _subMenu)
-                            {
-                                break;
-                            }
-
-                            p = p.Parent;
-                        }
-
-                        _subMenu.IsVisible = p != null;
+                        _gump.OpenSubMenu(_subMenu);
                     }
                 }
             }


### PR DESCRIPTION
Submenus that opened upward (above their parent item) could not be reached: moving the mouse up toward the submenu left the parent item's bounds, and the visibility logic keyed on mouse position closed the submenu before it could be entered.

Instead of toggling submenu visibility from mouse bounds every frame, a submenu now opens when its item is hovered and stays open until the menu is disposed (an item was clicked) or a different sibling submenu is opened. Opening one submenu recursively hides the others.