### PR TITLE
Fix overhead text hit-test alignment with camera transform

### DIFF
--- a/src/ClassicUO.Client/Game/Managers/TextRenderer.cs
+++ b/src/ClassicUO.Client/Game/Managers/TextRenderer.cs
@@ -36,6 +36,17 @@ namespace ClassicUO.Game.Managers
             int mouseX = Mouse.Position.X;
             int mouseY = Mouse.Position.Y;
 
+            // World overhead text is stored in world/game coordinates and drawn under the
+            // camera's ViewTransformMatrix, so the raw screen mouse position no longer lines up
+            // with it. Use the mouse position translated into that same world space (the value
+            // every other world hit-test uses) so the clickable region matches the drawn text.
+            // Gump text is in screen coordinates, so the raw mouse position is correct there.
+            if (!isGump)
+            {
+                mouseX = SelectedObject.TranslatedMousePositionByViewport.X;
+                mouseY = SelectedObject.TranslatedMousePositionByViewport.Y;
+            }
+
             for (TextObject o = DrawPointer; o != null; o = o.DLeft)
             {
                 if (o.IsDestroyed || o.TextBox == null || o.TextBox.IsDisposed || o.Time < ClassicUO.Time.Ticks)


### PR DESCRIPTION
World overhead text (mobile names, world messages) is stored in world/game coordinates and drawn under the camera's ViewTransformMatrix after the WorldToScreen() conversion was removed from the position calculation. The hit-test in TextRenderer.Draw, however, still used the raw screen mouse position, so the clickable region no longer matched the drawn text and was offset by the camera/viewport transform. This made single/double clicking a mobile's overhead name miss unless the cursor was held above the actual text.

Use the mouse position translated into world space (the same value every other world hit-test uses) when hit-testing non-gump overhead text. Gump text is still in screen coordinates, so the raw mouse position is kept for that path.