### PR TITLE
Add warning dialog when enabling Skip Empty Corpses setting

### DIFF
--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -5,7 +5,7 @@
 ; Missing keys are auto-appended with English defaults when
 ; this file's version is newer than the user's copy.
 ; -------------------------------------------------------
-_version=56
+_version=57
 accountname=Account Name
 accountcontextmenutooltip=Right click to select another account.
 music=Music
@@ -1179,6 +1179,8 @@ mog_general_corpseoptnothiding=Not hiding
 mog_general_corpseoptnottarg=Not targeting
 mog_general_corpseskipempty=Skip empty corpses
 mog_general_corpseskipemptytooltip=Most servers don't send corpse contents until it's opened.\nEnabling this will make this feature not work on most servers.
+mog_general_corpseskipemptywarningtitle=Skip Empty Corpses
+mog_general_corpseskipemptywarning=This setting does not work on most servers, make sure to verify this is working if you enable it. If corpses are not opening, disable this.
 mog_general_cotdistance=Distance
 mog_general_cottype=Type
 mog_general_cottypeoptfull=Full

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Option.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Option.cs
@@ -4,6 +4,7 @@ using System;
 using System.Linq;
 using ClassicUO.Common;
 using ClassicUO.Configuration;
+using ClassicUO.Game.Managers;
 using ClassicUO.Game.UI.MyraWindows.Options.Tabs;
 using ClassicUO.Game.UI.MyraWindows.Widgets;
 using ClassicUO.Utility;
@@ -39,6 +40,47 @@ internal static class Option
     /// <returns>An <see cref="OptionEntry"/> wrapping the checkbox widget</returns>
     public static OptionEntry Checkbox(string label, bool value, Action<bool> onValueChanged, string? tooltip = null, SearchMetadata? search = null) =>
         new(() => MyraCheckButton.CreateWithCallback(value, onValueChanged, label, tooltip), search ?? new SearchMetadata(label));
+
+    /// <summary>
+    /// Creates a checkbox entry bound to a <see cref="bool"/> property that displays a confirmation
+    /// warning dialog whenever the user enables it. Declining the dialog reverts the checkbox back to
+    /// its unchecked state.
+    /// </summary>
+    /// <param name="label">The checkbox label text</param>
+    /// <param name="backingProperty">Accessor for the underlying boolean value</param>
+    /// <param name="warningTitle">Title shown on the confirmation dialog</param>
+    /// <param name="warningMessage">Warning message shown in the confirmation dialog body</param>
+    /// <param name="tooltip">Optional tooltip text</param>
+    /// <param name="search">Optional search metadata; defaults to metadata seeded from <paramref name="label"/></param>
+    /// <returns>An <see cref="OptionEntry"/> wrapping the checkbox widget</returns>
+    public static OptionEntry CheckboxWithEnableWarning(
+        string label,
+        Accessor<bool> backingProperty,
+        string warningTitle,
+        string warningMessage,
+        string? tooltip = null,
+        SearchMetadata? search = null) =>
+        new(() =>
+        {
+            MyraCheckButton cb = MyraCheckButton.CreatePropBoundCheckButton(backingProperty, label, tooltip);
+
+            cb.IsCheckedChanged += (_, _) =>
+            {
+                if (!cb.IsChecked)
+                    return;
+
+                UIManager.Add(new ConfirmationModal(
+                    warningTitle,
+                    warningMessage,
+                    confirmed =>
+                    {
+                        if (!confirmed)
+                            cb.IsChecked = false;
+                    }));
+            };
+
+            return cb;
+        }, search ?? new SearchMetadata(label));
 
     /// <summary>
     /// Creates a hue-picker entry bound to a <see cref="ushort"/> hue property

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/MiscTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/MiscTab.cs
@@ -104,9 +104,11 @@ public static class MiscTab
                     new Accessor<float>(() => profile.AutoOpenCorpseRange, f => profile.AutoOpenCorpseRange = (int)f),
                     search: new SearchMetadata(TazLang.Get("mog_general_corpseopendistance"), Keywords: [TazLang.Get("mog_kw_corpse"), TazLang.Get("mog_kw_distance")])
                 ),
-                Option.Checkbox(
+                Option.CheckboxWithEnableWarning(
                     TazLang.Get("mog_general_corpseskipempty"),
                     new Accessor<bool>(() => profile.SkipEmptyCorpse),
+                    TazLang.Get("mog_general_corpseskipemptywarningtitle"),
+                    TazLang.Get("mog_general_corpseskipemptywarning"),
                     TazLang.Get("mog_general_corpseskipemptytooltip"),
                     search: new SearchMetadata(TazLang.Get("mog_general_corpseskipempty"), Keywords: [TazLang.Get("mog_kw_corpse"), TazLang.Get("mog_kw_empty")])
                 ),


### PR DESCRIPTION
Enabling the 'Skip empty corpses' option now shows a confirmation warning explaining that the feature does not work on most servers, since the fix relies on corpse contents that most servers only send once a corpse is opened. Declining the dialog reverts the checkbox.

Adds a reusable Option.CheckboxWithEnableWarning factory backed by the existing ConfirmationModal Myra dialog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a confirmation warning when enabling the “Skip Empty Corpses” setting.
  * Users can cancel activation and leave the setting disabled.
  * Added localized text for the warning title and message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->