### PR TITLE
Add optional attachments support to Firebase polls

### DIFF
--- a/docs/FirebasePollsFormat.md
+++ b/docs/FirebasePollsFormat.md
@@ -1,0 +1,116 @@
+# TazUO Firebase Polls Format
+
+TazUO community polls are stored in a Firebase realtime database and shown in the in-game
+**Polls** window (opened from the top bar menu). This document describes the JSON shape the
+client expects.
+
+- **Database root:** `https://tazuopolls-default-rtdb.firebaseio.com/polls`
+- **Client parser:** `src/ClassicUO.Client/Game/Managers/FirebasePollsManager.cs`
+- **Window:** `src/ClassicUO.Client/Game/UI/MyraWindows/PollsWindow.cs`
+
+Polls are parsed defensively. Each poll — and each option/attachment within it — is validated
+independently, so a single malformed entry is skipped rather than breaking the rest of the list.
+
+## Top-level structure
+
+`polls` is an object keyed by an arbitrary poll id. Each value is a poll object:
+
+```json
+{
+  "polls": {
+    "my-first-poll": {
+      "question": "What is your favorite feature?",
+      "type": 0,
+      "options": {
+        "Grid containers": 5,
+        "Auto loot": 12,
+        "Python scripting": 8
+      },
+      "attachments": [
+        {
+          "type": 0,
+          "data": "https://github.com/PlayTazUO/TazUO"
+        },
+        {
+          "type": 1,
+          "data": "https://example.com/preview.png"
+        }
+      ]
+    }
+  }
+}
+```
+
+## Poll fields
+
+| Field         | Required | Type   | Notes |
+|---------------|----------|--------|-------|
+| `question`    | Yes      | string | Must be a non-empty string, or the poll is skipped. |
+| `type`        | No       | number | `0` = single choice (default), `1` = multiple choice. Defaults to `0` if missing or malformed. |
+| `options`     | Yes      | object | Must contain at least one valid option, or the poll is skipped. |
+| `attachments` | No       | array  | Optional. See below. A missing, empty, or malformed value simply shows no attachments. |
+
+### Options
+
+Options live under `options` and support two shapes. Both may not be mixed meaningfully within a
+poll — pick whichever fits your tooling.
+
+**Bare number** — the key is the label and the value is the vote count:
+
+```json
+"options": {
+  "Yes!": 3,
+  "No": 1
+}
+```
+
+**Object** — the label comes from a text field and the count lives at `votes`:
+
+```json
+"options": {
+  "0": { "text": "Yes!", "votes": 3 },
+  "1": { "text": "No", "votes": 1 }
+}
+```
+
+The label is read from the first present of: `text`, `label`, `name`, `title`, `option`;
+if none exist, the option key is used. A missing `votes` defaults to `0`.
+
+Voting increments the option's stored count by exactly one (the database rules only allow a
+`current + 1` write), retrying if another client votes concurrently.
+
+## Attachments (optional)
+
+`attachments` is an optional array of extra content displayed with the poll. The key may be
+absent entirely — this produces no errors and shows nothing.
+
+Each attachment is an object:
+
+| Field  | Required | Type   | Notes |
+|--------|----------|--------|-------|
+| `type` | Yes      | number | `0` = URL (clickable link), `1` = image (downloaded and shown inline). |
+| `data` | Yes      | string | The URL of the link or image. Must be a non-empty string. |
+
+```json
+"attachments": [
+  { "type": 0, "data": "https://github.com/PlayTazUO/TazUO" },
+  { "type": 1, "data": "https://example.com/preview.png" }
+]
+```
+
+### Attachment types
+
+- **`0` — URL:** Rendered as a clickable link that opens in the system browser.
+- **`1` — Image:** Downloaded asynchronously on a background thread and displayed inline once
+  ready. Images are scaled down to fit the poll while preserving aspect ratio. Downloaded
+  textures are cached per URL for the process lifetime, so each image is only fetched once.
+
+### Handling of malformed attachments
+
+An individual attachment is **skipped** (the rest of the poll still displays) when:
+
+- it is not a JSON object;
+- `type` is missing, non-numeric, or not a known value (`0` or `1`);
+- `data` is missing, not a string, or empty/whitespace.
+
+A skipped attachment never produces an error or affects other attachments or the poll itself.

--- a/docs/FirebasePollsFormat.md
+++ b/docs/FirebasePollsFormat.md
@@ -7,6 +7,7 @@ client expects.
 - **Database root:** `https://tazuopolls-default-rtdb.firebaseio.com/polls`
 - **Client parser:** `src/ClassicUO.Client/Game/Managers/FirebasePollsManager.cs`
 - **Window:** `src/ClassicUO.Client/Game/UI/MyraWindows/PollsWindow.cs`
+- **Interactive builder:** `tools/poll_builder.py` — walks you through a poll and prints the JSON entry.
 
 Polls are parsed defensively. Each poll — and each option/attachment within it — is validated
 independently, so a single malformed entry is skipped rather than breaking the rest of the list.

--- a/src/ClassicUO.Client/Game/Managers/FirebasePollsManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/FirebasePollsManager.cs
@@ -36,6 +36,29 @@ public sealed class PollOption
     public string VotePath { get; set; }
 }
 
+/// <summary>The kind of content carried by a <see cref="PollAttachment"/>.</summary>
+public enum AttachmentType
+{
+    /// <summary>A clickable web link. <see cref="PollAttachment.Data"/> is the URL.</summary>
+    Url = 0,
+
+    /// <summary>An image to download and display. <see cref="PollAttachment.Data"/> is the image URL.</summary>
+    Image = 1
+}
+
+/// <summary>
+/// An optional piece of extra content attached to a <see cref="Poll"/>, such as a link or an image.
+/// Attachments are parsed defensively: a malformed entry (unknown type, missing/empty data) is skipped.
+/// </summary>
+public sealed class PollAttachment
+{
+    /// <summary>What kind of content <see cref="Data"/> refers to.</summary>
+    public AttachmentType Type { get; set; }
+
+    /// <summary>The URL of the link or image.</summary>
+    public string Data { get; set; }
+}
+
 /// <summary>
 /// A single poll as stored in the Firebase realtime database.
 /// </summary>
@@ -47,6 +70,9 @@ public sealed class Poll
 
     /// <summary>0 = single choice, 1 = multiple choice.</summary>
     public int Type { get; set; }
+
+    /// <summary>Optional extra content (links, images) shown alongside the poll. Never null.</summary>
+    public List<PollAttachment> Attachments { get; set; } = new();
 }
 
 /// <summary>Outcome of a vote attempt, carrying the server's error message when it fails.</summary>
@@ -205,7 +231,59 @@ public static class FirebasePollsManager
         if (options.Count == 0)
             return false;
 
-        poll = new Poll { Question = question, Type = type, Options = options };
+        // Attachments are entirely optional; a missing, malformed, or empty array yields no attachments.
+        List<PollAttachment> attachments = ParseAttachments(element);
+
+        poll = new Poll { Question = question, Type = type, Options = options, Attachments = attachments };
+        return true;
+    }
+
+    /// <summary>
+    /// Parses the optional <c>attachments</c> array. Individual entries are validated independently, and any
+    /// malformed one (not an object, unknown/missing type, or missing/empty data) is skipped rather than
+    /// failing the whole poll. Returns an empty list when the key is absent or not an array.
+    /// </summary>
+    private static List<PollAttachment> ParseAttachments(JsonElement element)
+    {
+        var attachments = new List<PollAttachment>();
+
+        if (!element.TryGetProperty("attachments", out JsonElement attachmentsEl) ||
+            attachmentsEl.ValueKind != JsonValueKind.Array)
+            return attachments;
+
+        foreach (JsonElement entry in attachmentsEl.EnumerateArray())
+        {
+            if (TryParseAttachment(entry, out PollAttachment attachment))
+                attachments.Add(attachment);
+        }
+
+        return attachments;
+    }
+
+    private static bool TryParseAttachment(JsonElement element, out PollAttachment attachment)
+    {
+        attachment = null;
+
+        if (element.ValueKind != JsonValueKind.Object)
+            return false;
+
+        // Type is required and must be a known value.
+        if (!element.TryGetProperty("type", out JsonElement typeEl) ||
+            typeEl.ValueKind != JsonValueKind.Number ||
+            !typeEl.TryGetInt32(out int type) ||
+            !Enum.IsDefined(typeof(AttachmentType), type))
+            return false;
+
+        // Data is required and must be a non-empty string.
+        if (!element.TryGetProperty("data", out JsonElement dataEl) ||
+            dataEl.ValueKind != JsonValueKind.String)
+            return false;
+
+        string data = dataEl.GetString();
+        if (string.IsNullOrWhiteSpace(data))
+            return false;
+
+        attachment = new PollAttachment { Type = (AttachmentType)type, Data = data };
         return true;
     }
 

--- a/src/ClassicUO.Client/Game/Managers/FirebasePollsManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/FirebasePollsManager.cs
@@ -115,13 +115,61 @@ public static class FirebasePollsManager
         {
             string json = await _httpClient.GetStringAsync($"{BASE_URL}.json");
 
-            return ParsePolls(json);
+            Dictionary<string, Poll> polls = ParsePolls(json);
+
+            // We only reach here on a successful fetch, so it is safe to drop saved "already voted" ids
+            // for polls that no longer exist and keep the per-profile list from growing without bound.
+            PruneVotedPolls(polls);
+
+            return polls;
         }
         catch (Exception e)
         {
             Log.Error($"Failed to fetch polls: {e}");
             return null;
         }
+    }
+
+    /// <summary>
+    /// Removes saved "already voted" poll ids that are no longer present in <paramref name="polls"/> so the
+    /// per-profile <see cref="Profile.VotedPolls"/> list cannot grow indefinitely. Only call this with a
+    /// successfully fetched set — passing a stale or failed result would wrongly forget real votes. The
+    /// write is marshalled to the main thread to match the rest of the profile-mutation code.
+    /// </summary>
+    private static void PruneVotedPolls(Dictionary<string, Poll> polls)
+    {
+        if (polls == null)
+            return;
+
+        Profile profile = ProfileManager.CurrentProfile;
+        if (profile == null)
+            return;
+
+        string[] voted = (profile.VotedPolls ?? string.Empty)
+            .Split(';', StringSplitOptions.RemoveEmptyEntries);
+
+        if (voted.Length == 0)
+            return;
+
+        var kept = new List<string>(voted.Length);
+        foreach (string id in voted)
+        {
+            if (polls.ContainsKey(id))
+                kept.Add(id);
+        }
+
+        // Nothing stale to remove.
+        if (kept.Count == voted.Length)
+            return;
+
+        string updated = string.Join(';', kept);
+
+        MainThreadQueue.InvokeOnMainThread(() =>
+        {
+            // Guard against the active profile changing between fetch and write.
+            if (ReferenceEquals(ProfileManager.CurrentProfile, profile))
+                profile.VotedPolls = updated;
+        });
     }
 
     /// <summary>

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/PollsWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/PollsWindow.cs
@@ -124,6 +124,8 @@ public sealed class PollsWindow : MyraControl
 
         panel.Widgets.Add(new MyraLabel(poll.Question, MyraLabel.TextStyle.H4));
 
+        AddAttachments(panel, poll);
+
         if (poll.Options == null || poll.Options.Count == 0)
         {
             panel.Widgets.Add(new MyraLabel(TazLang.Get("polls_no_options", "This poll has no options."), MyraLabel.TextStyle.P));
@@ -136,6 +138,31 @@ public sealed class PollsWindow : MyraControl
             AddVotingForm(panel, pollId, poll);
 
         return panel;
+    }
+
+    /// <summary>
+    /// Renders any attachments on the poll: URLs become clickable links, images are downloaded
+    /// asynchronously and shown inline. Malformed attachments are already filtered out during parsing,
+    /// so a poll with no valid attachments simply adds nothing here.
+    /// </summary>
+    private static void AddAttachments(VerticalStackPanel panel, Poll poll)
+    {
+        if (poll.Attachments == null || poll.Attachments.Count == 0)
+            return;
+
+        foreach (PollAttachment attachment in poll.Attachments)
+        {
+            switch (attachment.Type)
+            {
+                case AttachmentType.Url:
+                    panel.Widgets.Add(new LinkLabel(attachment.Data, attachment.Data, MyraLabel.TextStyle.P));
+                    break;
+
+                case AttachmentType.Image:
+                    panel.Widgets.Add(new MyraExternalImage(attachment.Data, 320));
+                    break;
+            }
+        }
     }
 
     private static void AddResults(VerticalStackPanel panel, Poll poll)

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/MyraExternalImage.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/MyraExternalImage.cs
@@ -1,0 +1,105 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using ClassicUO.Game.Managers;
+using ClassicUO.Utility.Logging;
+using Microsoft.Xna.Framework.Graphics;
+using Myra.Graphics2D.TextureAtlases;
+using Myra.Graphics2D.UI;
+
+namespace ClassicUO.Game.UI.MyraWindows.Widgets;
+
+/// <summary>
+/// A Myra Image widget that asynchronously downloads an image from a URL and displays it once available.
+/// The download happens off the UI thread; the GPU texture is created on the main thread (GraphicsDevice
+/// access is not thread-safe). Decoded textures are cached by URL for the process lifetime so the same
+/// image is only ever fetched and uploaded once — matching the behaviour of <c>ExternalUrlImage</c>.
+/// </summary>
+public class MyraExternalImage : Image
+{
+    private static readonly HttpClient _httpClient = new() { Timeout = TimeSpan.FromSeconds(30) };
+    private static readonly Dictionary<string, Texture2D?> _cache = new();
+
+    private readonly int _maxSize;
+
+    public MyraExternalImage(string url, int maxSize = 320)
+    {
+        _maxSize = maxSize;
+        MaxWidth = maxSize;
+        MaxHeight = maxSize;
+
+        LoadAsync(url);
+    }
+
+    private void LoadAsync(string url)
+    {
+        Task.Run(async () =>
+        {
+            Texture2D? texture = await GetOrDownloadAsync(url);
+
+            if (texture == null)
+                return;
+
+            MainThreadQueue.InvokeOnMainThread(() =>
+            {
+                if (!IsPlaced)
+                    return;
+
+                // Scale the image down to fit within maxSize while preserving its aspect ratio; the Image
+                // widget stretches its renderable to the arranged bounds, so we size the widget ourselves.
+                float scale = Math.Min(1f, _maxSize / (float)Math.Max(texture.Width, texture.Height));
+                Width = Math.Max(1, (int)(texture.Width * scale));
+                Height = Math.Max(1, (int)(texture.Height * scale));
+
+                Renderable = new TextureRegion(texture);
+            });
+        });
+    }
+
+    private static async Task<Texture2D?> GetOrDownloadAsync(string url)
+    {
+        lock (_cache)
+        {
+            if (_cache.TryGetValue(url, out Texture2D? cached))
+                return cached;
+        }
+
+        byte[]? data = null;
+        try
+        {
+            data = await _httpClient.GetByteArrayAsync(url);
+        }
+        catch (Exception e)
+        {
+            Log.Error($"Failed to download poll image '{url}': {e}");
+        }
+
+        // Creating the GPU texture must happen on the main thread; cache the result (including a null
+        // failure) so we don't repeatedly retry a broken URL.
+        Texture2D? texture = data == null
+            ? null
+            : MainThreadQueue.InvokeOnMainThread(() =>
+            {
+                try
+                {
+                    using var ms = new MemoryStream(data);
+                    return Texture2D.FromStream(Client.Game.GraphicsDevice, ms);
+                }
+                catch (Exception e)
+                {
+                    Log.Error($"Failed to decode poll image '{url}': {e}");
+                    return null;
+                }
+            });
+
+        lock (_cache)
+        {
+            _cache[url] = texture;
+        }
+
+        return texture;
+    }
+}

--- a/tools/poll_builder.py
+++ b/tools/poll_builder.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Interactive builder for a TazUO Firebase poll entry.
+
+Walks you through the question, type, options, and optional attachments, then
+prints the final JSON for a single poll entry that can be pasted under the
+`polls` node of the Firebase realtime database.
+
+See docs/FirebasePollsFormat.md for the full format description.
+"""
+
+import json
+
+
+def ask(prompt, default=None):
+    suffix = f" [{default}]" if default is not None else ""
+    value = input(f"{prompt}{suffix}: ").strip()
+    if not value and default is not None:
+        return default
+    return value
+
+
+def ask_yes_no(prompt, default=False):
+    d = "Y/n" if default else "y/N"
+    value = input(f"{prompt} ({d}): ").strip().lower()
+    if not value:
+        return default
+    return value in ("y", "yes")
+
+
+def ask_poll_type():
+    print("\nPoll type:")
+    print("  0 = single choice (default)")
+    print("  1 = multiple choice")
+    while True:
+        value = input("Choose type [0]: ").strip()
+        if not value:
+            return 0
+        if value in ("0", "1"):
+            return int(value)
+        print("  Please enter 0 or 1.")
+
+
+def ask_options():
+    print("\nEnter poll options. Leave the label blank to finish.")
+    options = {}
+    while True:
+        label = input(f"  Option {len(options) + 1} label: ").strip()
+        if not label:
+            if len(options) == 0:
+                print("  A poll needs at least one option.")
+                continue
+            break
+        if label in options:
+            print("  That option already exists, choose a different label.")
+            continue
+
+        votes_raw = input("    Starting votes [0]: ").strip()
+        try:
+            votes = int(votes_raw) if votes_raw else 0
+        except ValueError:
+            print("    Votes must be a whole number, using 0.")
+            votes = 0
+
+        # Bare-number shape: the label is the key and the value is the vote count.
+        options[label] = votes
+
+    return options
+
+
+def ask_attachments():
+    print("\nAttachments are optional. Types:")
+    print("  0 = URL   (clickable link)")
+    print("  1 = image (downloaded and shown inline)")
+
+    if not ask_yes_no("Add attachments?", default=False):
+        return None
+
+    attachments = []
+    while True:
+        type_raw = input(f"  Attachment {len(attachments) + 1} type (0=url, 1=image, blank=done): ").strip()
+        if not type_raw:
+            break
+        if type_raw not in ("0", "1"):
+            print("    Type must be 0 or 1.")
+            continue
+
+        data = input("    Data (URL): ").strip()
+        if not data:
+            print("    Data is required, skipping this attachment.")
+            continue
+
+        attachments.append({"type": int(type_raw), "data": data})
+
+    return attachments or None
+
+
+def build_poll():
+    print("--- TazUO Poll Builder ---")
+
+    question = ""
+    while not question:
+        question = ask("Poll question").strip()
+        if not question:
+            print("  The question cannot be empty.")
+
+    poll_type = ask_poll_type()
+    options = ask_options()
+    attachments = ask_attachments()
+
+    poll = {
+        "question": question,
+        "type": poll_type,
+        "options": options,
+    }
+    if attachments:
+        poll["attachments"] = attachments
+
+    poll_id = ask("\nPoll id (the key under 'polls')", default="my-poll")
+
+    print("\n--- Poll entry JSON ---")
+    print(json.dumps({poll_id: poll}, indent=2))
+    print("-----------------------")
+
+
+if __name__ == "__main__":
+    while True:
+        build_poll()
+        if not ask_yes_no("\nBuild another poll?", default=False):
+            break


### PR DESCRIPTION
Polls may now include an optional "attachments" array. Each entry has a type (0 = URL, 1 = image) and a data URL. URLs render as clickable links and images are downloaded asynchronously and displayed inline in the polls window.

Attachments are parsed defensively: a missing "attachments" key produces no attachments and no error, and any malformed entry (wrong/missing type or missing/empty data) is skipped while the rest of the poll still shows.

Adds docs/FirebasePollsFormat.md documenting the poll JSON format.