### PR TITLE
Add UI scaling support to both skill gumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to TazUO will be recorded here.
 ## In Development
 
 ### Features
+* Added UI scaling support to both skill gumps (standard and advanced), sharing a single configurable scale setting - [P.R 722](https://github.com/PlayTazUO/TazUO/pull/722) ([bittiez](https://github.com/bittiez))
 * Added options to show the heal/cure buttons on all health bars (except invulnerable notoriety) and on health bars of mobiles in the friends list - [P.R 726](https://github.com/PlayTazUO/TazUO/pull/726) ([bittiez](https://github.com/bittiez))
 * Moved the Health Bars options tab from the Interface category to Gameplay > Mobiles - [P.R 714](https://github.com/PlayTazUO/TazUO/pull/714) ([bittiez](https://github.com/bittiez))
 * Added an "Import Map File" option to the world map context menu (under Map Marker Options) that copies a selected .map/.csv/.xml file into the current server's marker directory and reloads markers - [P.R 710](https://github.com/PlayTazUO/TazUO/pull/710) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.59</AssemblyVersion>
-    <FileVersion>5.3.59</FileVersion>
+    <AssemblyVersion>5.3.60</AssemblyVersion>
+    <FileVersion>5.3.60</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -823,6 +823,8 @@ namespace ClassicUO.Configuration
 
         public double StatusGumpScale { get; set => SetProperty(ref field, Math.Clamp(value, 0.5d, 3.0d)); } = 1f;
 
+        public double SkillsGumpScale { get; set => SetProperty(ref field, Math.Clamp(value, 0.5d, 3.0d)); } = 1f;
+
         public double ContextMenuScale { get; set => SetProperty(ref field, Math.Clamp(value, 0.5d, 3.0d)); } = 1f;
 
         public double TradeGumpScale { get; set => SetProperty(ref field, Math.Clamp(value, 0.5d, 3.0d)); } = 1f;

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -5,7 +5,7 @@
 ; Missing keys are auto-appended with English defaults when
 ; this file's version is newer than the user's copy.
 ; -------------------------------------------------------
-_version=50
+_version=51
 accountname=Account Name
 accountcontextmenutooltip=Right click to select another account.
 music=Music
@@ -749,6 +749,8 @@ uimanager_toomanygumps=Warning: You have {0} '{1}' gumps open. This may cause pe
 ; Gump scaling
 gumpscaling_statusgump=Status Gump
 gumpscaling_statusgumpscaling=Status gump scaling
+gumpscaling_skillgump=Skills Gump
+gumpscaling_skillgumpscaling=Skills gump scaling
 gumpscaling_contextmenu=Context Menus
 gumpscaling_contextmenuscaling=Context menu scaling
 gumpscaling_tradegump=Trade Gump

--- a/src/ClassicUO.Client/Game/UI/Controls/ExpandableScroll.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ExpandableScroll.cs
@@ -113,7 +113,19 @@ namespace ClassicUO.Game.UI.Controls
 
             int off = w0 - w3;
 
-            _gumpRight.X = _gumpMiddle.X = S((width - w1) / 2);
+            if (_scale == 1.0)
+            {
+                _gumpRight.X = _gumpMiddle.X = (width - w1) / 2;
+            }
+            else
+            {
+                // Center each tiled piece by its own (scaled) width. The original shares the w1-based
+                // offset for both pieces; when the body width differs from w1 that tiny off-center error
+                // gets multiplied by the scale and becomes visible, so re-center from each real width.
+                _gumpRight.X = (S(width) - _gumpRight.Width) / 2;
+                _gumpMiddle.X = (S(width) - _gumpMiddle.Width) / 2;
+            }
+
             _gumpRight.Y = _gumpMiddle.Y = _gumplingMidY;
             _gumpRight.Height = _gumpMiddle.Height = _gumplingMidHeight;
             _gumpRight.WantUpdateSize = _gumpMiddle.WantUpdateSize = true;

--- a/src/ClassicUO.Client/Game/UI/Controls/ExpandableScroll.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ExpandableScroll.cs
@@ -24,14 +24,20 @@ namespace ClassicUO.Game.UI.Controls
         private readonly bool _isResizable = true;
         private Point _lastExpanderPosition;
 
+        // Gump scale baked into the scroll's graphics/layout. SpecialHeight is always kept in design
+        // (unscaled) space so persisted heights stay valid regardless of the current scale.
+        private readonly double _scale = 1.0;
+        private int S(int v) => (int)(v * _scale);
+
         public event EventHandler SizeChanged;
 
-        public ExpandableScroll(int x, int y, int height, ushort graphic, bool isResizable = true)
+        public ExpandableScroll(int x, int y, int height, ushort graphic, bool isResizable = true, double scale = 1.0)
         {
             X = x;
             Y = y;
             SpecialHeight = height;
             _isResizable = isResizable;
+            _scale = scale <= 0 ? 1.0 : scale;
             CanMove = true;
             AcceptMouseInput = true;
 
@@ -94,15 +100,26 @@ namespace ClassicUO.Game.UI.Controls
                 _gumpExpander.MouseUp += expander_OnMouseUp;
             }
 
+            // Bake the gump scale into every part's size (positions are (re)computed below / in
+            // RepositionElements). Guarded so the default scale of 1.0 leaves behaviour untouched.
+            if (_scale != 1.0)
+            {
+                _gumpTop.ApplyScale(_scale, scalePosition: false);
+                _gumpRight.ApplyScale(_scale, scalePosition: false);
+                _gumpMiddle.ApplyScale(_scale, scalePosition: false);
+                _gumpBottom.ApplyScale(_scale, scalePosition: false);
+                _gumpExpander?.ApplyScale(_scale, scalePosition: false);
+            }
+
             int off = w0 - w3;
 
-            _gumpRight.X = _gumpMiddle.X = (width - w1) / 2;
+            _gumpRight.X = _gumpMiddle.X = S((width - w1) / 2);
             _gumpRight.Y = _gumpMiddle.Y = _gumplingMidY;
             _gumpRight.Height = _gumpMiddle.Height = _gumplingMidHeight;
             _gumpRight.WantUpdateSize = _gumpMiddle.WantUpdateSize = true;
-            _gumpBottom.X = (off / 2) + (off / 4);
+            _gumpBottom.X = S((off / 2) + (off / 4));
 
-            Width = width;
+            Width = S(width);
 
             RepositionElements();
 
@@ -112,15 +129,15 @@ namespace ClassicUO.Game.UI.Controls
         private int _gumplingMidY => _gumpTop.Height;
 
         private int _gumplingMidHeight =>
-            SpecialHeight - _gumpTop.Height - _gumpBottom.Height - (_gumpExpander?.Height ?? 0);
+            S(SpecialHeight) - _gumpTop.Height - _gumpBottom.Height - (_gumpExpander?.Height ?? 0);
 
         private int _gumplingBottomY =>
-            SpecialHeight - _gumpBottom.Height - (_gumpExpander?.Height ?? 0);
+            S(SpecialHeight) - _gumpBottom.Height - (_gumpExpander?.Height ?? 0);
 
         private int _gumplingExpanderX => (Width - (_gumpExpander?.Width ?? 0)) >> 1;
 
         private int _gumplingExpanderY =>
-            SpecialHeight - (_gumpExpander?.Height ?? 0) - c_GumplingExpanderY_Offset;
+            S(SpecialHeight) - (_gumpExpander?.Height ?? 0) - S(c_GumplingExpanderY_Offset);
 
         public int TitleGumpID
         {
@@ -201,7 +218,8 @@ namespace ClassicUO.Game.UI.Controls
         {
             if (Mouse.LButtonPressed && _isExpanding)
             {
-                SpecialHeight += Mouse.Position.Y - _lastExpanderPosition.Y;
+                // Mouse movement is in scaled (logical) space; SpecialHeight is in design space.
+                SpecialHeight += (int)((Mouse.Position.Y - _lastExpanderPosition.Y) / _scale);
                 _lastExpanderPosition = Mouse.Position;
 
                 RepositionElements();
@@ -216,6 +234,10 @@ namespace ClassicUO.Game.UI.Controls
 
                 _gumplingTitle?.Dispose();
                 Add(_gumplingTitle = new GumpPic(0, 0, (ushort)_gumplingTitleGumpID, 0));
+
+                if (_scale != 1.0)
+                    _gumplingTitle.ApplyScale(_scale, scalePosition: false);
+
                 RepositionElements();
             }
 

--- a/src/ClassicUO.Client/Game/UI/Controls/ExpandableScroll.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/ExpandableScroll.cs
@@ -109,6 +109,11 @@ namespace ClassicUO.Game.UI.Controls
                 _gumpMiddle.ApplyScale(_scale, scalePosition: false);
                 _gumpBottom.ApplyScale(_scale, scalePosition: false);
                 _gumpExpander?.ApplyScale(_scale, scalePosition: false);
+
+                // The side/body pieces are tiled; scale the tile so their baked-in edges land on the
+                // scaled width instead of repeating at the native width.
+                _gumpRight.ScaleTiledTexture = true;
+                _gumpMiddle.ScaleTiledTexture = true;
             }
 
             int off = w0 - w3;

--- a/src/ClassicUO.Client/Game/UI/Controls/GumpPicTiled.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/GumpPicTiled.cs
@@ -13,6 +13,13 @@ namespace ClassicUO.Game.UI.Controls
         private ushort hue;
         Vector3 hueVector;
 
+        /// <summary>
+        /// When true and <see cref="Control.InternalScale"/> is not 1.0, the tiled texture is drawn at
+        /// the scaled tile size (so any edge baked into the texture lands on the scaled bounds). Opt-in
+        /// so ordinary/server tiled graphics keep tiling at their native size.
+        /// </summary>
+        public bool ScaleTiledTexture { get; set; }
+
         public GumpPicTiled(ushort graphic)
         {
             CanMove = true;
@@ -95,12 +102,25 @@ namespace ClassicUO.Game.UI.Controls
 
             if (gumpInfo.Texture != null)
             {
-                batcher.DrawTiled(
-                    gumpInfo.Texture,
-                    new Rectangle(x, y, Width, Height),
-                    gumpInfo.UV,
-                    hueVector
-                );
+                if (ScaleTiledTexture && InternalScale != 1.0)
+                {
+                    batcher.DrawTiled(
+                        gumpInfo.Texture,
+                        new Rectangle(x, y, Width, Height),
+                        gumpInfo.UV,
+                        hueVector,
+                        (float)InternalScale
+                    );
+                }
+                else
+                {
+                    batcher.DrawTiled(
+                        gumpInfo.Texture,
+                        new Rectangle(x, y, Width, Height),
+                        gumpInfo.UV,
+                        hueVector
+                    );
+                }
             }
 
             return base.Draw(batcher, x, y);

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
@@ -4789,6 +4789,20 @@ namespace ClassicUO.Game.UI.Gumps
             (
                 new SliderWithLabel
                 (
+                    TazLang.Get("gumpscaling_skillgump", "Skills Gump"), 0, ThemeSettings.SLIDER_WIDTH, 50, 300,
+                    (int)(profile.SkillsGumpScale * 100), (i) =>
+                    {
+                        //Must be cast even though VS thinks it's redundant.
+                        double v = (double)i / (double)100;
+                        profile.SkillsGumpScale = v > 0 ? v : 1f;
+                    }
+                ), true, page
+            );
+
+            content.AddToRight
+            (
+                new SliderWithLabel
+                (
                     TazLang.Get("gumpscaling_contextmenu", "Context Menus"), 0, ThemeSettings.SLIDER_WIDTH, 50, 300,
                     (int)(profile.ContextMenuScale * 100), (i) =>
                     {

--- a/src/ClassicUO.Client/Game/UI/Gumps/ScalableGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ScalableGump.cs
@@ -64,5 +64,31 @@ namespace ClassicUO.Game.UI.Gumps
                 child.ApplyScale(_gumpScale, scalePosition, scaleSize, force);
             }
         }
+
+        /// <summary>
+        /// Recursively apply <see cref="GumpScale"/> to a control and every one of its descendants.
+        /// Needed for composite controls whose visuals live in nested children (the shallow scale done
+        /// by <see cref="Add{T}"/> only touches the top-level control). The per-control InternalScale
+        /// guard makes this safe to call again on subtrees that already contain some scaled controls.
+        /// </summary>
+        /// <param name="control">Root of the subtree to scale.</param>
+        /// <param name="scaleRootPosition">Whether to scale the root's own X/Y (descendants are always positioned).</param>
+        protected void ApplyScaleRecursive(Control control, bool scaleRootPosition = true)
+        {
+            if (_gumpScale == 1.0 || control == null)
+                return;
+
+            ScaleTree(control, scaleRootPosition, _gumpScale);
+        }
+
+        private static void ScaleTree(IGui control, bool scalePosition, double scale)
+        {
+            control.ApplyScale(scale, scalePosition: scalePosition);
+
+            for (int i = 0; i < control.Children.Count; i++)
+            {
+                ScaleTree(control.Children[i], true, scale);
+            }
+        }
     }
 }

--- a/src/ClassicUO.Client/Game/UI/Gumps/SkillGumpAdvanced.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/SkillGumpAdvanced.cs
@@ -19,9 +19,12 @@ using System.Xml;
 
 namespace ClassicUO.Game.UI.Gumps
 {
-    public class SkillGumpAdvanced : Gump
+    public class SkillGumpAdvanced : ScalableGump
     {
         private const int WIDTH = 400;
+
+        // Design-space (unscaled) height of the gump. The visible Height field is this value scaled by GumpScale.
+        private int _designHeight = 310;
 
         private static readonly Dictionary<Buttons, string> _buttonsToSkillsValues = new()
         {
@@ -57,10 +60,17 @@ namespace ClassicUO.Game.UI.Gumps
             AcceptMouseInput = true;
             WantUpdateSize = false;
 
-            Width = WIDTH;
-            Height = 310;
+            GumpScale = ProfileManager.CurrentProfile?.SkillsGumpScale ?? 1.0;
+            // The gump is built in design space and scaled explicitly (statics at the end of Build,
+            // dynamic content in BuildGump), so keep the base Add() from also scaling children.
+            AutoScaleChildren = false;
+
+            _designHeight = 310;
             if (ProfileManager.CurrentProfile != null)
-                Height = ProfileManager.CurrentProfile.AdvancedSkillsGumpHeight;
+                _designHeight = ProfileManager.CurrentProfile.AdvancedSkillsGumpHeight;
+
+            Width = ScaleHelper.Scaled(WIDTH, GumpScale);
+            Height = ScaleHelper.Scaled(_designHeight, GumpScale);
 
             Build();
         }
@@ -75,7 +85,7 @@ namespace ClassicUO.Game.UI.Gumps
                     X = 1,
                     Y = 1,
                     Width = WIDTH - 1,
-                    Height = Height - 1
+                    Height = _designHeight - 1
                 }
             );
 
@@ -84,7 +94,7 @@ namespace ClassicUO.Game.UI.Gumps
                 5,
                 40,
                 WIDTH - 10,
-                Height - 60,
+                _designHeight - 60,
                 true
             )
             {
@@ -203,7 +213,7 @@ namespace ClassicUO.Game.UI.Gumps
                 AcceptMouseInput = true,
                 WantUpdateSize = false,
                 CanMove = true,
-                Width = Width,
+                Width = WIDTH,
                 Height = 20
             };
             Checkbox showGrp;
@@ -233,13 +243,17 @@ namespace ClassicUO.Game.UI.Gumps
             Add(resizeDrag = new Button(0, 0x837, 0x838, 0x838));
             resizeDrag.MouseDown += ResizeDrag_MouseDown;
             resizeDrag.MouseUp += ResizeDrag_MouseUp;
-            resizeDrag.X = Width - 10;
-            resizeDrag.Y = Height - 10;
+            resizeDrag.X = WIDTH - 10;
+            resizeDrag.Y = _designHeight - 10;
 
             if(X == 0)
                 X = last_x;
             if(Y == 0)
                 Y = last_y;
+
+            // Everything above was laid out in design space; bake GumpScale into the whole static tree.
+            foreach (Control c in Children)
+                ApplyScaleRecursive(c, scaleRootPosition: true);
 
             SetSortIndicatorPosition();
             ForceUpdate();
@@ -255,8 +269,8 @@ namespace ClassicUO.Game.UI.Gumps
                 ushort g = (ushort)(_sortAsc ? 0x985 : 0x983);
 
                 _sortOrderIndicator.Graphic = g;
-                _sortOrderIndicator.X = btn.X + btn.Width - 15;
-                _sortOrderIndicator.Y = btn.Y + 5;
+                _sortOrderIndicator.X = btn.X + btn.Width - ScaleHelper.Scaled(15, GumpScale);
+                _sortOrderIndicator.Y = btn.Y + ScaleHelper.Scaled(5, GumpScale);
                 btn.IsSelected = true;
             }
         }
@@ -341,7 +355,7 @@ namespace ClassicUO.Game.UI.Gumps
                     a.WantUpdateSize = false;
                     a.CanMove = true;
                     a.Height = 26;
-                    a.Width = Width - 26;
+                    a.Width = WIDTH - 26;
                     a.Tag = g.IsMaximized;
                     a.MouseUp += (sender, e) =>
                     {
@@ -472,11 +486,22 @@ namespace ClassicUO.Game.UI.Gumps
             }
 
 
+            // Entries/group headers were built in design space; scale each subtree before the databox
+            // stacks them so ReArrangeChildren works entirely in scaled space.
+            foreach (Control c in _databox.Children)
+                ApplyScaleRecursive(c, scaleRootPosition: true);
+
             _databox.WantUpdateSize = true;
             _databox.ReArrangeChildren();
 
-            Add(real = new Label(_totalReal.ToString("F1"), true, 1153) { X = 205, Y = Height - 20, AcceptMouseInput = false});
-            Add(value = new Label(_totalValue.ToString("F1"), true, 1153) { X = 255, Y = Height - 20, AcceptMouseInput = false});
+            int realX = ScaleHelper.Scaled(205, GumpScale);
+            int valueX = ScaleHelper.Scaled(255, GumpScale);
+            int bottomY = Height - ScaleHelper.Scaled(20, GumpScale);
+
+            Add(real = new Label(_totalReal.ToString("F1"), true, 1153) { X = realX, Y = bottomY, AcceptMouseInput = false});
+            Add(value = new Label(_totalValue.ToString("F1"), true, 1153) { X = valueX, Y = bottomY, AcceptMouseInput = false});
+            real.SetInternalScale(GumpScale);
+            value.SetInternalScale(GumpScale);
 
             SetSortIndicatorPosition();
         }
@@ -531,16 +556,19 @@ namespace ClassicUO.Game.UI.Gumps
             if (Dragging && steps != 0)
             {
                 Height = dragStartH + steps;
-                if (Height < 170)
-                    Height = 170;
-                ProfileManager.CurrentProfile.AdvancedSkillsGumpHeight = Height;
+                int minHeight = ScaleHelper.Scaled(170, GumpScale);
+                if (Height < minHeight)
+                    Height = minHeight;
+                // Persist the design-space height so the stored value is independent of the current scale.
+                _designHeight = ScaleHelper.Unscaled(Height, GumpScale);
+                ProfileManager.CurrentProfile.AdvancedSkillsGumpHeight = _designHeight;
 
-                area.Height = Height - 60;
-                background.Height = Height - 1;
+                area.Height = Height - ScaleHelper.Scaled(60, GumpScale);
+                background.Height = Height - ScaleHelper.Scaled(1, GumpScale);
                 _databox.WantUpdateSize = true;
-                resizeDrag.Y = Height - 11;
-                real.Y = Height - 20;
-                value.Y = Height - 20;
+                resizeDrag.Y = Height - ScaleHelper.Scaled(11, GumpScale);
+                real.Y = Height - ScaleHelper.Scaled(20, GumpScale);
+                value.Y = Height - ScaleHelper.Scaled(20, GumpScale);
                 BottomArea.Y = area.Height + area.Y - 1;
             }
         }

--- a/src/ClassicUO.Client/Game/UI/Gumps/StandardSkillsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/StandardSkillsGump.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
+using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.UI.Controls;
@@ -18,9 +19,15 @@ using System.Diagnostics;
 
 namespace ClassicUO.Game.UI.Gumps
 {
-    public class StandardSkillsGump : Gump
+    public class StandardSkillsGump : ScalableGump
     {
         private const int _diffY = 22;
+
+        /// <summary>Scale a design-space value into this gump's scaled (logical) space.</summary>
+        private int S(int v) => ScaleHelper.Scaled(v, GumpScale);
+
+        /// <summary>Exposes the gump scale to the nested skill/group controls.</summary>
+        internal double UIScale => GumpScale;
 
         private readonly ScrollArea _area;
         private readonly GumpPic _bottomComment;
@@ -44,12 +51,19 @@ namespace ClassicUO.Game.UI.Gumps
             CanMove = true;
             CanCloseWithRightClick = true;
 
-            Height = 200 + _diffY;
+            GumpScale = ProfileManager.CurrentProfile?.SkillsGumpScale ?? 1.0;
+            // Built directly in scaled space (it reads the self-scaled ExpandableScroll's dimensions and
+            // scales the composite skill/group controls itself), so the base Add() must not scale again.
+            AutoScaleChildren = false;
 
-            Add(_gumpPic = new GumpPic(160, 0, 0x82D, 0));
+            Height = S(200 + _diffY);
+
+            Add(_gumpPic = new GumpPic(S(160), 0, 0x82D, 0));
+            _gumpPic.ApplyScale(GumpScale, scalePosition: false);
             _gumpPic.MouseDoubleClick += _picBase_MouseDoubleClick;
 
-            _scrollArea = new ExpandableScroll(0, _diffY, Height, 0x1F40)
+            // SpecialHeight stays in design space; ExpandableScroll scales its own graphics internally.
+            _scrollArea = new ExpandableScroll(0, S(_diffY), 200 + _diffY, 0x1F40, true, GumpScale)
             {
                 TitleGumpID = 0x0834,
                 AcceptMouseInput = true
@@ -59,16 +73,22 @@ namespace ClassicUO.Game.UI.Gumps
 
             Add(_scrollArea);
 
-            Add(new GumpPic(50, 35 + _diffY, 0x082B, 0));
-            Add(_bottomLine = new GumpPic(50, Height - 98, 0x082B, 0));
-            Add(_bottomComment = new GumpPic(25, Height - 85, 0x0836, 0));
+            GumpPic topLine = new GumpPic(S(50), S(35 + _diffY), 0x082B, 0);
+            topLine.ApplyScale(GumpScale, scalePosition: false);
+            Add(topLine);
+
+            Add(_bottomLine = new GumpPic(S(50), Height - S(98), 0x082B, 0));
+            _bottomLine.ApplyScale(GumpScale, scalePosition: false);
+
+            Add(_bottomComment = new GumpPic(S(25), Height - S(85), 0x0836, 0));
+            _bottomComment.ApplyScale(GumpScale, scalePosition: false);
 
             _area = new ScrollArea
             (
-                22,
-                45 + _diffY + _bottomLine.Height - 10,
-                _scrollArea.Width - 14 - 44,
-                _scrollArea.Height - (83 + _diffY),
+                S(22),
+                S(45 + _diffY) + _bottomLine.Height - S(10),
+                _scrollArea.Width - S(14 + 44),
+                _scrollArea.Height - S(83 + _diffY),
                 false
             ) { AcceptMouseInput = true, CanMove = true };
 
@@ -90,11 +110,12 @@ namespace ClassicUO.Game.UI.Gumps
                     600,
                     0,
                     3
-                ) { X = _bottomComment.X + _bottomComment.Width + 5, Y = _bottomComment.Y - 5 }
+                ) { X = _bottomComment.X + _bottomComment.Width + S(5), Y = _bottomComment.Y - S(5) }
             );
+            _skillsLabelSum.SetInternalScale(GumpScale);
 
             //new group
-            int x = 60;
+            int x = S(60);
 
             Add
             (
@@ -106,6 +127,7 @@ namespace ClassicUO.Game.UI.Gumps
                     ButtonAction = ButtonAction.Activate
                 }
             );
+            _newGroupButton.ApplyScale(GumpScale, scalePosition: false);
 
             Add
             (
@@ -117,8 +139,9 @@ namespace ClassicUO.Game.UI.Gumps
                     1,
                     0x0386,
                     false
-                ) { X = _newGroupButton.X + _newGroupButton.Width + 30, Y = _newGroupButton.Y - 6 }
+                ) { X = _newGroupButton.X + _newGroupButton.Width + S(30), Y = _newGroupButton.Y - S(6) }
             );
+            _checkReal.ApplyScale(GumpScale, scalePosition: false);
 
             Add
             (
@@ -130,8 +153,9 @@ namespace ClassicUO.Game.UI.Gumps
                     1,
                     0x0386,
                     false
-                ) { X = _newGroupButton.X + _newGroupButton.Width + 30, Y = _newGroupButton.Y + 7 }
+                ) { X = _newGroupButton.X + _newGroupButton.Width + S(30), Y = _newGroupButton.Y + S(7) }
             );
+            _checkCaps.ApplyScale(GumpScale, scalePosition: false);
 
             _checkReal.ValueChanged += UpdateSkillsValues;
             _checkCaps.ValueChanged += UpdateSkillsValues;
@@ -139,7 +163,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             LoadSkills();
 
-            Add(_resetGroups = new NiceButton(_scrollArea.X + 25, _scrollArea.Y + 7, 100, 18,
+            Add(_resetGroups = new NiceButton(_scrollArea.X + S(25), _scrollArea.Y + S(7), S(100), S(18),
                                               ButtonAction.Activate, ResGumps.ResetGroups,
                                               unicode: false,
                                               font: 6)
@@ -148,8 +172,11 @@ namespace ClassicUO.Game.UI.Gumps
                 IsSelectable = false,
                 //Alpha = 1f
             });
+            // NiceButton renders its label through a child control; scale that subtree (size only,
+            // the position above is already in scaled space).
+            ApplyScaleRecursive(_resetGroups, scaleRootPosition: false);
 
-            _hitBox = new HitBox(160, 0, 23, 24);
+            _hitBox = new HitBox(S(160), 0, S(23), S(24));
             Add(_hitBox);
             _hitBox.MouseUp += _hitBox_MouseUp;
 
@@ -189,7 +216,7 @@ namespace ClassicUO.Game.UI.Gumps
                     }
                     else
                     {
-                        _gumpPic.X = 160;
+                        _gumpPic.X = S(160);
                     }
 
                     foreach (Control c in Children)
@@ -302,13 +329,13 @@ namespace ClassicUO.Game.UI.Gumps
         {
             WantUpdateSize = true;
 
-            _bottomLine.Y = Height - 98;
-            _bottomComment.Y = Height - 85;
-            _area.Height = Height - (150 + _diffY);
-            _newGroupButton.Y = Height - 52;
-            _skillsLabelSum.Y = _bottomComment.Y + 2;
-            _checkReal.Y = _newGroupButton.Y - 6;
-            _checkCaps.Y = _newGroupButton.Y + 7;
+            _bottomLine.Y = Height - S(98);
+            _bottomComment.Y = Height - S(85);
+            _area.Height = Height - S(150 + _diffY);
+            _newGroupButton.Y = Height - S(52);
+            _skillsLabelSum.Y = _bottomComment.Y + S(2);
+            _checkReal.Y = _newGroupButton.Y - S(6);
+            _checkCaps.Y = _newGroupButton.Y + S(7);
         }
 
         public override void Update()
@@ -398,6 +425,8 @@ namespace ClassicUO.Game.UI.Gumps
             private byte _status;
             private readonly StbTextBox _textbox;
 
+            private int S(int v) => ScaleHelper.Scaled(v, _gump.UIScale);
+
             public SkillsGroupControl(StandardSkillsGump gump, SkillsGroup group, int x, int y)
             {
                 _gump = gump;
@@ -406,10 +435,10 @@ namespace ClassicUO.Game.UI.Gumps
                 WantUpdateSize = true;
                 AcceptKeyboardInput = true;
 
-                X = x;
-                Y = y;
-                Width = 200;
-                Height = 20;
+                X = S(x);
+                Y = S(y);
+                Width = S(200);
+                Height = S(20);
 
                 _group = group;
 
@@ -421,6 +450,7 @@ namespace ClassicUO.Game.UI.Gumps
                 };
 
                 Add(_button);
+                _button.ApplyScale(_gump.UIScale, scalePosition: false);
 
                 int width = Client.Game.UO.FileManager.Fonts.GetWidthASCII(6, group.Name);
 
@@ -430,28 +460,29 @@ namespace ClassicUO.Game.UI.Gumps
                     (
                         6,
                         -1,
-                        200,
+                        S(200),
                         false,
                         FontStyle.Fixed
                     )
                     {
-                        X = 16,
-                        Y = -3,
-                        Width = 200,
-                        Height = 17,
+                        X = S(16),
+                        Y = S(-3),
+                        Width = S(200),
+                        Height = S(17),
                         IsEditable = false
                     }
                 );
 
+                _textbox.SetInternalScale(_gump.UIScale);
                 _textbox.SetText(group.Name);
 
                 int xx = width + 11 + 16;
 
                 _gumpPic = new GumpPicTiled(0x0835)
                 {
-                    X = xx,
-                    Y = 5,
-                    Width = 215 - xx,
+                    X = S(xx),
+                    Y = S(5),
+                    Width = S(215 - xx),
                     AcceptMouseInput = false
                 };
 
@@ -657,8 +688,8 @@ namespace ClassicUO.Game.UI.Gumps
                 if (xx > 0)
                 {
                     _gumpPic.IsVisible = true;
-                    _gumpPic.X = xx;
-                    _gumpPic.Width = 215 - xx;
+                    _gumpPic.X = S(xx);
+                    _gumpPic.Width = S(215 - xx);
                 }
                 else
                 {
@@ -724,12 +755,12 @@ namespace ClassicUO.Game.UI.Gumps
 
             private void UpdateSkillsPosition()
             {
-                int currY = 17;
+                int currY = S(17);
 
                 foreach (SkillItemControl c in _skills)
                 {
                     c.Y = currY;
-                    currY += 17;
+                    currY += S(17);
                 }
 
                 _box.WantUpdateSize = true;
@@ -750,7 +781,7 @@ namespace ClassicUO.Game.UI.Gumps
                             x,
                             y,
                             Width,
-                            17
+                            S(17)
                         ),
                         hueVector
                     );
@@ -762,10 +793,10 @@ namespace ClassicUO.Game.UI.Gumps
                         SolidColorTextureCache.GetTexture(Color.Bisque),
                         new Rectangle
                         (
-                            x + 16,
+                            x + S(16),
                             y,
-                            200,
-                            17
+                            S(200),
+                            S(17)
                         ),
                         hueVector
                     );
@@ -783,12 +814,14 @@ namespace ClassicUO.Game.UI.Gumps
             private readonly Label _value;
 
 
+            private int S(int v) => ScaleHelper.Scaled(v, _gump.UIScale);
+
             public SkillItemControl(StandardSkillsGump gump, int index, int x, int y)
             {
                 _gump = gump;
                 Index = index;
-                X = x;
-                Y = y;
+                X = S(x);
+                Y = S(y);
 
                 if (index < 0 || index >= Client.Game.UO.FileManager.Skills.Skills.Count)
                 {
@@ -806,10 +839,11 @@ namespace ClassicUO.Game.UI.Gumps
                         var buttonUse = new Button(0, 0x0837, 0x0838, 0x0838)
                         {
                             ButtonAction = ButtonAction.Activate,
-                            X = 8
+                            X = S(8)
                         };
 
                         Add(buttonUse);
+                        buttonUse.ApplyScale(_gump.UIScale, scalePosition: false);
                     }
 
                     _status = skill.Lock;
@@ -819,17 +853,20 @@ namespace ClassicUO.Game.UI.Gumps
                     _buttonStatus = new Button(1, graphic, graphic, graphic)
                     {
                         ButtonAction = ButtonAction.Activate,
-                        X = 251,
+                        X = S(251),
                         ContainsByBounds = true
                     };
 
                     Add(_buttonStatus);
+                    _buttonStatus.ApplyScale(_gump.UIScale, scalePosition: false);
 
                     Label name;
                     Add(name = new Label(skill.Name, false, 0x0288, font: 9));
-                    name.X = 22;
+                    name.X = S(22);
+                    name.SetInternalScale(_gump.UIScale);
 
                     Add(_value = new Label("", false, 0x0288, font: 9));
+                    _value.SetInternalScale(_gump.UIScale);
 
                     UpdateValueText(false, false);
                 }
@@ -841,8 +878,8 @@ namespace ClassicUO.Game.UI.Gumps
                 }
 
 
-                Width = 255;
-                Height = 17;
+                Width = S(255);
+                Height = S(17);
                 WantUpdateSize = true;
                 AcceptMouseInput = true;
                 CanMove = false;
@@ -916,7 +953,7 @@ namespace ClassicUO.Game.UI.Gumps
                     }
 
                     _value.Text = $"{val:F1}";
-                    _value.X = 250 - _value.Width;
+                    _value.X = S(250) - _value.Width;
                 }
             }
 

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/VideoTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/VideoTab.cs
@@ -277,6 +277,16 @@ public static class VideoTab
                 search: new SearchMetadata(TazLang.Get("gumpscaling_statusgumpscaling", "Status gump scaling"), Keywords: [TazLang.Get("mog_kw_scale")])
             ),
             Option.Slider(
+                TazLang.Get("gumpscaling_skillgumpscaling", "Skills gump scaling"),
+                50,
+                300,
+                new Accessor<float>(() => (int)(profile.SkillsGumpScale * 100), newValue =>
+                {
+                    profile.SkillsGumpScale = Math.Clamp(newValue / 100, 0.5f, 3.0f);
+                }),
+                search: new SearchMetadata(TazLang.Get("gumpscaling_skillgumpscaling", "Skills gump scaling"), Keywords: [TazLang.Get("mog_kw_scale")])
+            ),
+            Option.Slider(
                 TazLang.Get("gumpscaling_contextmenuscaling", "Context menu scaling"),
                 50,
                 300,

--- a/src/ClassicUO.Renderer/Batcher2D.cs
+++ b/src/ClassicUO.Renderer/Batcher2D.cs
@@ -754,6 +754,77 @@ namespace ClassicUO.Renderer
             }
         }
 
+        /// <summary>
+        /// Tiled draw where the tile itself is scaled by <paramref name="scale"/>. The default
+        /// <see cref="DrawTiled(Texture2D, Rectangle, Rectangle, Vector3)"/> always steps by the native
+        /// texture size, which repeats the texture (and any edges baked into it) across a scaled area.
+        /// This variant steps by the scaled tile size so a scaled control renders one scaled tile, with
+        /// edges landing on the scaled bounds instead of the native ones.
+        /// </summary>
+        public void DrawTiled
+        (
+            Texture2D texture,
+            Rectangle destinationRectangle,
+            Rectangle sourceRectangle,
+            Vector3 hue,
+            float scale
+        )
+        {
+            if (texture == null || texture.IsDisposed)
+            {
+                return;
+            }
+
+            if (scale <= 0f || Math.Abs(scale - 1f) < 0.0001f)
+            {
+                DrawTiled(texture, destinationRectangle, sourceRectangle, hue);
+                return;
+            }
+
+            int tileW = Math.Max(1, (int)(sourceRectangle.Width * scale));
+            int tileH = Math.Max(1, (int)(sourceRectangle.Height * scale));
+
+            var scaleVec = new Vector2(scale, scale);
+            var pos = new Vector2(destinationRectangle.X, destinationRectangle.Y);
+
+            int h = destinationRectangle.Height;
+            Rectangle rect = sourceRectangle;
+
+            while (h > 0)
+            {
+                // Source height for this row, scaled down from the remaining destination height so the
+                // final (partial) tile only draws the part of the texture that fits.
+                rect.Height = h >= tileH ? sourceRectangle.Height : Math.Clamp((int)(h / scale), 1, sourceRectangle.Height);
+
+                pos.X = destinationRectangle.X;
+                int w = destinationRectangle.Width;
+
+                while (w > 0)
+                {
+                    rect.Width = w >= tileW ? sourceRectangle.Width : Math.Clamp((int)(w / scale), 1, sourceRectangle.Width);
+
+                    Draw
+                    (
+                        texture,
+                        pos,
+                        rect,
+                        hue,
+                        0f,
+                        Vector2.Zero,
+                        scaleVec,
+                        SpriteEffects.None,
+                        0f
+                    );
+
+                    w -= tileW;
+                    pos.X += tileW;
+                }
+
+                h -= tileH;
+                pos.Y += tileH;
+            }
+        }
+
         public bool DrawRectangle
         (
             Texture2D texture,


### PR DESCRIPTION
Adds a shared SkillsGumpScale profile setting (like StatusGumpScale) that scales both the advanced (SkillGumpAdvanced) and standard (StandardSkillsGump) skill gumps.

- Profile: new SkillsGumpScale (clamped 0.5-3.0, default 1.0).
- ScalableGump: ApplyScaleRecursive helper for composite/dynamic child trees.
- SkillGumpAdvanced: extends ScalableGump; built in design space then scaled, with the resize/reposition math converted to scaled space.
- StandardSkillsGump: extends ScalableGump; built in scaled space, including the nested group/skill row controls.
- ExpandableScroll: optional scale parameter (default 1.0 is byte-identical, so Journal/Profile/BulletinBoard/TipNotice are unaffected).
- Options: sliders added to ModernOptionsGump and VideoTab; language.ini keys.
