### PR TITLE
Add per-config enabled toggle to grid highlighting

### DIFF
--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -5,7 +5,7 @@
 ; Missing keys are auto-appended with English defaults when
 ; this file's version is newer than the user's copy.
 ; -------------------------------------------------------
-_version=55
+_version=56
 accountname=Account Name
 accountcontextmenutooltip=Right click to select another account.
 music=Music
@@ -143,6 +143,7 @@ gridhighlight_add=Add +
 gridhighlight_export=Export
 gridhighlight_import=Import
 gridhighlight_configs=Configs
+gridhighlight_enabled_tooltip=Enable or disable this highlight configuration.\nWhen un-checked: This configuration will not highlight items and will not auto loot.
 gridhighlight_color=Color
 gridhighlight_color_tooltip=Select grid highlight color
 gridhighlight_properties=Properties

--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -434,6 +434,7 @@ namespace ClassicUO.Game.Scenes
             SpellVisualRangeManager.Instance.Save();
             SpellVisualRangeManager.Instance.OnSceneUnload();
             AutoLootManager.Instance.OnSceneUnload();
+            GridHighlightData.Unload();
             AutoSkinningManager.Instance.OnSceneUnload();
             FriendsListManager.Instance.OnSceneUnload();
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightData.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightData.cs
@@ -219,6 +219,14 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
             list.Insert(up ? index - 1 : index + 1, _entry);
         }
 
+        public static void Unload()
+        {
+            allConfigs = null;
+            _queue.Clear();
+            _queuedItems.Clear();
+            hasQueuedItems = false;
+        }
+
         public static void ProcessItemOpl(World world, Item item)
         {
             if (item.HighlightChecked) return;

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightData.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightData.cs
@@ -36,6 +36,12 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
             set => allConfigs = value;
         }
 
+        public bool Enabled
+        {
+            get => _entry.Enabled;
+            set => _entry.Enabled = value;
+        }
+
         public string Name
         {
             get => _entry.Name;
@@ -628,6 +634,10 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
 
             foreach (GridHighlightData config in AllConfigs)
             {
+                // Disabled configs highlight nothing and never trigger auto loot
+                if (!config.Enabled)
+                    continue;
+
                 if (!config.IsMatch(itemData))
                     continue;
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightProfile.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightProfile.cs
@@ -6,6 +6,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
 {
     public class GridHighlightSetupEntry
     {
+        public bool Enabled { get; set; } = true;
         public string Name { get; set; }
         public List<string> ItemNames { get; set; } = new();
         public ushort Hue { get; set; }

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHightlightMenu.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHightlightMenu.cs
@@ -108,6 +108,15 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
             y = 0;
             int spaceBetween = 7;
 
+            Checkbox enabledCheckbox;
+            area.Add(enabledCheckbox = new Checkbox(0x00D2, 0x00D3) { X = 0, Y = y, IsChecked = data.Enabled });
+            enabledCheckbox.SetTooltip(TazLang.Get("gridhighlight_enabled_tooltip"));
+            enabledCheckbox.ValueChanged += (s, e) =>
+            {
+                data.Enabled = enabledCheckbox.IsChecked;
+                GridHighlightData.RecheckMatchStatus(); //Request new opl data and re-check item matches
+            };
+
             NiceButton colorButton;
             area.Add(colorButton = new NiceButton(0, y, 60, 20, ButtonAction.Activate, TazLang.Get("gridhighlight_color")) { BackgroundColor = data.HighlightColor, IsSelectable = false });
             colorButton.SetTooltip(TazLang.Get("gridhighlight_color_tooltip"));
@@ -180,10 +189,11 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
             pos.PositionLeftOf(_propertiesButton, _del);
             pos.PositionLeftOf(colorButton, _propertiesButton);
 
+            int nameX = enabledCheckbox.Width + spaceBetween;
             InputField _name;
-            area.Add(_name = new InputField(0x0BB8, 0xFF, 0xFFFF, true, colorButton.X - spaceBetween, 20)
+            area.Add(_name = new InputField(0x0BB8, 0xFF, 0xFFFF, true, colorButton.X - spaceBetween - nameX, 20)
             {
-                X = 0,
+                X = nameX,
                 Y = y,
                 AcceptKeyboardInput = true
             }


### PR DESCRIPTION
Add an Enabled flag to each grid highlight configuration entry (the overall entry, not individual properties). Disabling a config prevents it from highlighting items and also stops it from triggering auto loot on match, since both are resolved through GetBestMatch which now skips disabled configs.

A checkbox is added to each config row in the grid highlight menu.