### PR TITLE
Add corpse container style setting for grid containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to TazUO will be recorded here.
 ## In Development
 
 ### Features
+* Added a corpse container style setting to grid containers, allowing corpses to open in Grid or Original style independently of the global "open new containers in the original view" option - [P.R 733](https://github.com/PlayTazUO/TazUO/pull/733) ([bittiez](https://github.com/bittiez))
 * Added UI scaling support to both skill gumps (standard and advanced), sharing a single configurable scale setting - [P.R 722](https://github.com/PlayTazUO/TazUO/pull/722) ([bittiez](https://github.com/bittiez))
 * Added options to show the heal/cure buttons on all health bars (except invulnerable notoriety) and on health bars of mobiles in the friends list - [P.R 726](https://github.com/PlayTazUO/TazUO/pull/726) ([bittiez](https://github.com/bittiez))
 * Moved the Health Bars options tab from the Interface category to Gameplay > Mobiles - [P.R 714](https://github.com/PlayTazUO/TazUO/pull/714) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.3.60</AssemblyVersion>
-    <FileVersion>5.3.60</FileVersion>
+    <AssemblyVersion>5.3.61</AssemblyVersion>
+    <FileVersion>5.3.61</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -531,7 +531,7 @@ namespace ClassicUO.Configuration
         #region GRID CONTAINER
         public bool UseGridLayoutContainerGumps { get; set => SetProperty(ref field, value); } = true;
         public bool GridContainersDefaultToOldStyleView { get; set => SetProperty(ref field, value); } = false;
-        public int CorpseContainerStyle { get; set => SetProperty(ref field, value); } = 0; // 0 = Follow global, 1 = Grid, 2 = Original
+        public CorpseContainerStyle CorpseContainerStyle { get; set => SetProperty(ref field, value); } = CorpseContainerStyle.Default;
         public int GridContainerViewMode { get; set => SetProperty(ref field, value); } = 0; // 0 = Grid, 1 = List
         public int GridContainerSearchMode { get; set => SetProperty(ref field, value); } = 0;
         public bool EnableGridContainerAnchor { get; set => SetProperty(ref field, value); } = false;

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -531,6 +531,7 @@ namespace ClassicUO.Configuration
         #region GRID CONTAINER
         public bool UseGridLayoutContainerGumps { get; set => SetProperty(ref field, value); } = true;
         public bool GridContainersDefaultToOldStyleView { get; set => SetProperty(ref field, value); } = false;
+        public int CorpseContainerStyle { get; set => SetProperty(ref field, value); } = 0; // 0 = Follow global, 1 = Grid, 2 = Original
         public int GridContainerViewMode { get; set => SetProperty(ref field, value); } = 0; // 0 = Grid, 1 = List
         public int GridContainerSearchMode { get; set => SetProperty(ref field, value); } = 0;
         public bool EnableGridContainerAnchor { get; set => SetProperty(ref field, value); } = false;

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -5,7 +5,7 @@
 ; Missing keys are auto-appended with English defaults when
 ; this file's version is newer than the user's copy.
 ; -------------------------------------------------------
-_version=57
+_version=58
 accountname=Account Name
 accountcontextmenutooltip=Right click to select another account.
 music=Music
@@ -1786,6 +1786,11 @@ mog_tazuo_globalscale=Scale
 mog_tazuo_gridcontainers=Grid containers
 mog_tazuo_gridcontainerscale=Grid container scale
 mog_tazuo_gridcontainersdefaulttooldstyleview=Open new containers in the original view
+mog_tazuo_corpsecontainerstyle=Corpse container style
+mog_tazuo_corpsestyleopt_default=Follow global setting
+mog_tazuo_corpsestyleopt_grid=Grid
+mog_tazuo_corpsestyleopt_original=Original
+mog_tazuo_tooltipcorpsecontainerstyle=Choose which container style corpses open in. This overrides the "Open new containers in the original view" option for corpses.
 mog_tazuo_griddisabletargeting=Disable Targeting Grid Containers
 mog_tazuo_gridhighlightproperties=Show highlighted item properties in tooltip
 mog_tazuo_gridhighlightsettings=Grid highlight settings

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/Enums/CorpseContainerStyle.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/Enums/CorpseContainerStyle.cs
@@ -1,0 +1,17 @@
+namespace ClassicUO.Game.UI.Gumps;
+
+/// <summary>
+///     Controls which container style corpses open in, independent of the global
+///     <see cref="ClassicUO.Configuration.Profile.GridContainersDefaultToOldStyleView" /> preference.
+/// </summary>
+public enum CorpseContainerStyle
+{
+    /// <summary>Use the global default (the "Open new containers in the original view" setting).</summary>
+    Default,
+
+    /// <summary>Always open corpses as grid containers.</summary>
+    Grid,
+
+    /// <summary>Always open corpses as original-style containers.</summary>
+    Original
+}

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/GridContainer.cs
@@ -539,9 +539,9 @@ public partial class GridContainer : ResizableGump
                 {
                     switch (ProfileManager.CurrentProfile.CorpseContainerStyle)
                     {
-                        case 1: return false; // Force grid style
-                        case 2: return true;  // Force original style
-                        // case 0 falls through to the global default
+                        case CorpseContainerStyle.Grid: return false;
+                        case CorpseContainerStyle.Original: return true;
+                        // CorpseContainerStyle.Default falls through to the global default
                     }
                 }
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/GridContainer.cs
@@ -532,7 +532,21 @@ public partial class GridContainer : ResizableGump
         {
             // If the container has no stored preference and was not opened in a specific mode, use the global default
             if (_gridContainerEntry.UseOriginalContainer == null && UseOldContainerStyle == null)
+            {
+                // Corpses can override the global "open all containers in original style" preference
+                // via their own dedicated setting.
+                if (_isCorpse)
+                {
+                    switch (ProfileManager.CurrentProfile.CorpseContainerStyle)
+                    {
+                        case 1: return false; // Force grid style
+                        case 2: return true;  // Force original style
+                        // case 0 falls through to the global default
+                    }
+                }
+
                 return ProfileManager.CurrentProfile.GridContainersDefaultToOldStyleView;
+            }
 
             // Next, if the open request was made with a specific mode (i.e., useGridStyle != nul), use that,
             // otherwise, fallback to the stored preference (which, if we got here is *not* null, or we'd fall into the default case above)

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/ContainersTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/ContainersTab.cs
@@ -175,6 +175,18 @@ public static class ContainersTab
                     search: new SearchMetadata(TazLang.Get("mog_tazuo_gridcontainersdefaulttooldstyleview"), Keywords: [TazLang.Get("mog_kw_old"), TazLang.Get("mog_kw_style"), TazLang.Get("mog_kw_view")])
                 ),
                 Option.ComboBox(
+                    TazLang.Get("mog_tazuo_corpsecontainerstyle"),
+                    profile.CorpseContainerStyle,
+                    [
+                        TazLang.Get("mog_tazuo_corpsestyleopt_default"),
+                        TazLang.Get("mog_tazuo_corpsestyleopt_grid"),
+                        TazLang.Get("mog_tazuo_corpsestyleopt_original")
+                    ],
+                    i => profile.CorpseContainerStyle = i,
+                    TazLang.Get("mog_tazuo_tooltipcorpsecontainerstyle"),
+                    search: new SearchMetadata(TazLang.Get("mog_tazuo_corpsecontainerstyle"), Keywords: [TazLang.Get("mog_kw_corpse"), TazLang.Get("mog_kw_style"), TazLang.Get("mog_kw_container")])
+                ),
+                Option.ComboBox(
                     TazLang.Get("mog_tazuo_searchstyle"),
                     profile.GridContainerSearchMode,
                     [TazLang.Get("mog_tazuo_onlyshow"), TazLang.Get("mog_tazuo_highlight")],

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/ContainersTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/ContainersTab.cs
@@ -174,15 +174,10 @@ public static class ContainersTab
                     new Accessor<bool>(() => profile.GridContainersDefaultToOldStyleView),
                     search: new SearchMetadata(TazLang.Get("mog_tazuo_gridcontainersdefaulttooldstyleview"), Keywords: [TazLang.Get("mog_kw_old"), TazLang.Get("mog_kw_style"), TazLang.Get("mog_kw_view")])
                 ),
-                Option.ComboBox(
+                Option.LComboBox(
                     TazLang.Get("mog_tazuo_corpsecontainerstyle"),
-                    profile.CorpseContainerStyle,
-                    [
-                        TazLang.Get("mog_tazuo_corpsestyleopt_default"),
-                        TazLang.Get("mog_tazuo_corpsestyleopt_grid"),
-                        TazLang.Get("mog_tazuo_corpsestyleopt_original")
-                    ],
-                    i => profile.CorpseContainerStyle = i,
+                    new Accessor<CorpseContainerStyle>(() => profile.CorpseContainerStyle, v => profile.CorpseContainerStyle = v),
+                    "mog_tazuo_corpsestyleopt_",
                     TazLang.Get("mog_tazuo_tooltipcorpsecontainerstyle"),
                     search: new SearchMetadata(TazLang.Get("mog_tazuo_corpsecontainerstyle"), Keywords: [TazLang.Get("mog_kw_corpse"), TazLang.Get("mog_kw_style"), TazLang.Get("mog_kw_container")])
                 ),


### PR DESCRIPTION
Adds a dropdown in the grid container settings to choose whether corpses open in Grid or Original style, overriding the global 'Open new containers in the original view' preference for corpses specifically.

The setting offers three options: Follow global setting (default, preserves existing behavior), Grid, and Original. When set to Grid or Original, it takes precedence over GridContainersDefaultToOldStyleView for corpse containers only.