### PR TITLE
Reclaim depth-buffer precision and centralize render depth bands

### DIFF
--- a/src/ClassicUO.Client/Game/GameObjects/RenderDepth.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/RenderDepth.cs
@@ -1,0 +1,89 @@
+namespace ClassicUO.Game.GameObjects
+{
+    /// <summary>
+    /// Centralized depth (Z) constants for the isometric world renderer.
+    ///
+    /// The world is drawn into a hardware depth buffer. Every sprite gets a float depth written to
+    /// <c>Position.Z</c>; higher depth values render <b>in front</b>. The base value for an object is
+    /// <see cref="GameObject.CalculateDepthZ"/>, whose integer part is the isometric diagonal row
+    /// (<c>X + Y</c>) and whose fractional part is a height tie-breaker. The constants below are the
+    /// <b>sub-tile bands</b> added on top of that base value to control the layering of things that
+    /// share a tile cell (shadows, land, statics, mobiles, effects, ...).
+    ///
+    /// Two families of bands exist:
+    /// <list type="bullet">
+    /// <item><description><b>Surface bands</b> live in the range [0, 1) so they only reorder objects
+    /// <i>within the same tile cell</i> and never override the coarse <c>X + Y</c> row ordering.</description></item>
+    /// <item><description><b>Forward-projected bands</b> (&gt;= 1.0) intentionally push an object toward the
+    /// viewer by one or more tile rows so it can correctly occlude taller objects standing in front of
+    /// it (e.g. a mobile in front of a wall).</description></item>
+    /// </list>
+    ///
+    /// To add a "between-layer" effect, pick the appropriate band. For example, a ground decal that must
+    /// sit on top of the land but below statics uses <see cref="LandOverlay"/>; an effect that must sit
+    /// on top of statics but below mobiles uses <see cref="SurfaceOverlay"/>.
+    /// </summary>
+    public static class RenderDepth
+    {
+        // ----- Projection depth range (see UltimaBatcher2D.SetProjectionDepthRange) -----
+
+        /// <summary>
+        /// Upper bound of the world depth range. World sprite depths are expected to fall in
+        /// [0, <see cref="FarPlane"/>], which the projection maps across the full depth buffer.
+        /// It must exceed the largest possible <c>X + Y</c> diagonal of any supported map
+        /// (Felucca, the largest standard map, tops out around 11264) plus every band below,
+        /// while staying small enough to keep good Z precision. 0x8000 fills the whole 24-bit
+        /// buffer, roughly doubling the usable precision versus the legacy short range.
+        /// </summary>
+        public const float FarPlane = 0x8000; // 32768
+
+        /// <summary>
+        /// Depth used by things that must always draw over the entire world (e.g. weather).
+        /// </summary>
+        public const float Top = FarPlane - 1f;
+
+        // ----- Surface bands: within a single tile cell, kept in [0, 1) -----
+
+        /// <summary>Drop shadows for statics, foliage, trees and rocks. Below everything else on the tile.</summary>
+        public const float ObjectShadow = 0.25f;
+
+        /// <summary>Land / terrain tile surface.</summary>
+        public const float Land = 0.30f;
+
+        /// <summary>
+        /// NEW band: on top of the land but below statics. Use for ground decals, spell/AoE tile
+        /// indicators, footprints, terrain glows, etc.
+        /// </summary>
+        public const float LandOverlay = 0.40f;
+
+        /// <summary>Base layer of the animated-water effect, drawn just under <see cref="Surface"/> to avoid z-fighting with the animated top layer.</summary>
+        public const float SurfaceWetBase = 0.49f;
+
+        /// <summary>Statics, ground items, multis and gump-art tiles. The default "surface" layer.</summary>
+        public const float Surface = 0.50f;
+
+        /// <summary>Outline pass, drawn a hair under <see cref="Surface"/> so the silhouette stays behind its sprite.</summary>
+        public const float SurfaceOutline = Surface - 0.001f;
+
+        /// <summary>
+        /// NEW band: on top of statics but below mobiles. Use for effects that should hug a wall or
+        /// static (mist, glowing runes, wall overlays) yet still be walked in front of by a mobile.
+        /// </summary>
+        public const float SurfaceOverlay = 0.60f;
+
+        // ----- Forward-projected bands: reach into the next tile row (>= 1.0) -----
+
+        /// <summary>
+        /// Mobile body, aura and health bar. Pushed a full tile forward so a character correctly
+        /// occludes statics on the tile it is standing on. Tall sprites are additionally sliced
+        /// (see <c>MobileDepthSliceStep</c>) to occlude walls one or more rows behind them.
+        /// </summary>
+        public const float Mobile = 1.0f;
+
+        /// <summary>
+        /// NEW band: locked above mobiles. Also the effective band of source-attached game effects
+        /// (which use <see cref="Mobile"/> plus the <see cref="Surface"/> offset applied while drawing).
+        /// </summary>
+        public const float MobileOverlay = 1.5f;
+    }
+}

--- a/src/ClassicUO.Client/Game/GameObjects/Views/LandView.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Views/LandView.cs
@@ -10,7 +10,8 @@ namespace ClassicUO.Game.GameObjects
 {
     public sealed partial class Land
     {
-        private const float LAND_DEPTH_OFFSET = 0.5f;
+        // Land sits below statics within a tile cell so ground decals/effects can be layered between them.
+        private const float LAND_DEPTH_OFFSET = RenderDepth.Land;
         private const int Z_TO_PIXEL_MULTIPLIER = 4;
 
         private static float _cachedWaterSin;

--- a/src/ClassicUO.Client/Game/GameObjects/Views/View.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Views/View.cs
@@ -27,9 +27,10 @@ namespace ClassicUO.Game.GameObjects
         private const int ART_STATIC_OFFSET = 0x4000;
         private const float DEPTH_Z_SCALE = 0.01f;
         private const int DEPTH_Z_OFFSET = 127;
-        private const float DEPTH_RENDER_OFFSET = 0.5f;
-        private const float DEPTH_WET_BASE_OFFSET = 0.49f;
-        private const float DEPTH_SHADOW_OFFSET = 0.25f;
+        // Sub-tile depth bands live in RenderDepth. Aliases kept for readability at the call sites below.
+        private const float DEPTH_RENDER_OFFSET = RenderDepth.Surface;
+        private const float DEPTH_WET_BASE_OFFSET = RenderDepth.SurfaceWetBase;
+        private const float DEPTH_SHADOW_OFFSET = RenderDepth.ObjectShadow;
 
         // Water animation caching for performance
         private static float _cachedWaterSin;

--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -39,7 +39,7 @@ namespace ClassicUO.Game.Scenes
         private long _windowResizeStartTime = 0;
         private const int WINDOW_RESIZE_TIMEOUT_MS = 500;
         private const int TOLERANCE = 5;
-        private const float MAX_LAYER_DEPTH = 0x8000;
+        private const float MAX_LAYER_DEPTH = GameObjects.RenderDepth.FarPlane;
 
         private static readonly Lazy<BlendState> _darknessBlend = new Lazy<BlendState>(() =>
         {
@@ -1269,6 +1269,10 @@ namespace ClassicUO.Game.Scenes
             batcher.SetBrightlight(ProfileManager.CurrentProfile.TerrainShadowsLevel * 0.1f);
             batcher.SetStencil(DepthStencilState.Default);
 
+            // Map world depth [0, FarPlane] across the entire depth buffer so tile depth values use
+            // the full 24-bit precision instead of only a fraction of it. Higher depth = nearer.
+            batcher.SetProjectionDepthRange(-GameObjects.RenderDepth.FarPlane, 0f);
+
             RenderedObjectsCount = 0;
             Profiler.EnterContext("Statics");
             RenderedObjectsCount += DrawRenderList(batcher, _renderListStatics);
@@ -1314,6 +1318,9 @@ namespace ClassicUO.Game.Scenes
             }
 
             //GameController.DrawFlushCounts(batcher, 200, 200);
+
+            // Restore the default projection depth range for all other (non-world) batcher passes.
+            batcher.ResetProjectionDepthRange();
 
             batcher.End();
 

--- a/src/ClassicUO.Renderer/Batcher2D.cs
+++ b/src/ClassicUO.Renderer/Batcher2D.cs
@@ -51,6 +51,13 @@ namespace ClassicUO.Renderer
         private SamplerState _sampler;
         private bool _started;
         private DepthStencilState _stencil;
+
+        // Near/far planes used to build the orthographic projection. The world sprite depth
+        // (Position.Z) is mapped linearly from [near, far] into the depth buffer's [0,1] range.
+        // Defaults match the legacy short range; the world pass narrows them so the tile depth
+        // values fill the whole 24-bit buffer instead of only a third of it (see SetProjectionDepthRange).
+        private float _projectionZNear = short.MinValue;
+        private float _projectionZFar = short.MaxValue;
         private Matrix _transformMatrix;
         private readonly DynamicVertexBuffer _vertexBuffer;
         private readonly BasicUOEffect _basicUOEffect;
@@ -1549,8 +1556,8 @@ namespace ClassicUO.Renderer
                 GraphicsDevice.Viewport.Width,
                 GraphicsDevice.Viewport.Height,
                 0,
-                short.MinValue,
-                short.MaxValue,
+                _projectionZNear,
+                _projectionZFar,
                 out matrix
             );
             Matrix.Multiply(ref _transformMatrix, ref matrix, out matrix);
@@ -1730,6 +1737,33 @@ namespace ClassicUO.Renderer
             Flush();
 
             _stencil = stencil ?? Stencil;
+        }
+
+        /// <summary>
+        /// Overrides the near/far planes of the orthographic projection so that sprite depth
+        /// (Position.Z) values in [near, far] fill the entire depth buffer. Narrowing the range to
+        /// the world's actual depth span reclaims Z-buffer precision and reduces z-fighting.
+        /// Call <see cref="ResetProjectionDepthRange"/> to restore the default range.
+        /// </summary>
+        public void SetProjectionDepthRange(float near, float far)
+        {
+            if (_projectionZNear == near && _projectionZFar == far)
+            {
+                return;
+            }
+
+            Flush();
+
+            _projectionZNear = near;
+            _projectionZFar = far;
+        }
+
+        /// <summary>
+        /// Restores the default (legacy short-range) projection depth planes.
+        /// </summary>
+        public void ResetProjectionDepthRange()
+        {
+            SetProjectionDepthRange(short.MinValue, short.MaxValue);
         }
 
         public void SetSampler(SamplerState sampler)


### PR DESCRIPTION
A) Reclaim Z precision: the world sprite depth was mapped through an orthographic projection spanning the full short range, so tile depth values (0..~11k) only used about a third of the 24-bit depth buffer. Add a scoped SetProjectionDepthRange/ResetProjectionDepthRange on the batcher and narrow the world pass to [0, FarPlane], mapping tile depth across the entire buffer (~2x precision, less z-fighting). Object ordering is unchanged: higher depth is still nearer. The default range is preserved for all non-world (UI) passes.

B) Centralize depth bands: introduce RenderDepth with named, documented sub-tile bands (ObjectShadow, Land, LandOverlay, SurfaceWetBase, Surface, SurfaceOutline, SurfaceOverlay, Mobile, MobileOverlay) plus FarPlane/Top. Existing magic-number offsets in View/LandView/GameScene now reference these constants. Land is separated from statics (0.5 -> 0.30) which fixes same-Z land/static z-fighting and opens LandOverlay/SurfaceOverlay bands for future between-layer effects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Rendering Improvements**
  * Improved depth ordering for terrain, surfaces, shadows, overlays, and mobile objects.
  * Reduced visual overlap issues between taller objects and nearby tiles.
  * Added more consistent world rendering across different depth layers.
  * Preserved correct rendering behavior when switching between world and interface elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->