### PR TITLE
Notify user of unvoted polls after login

### DIFF
--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -5,7 +5,7 @@
 ; Missing keys are auto-appended with English defaults when
 ; this file's version is newer than the user's copy.
 ; -------------------------------------------------------
-_version=43
+_version=44
 accountname=Account Name
 accountcontextmenutooltip=Right click to select another account.
 music=Music
@@ -1948,3 +1948,5 @@ mog_videotab_zoom_paperdollscaling=Paperdoll scaling
 mog_videotab_zoom_returndefaultzoom=Return to default zoom after unpressing Ctrl
 mog_videotab_zoom_zoomlabel=Zoom
 mog_videotab_zoom_zoomwheel=Enable mousewheel zoom
+polls_notify_one=There is a new TazUO poll you haven't voted on. Open Polls from the top bar menu to vote.
+polls_notify_many=There are {0} TazUO polls you haven't voted on. Open Polls from the top bar menu to vote.

--- a/src/ClassicUO.Client/Game/Managers/FirebasePollsManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/FirebasePollsManager.cs
@@ -99,38 +99,29 @@ public static class FirebasePollsManager
     }
 
     /// <summary>
-    /// Fetches the available polls and, if the current profile has any it hasn't voted on yet, prints a
-    /// notification to the user. Intended to be called once after login. Runs the fetch on a background
-    /// task and prints on the main thread; does nothing when the fetch fails, there are no polls, or every
-    /// poll has already been voted on.
+    /// Fetches the available polls and, if the current profile has any it hasn't voted on yet, returns a
+    /// user-facing reminder message. Returns <c>null</c> when the fetch fails, there are no polls, or every
+    /// poll has already been voted on. Intended to be shown once after the user is in-world.
     /// </summary>
-    public static void NotifyUnvotedPolls(World world)
+    public static async Task<string> GetUnvotedNotificationAsync()
     {
-        Task.Run(async () =>
-        {
-            Dictionary<string, Poll> polls = await FetchPollsAsync();
+        Dictionary<string, Poll> polls = await FetchPollsAsync();
 
-            if (polls == null || polls.Count == 0)
-                return;
+        if (polls == null || polls.Count == 0)
+            return null;
 
-            int unvoted = CountUnvoted(polls);
+        int unvoted = CountUnvoted(polls);
 
-            if (unvoted <= 0)
-                return;
+        if (unvoted <= 0)
+            return null;
 
-            MainThreadQueue.InvokeOnMainThread(() =>
-            {
-                string message = unvoted == 1
-                    ? TazLang.Get("polls_notify_one",
-                        "There is a new TazUO poll you haven't voted on. Open Polls from the top bar menu to vote.")
-                    : string.Format(
-                        TazLang.Get("polls_notify_many",
-                            "There are {0} TazUO polls you haven't voted on. Open Polls from the top bar menu to vote."),
-                        unvoted);
-
-                GameActions.Print(world, message);
-            });
-        });
+        return unvoted == 1
+            ? TazLang.Get("polls_notify_one",
+                "There is a new TazUO poll you haven't voted on. Open Polls from the top bar menu to vote.")
+            : string.Format(
+                TazLang.Get("polls_notify_many",
+                    "There are {0} TazUO polls you haven't voted on. Open Polls from the top bar menu to vote."),
+                unvoted);
     }
 
     /// <summary>Counts how many of the given polls the current profile has not yet voted on.</summary>

--- a/src/ClassicUO.Client/Game/Managers/FirebasePollsManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/FirebasePollsManager.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using ClassicUO.Configuration;
 using ClassicUO.Utility.Logging;
 
 namespace ClassicUO.Game.Managers;
@@ -95,6 +96,59 @@ public static class FirebasePollsManager
             Log.Error($"Failed to fetch polls: {e}");
             return null;
         }
+    }
+
+    /// <summary>
+    /// Fetches the available polls and, if the current profile has any it hasn't voted on yet, prints a
+    /// notification to the user. Intended to be called once after login. Runs the fetch on a background
+    /// task and prints on the main thread; does nothing when the fetch fails, there are no polls, or every
+    /// poll has already been voted on.
+    /// </summary>
+    public static void NotifyUnvotedPolls(World world)
+    {
+        Task.Run(async () =>
+        {
+            Dictionary<string, Poll> polls = await FetchPollsAsync();
+
+            if (polls == null || polls.Count == 0)
+                return;
+
+            int unvoted = CountUnvoted(polls);
+
+            if (unvoted <= 0)
+                return;
+
+            MainThreadQueue.InvokeOnMainThread(() =>
+            {
+                string message = unvoted == 1
+                    ? TazLang.Get("polls_notify_one",
+                        "There is a new TazUO poll you haven't voted on. Open Polls from the top bar menu to vote.")
+                    : string.Format(
+                        TazLang.Get("polls_notify_many",
+                            "There are {0} TazUO polls you haven't voted on. Open Polls from the top bar menu to vote."),
+                        unvoted);
+
+                GameActions.Print(world, message);
+            });
+        });
+    }
+
+    /// <summary>Counts how many of the given polls the current profile has not yet voted on.</summary>
+    private static int CountUnvoted(Dictionary<string, Poll> polls)
+    {
+        Profile profile = ProfileManager.CurrentProfile;
+
+        var voted = new HashSet<string>((profile?.VotedPolls ?? string.Empty)
+            .Split(';', StringSplitOptions.RemoveEmptyEntries));
+
+        int count = 0;
+        foreach (string pollId in polls.Keys)
+        {
+            if (!voted.Contains(pollId))
+                count++;
+        }
+
+        return count;
     }
 
     /// <summary>

--- a/src/ClassicUO.Client/Game/UI/Gumps/WorldViewportGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/WorldViewportGump.cs
@@ -131,24 +131,63 @@ namespace ClassicUO.Game.UI.Gumps
                 _userNotifications.Add(("Warning: It looks like your UO folder is stored inside TazUO, this is discouraged as you may accidentally have your UO files deleted.", Constants.HUE_ERROR));
             }
 
+            // Community poll reminder is fetched asynchronously; kick it off before starting the flush
+            // timer so a fast result lands in the same batch as the notifications above.
+            QueueUnvotedPollsNotification();
+
             if (_userNotifications != null) //Why is this here? This ensures the user is in-game and can see the world viewport before sending them messages
             {
                 var timer = new Timer(TimeSpan.FromSeconds(5));
                 timer.Elapsed += (sender, args) =>
                 {
-                    if (World.Instance != null)
-                        _userNotifications.ForEach((s) =>
-                        {
-                            (string item1, ushort item2) = s;
-                            GameActions.Print(item1, item2);
-                        });
-
-                    _userNotifications.Clear();
-                    _userNotifications = null;
+                    // Flush on the main thread so the list is only ever touched from one thread
+                    // (the async poll fetch also appends to it from the main thread).
+                    MainThreadQueue.InvokeOnMainThread(FlushUserNotifications);
                     timer?.Stop();
                 };
                 timer.Start();
             }
+        }
+
+        /// <summary>Prints and clears any queued in-world user notifications. Main thread only.</summary>
+        private void FlushUserNotifications()
+        {
+            if (_userNotifications == null)
+                return;
+
+            if (World.Instance != null)
+                _userNotifications.ForEach((s) =>
+                {
+                    (string item1, ushort item2) = s;
+                    GameActions.Print(item1, item2);
+                });
+
+            _userNotifications.Clear();
+            _userNotifications = null;
+        }
+
+        /// <summary>
+        /// Fetches the community polls from Firebase and, if the profile has any it hasn't voted on,
+        /// shows a reminder. The fetch is asynchronous, so the message is added to the pending
+        /// notification batch while it is still open, otherwise printed directly once we are in-world.
+        /// </summary>
+        private void QueueUnvotedPollsNotification()
+        {
+            Task.Run(async () =>
+            {
+                string message = await FirebasePollsManager.GetUnvotedNotificationAsync();
+
+                if (string.IsNullOrEmpty(message))
+                    return;
+
+                MainThreadQueue.InvokeOnMainThread(() =>
+                {
+                    if (_userNotifications != null)
+                        _userNotifications.Add((message, Constants.HUE_WARN));
+                    else if (World.Instance != null)
+                        GameActions.Print(message, Constants.HUE_WARN);
+                });
+            });
         }
 
         public override void Update()

--- a/src/ClassicUO.Client/Network/PacketHandlers/LoginComplete.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers/LoginComplete.cs
@@ -45,9 +45,6 @@ internal static class LoginComplete
             if (gumps != null)
                 foreach (Gump gump in gumps)
                     UIManager.Add(gump);
-
-            // Let the user know if there are community polls they haven't voted on yet.
-            FirebasePollsManager.NotifyUnvotedPolls(world);
         }
     }
 }

--- a/src/ClassicUO.Client/Network/PacketHandlers/LoginComplete.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers/LoginComplete.cs
@@ -45,6 +45,9 @@ internal static class LoginComplete
             if (gumps != null)
                 foreach (Gump gump in gumps)
                     UIManager.Add(gump);
+
+            // Let the user know if there are community polls they haven't voted on yet.
+            FirebasePollsManager.NotifyUnvotedPolls(world);
         }
     }
 }


### PR DESCRIPTION
After LoginComplete, fetch the community polls from Firebase and print a GameActions.Print() notification if the current profile has any polls it hasn't voted on yet. The check runs on a background task and prints on the main thread, and does nothing when the fetch fails, there are no polls, or every poll has already been voted on.