### PR TITLE
Fix NullReferenceException in SkillProgressBar constructor

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/SkillProgressBar.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/SkillProgressBar.cs
@@ -15,12 +15,15 @@ namespace ClassicUO.Game.UI.Gumps
             Height = 40;
             Width = 300;
 
-            if (ProfileManager.CurrentProfile.SkillProgressBarPosition == Point.Zero)
-            {
-                WorldViewportGump vp = UIManager.GetGump<WorldViewportGump>();
+            WorldViewportGump vp = UIManager.GetGump<WorldViewportGump>();
 
-                Y = vp.Location.Y + 80;
-                X = (vp.Location.X + (vp.Width / 2)) - (Width / 2);
+            if (ProfileManager.CurrentProfile == null || ProfileManager.CurrentProfile.SkillProgressBarPosition == Point.Zero)
+            {
+                if (vp != null)
+                {
+                    Y = vp.Location.Y + 80;
+                    X = (vp.Location.X + (vp.Width / 2)) - (Width / 2);
+                }
             }
             else
             {


### PR DESCRIPTION
Guard against WorldViewportGump being null when a skill update packet arrives before the viewport gump exists. Also null-check ProfileManager.CurrentProfile before accessing it.