### PR TITLE
Add Firebase-backed community polls window

### DIFF
--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -249,6 +249,11 @@ namespace ClassicUO.Configuration
         [SqlSetting(SettingsScope.Char, Constants.SqlSettings.BANDAGE_JOURNAL_MESSAGES, "")]
         public partial string BandageAgentJournalMessages { get; set; }
 
+        // Semicolon-separated list of poll ids the user has already voted on (see PollsWindow / FirebasePollsManager).
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, Constants.SqlSettings.VOTED_POLLS, "")]
+        public partial string VotedPolls { get; set; }
+
         public bool EnableDeathScreen { get; set => SetProperty(ref field, value); } = true;
         public bool EnableBlackWhiteEffect { get; set => SetProperty(ref field, value); } = true;
         public ushort HiddenBodyHue { get; set => SetProperty(ref field, value); } = 0x038E;
@@ -1658,6 +1663,11 @@ namespace ClassicUO.Configuration
                     var smw = new ScriptManagerWindow();
                     smw.Load(xml);
                     UIManager.Add(smw);
+                    break;
+                case "ClassicUO.Game.UI.MyraWindows.PollsWindow":
+                    var polls = new PollsWindow();
+                    polls.Load(xml);
+                    UIManager.Add(polls);
                     break;
             }
         }

--- a/src/ClassicUO.Client/Game/Constants.cs
+++ b/src/ClassicUO.Client/Game/Constants.cs
@@ -145,6 +145,7 @@ public const string SCALE_PETS_ENABLED = "scale_pets_enabled";
             public const string AUTO_OPEN_DOORS_HIDDEN = "auto_open_doors_hidden";
             public const string BANDAGE_JOURNAL_TRIGGER = "bandage_journal_trigger";
             public const string BANDAGE_JOURNAL_MESSAGES = "bandage_journal_messages";
+            public const string VOTED_POLLS = "voted_polls";
         }
     }
 }

--- a/src/ClassicUO.Client/Game/Managers/FirebasePollsManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/FirebasePollsManager.cs
@@ -4,33 +4,59 @@ using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using ClassicUO.Utility.Logging;
 
 namespace ClassicUO.Game.Managers;
 
 /// <summary>
+/// A single option within a <see cref="Poll"/>.
+///
+/// Two storage shapes are supported so the client tolerates schema differences:
+/// <list type="bullet">
+/// <item>a bare number, e.g. <c>"Yes!": 3</c> — the option key is the label and the count lives directly at
+/// <c>options/&lt;key&gt;</c>;</item>
+/// <item>an object, e.g. <c>"0": { "text": "Yes!", "votes": 3 }</c> — the label comes from a text field and the
+/// count lives at <c>options/&lt;key&gt;/votes</c>.</item>
+/// </list>
+/// </summary>
+public sealed class PollOption
+{
+    /// <summary>The Firebase key of this option under <c>options/</c>.</summary>
+    public string Key { get; set; }
+
+    /// <summary>Human-readable text shown to the user.</summary>
+    public string Label { get; set; }
+
+    /// <summary>Current vote count.</summary>
+    public int Votes { get; set; }
+
+    /// <summary>Relative Firebase path (under the poll) whose integer value is the vote count.</summary>
+    public string VotePath { get; set; }
+}
+
+/// <summary>
 /// A single poll as stored in the Firebase realtime database.
-/// The JSON shape is:
-/// <code>{ "options": { "No :(": 0, "Yes!": 0 }, "question": "Are you enjoying TazUO?", "type": 0 }</code>
 /// </summary>
 public sealed class Poll
 {
-    [JsonPropertyName("options")]
-    public Dictionary<string, int> Options { get; set; } = new();
+    public List<PollOption> Options { get; set; } = new();
 
-    [JsonPropertyName("question")]
     public string Question { get; set; } = string.Empty;
 
     /// <summary>0 = single choice, 1 = multiple choice.</summary>
-    [JsonPropertyName("type")]
     public int Type { get; set; }
 }
 
-[JsonSerializable(typeof(Dictionary<string, Poll>))]
-[JsonSerializable(typeof(Poll))]
-internal sealed partial class PollsJsonContext : JsonSerializerContext { }
+/// <summary>Outcome of a vote attempt, carrying the server's error message when it fails.</summary>
+public readonly struct VoteResult
+{
+    public bool Success { get; init; }
+    public string Error { get; init; }
+
+    public static VoteResult Ok() => new() { Success = true };
+    public static VoteResult Fail(string error) => new() { Success = false, Error = error };
+}
 
 /// <summary>
 /// Fetches available polls from the TazUO Firebase realtime database and submits votes.
@@ -38,6 +64,9 @@ internal sealed partial class PollsJsonContext : JsonSerializerContext { }
 /// The database security rules only permit a write to an option when the new value is exactly
 /// <c>current + 1</c>, so a vote reads the option's current count and writes count + 1. If another
 /// client votes between the read and the write, the write is rejected and we retry with a fresh count.
+///
+/// Poll data is parsed defensively: malformed or incomplete entries (missing question, missing/empty
+/// options, non-numeric counts) are skipped so one bad entry can't hide the rest.
 /// </summary>
 public static class FirebasePollsManager
 {
@@ -49,20 +78,17 @@ public static class FirebasePollsManager
         Timeout = TimeSpan.FromSeconds(30)
     };
 
-    /// <summary>Downloads all available polls keyed by their poll id.</summary>
+    /// <summary>
+    /// Downloads all available polls keyed by their poll id. Returns <c>null</c> only when the request
+    /// itself fails; a successful request with no (or only invalid) polls returns an empty dictionary.
+    /// </summary>
     public static async Task<Dictionary<string, Poll>> FetchPollsAsync()
     {
         try
         {
             string json = await _httpClient.GetStringAsync($"{BASE_URL}.json");
 
-            if (string.IsNullOrWhiteSpace(json) || json == "null")
-                return new Dictionary<string, Poll>();
-
-            Dictionary<string, Poll> polls =
-                JsonSerializer.Deserialize(json, PollsJsonContext.Default.DictionaryStringPoll);
-
-            return polls ?? new Dictionary<string, Poll>();
+            return ParsePolls(json);
         }
         catch (Exception e)
         {
@@ -72,26 +98,150 @@ public static class FirebasePollsManager
     }
 
     /// <summary>
-    /// Casts a vote for <paramref name="optionName"/> on <paramref name="pollId"/> by incrementing the
-    /// stored count by one. Retries a few times if a concurrent vote invalidates the +1 write rule.
+    /// Parses the polls payload, keeping only entries that are well-formed enough to display and vote on.
+    /// Each poll is validated independently so a single malformed entry does not break the whole list.
     /// </summary>
-    /// <returns>True if the vote was recorded, otherwise false.</returns>
-    public static async Task<bool> VoteAsync(string pollId, string optionName)
+    private static Dictionary<string, Poll> ParsePolls(string json)
     {
-        string optionUrl =
-            $"{BASE_URL}/{Uri.EscapeDataString(pollId)}/options/{Uri.EscapeDataString(optionName)}.json";
+        var result = new Dictionary<string, Poll>();
+
+        if (string.IsNullOrWhiteSpace(json) || json == "null")
+            return result;
+
+        using JsonDocument doc = JsonDocument.Parse(json);
+
+        if (doc.RootElement.ValueKind != JsonValueKind.Object)
+            return result;
+
+        foreach (JsonProperty entry in doc.RootElement.EnumerateObject())
+        {
+            if (TryParsePoll(entry.Value, out Poll poll))
+                result[entry.Name] = poll;
+        }
+
+        return result;
+    }
+
+    private static bool TryParsePoll(JsonElement element, out Poll poll)
+    {
+        poll = null;
+
+        if (element.ValueKind != JsonValueKind.Object)
+            return false;
+
+        // Question is required and must be a non-empty string.
+        if (!element.TryGetProperty("question", out JsonElement questionEl) ||
+            questionEl.ValueKind != JsonValueKind.String)
+            return false;
+
+        string question = questionEl.GetString();
+        if (string.IsNullOrWhiteSpace(question))
+            return false;
+
+        // Type is optional; default to single-choice (0) when absent or malformed.
+        int type = 0;
+        if (element.TryGetProperty("type", out JsonElement typeEl) &&
+            typeEl.ValueKind == JsonValueKind.Number &&
+            typeEl.TryGetInt32(out int parsedType))
+            type = parsedType;
+
+        // Options are required.
+        if (!element.TryGetProperty("options", out JsonElement optionsEl) ||
+            optionsEl.ValueKind != JsonValueKind.Object)
+            return false;
+
+        var options = new List<PollOption>();
+        foreach (JsonProperty option in optionsEl.EnumerateObject())
+        {
+            if (TryParseOption(option.Name, option.Value, out PollOption parsed))
+                options.Add(parsed);
+        }
+
+        if (options.Count == 0)
+            return false;
+
+        poll = new Poll { Question = question, Type = type, Options = options };
+        return true;
+    }
+
+    /// <summary>Parses a single option in either the bare-number or object (<c>votes</c>) shape.</summary>
+    private static bool TryParseOption(string key, JsonElement value, out PollOption option)
+    {
+        option = null;
+
+        // Shape 1: bare number — key is the label, count is the value at options/<key>.
+        if (value.ValueKind == JsonValueKind.Number && value.TryGetInt32(out int directCount))
+        {
+            option = new PollOption
+            {
+                Key = key,
+                Label = key,
+                Votes = directCount,
+                VotePath = $"options/{Uri.EscapeDataString(key)}"
+            };
+            return true;
+        }
+
+        // Shape 2: object — count lives at options/<key>/votes, label from a text field (or the key).
+        if (value.ValueKind == JsonValueKind.Object)
+        {
+            int votes = 0;
+            if (value.TryGetProperty("votes", out JsonElement votesEl) &&
+                votesEl.ValueKind == JsonValueKind.Number &&
+                votesEl.TryGetInt32(out int parsedVotes))
+                votes = parsedVotes;
+
+            option = new PollOption
+            {
+                Key = key,
+                Label = ReadLabel(value) ?? key,
+                Votes = votes,
+                VotePath = $"options/{Uri.EscapeDataString(key)}/votes"
+            };
+            return true;
+        }
+
+        return false;
+    }
+
+    private static string ReadLabel(JsonElement optionObj)
+    {
+        foreach (string field in new[] { "text", "label", "name", "title", "option" })
+        {
+            if (optionObj.TryGetProperty(field, out JsonElement el) &&
+                el.ValueKind == JsonValueKind.String &&
+                !string.IsNullOrWhiteSpace(el.GetString()))
+                return el.GetString();
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Casts a vote for <paramref name="option"/> on <paramref name="pollId"/> by incrementing its stored
+    /// count by one. Retries a few times if a concurrent vote invalidates the +1 write rule.
+    /// </summary>
+    public static async Task<VoteResult> VoteAsync(string pollId, PollOption option)
+    {
+        string url = $"{BASE_URL}/{Uri.EscapeDataString(pollId)}/{option.VotePath}.json";
+
+        string lastError = "Unknown error";
 
         for (int attempt = 0; attempt < VOTE_RETRIES; attempt++)
         {
             try
             {
-                int current = await GetOptionValueAsync(optionUrl);
+                int current = await GetOptionValueAsync(url);
 
                 var content = new StringContent((current + 1).ToString(), Encoding.UTF8, "application/json");
-                HttpResponseMessage response = await _httpClient.PutAsync(optionUrl, content);
+                HttpResponseMessage response = await _httpClient.PutAsync(url, content);
 
                 if (response.IsSuccessStatusCode)
-                    return true;
+                    return VoteResult.Ok();
+
+                string body = await response.Content.ReadAsStringAsync();
+                lastError = $"{(int)response.StatusCode} {response.StatusCode}: {body}";
+                Log.Error($"Vote for poll '{pollId}' option '{option.Key}' rejected ({url}): {lastError}");
 
                 // A rejected write (e.g. permission denied because someone else voted first) is worth
                 // retrying with a freshly read count; anything else is unlikely to recover.
@@ -99,23 +249,22 @@ public static class FirebasePollsManager
                     response.StatusCode != HttpStatusCode.Forbidden &&
                     response.StatusCode != HttpStatusCode.BadRequest)
                 {
-                    Log.Error($"Vote for poll '{pollId}' option '{optionName}' failed: {response.StatusCode}");
-                    return false;
+                    return VoteResult.Fail(lastError);
                 }
             }
             catch (Exception e)
             {
                 Log.Error($"Error voting on poll '{pollId}': {e}");
-                return false;
+                return VoteResult.Fail(e.Message);
             }
         }
 
-        return false;
+        return VoteResult.Fail(lastError);
     }
 
-    private static async Task<int> GetOptionValueAsync(string optionUrl)
+    private static async Task<int> GetOptionValueAsync(string url)
     {
-        string json = await _httpClient.GetStringAsync(optionUrl);
+        string json = await _httpClient.GetStringAsync(url);
 
         if (string.IsNullOrWhiteSpace(json) || json == "null")
             return 0;

--- a/src/ClassicUO.Client/Game/Managers/FirebasePollsManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/FirebasePollsManager.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using ClassicUO.Utility.Logging;
+
+namespace ClassicUO.Game.Managers;
+
+/// <summary>
+/// A single poll as stored in the Firebase realtime database.
+/// The JSON shape is:
+/// <code>{ "options": { "No :(": 0, "Yes!": 0 }, "question": "Are you enjoying TazUO?", "type": 0 }</code>
+/// </summary>
+public sealed class Poll
+{
+    [JsonPropertyName("options")]
+    public Dictionary<string, int> Options { get; set; } = new();
+
+    [JsonPropertyName("question")]
+    public string Question { get; set; } = string.Empty;
+
+    /// <summary>0 = single choice, 1 = multiple choice.</summary>
+    [JsonPropertyName("type")]
+    public int Type { get; set; }
+}
+
+[JsonSerializable(typeof(Dictionary<string, Poll>))]
+[JsonSerializable(typeof(Poll))]
+internal sealed partial class PollsJsonContext : JsonSerializerContext { }
+
+/// <summary>
+/// Fetches available polls from the TazUO Firebase realtime database and submits votes.
+///
+/// The database security rules only permit a write to an option when the new value is exactly
+/// <c>current + 1</c>, so a vote reads the option's current count and writes count + 1. If another
+/// client votes between the read and the write, the write is rejected and we retry with a fresh count.
+/// </summary>
+public static class FirebasePollsManager
+{
+    private const string BASE_URL = "https://tazuopolls-default-rtdb.firebaseio.com/polls";
+    private const int VOTE_RETRIES = 4;
+
+    private static readonly HttpClient _httpClient = new()
+    {
+        Timeout = TimeSpan.FromSeconds(30)
+    };
+
+    /// <summary>Downloads all available polls keyed by their poll id.</summary>
+    public static async Task<Dictionary<string, Poll>> FetchPollsAsync()
+    {
+        try
+        {
+            string json = await _httpClient.GetStringAsync($"{BASE_URL}.json");
+
+            if (string.IsNullOrWhiteSpace(json) || json == "null")
+                return new Dictionary<string, Poll>();
+
+            Dictionary<string, Poll> polls =
+                JsonSerializer.Deserialize(json, PollsJsonContext.Default.DictionaryStringPoll);
+
+            return polls ?? new Dictionary<string, Poll>();
+        }
+        catch (Exception e)
+        {
+            Log.Error($"Failed to fetch polls: {e}");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Casts a vote for <paramref name="optionName"/> on <paramref name="pollId"/> by incrementing the
+    /// stored count by one. Retries a few times if a concurrent vote invalidates the +1 write rule.
+    /// </summary>
+    /// <returns>True if the vote was recorded, otherwise false.</returns>
+    public static async Task<bool> VoteAsync(string pollId, string optionName)
+    {
+        string optionUrl =
+            $"{BASE_URL}/{Uri.EscapeDataString(pollId)}/options/{Uri.EscapeDataString(optionName)}.json";
+
+        for (int attempt = 0; attempt < VOTE_RETRIES; attempt++)
+        {
+            try
+            {
+                int current = await GetOptionValueAsync(optionUrl);
+
+                var content = new StringContent((current + 1).ToString(), Encoding.UTF8, "application/json");
+                HttpResponseMessage response = await _httpClient.PutAsync(optionUrl, content);
+
+                if (response.IsSuccessStatusCode)
+                    return true;
+
+                // A rejected write (e.g. permission denied because someone else voted first) is worth
+                // retrying with a freshly read count; anything else is unlikely to recover.
+                if (response.StatusCode != HttpStatusCode.Unauthorized &&
+                    response.StatusCode != HttpStatusCode.Forbidden &&
+                    response.StatusCode != HttpStatusCode.BadRequest)
+                {
+                    Log.Error($"Vote for poll '{pollId}' option '{optionName}' failed: {response.StatusCode}");
+                    return false;
+                }
+            }
+            catch (Exception e)
+            {
+                Log.Error($"Error voting on poll '{pollId}': {e}");
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    private static async Task<int> GetOptionValueAsync(string optionUrl)
+    {
+        string json = await _httpClient.GetStringAsync(optionUrl);
+
+        if (string.IsNullOrWhiteSpace(json) || json == "null")
+            return 0;
+
+        return int.TryParse(json.Trim(), out int value) ? value : 0;
+    }
+}

--- a/src/ClassicUO.Client/Game/UI/Gumps/TopBarGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/TopBarGump.cs
@@ -250,6 +250,8 @@ namespace ClassicUO.Game.UI.Gumps
 
             moreMenu.ContextMenu.Add(new ContextMenuItemEntry(TazLang.Get("topbargump_radarmap", "Radar Map"), () => { GameActions.OpenMiniMap(World); }));
 
+            moreMenu.ContextMenu.Add(new ContextMenuItemEntry(TazLang.Get("topbargump_polls", "Polls"), MyraWindows.PollsWindow.Show));
+
             var submenu = new ContextMenuItemEntry(TazLang.Get("topbargump_tools", "Tools"));
             submenu.Add(new ContextMenuItemEntry(TazLang.Get("topbargump_spellquickcast", "Spell quick cast"), () => { UIManager.Add(new SpellQuickSearch(World, 200, 200, (sp) => {if (sp != null) GameActions.CastSpell(sp.ID);})); }));
             submenu.Add(new ContextMenuItemEntry(TazLang.Get("topbargump_openboatcontrol", "Open boat control"), () => { UIManager.Add(new BoatControl(World) { X = 200, Y = 200 }); }));

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/PollsWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/PollsWindow.cs
@@ -140,12 +140,12 @@ public sealed class PollsWindow : MyraControl
 
     private static void AddResults(VerticalStackPanel panel, Poll poll)
     {
-        int total = poll.Options.Values.Sum();
+        int total = poll.Options.Sum(o => o.Votes);
 
-        foreach (KeyValuePair<string, int> opt in poll.Options)
+        foreach (PollOption opt in poll.Options)
         {
-            int percent = total > 0 ? (int)Math.Round(opt.Value * 100.0 / total) : 0;
-            panel.Widgets.Add(new MyraLabel($"{opt.Key} — {opt.Value} ({percent}%)", MyraLabel.TextStyle.P));
+            int percent = total > 0 ? (int)Math.Round(opt.Votes * 100.0 / total) : 0;
+            panel.Widgets.Add(new MyraLabel($"{opt.Label} — {opt.Votes} ({percent}%)", MyraLabel.TextStyle.P));
         }
 
         panel.Widgets.Add(new MyraLabel(
@@ -156,11 +156,11 @@ public sealed class PollsWindow : MyraControl
     private void AddVotingForm(VerticalStackPanel panel, string pollId, Poll poll)
     {
         bool singleChoice = poll.Type == 0;
-        var choices = new List<(string name, MyraCheckButton cb)>();
+        var choices = new List<(PollOption option, MyraCheckButton cb)>();
 
-        foreach (string optionName in poll.Options.Keys)
+        foreach (PollOption option in poll.Options)
         {
-            var cb = new MyraCheckButton(optionName);
+            var cb = new MyraCheckButton(option.Label);
 
             if (singleChoice)
             {
@@ -170,7 +170,7 @@ public sealed class PollsWindow : MyraControl
                         return;
 
                     // Radio-style behaviour: selecting one option clears the others.
-                    foreach ((string _, MyraCheckButton other) in choices)
+                    foreach ((PollOption _, MyraCheckButton other) in choices)
                     {
                         if (!ReferenceEquals(other, cb))
                             other.IsChecked = false;
@@ -178,7 +178,7 @@ public sealed class PollsWindow : MyraControl
                 };
             }
 
-            choices.Add((optionName, cb));
+            choices.Add((option, cb));
             panel.Widgets.Add(cb);
         }
 
@@ -187,9 +187,9 @@ public sealed class PollsWindow : MyraControl
             () => SubmitVote(pollId, poll, choices)));
     }
 
-    private void SubmitVote(string pollId, Poll poll, List<(string name, MyraCheckButton cb)> choices)
+    private void SubmitVote(string pollId, Poll poll, List<(PollOption option, MyraCheckButton cb)> choices)
     {
-        List<string> selected = choices.Where(c => c.cb.IsChecked).Select(c => c.name).ToList();
+        List<PollOption> selected = choices.Where(c => c.cb.IsChecked).Select(c => c.option).ToList();
 
         if (selected.Count == 0)
         {
@@ -203,8 +203,17 @@ public sealed class PollsWindow : MyraControl
         Task.Run(async () =>
         {
             bool allOk = true;
-            foreach (string option in selected)
-                allOk &= await FirebasePollsManager.VoteAsync(pollId, option);
+            string error = null;
+            foreach (PollOption option in selected)
+            {
+                VoteResult result = await FirebasePollsManager.VoteAsync(pollId, option);
+                if (!result.Success)
+                {
+                    allOk = false;
+                    error = result.Error;
+                    break;
+                }
+            }
 
             MainThreadQueue.InvokeOnMainThread(() =>
             {
@@ -214,19 +223,20 @@ public sealed class PollsWindow : MyraControl
                 if (allOk)
                 {
                     // Reflect our own votes immediately so the results view is accurate without a re-fetch.
-                    foreach (string option in selected)
-                    {
-                        if (poll.Options.ContainsKey(option))
-                            poll.Options[option]++;
-                    }
+                    foreach (PollOption option in selected)
+                        option.Votes++;
 
                     MarkVoted(pollId);
                 }
                 else
                 {
+                    string message = TazLang.Get("polls_vote_failed", "Your vote could not be recorded. Please try again.");
+                    if (!string.IsNullOrEmpty(error))
+                        message += $"\n\n{error}";
+
                     new MyraDialog(
                         TazLang.Get("polls_title", "TazUO Polls"),
-                        new MyraLabel(TazLang.Get("polls_vote_failed", "Your vote could not be recorded. Please try again."), MyraLabel.TextStyle.P),
+                        new MyraLabel(message, MyraLabel.TextStyle.P),
                         _ => { });
                 }
 

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/PollsWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/PollsWindow.cs
@@ -1,0 +1,258 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using ClassicUO.Configuration;
+using ClassicUO.Game.Managers;
+using ClassicUO.Game.UI.Controls;
+using ClassicUO.Game.UI.MyraWindows.Widgets;
+using Microsoft.Xna.Framework;
+using Myra.Graphics2D;
+using Myra.Graphics2D.Brushes;
+using Myra.Graphics2D.UI;
+
+namespace ClassicUO.Game.UI.MyraWindows;
+
+/// <summary>
+/// Displays the community polls hosted in the TazUO Firebase realtime database and lets the user vote.
+/// Single-choice polls (type 0) present the options as a radio-style group; multiple-choice polls
+/// (type 1) allow any number of options. Once the user votes on a poll — tracked per-profile via
+/// <see cref="Profile.VotedPolls"/> — that poll is shown as read-only results instead of a voting form.
+/// </summary>
+public sealed class PollsWindow : MyraControl
+{
+    private readonly VerticalStackPanel _contentPanel = new() { Spacing = 8 };
+    private Dictionary<string, Poll> _polls;
+    private bool _loading;
+
+    public PollsWindow() : base(TazLang.Get("polls_title", "TazUO Polls"))
+    {
+        CanBeSaved = true;
+        Build();
+        CenterInViewPort();
+        LoadPolls();
+    }
+
+    public static void Show()
+    {
+        foreach (IGui gump in UIManager.Gumps)
+        {
+            if (gump is PollsWindow w && !w.IsDisposed)
+            {
+                w.BringOnTop();
+                return;
+            }
+        }
+
+        UIManager.Add(new PollsWindow());
+    }
+
+    private void Build()
+    {
+        var root = new VerticalStackPanel { Spacing = MyraStyle.STANDARD_SPACING, Padding = new Thickness(6) };
+
+        var toolbar = new HorizontalStackPanel { Spacing = 4, VerticalAlignment = VerticalAlignment.Center };
+        toolbar.Widgets.Add(new MyraButton(TazLang.Get("polls_refresh", "Refresh"), LoadPolls));
+        root.Widgets.Add(toolbar);
+
+        root.Widgets.Add(new ScrollViewer { MaxHeight = 500, Content = _contentPanel });
+
+        SetRootContent(root);
+    }
+
+    private void LoadPolls()
+    {
+        if (_loading)
+            return;
+
+        _loading = true;
+        _contentPanel.Widgets.Clear();
+        _contentPanel.Widgets.Add(new MyraLabel(TazLang.Get("polls_loading", "Loading polls..."), MyraLabel.TextStyle.P));
+
+        Task.Run(async () =>
+        {
+            Dictionary<string, Poll> polls = await FirebasePollsManager.FetchPollsAsync();
+
+            MainThreadQueue.InvokeOnMainThread(() =>
+            {
+                _loading = false;
+
+                if (IsDisposed)
+                    return;
+
+                _polls = polls;
+                RebuildList();
+            });
+        });
+    }
+
+    private void RebuildList()
+    {
+        _contentPanel.Widgets.Clear();
+
+        if (_polls == null)
+        {
+            _contentPanel.Widgets.Add(new MyraLabel(
+                TazLang.Get("polls_load_failed", "Failed to load polls. Please try again later."),
+                MyraLabel.TextStyle.P));
+            return;
+        }
+
+        if (_polls.Count == 0)
+        {
+            _contentPanel.Widgets.Add(new MyraLabel(
+                TazLang.Get("polls_none", "There are no polls available right now."),
+                MyraLabel.TextStyle.P));
+            return;
+        }
+
+        foreach (KeyValuePair<string, Poll> kvp in _polls)
+            _contentPanel.Widgets.Add(BuildPollWidget(kvp.Key, kvp.Value));
+    }
+
+    private Widget BuildPollWidget(string pollId, Poll poll)
+    {
+        var panel = new VerticalStackPanel
+        {
+            Spacing = 4,
+            Padding = new Thickness(8),
+            Background = new SolidBrush(new Color(0, 0, 0, 60)),
+            Border = new SolidBrush(MyraStyle.GridBorderColor),
+            BorderThickness = new Thickness(1),
+            Width = 340
+        };
+
+        panel.Widgets.Add(new MyraLabel(poll.Question, MyraLabel.TextStyle.H4));
+
+        if (poll.Options == null || poll.Options.Count == 0)
+        {
+            panel.Widgets.Add(new MyraLabel(TazLang.Get("polls_no_options", "This poll has no options."), MyraLabel.TextStyle.P));
+            return panel;
+        }
+
+        if (HasVoted(pollId))
+            AddResults(panel, poll);
+        else
+            AddVotingForm(panel, pollId, poll);
+
+        return panel;
+    }
+
+    private static void AddResults(VerticalStackPanel panel, Poll poll)
+    {
+        int total = poll.Options.Values.Sum();
+
+        foreach (KeyValuePair<string, int> opt in poll.Options)
+        {
+            int percent = total > 0 ? (int)Math.Round(opt.Value * 100.0 / total) : 0;
+            panel.Widgets.Add(new MyraLabel($"{opt.Key} — {opt.Value} ({percent}%)", MyraLabel.TextStyle.P));
+        }
+
+        panel.Widgets.Add(new MyraLabel(
+            TazLang.Get("polls_already_voted", "You have already voted on this poll."),
+            MyraLabel.TextStyle.H6));
+    }
+
+    private void AddVotingForm(VerticalStackPanel panel, string pollId, Poll poll)
+    {
+        bool singleChoice = poll.Type == 0;
+        var choices = new List<(string name, MyraCheckButton cb)>();
+
+        foreach (string optionName in poll.Options.Keys)
+        {
+            var cb = new MyraCheckButton(optionName);
+
+            if (singleChoice)
+            {
+                cb.IsCheckedChanged += (_, _) =>
+                {
+                    if (!cb.IsChecked)
+                        return;
+
+                    // Radio-style behaviour: selecting one option clears the others.
+                    foreach ((string _, MyraCheckButton other) in choices)
+                    {
+                        if (!ReferenceEquals(other, cb))
+                            other.IsChecked = false;
+                    }
+                };
+            }
+
+            choices.Add((optionName, cb));
+            panel.Widgets.Add(cb);
+        }
+
+        panel.Widgets.Add(new MyraButton(
+            TazLang.Get("polls_vote", "Vote"),
+            () => SubmitVote(pollId, poll, choices)));
+    }
+
+    private void SubmitVote(string pollId, Poll poll, List<(string name, MyraCheckButton cb)> choices)
+    {
+        List<string> selected = choices.Where(c => c.cb.IsChecked).Select(c => c.name).ToList();
+
+        if (selected.Count == 0)
+        {
+            new MyraDialog(
+                TazLang.Get("polls_title", "TazUO Polls"),
+                new MyraLabel(TazLang.Get("polls_select_prompt", "Please select an option before voting."), MyraLabel.TextStyle.P),
+                _ => { });
+            return;
+        }
+
+        Task.Run(async () =>
+        {
+            bool allOk = true;
+            foreach (string option in selected)
+                allOk &= await FirebasePollsManager.VoteAsync(pollId, option);
+
+            MainThreadQueue.InvokeOnMainThread(() =>
+            {
+                if (IsDisposed)
+                    return;
+
+                if (allOk)
+                {
+                    // Reflect our own votes immediately so the results view is accurate without a re-fetch.
+                    foreach (string option in selected)
+                    {
+                        if (poll.Options.ContainsKey(option))
+                            poll.Options[option]++;
+                    }
+
+                    MarkVoted(pollId);
+                }
+                else
+                {
+                    new MyraDialog(
+                        TazLang.Get("polls_title", "TazUO Polls"),
+                        new MyraLabel(TazLang.Get("polls_vote_failed", "Your vote could not be recorded. Please try again."), MyraLabel.TextStyle.P),
+                        _ => { });
+                }
+
+                RebuildList();
+            });
+        });
+    }
+
+    private static bool HasVoted(string pollId)
+    {
+        Profile profile = ProfileManager.CurrentProfile;
+        if (profile == null)
+            return false;
+
+        return (profile.VotedPolls ?? string.Empty)
+            .Split(';', StringSplitOptions.RemoveEmptyEntries)
+            .Contains(pollId);
+    }
+
+    private static void MarkVoted(string pollId)
+    {
+        Profile profile = ProfileManager.CurrentProfile;
+        if (profile == null || HasVoted(pollId))
+            return;
+
+        string voted = profile.VotedPolls ?? string.Empty;
+        profile.VotedPolls = string.IsNullOrEmpty(voted) ? pollId : $"{voted};{pollId}";
+    }
+}


### PR DESCRIPTION
Add a Myra window that lists the polls hosted in the TazUO Firebase realtime database and lets the user vote on them.

- FirebasePollsManager fetches polls from the realtime DB and submits votes by writing current+1 to an option (with retry, since the DB rules only allow a +1 write).
- PollsWindow shows single-choice (type 0, radio-style) and multiple-choice (type 1) polls; polls already voted on are shown as read-only results.
- Voted poll ids are persisted per-profile in the settings DB via a new Profile.VotedPolls SqlSetting accessor (semicolon-separated).
- Launch from the top bar "More +" menu.