### PR TITLE
Guard against null JournalData in ResizableJournal Reset

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/ResizableJournal.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ResizableJournal.cs
@@ -692,7 +692,7 @@ namespace ClassicUO.Game.UI.Gumps
                         ClearSelection();
                     }
 
-                    removed.Destroy();
+                    removed?.Destroy();
                 }
 
                 string timestampText = $"{time:t}";
@@ -1136,7 +1136,7 @@ namespace ClassicUO.Game.UI.Gumps
             private void Reset()
             {
                 foreach (JournalData _ in journalDatas)
-                    _.Destroy();
+                    _?.Destroy();
 
                 journalDatas.Clear();
                 ClearSelection();


### PR DESCRIPTION
Reset() iterated journalDatas calling _.Destroy() without a null check, unlike the other loops over the same deque which already guard for null. A null entry caused a NullReferenceException during Dispose on logout. Use null-conditional invocation here and in AddEntry's eviction path.