### PR TITLE
Add negative search to nameplate manager gump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ All notable changes to TazUO will be recorded here.
 * Added an option to hide the "Target: name" overhead message shown when a macro sets a target - [P.R 687](https://github.com/PlayTazUO/TazUO/pull/687) ([bittiez](https://github.com/bittiez))
 * Added a "Borderless window (no title bar)" video option that removes the window border while keeping a normal windowed size, separate from fullscreen-borderless - [P.R 680](https://github.com/PlayTazUO/TazUO/pull/680) ([bittiez](https://github.com/bittiez))
 * The Open macro type's gump list in the Macros tab is now sorted alphabetically and spaced after capitals for legibility, matching the main macro list - [P.R 688](https://github.com/PlayTazUO/TazUO/pull/688) ([bittiez](https://github.com/bittiez))
+* Added a negative search field to the nameplate manager that hides matching nameplates (the opposite of search); both search fields now accept multiple terms separated by `;` - [P.R 691](https://github.com/PlayTazUO/TazUO/pull/691) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
 * Fixed client crash ("pointer being freed was not allocated") when deleting map markers in the marker manager, caused by leaked marker list controls whose graphics textures were freed off the render thread by the GC finalizer - [P.R 678](https://github.com/PlayTazUO/TazUO/pull/678) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.47</AssemblyVersion>
-    <FileVersion>5.3.47</FileVersion>
+    <AssemblyVersion>5.3.48</AssemblyVersion>
+    <FileVersion>5.3.48</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/Managers/NameOverHeadManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/NameOverHeadManager.cs
@@ -90,6 +90,48 @@ namespace ClassicUO.Game.Managers
 
         public static string Search { get; set; } = string.Empty;
 
+        /// <summary>
+        /// Nameplates whose text matches this filter are hidden (the opposite of <see cref="Search"/>).
+        /// </summary>
+        public static string NegativeSearch { get; set; } = string.Empty;
+
+        /// <summary>True when either the positive or negative search filter is active.</summary>
+        public static bool HasSearchFilter => !string.IsNullOrEmpty(Search) || !string.IsNullOrEmpty(NegativeSearch);
+
+        /// <summary>
+        /// Returns true when any of the supplied text pieces matches the positive <see cref="Search"/> filter.
+        /// An empty filter matches everything. Multiple terms may be separated with ';' and are OR'd together.
+        /// </summary>
+        public static bool MatchesSearch(params string[] textPieces) => MatchesFilter(Search, textPieces, matchWhenEmpty: true);
+
+        /// <summary>
+        /// Returns true when any of the supplied text pieces matches the <see cref="NegativeSearch"/> filter.
+        /// An empty filter matches nothing. Multiple terms may be separated with ';' and are OR'd together.
+        /// </summary>
+        public static bool MatchesNegativeSearch(params string[] textPieces) => MatchesFilter(NegativeSearch, textPieces, matchWhenEmpty: false);
+
+        private static bool MatchesFilter(string filter, string[] textPieces, bool matchWhenEmpty)
+        {
+            if (string.IsNullOrEmpty(filter))
+                return matchWhenEmpty;
+
+            string[] terms = filter.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+            if (terms.Length == 0)
+                return matchWhenEmpty;
+
+            foreach (string term in terms)
+            {
+                foreach (string piece in textPieces)
+                {
+                    if (piece != null && piece.ContainsIgnoreCase(term))
+                        return true;
+                }
+            }
+
+            return false;
+        }
+
         public static bool IsTemporarilyShowing { get; private set; }
         public static bool IsShowing => IsPermaToggled || IsTemporarilyShowing || HotKeys.IsPressed(HotKeyRegistrar.ShowNameplatesId);
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/NameOverHeadHandlerGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/NameOverHeadHandlerGump.cs
@@ -14,7 +14,7 @@ namespace ClassicUO.Game.UI.Gumps
 
         public override GumpType GumpType => GumpType.NameOverHeadHandler;
 
-        private const int OPTIONS_TOP_OFFSET = 64;
+        private const int OPTIONS_TOP_OFFSET = 66;
 
         private readonly List<RadioButton> _overheadButtons = new List<RadioButton>();
         private Control _alpha;
@@ -129,8 +129,8 @@ namespace ClassicUO.Game.UI.Gumps
                 UIManager.KeyboardFocusControl = searchBox; //Return focus to the input in case clicking the X moved it
             };
 
-            int negativeSearchY = searchY + 20;
-            Add(new AlphaBlendControl() { Y = negativeSearchY, Width = 150, Height = 20, Hue = 0x0481 });
+            int negativeSearchY = searchY + 22;
+            Add(new AlphaBlendControl(0.4f) { Y = negativeSearchY, Width = 150, Height = 20, Hue = 0x0481 });
             Add(negativeSearchBox = new StbTextBox(0, -1, 134, hue: 0xFFFF) { Y = negativeSearchY, Width = 134, Height = 20 });
             negativeSearchBox.Text = NameOverHeadManager.NegativeSearch;
             negativeSearchBox.SetTooltip("Hide nameplates matching this text (opposite of search).\nSeparate multiple terms with ';'");

--- a/src/ClassicUO.Client/Game/UI/Gumps/NameOverHeadHandlerGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/NameOverHeadHandlerGump.cs
@@ -130,7 +130,7 @@ namespace ClassicUO.Game.UI.Gumps
             };
 
             int negativeSearchY = searchY + 20;
-            Add(new AlphaBlendControl() { Y = negativeSearchY, Width = 150, Height = 20, Hue = 0x0021 });
+            Add(new AlphaBlendControl() { Y = negativeSearchY, Width = 150, Height = 20, Hue = 0x0481 });
             Add(negativeSearchBox = new StbTextBox(0, -1, 134, hue: 0xFFFF) { Y = negativeSearchY, Width = 134, Height = 20 });
             negativeSearchBox.Text = NameOverHeadManager.NegativeSearch;
             negativeSearchBox.SetTooltip("Hide nameplates matching this text (opposite of search).\nSeparate multiple terms with ';'");

--- a/src/ClassicUO.Client/Game/UI/Gumps/NameOverHeadHandlerGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/NameOverHeadHandlerGump.cs
@@ -14,9 +14,12 @@ namespace ClassicUO.Game.UI.Gumps
 
         public override GumpType GumpType => GumpType.NameOverHeadHandler;
 
+        private const int OPTIONS_TOP_OFFSET = 64;
+
         private readonly List<RadioButton> _overheadButtons = new List<RadioButton>();
         private Control _alpha;
         private StbTextBox searchBox;
+        private StbTextBox negativeSearchBox;
 
         public NameOverHeadHandlerGump(World world) : base(world, 0, 0)
         {
@@ -105,6 +108,7 @@ namespace ClassicUO.Game.UI.Gumps
             Add(new AlphaBlendControl() { Y = searchY, Width = 150, Height = 20, Hue = 0x0481 });
             Add(searchBox = new StbTextBox(0, -1, 134, hue: 0xFFFF) { Y = searchY, Width = 134, Height = 20 });
             searchBox.Text = NameOverHeadManager.Search;
+            searchBox.SetTooltip("Only show nameplates matching this text.\nSeparate multiple terms with ';'");
             searchBox.TextChanged += (s, e) => { NameOverHeadManager.Search = searchBox.Text; };
 
             Label clearSearch;
@@ -123,6 +127,31 @@ namespace ClassicUO.Game.UI.Gumps
                 searchBox.Text = "";
                 NameOverHeadManager.Search = "";
                 UIManager.KeyboardFocusControl = searchBox; //Return focus to the input in case clicking the X moved it
+            };
+
+            int negativeSearchY = searchY + 20;
+            Add(new AlphaBlendControl() { Y = negativeSearchY, Width = 150, Height = 20, Hue = 0x0021 });
+            Add(negativeSearchBox = new StbTextBox(0, -1, 134, hue: 0xFFFF) { Y = negativeSearchY, Width = 134, Height = 20 });
+            negativeSearchBox.Text = NameOverHeadManager.NegativeSearch;
+            negativeSearchBox.SetTooltip("Hide nameplates matching this text (opposite of search).\nSeparate multiple terms with ';'");
+            negativeSearchBox.TextChanged += (s, e) => { NameOverHeadManager.NegativeSearch = negativeSearchBox.Text; };
+
+            Label clearNegativeSearch;
+            Add
+            (
+                clearNegativeSearch = new Label("X", true, 0xFFFF, font: 1)
+                {
+                    AcceptMouseInput = true,
+                    X = 138
+                }
+            );
+            clearNegativeSearch.Y = negativeSearchY + ((20 - clearNegativeSearch.Height) >> 1);
+            clearNegativeSearch.SetTooltip("Clear hide search");
+            clearNegativeSearch.MouseUp += (s, e) =>
+            {
+                negativeSearchBox.Text = "";
+                NameOverHeadManager.NegativeSearch = "";
+                UIManager.KeyboardFocusControl = negativeSearchBox; //Return focus to the input in case clicking the X moved it
             };
 
             DrawChoiceButtons();
@@ -155,7 +184,7 @@ namespace ClassicUO.Game.UI.Gumps
             }
 
             _alpha.Width = biggestWidth;
-            _alpha.Height = Math.Max(30, options.Count * 20) + 44;
+            _alpha.Height = Math.Max(30, options.Count * 20) + OPTIONS_TOP_OFFSET;
 
             Width = _alpha.Width;
             Height = _alpha.Height;
@@ -173,7 +202,7 @@ namespace ClassicUO.Game.UI.Gumps
                     color: 0xFFFF
                 )
                 {
-                    Y = 20 * index + 44,
+                    Y = 20 * index + OPTIONS_TOP_OFFSET,
                     IsChecked = NameOverHeadManager.LastActiveNameOverheadOption.Replace("\\u0026", "&") == option.Name,
                 }
             );
@@ -199,6 +228,7 @@ namespace ClassicUO.Game.UI.Gumps
         public override void Dispose()
         {
             NameOverHeadManager.Search = "";
+            NameOverHeadManager.NegativeSearch = "";
             base.Dispose();
         }
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/NameOverheadGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/NameOverheadGump.cs
@@ -839,24 +839,17 @@ namespace ClassicUO.Game.UI.Gumps
                     return false;
                 }
 
-                if (NameOverHeadManager.Search.NotNullNotEmpty())
+                if (NameOverHeadManager.HasSearchFilter)
                 {
-                    string sText = NameOverHeadManager.Search;
-                    if (m.Name == null || !m.Name.ContainsIgnoreCase(sText))
+                    string oplName = null;
+                    if (World.OPL.TryGetNameAndData(m.Serial, out string name, out string _))
+                        oplName = name;
+
+                    if (NameOverHeadManager.MatchesNegativeSearch(m.Name, oplName)
+                        || !NameOverHeadManager.MatchesSearch(m.Name, oplName))
                     {
-                        if (World.OPL.TryGetNameAndData(m.Serial, out string name, out string data))
-                        {
-                            if (name != null && !name.ContainsIgnoreCase(sText))
-                            {
-                                IsVisible = false;
-                                return true;
-                            }
-                        }
-                        else
-                        {
-                            IsVisible = false;
-                            return true;
-                        }
+                        IsVisible = false;
+                        return true;
                     }
                 }
 
@@ -925,24 +918,20 @@ namespace ClassicUO.Game.UI.Gumps
 
                 nameplateEntity = item;
 
-                if (!string.IsNullOrEmpty(NameOverHeadManager.Search))
+                if (NameOverHeadManager.HasSearchFilter)
                 {
-                    string sText = NameOverHeadManager.Search.ToLower();
-                    if (item.Name == null || !item.Name.ToLower().Contains(sText))// && (!item.ItemData.Name?.ToLower().Contains(sText)))
+                    string oplName = null, oplData = null;
+                    if (World.OPL.TryGetNameAndData(item.Serial, out string name, out string data))
                     {
-                        if (World.OPL.TryGetNameAndData(item.Serial, out string name, out string data))
-                        {
-                            if ((data != null && !data.ToLower().Contains(sText)) && (name != null && !name.ToLower().Contains(sText)))
-                            {
-                                IsVisible = false;
-                                return true;
-                            }
-                        }
-                        else
-                        {
-                            IsVisible = false;
-                            return true;
-                        }
+                        oplName = name;
+                        oplData = data;
+                    }
+
+                    if (NameOverHeadManager.MatchesNegativeSearch(item.Name, oplName, oplData)
+                        || !NameOverHeadManager.MatchesSearch(item.Name, oplName, oplData))
+                    {
+                        IsVisible = false;
+                        return true;
                     }
                 }
 


### PR DESCRIPTION
Add a second search input to the nameplate handler gump that hides any nameplate matching its text (the opposite of the existing search). Both the search and negative search now accept multiple terms separated with ';', which are OR'd together.