### PR TITLE
Add 'Pathfind to location' option to world map context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to TazUO will be recorded here.
 ## In Development
 
 ### Features
+* Added a "Pathfind to location" option to the world map context menu (below "Go to location") that walks the player to entered map/sextant coordinates - [P.R 699](https://github.com/PlayTazUO/TazUO/pull/699) ([bittiez](https://github.com/bittiez))
 * Overhauled the options window with a new, modern UI (use command `old-options-window` to open legacy window) - [P.R #](https://github.com/PlayTazUO/TazUO/pull/#) ([yuval-po](https://github.com/yuval-po))
 * Added reorder support to CoolDown Bars - [P.R #](https://github.com/PlayTazUO/TazUO/pull/#) ([yuval-po](https://github.com/yuval-po))
 * Pet support for the bandage agent - [P.R 485](https://github.com/PlayTazUO/TazUO/pull/485) ([yuval-po](https://github.com/yuval-po))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.51</AssemblyVersion>
-    <FileVersion>5.3.51</FileVersion>
+    <AssemblyVersion>5.3.52</AssemblyVersion>
+    <FileVersion>5.3.52</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -5,7 +5,7 @@
 ; Missing keys are auto-appended with English defaults when
 ; this file's version is newer than the user's copy.
 ; -------------------------------------------------------
-_version=42
+_version=43
 accountname=Account Name
 accountcontextmenutooltip=Right click to select another account.
 music=Music

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -712,6 +712,7 @@ map_doubleclick_toggle_fullscreen=Toggle fullscreen
 
 ; Go to location window
 map_goto_location=Go to location
+map_pathfind_location=Pathfind to location
 map_goto_title=Enter Location
 map_goto_hint=e.g. 1639, 1532
 map_goto_clear=Clear

--- a/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
@@ -388,6 +388,16 @@ public class WorldMapGump : ResizableGump
                 )
         );
 
+        _options["pathfind_location"] = new ContextMenuItemEntry
+        (
+            TazLang.Get("map_pathfind_location", "Pathfind to location"),
+            () => LocationGoWindow.Show(
+                    World,
+                    (x, y) => BeginFreshNavTo(_world.Map.Index, x, y),
+                    null
+                )
+        );
+
         _options["top_most"] = new ContextMenuItemEntry(ResGumps.TopMost, () => { TopMost = !TopMost; }, true, _isTopMost);
 
         _options["free_view"] = new ContextMenuItemEntry(ResGumps.FreeView, () => { FreeView = !FreeView; }, true, FreeView);
@@ -658,6 +668,7 @@ public class WorldMapGump : ResizableGump
 
         ContextMenu.Add("", null);
         ContextMenu.Add(_options["goto_location"]);
+        ContextMenu.Add(_options["pathfind_location"]);
         ContextMenu.Add(_options["flip_map"]);
         ContextMenu.Add(_options["top_most"]);
 
@@ -3650,29 +3661,7 @@ public class WorldMapGump : ResizableGump
                     return;
                 }
 
-                _navDest = new Point(wX, wY);
-                _navDestSetTime = Environment.TickCount64;
-                _navPath = null;
-                _navPlannedEnd = new Point(wX, wY);
-                _navPlannedEndZ = _world.Player.Z;
-                _navSegments = 1;
-                ClearGoToMarker();
-
-                // Fresh nav session: clear any dynamic-block memory from a previous run,
-                // reset the hook so a stale closure from an old session can't fire, and
-                // stop any walk that may still be in progress.
-                WorldMapPathfinder.ClearDynamicBlocks();
-                if (_world.Player?.Pathfinder != null)
-                {
-                    if (_navStepFailedHandler != null)
-                        _world.Player.Pathfinder.OnComputedPathStepFailed -= _navStepFailedHandler;
-                    _navStepFailedHandler = null;
-                    _world.Player.Pathfinder.StopAutoWalk();
-                }
-                _navReplansLeft = MaxNavReplans;
-
-                StartNavPath(mapIndex, _world.Player.X, _world.Player.Y, _world.Player.Z, wX, wY,
-                             firstAttempt: true, append: false);
+                BeginFreshNavTo(mapIndex, wX, wY);
                 return;
             }
 
@@ -3700,6 +3689,41 @@ public class WorldMapGump : ResizableGump
         }
 
         base.OnMouseDown(x, y, button);
+    }
+
+    /// <summary>
+    /// Starts a fresh pathfinding session from the player to (wX, wY) on the given map,
+    /// replacing any route currently being walked. Shared by the right-click pathfind hotkey
+    /// and the "Pathfind to location" context-menu option.
+    /// </summary>
+    public void BeginFreshNavTo(int mapIndex, int wX, int wY)
+    {
+        if (_world.Player == null)
+            return;
+
+        _navDest = new Point(wX, wY);
+        _navDestSetTime = Environment.TickCount64;
+        _navPath = null;
+        _navPlannedEnd = new Point(wX, wY);
+        _navPlannedEndZ = _world.Player.Z;
+        _navSegments = 1;
+        ClearGoToMarker();
+
+        // Fresh nav session: clear any dynamic-block memory from a previous run,
+        // reset the hook so a stale closure from an old session can't fire, and
+        // stop any walk that may still be in progress.
+        WorldMapPathfinder.ClearDynamicBlocks();
+        if (_world.Player?.Pathfinder != null)
+        {
+            if (_navStepFailedHandler != null)
+                _world.Player.Pathfinder.OnComputedPathStepFailed -= _navStepFailedHandler;
+            _navStepFailedHandler = null;
+            _world.Player.Pathfinder.StopAutoWalk();
+        }
+        _navReplansLeft = MaxNavReplans;
+
+        StartNavPath(mapIndex, _world.Player.X, _world.Player.Y, _world.Player.Z, wX, wY,
+                     firstAttempt: true, append: false);
     }
 
     /// <summary>


### PR DESCRIPTION
Adds a 'Pathfind to location' entry below 'Go to location' in the world map context menu. It reuses the LocationGoWindow to collect map/sextant coordinates, then dispatches a WorldMapPathfinder search from the player to the entered location and walks the computed path.

The fresh-nav setup previously inlined in the right-click pathfind handler is extracted into a shared BeginFreshNavTo method used by both the hotkey and the new menu option.