### PR TITLE
Size nameplate overhead manager gump to fit all controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ All notable changes to TazUO will be recorded here.
 * Nameplate search and negative search now save per nameplate profile — switching profiles and logging out/in restore each profile's filters, and both fields are editable in the nameplate profile editor - [P.R 695](https://github.com/PlayTazUO/TazUO/pull/695) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
+* Fixed the nameplate overhead manager gump not resizing to fit all buttons and profile names, and now refreshes its buttons when a profile is renamed in the options window - [P.R 698](https://github.com/PlayTazUO/TazUO/pull/698) ([bittiez](https://github.com/bittiez))
 * Fixed client crash ("pointer being freed was not allocated") when deleting map markers in the marker manager, caused by leaked marker list controls whose graphics textures were freed off the render thread by the GC finalizer - [P.R 678](https://github.com/PlayTazUO/TazUO/pull/678) ([bittiez](https://github.com/bittiez))
 * Auto open doors no longer closes a door that is already open - [P.R 674](https://github.com/PlayTazUO/TazUO/pull/674) ([bittiez](https://github.com/bittiez))
 * Added a Video > Misc option to reduce mobile feet clipping through walls (character depth slice step, default now minimizes clipping) - [P.R 666](https://github.com/PlayTazUO/TazUO/pull/666) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.50</AssemblyVersion>
-    <FileVersion>5.3.50</FileVersion>
+    <AssemblyVersion>5.3.51</AssemblyVersion>
+    <FileVersion>5.3.51</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/Managers/NameOverHeadManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/NameOverHeadManager.cs
@@ -440,6 +440,18 @@ namespace ClassicUO.Game.Managers
             _gump?.RedrawOverheadOptions();
         }
 
+        /// <summary>
+        ///     Refreshes the active overhead handler gump after an option was renamed so the buttons show the new name.
+        /// </summary>
+        public void HandleRenamedOption(NameOverheadOption option)
+        {
+            // The active option is persisted by name, so keep it in sync if that option was the one renamed.
+            if (option != null && option == ActiveOption)
+                LastActiveNameOverheadOption = option.Name;
+
+            _gump?.RedrawOverheadOptions();
+        }
+
         public static NameOverheadOption FindOptionByHotkey(SDL.SDL_Keycode key, bool alt, bool ctrl, bool shift) => Options.FirstOrDefault(o => o.Key == key && o.Alt == alt && o.Ctrl == ctrl && o.Shift == shift);
 
         public static List<NameOverheadOption> GetAllOptions() => Options;

--- a/src/ClassicUO.Client/Game/UI/Gumps/NameOverHeadHandlerGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/NameOverHeadHandlerGump.cs
@@ -20,6 +20,7 @@ namespace ClassicUO.Game.UI.Gumps
         private Control _alpha;
         private StbTextBox searchBox;
         private StbTextBox negativeSearchBox;
+        private int _topContentWidth;
 
         public NameOverHeadHandlerGump(World world) : base(world, 0, 0)
         {
@@ -102,9 +103,13 @@ namespace ClassicUO.Game.UI.Gumps
             hideInWarmode.SetTooltip("Only hide 100% hp nameplates in warmode.");
             hideInWarmode.ValueChanged += (sender, e) => { ProfileManager.CurrentProfile.NamePlateHideAtFullHealthInWarmode = hideInWarmode.IsChecked; };
 
+            // Track how wide the checkbox row is so the background can be sized to contain it.
+            _topContentWidth = Math.Max(_topContentWidth, hideInWarmode.X + hideInWarmode.Width);
+
 
 
             int searchY = stayActive.Height + stayActive.Y;
+            _topContentWidth = Math.Max(_topContentWidth, 150);
             Add(new AlphaBlendControl() { Y = searchY, Width = 150, Height = 20, Hue = 0x0481 });
             Add(searchBox = new StbTextBox(0, -1, 134, hue: 0xFFFF) { Y = searchY, Width = 134, Height = 20 });
             searchBox.Text = NameOverHeadManager.Search;
@@ -121,6 +126,7 @@ namespace ClassicUO.Game.UI.Gumps
                 }
             );
             clearSearch.Y = searchY + ((20 - clearSearch.Height) >> 1);
+            _topContentWidth = Math.Max(_topContentWidth, clearSearch.X + clearSearch.Width);
             clearSearch.SetTooltip("Clear search");
             clearSearch.MouseUp += (s, e) =>
             {
@@ -146,6 +152,7 @@ namespace ClassicUO.Game.UI.Gumps
                 }
             );
             clearNegativeSearch.Y = negativeSearchY + ((20 - clearNegativeSearch.Height) >> 1);
+            _topContentWidth = Math.Max(_topContentWidth, clearNegativeSearch.X + clearNegativeSearch.Width);
             clearNegativeSearch.SetTooltip("Clear hide search");
             clearNegativeSearch.MouseUp += (s, e) =>
             {
@@ -185,7 +192,7 @@ namespace ClassicUO.Game.UI.Gumps
 
         private void DrawChoiceButtons()
         {
-            int biggestWidth = 100;
+            int biggestWidth = Math.Max(100, _topContentWidth);
             List<NameOverheadOption> options = NameOverHeadManager.GetAllOptions();
 
             for (int i = 0; i < options.Count; i++)

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Editors/Profile/ProfileEditor.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Editors/Profile/ProfileEditor.cs
@@ -50,6 +50,11 @@ public class ProfileEditor<TProfile> : Widget where TProfile : IProfile
     private readonly Action<TProfile> _onDeleteProfile;
 
     /// <summary>
+    ///     An optional action invoked after a profile is renamed via the editor's "Rename" flow.
+    /// </summary>
+    private readonly Action<TProfile> _onRenameProfile;
+
+    /// <summary>
     ///     Margins for the profile combo box.
     /// </summary>
     private readonly Thickness _profileBoxMargins = new(0, 0, 20, 0);
@@ -99,11 +104,13 @@ public class ProfileEditor<TProfile> : Widget where TProfile : IProfile
     /// <param name="createProfile">The function to create a new profile.</param>
     /// <param name="onDeleteProfile">The action to perform when deleting a profile.</param>
     /// <param name="profiles">The initial list of profiles.</param>
+    /// <param name="onRenameProfile">An optional action to perform after renaming a profile.</param>
     public ProfileEditor(
         Func<TProfile, Widget> getConfigUiForProfile,
         Func<string, TProfile> createProfile,
         Action<TProfile> onDeleteProfile,
-        IEnumerable<TProfile> profiles = null
+        IEnumerable<TProfile> profiles = null,
+        Action<TProfile> onRenameProfile = null
     )
     {
         ArgumentNullException.ThrowIfNull(getConfigUiForProfile);
@@ -113,6 +120,7 @@ public class ProfileEditor<TProfile> : Widget where TProfile : IProfile
         _configUiGetter = getConfigUiForProfile;
         _createProfile = createProfile;
         _onDeleteProfile = onDeleteProfile;
+        _onRenameProfile = onRenameProfile;
 
         foreach (TProfile profile in profiles ?? [])
             AddProfile(profile);
@@ -205,6 +213,7 @@ public class ProfileEditor<TProfile> : Widget where TProfile : IProfile
             return;
 
         _selectedProfile.Name = newName;
+        _onRenameProfile?.Invoke(_selectedProfile);
 
         _isRenaming = false;
         RebuildUi();

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/NameplatesTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/NameplatesTab.cs
@@ -59,7 +59,11 @@ public static class NameplatesTab
             {
                 World.Instance.NameOverHeadManager.RemoveOption(profile);
             },
-            NameOverHeadManager.GetAllOptions()
+            NameOverHeadManager.GetAllOptions(),
+            profile =>
+            {
+                World.Instance.NameOverHeadManager.HandleRenamedOption(profile);
+            }
         );
         return profileEditor;
     }


### PR DESCRIPTION
The name overhead manager gump derived its width solely from the radio button widths (minimum 100px), ignoring the top controls. When profile names were short, the 150px-wide search boxes and the checkbox row overflowed the background. Track the widest top control extent and use it as a floor for the gump width.