### PR TITLE
Add heal/cure button toggles for non-party health bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to TazUO will be recorded here.
 ## In Development
 
 ### Features
+* Added options to show the heal/cure buttons on all health bars (except invulnerable notoriety) and on health bars of mobiles in the friends list - [P.R 726](https://github.com/PlayTazUO/TazUO/pull/726) ([bittiez](https://github.com/bittiez))
 * Moved the Health Bars options tab from the Interface category to Gameplay > Mobiles - [P.R 714](https://github.com/PlayTazUO/TazUO/pull/714) ([bittiez](https://github.com/bittiez))
 * Added an "Import Map File" option to the world map context menu (under Map Marker Options) that copies a selected .map/.csv/.xml file into the current server's marker directory and reloads markers - [P.R 710](https://github.com/PlayTazUO/TazUO/pull/710) ([bittiez](https://github.com/bittiez))
 * Added a "Keep Existing" option to cooldown bars that preserves the running countdown instead of adding a new bar when the same rule triggers again; mutually exclusive with "Replace Existing" - [P.R 709](https://github.com/PlayTazUO/TazUO/pull/709) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.58</AssemblyVersion>
-    <FileVersion>5.3.58</FileVersion>
+    <AssemblyVersion>5.3.59</AssemblyVersion>
+    <FileVersion>5.3.59</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -347,6 +347,8 @@ namespace ClassicUO.Configuration
         public bool CustomBarsToggled { get; set => SetProperty(ref field, value); }
         public bool CBBlackBGToggled { get; set => SetProperty(ref field, value); }
         public bool UsePartyHealthBars { get; set => SetProperty(ref field, value); } = true;
+        public bool ShowHealCureButtonsAllHealthbars { get; set => SetProperty(ref field, value); }
+        public bool ShowHealCureButtonsFriends { get; set => SetProperty(ref field, value); }
 
         public bool ShowInfoBar { get; set => SetProperty(ref field, value); }
         public int InfoBarHighlightType { get; set => SetProperty(ref field, value); } // 0 = text colour changes, 1 = underline

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -5,7 +5,7 @@
 ; Missing keys are auto-appended with English defaults when
 ; this file's version is newer than the user's copy.
 ; -------------------------------------------------------
-_version=50
+_version=51
 accountname=Account Name
 accountcontextmenutooltip=Right click to select another account.
 music=Music
@@ -456,6 +456,8 @@ nameplate_health_black=Black
 
 ; Health Bars
 healthbar_usepartystyle=Use party health bar style for party members
+healthbar_healcureall=Show heal/cure buttons on all health bars (except invulnerable)
+healthbar_healcurefriends=Show heal/cure buttons on friends list health bars
 gridcontainer_renamecontainer=Rename container
 gridcontainer_rename_title=Rename Container
 gridcontainer_rename_desc=Type in a custom name for this container.
@@ -1395,6 +1397,7 @@ mog_kw_gump=Gump
 mog_kw_hang=Hang
 mog_kw_harmful=Harmful
 mog_kw_health=Health
+mog_kw_heal=Heal
 mog_kw_healthbar=Health Bar
 mog_kw_height=Height
 mog_kw_help=Help

--- a/src/ClassicUO.Client/Game/UI/Gumps/HealthBarGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/HealthBarGump.cs
@@ -474,6 +474,30 @@ namespace ClassicUO.Game.UI.Gumps
             && !World.Party.Contains(LocalSerial);
 
         /// <summary>
+        /// Whether the heal/cure buttons should be shown for this entity's (non-party) health bar.
+        /// Always true for pets. Additionally shown when the profile enables them for every health
+        /// bar (excluding invulnerable notoriety) or for mobiles in the friends list.
+        /// </summary>
+        protected bool ShouldShowHealButtons(Entity entity)
+        {
+            if (IsPet(entity))
+                return true;
+
+            Profile profile = ProfileManager.CurrentProfile;
+
+            if (profile == null || entity is not Mobile mobile || mobile == World.Player)
+                return false;
+
+            if (profile.ShowHealCureButtonsFriends && FriendsListManager.Instance.IsFriend(LocalSerial))
+                return true;
+
+            if (profile.ShowHealCureButtonsAllHealthbars && mobile.NotorietyFlag != NotorietyFlag.Invulnerable)
+                return true;
+
+            return false;
+        }
+
+        /// <summary>
         /// Whether this bar should be drawn using the special compact party style.
         /// Returns true only when the entity is in the party and the user has not
         /// disabled the party health bar style via <see cref="Profile.UsePartyHealthBars"/>.
@@ -766,7 +790,7 @@ namespace ClassicUO.Game.UI.Gumps
                         }
                     }
 
-                    if (_buttonHeal1 != null && _buttonHeal2 != null && IsPet(entity))
+                    if (_buttonHeal1 != null && _buttonHeal2 != null && ShouldShowHealButtons(entity))
                     {
                         _buttonHeal1.IsVisible = _buttonHeal2.IsVisible = true;
                     }
@@ -1409,8 +1433,8 @@ namespace ClassicUO.Game.UI.Gumps
                         )
                     );
 
-                    // Add healing buttons for pets
-                    if (IsPet(entity))
+                    // Add healing buttons for pets and, when enabled, other mobiles
+                    if (ShouldShowHealButtons(entity))
                     {
                         Add(_buttonHeal1 = new Button(
                             (int)ButtonParty.Heal1,
@@ -1861,8 +1885,8 @@ namespace ClassicUO.Game.UI.Gumps
                     Width = _background.Width;
                     Height = _background.Height;
 
-                    // Add healing buttons for pets
-                    if (IsPet(entity))
+                    // Add healing buttons for pets and, when enabled, other mobiles
+                    if (ShouldShowHealButtons(entity))
                     {
                         Add(_buttonHeal1 = new Button(
                             (int)ButtonParty.Heal1,
@@ -2108,7 +2132,7 @@ namespace ClassicUO.Game.UI.Gumps
                             _bars[2].IsVisible = true;
                         }
                     }
-                    else if (_buttonHeal1 != null && _buttonHeal2 != null && IsPet(entity))
+                    else if (_buttonHeal1 != null && _buttonHeal2 != null && ShouldShowHealButtons(entity))
                     {
                         _buttonHeal1.IsVisible = _buttonHeal2.IsVisible = true;
                     }

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/HealthBarsTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/HealthBarsTab.cs
@@ -21,6 +21,8 @@ public static class HealthBarsTab
         Profile profile = ProfileManager.CurrentProfile;
 
         string usePartyHealthBarsLabel = TazLang.Get("healthbar_usepartystyle", "Use party health bar style for party members");
+        string healCureAllLabel = TazLang.Get("healthbar_healcureall", "Show heal/cure buttons on all health bars (except invulnerable)");
+        string healCureFriendsLabel = TazLang.Get("healthbar_healcurefriends", "Show heal/cure buttons on friends list health bars");
 
         return OptionsUi.Vertical(
             OptionsUi.CheckBoxGroup(
@@ -35,6 +37,16 @@ public static class HealthBarsTab
                 usePartyHealthBarsLabel,
                 new Accessor<bool>(() => profile.UsePartyHealthBars),
                 search: new SearchMetadata(usePartyHealthBarsLabel, Keywords: [TazLang.Get("mog_kw_party"), TazLang.Get("mog_kw_healthbar")])
+            ),
+            Option.Checkbox(
+                healCureAllLabel,
+                new Accessor<bool>(() => profile.ShowHealCureButtonsAllHealthbars),
+                search: new SearchMetadata(healCureAllLabel, Keywords: [TazLang.Get("mog_kw_healthbar"), TazLang.Get("mog_kw_heal")])
+            ),
+            Option.Checkbox(
+                healCureFriendsLabel,
+                new Accessor<bool>(() => profile.ShowHealCureButtonsFriends),
+                search: new SearchMetadata(healCureFriendsLabel, Keywords: [TazLang.Get("mog_kw_healthbar"), TazLang.Get("mog_kw_heal")])
             ),
             Option.Checkbox(
                 TazLang.Get("mog_general_savehpbars"),


### PR DESCRIPTION
Add two profile options that extend the heal/cure buttons (previously only shown on party members and pets) to additional health bars:
- Show on all health bars except invulnerable notoriety
- Show on health bars of mobiles in the friends list

Introduces ShouldShowHealButtons in BaseHealthBarGump used by both the custom and classic health bar gumps for button creation and visibility.