### PR TITLE
Add SqliteDatabase base class for easy SQLite handling

### DIFF
--- a/src/ClassicUO.Client/Game/Managers/SqliteColumn.cs
+++ b/src/ClassicUO.Client/Game/Managers/SqliteColumn.cs
@@ -81,7 +81,11 @@ namespace ClassicUO.Game.Managers
         public string ToDefinition(bool includePrimaryKey = true)
         {
             System.Text.StringBuilder sb = new();
-            sb.Append(Name);
+            // Quote the identifier so names that are keywords or contain unusual characters cannot
+            // break out of the DDL (identifiers cannot be passed as SQL parameters).
+            sb.Append('"');
+            sb.Append(Name.Replace("\"", "\"\""));
+            sb.Append('"');
             sb.Append(' ');
             sb.Append(SqlType);
 

--- a/src/ClassicUO.Client/Game/Managers/SqliteColumn.cs
+++ b/src/ClassicUO.Client/Game/Managers/SqliteColumn.cs
@@ -1,0 +1,103 @@
+namespace ClassicUO.Game.Managers
+{
+    /// <summary>
+    /// The SQLite storage class / affinity used when declaring a column.
+    /// </summary>
+    public enum SqliteColumnType
+    {
+        Integer,
+        Text,
+        Real,
+        Blob
+    }
+
+    /// <summary>
+    /// Describes a single column for use with <see cref="SqliteDatabase.EnsureTableAsync"/> and
+    /// <see cref="SqliteDatabase.EnsureColumnsAsync"/>. Use the static factory helpers
+    /// (<see cref="Int"/>, <see cref="Str"/>, <see cref="Number"/>, <see cref="Binary"/>) for terse
+    /// declarations, e.g. <c>SqliteColumn.Int("id", primaryKey: true)</c>.
+    /// </summary>
+    public readonly struct SqliteColumn
+    {
+        /// <summary>The column name.</summary>
+        public readonly string Name;
+
+        /// <summary>The column storage type.</summary>
+        public readonly SqliteColumnType Type;
+
+        /// <summary>Whether this column is (part of) the table's PRIMARY KEY.</summary>
+        public readonly bool PrimaryKey;
+
+        /// <summary>Whether this column has a NOT NULL constraint.</summary>
+        public readonly bool NotNull;
+
+        /// <summary>
+        /// Optional DEFAULT clause value, written verbatim into the DDL. For string defaults include
+        /// the quotes yourself, e.g. <c>"''"</c>. Null/empty means no DEFAULT clause.
+        /// </summary>
+        public readonly string DefaultValue;
+
+        public SqliteColumn(string name, SqliteColumnType type, bool primaryKey = false, bool notNull = false, string defaultValue = null)
+        {
+            Name = name;
+            Type = type;
+            PrimaryKey = primaryKey;
+            NotNull = notNull;
+            DefaultValue = defaultValue;
+        }
+
+        /// <summary>Creates an INTEGER column.</summary>
+        public static SqliteColumn Int(string name, bool primaryKey = false, bool notNull = false, string def = null)
+            => new(name, SqliteColumnType.Integer, primaryKey, notNull, def);
+
+        /// <summary>Creates a TEXT column.</summary>
+        public static SqliteColumn Str(string name, bool primaryKey = false, bool notNull = false, string def = null)
+            => new(name, SqliteColumnType.Text, primaryKey, notNull, def);
+
+        /// <summary>Creates a REAL (floating point) column.</summary>
+        public static SqliteColumn Number(string name, bool primaryKey = false, bool notNull = false, string def = null)
+            => new(name, SqliteColumnType.Real, primaryKey, notNull, def);
+
+        /// <summary>Creates a BLOB column.</summary>
+        public static SqliteColumn Binary(string name, bool primaryKey = false, bool notNull = false, string def = null)
+            => new(name, SqliteColumnType.Blob, primaryKey, notNull, def);
+
+        private string SqlType => Type switch
+        {
+            SqliteColumnType.Integer => "INTEGER",
+            SqliteColumnType.Text => "TEXT",
+            SqliteColumnType.Real => "REAL",
+            SqliteColumnType.Blob => "BLOB",
+            _ => "TEXT"
+        };
+
+        /// <summary>
+        /// Builds the DDL fragment for this column, e.g. <c>Name TEXT NOT NULL DEFAULT ''</c>.
+        /// </summary>
+        /// <param name="includePrimaryKey">
+        /// When true, an inline <c>PRIMARY KEY</c> is appended for single-column primary keys.
+        /// Set false when the primary key is declared separately as a table-level constraint.
+        /// </param>
+        public string ToDefinition(bool includePrimaryKey = true)
+        {
+            System.Text.StringBuilder sb = new();
+            sb.Append(Name);
+            sb.Append(' ');
+            sb.Append(SqlType);
+
+            if (includePrimaryKey && PrimaryKey)
+                sb.Append(" PRIMARY KEY");
+
+            if (NotNull)
+                sb.Append(" NOT NULL");
+
+            if (!string.IsNullOrEmpty(DefaultValue))
+            {
+                sb.Append(" DEFAULT ");
+                sb.Append(DefaultValue);
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/src/ClassicUO.Client/Game/Managers/SqliteDatabase.cs
+++ b/src/ClassicUO.Client/Game/Managers/SqliteDatabase.cs
@@ -118,7 +118,7 @@ namespace ClassicUO.Game.Managers
 
             StringBuilder sb = new();
             sb.Append("CREATE TABLE IF NOT EXISTS ");
-            sb.Append(tableName);
+            sb.Append(QuoteIdentifier(tableName));
             sb.Append(" (");
 
             for (int i = 0; i < columns.Length; i++)
@@ -132,7 +132,13 @@ namespace ClassicUO.Game.Managers
             if (compositeKey)
             {
                 sb.Append(", PRIMARY KEY (");
-                sb.Append(string.Join(", ", primaryKeys));
+                for (int i = 0; i < primaryKeys.Count; i++)
+                {
+                    if (i > 0)
+                        sb.Append(", ");
+
+                    sb.Append(QuoteIdentifier(primaryKeys[i]));
+                }
                 sb.Append(')');
             }
 
@@ -143,8 +149,10 @@ namespace ClassicUO.Game.Managers
 
         /// <summary>
         /// Ensures each given column exists on a table, adding any that are missing via
-        /// <c>ALTER TABLE ... ADD COLUMN</c>. Columns that already exist are skipped silently, so this
-        /// is safe to call on every startup for schema migrations.
+        /// <c>ALTER TABLE ... ADD COLUMN</c>. Existing columns are detected up front (via
+        /// <c>PRAGMA table_info</c>) and skipped, so this is safe to call on every startup for schema
+        /// migrations. Unlike a blanket exception swallow, a genuine ALTER failure is not hidden - it
+        /// surfaces and is logged.
         /// </summary>
         /// <param name="tableName">The table to add columns to.</param>
         /// <param name="columns">The columns to ensure exist.</param>
@@ -160,19 +168,29 @@ namespace ClassicUO.Game.Managers
             {
                 await using SqliteConnection connection = await OpenConnectionAsync().ConfigureAwait(false);
 
+                // Determine which columns already exist so we only ALTER the missing ones. This avoids
+                // swallowing SqliteExceptions blindly (which would hide real schema/SQL errors).
+                HashSet<string> existing = new(StringComparer.OrdinalIgnoreCase);
+                await using (SqliteCommand info = connection.CreateCommand())
+                {
+                    info.CommandText = $"PRAGMA table_info({QuoteIdentifier(tableName)})";
+                    await using SqliteDataReader reader = await info.ExecuteReaderAsync().ConfigureAwait(false);
+                    while (await reader.ReadAsync().ConfigureAwait(false))
+                    {
+                        // PRAGMA table_info columns: cid(0), name(1), type(2), ...
+                        existing.Add(reader.GetString(1));
+                    }
+                }
+
                 foreach (SqliteColumn column in columns)
                 {
-                    try
-                    {
-                        await using SqliteCommand cmd = connection.CreateCommand();
-                        // A primary key cannot be added via ALTER TABLE, so never inline it here.
-                        cmd.CommandText = $"ALTER TABLE {tableName} ADD COLUMN {column.ToDefinition(includePrimaryKey: false)}";
-                        await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
-                    }
-                    catch (SqliteException)
-                    {
-                        // Column already exists - ignore, this is the expected migration path.
-                    }
+                    if (existing.Contains(column.Name))
+                        continue;
+
+                    await using SqliteCommand cmd = connection.CreateCommand();
+                    // A primary key cannot be added via ALTER TABLE, so never inline it here.
+                    cmd.CommandText = $"ALTER TABLE {QuoteIdentifier(tableName)} ADD COLUMN {column.ToDefinition(includePrimaryKey: false)}";
+                    await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
                 }
             }
             catch (Exception ex)
@@ -198,7 +216,8 @@ namespace ClassicUO.Game.Managers
             if (columns == null || columns.Length == 0)
                 throw new ArgumentException("At least one column is required.", nameof(columns));
 
-            string sql = $"CREATE INDEX IF NOT EXISTS {indexName} ON {tableName} ({string.Join(", ", columns)})";
+            string quotedColumns = string.Join(", ", Array.ConvertAll(columns, QuoteIdentifier));
+            string sql = $"CREATE INDEX IF NOT EXISTS {QuoteIdentifier(indexName)} ON {QuoteIdentifier(tableName)} ({quotedColumns})";
             await ExecuteNonQueryAsync(sql).ConfigureAwait(false);
         }
 
@@ -239,14 +258,14 @@ namespace ClassicUO.Game.Managers
                 }
 
                 string paramName = $"$p{i}";
-                columnList.Append(pair.Key);
+                columnList.Append(QuoteIdentifier(pair.Key));
                 valueList.Append(paramName);
                 parameters.Add(new KeyValuePair<string, object>(paramName, pair.Value ?? DBNull.Value));
                 i++;
             }
 
             string verb = orReplace ? "INSERT OR REPLACE INTO" : "INSERT INTO";
-            string sql = $"{verb} {tableName} ({columnList}) VALUES ({valueList})";
+            string sql = $"{verb} {QuoteIdentifier(tableName)} ({columnList}) VALUES ({valueList})";
 
             await ExecuteNonQueryAsync(sql, parameters).ConfigureAwait(false);
         }
@@ -306,6 +325,20 @@ namespace ClassicUO.Game.Managers
             {
                 _dbLock.Release();
             }
+        }
+
+        /// <summary>
+        /// Quotes a SQLite identifier (table/column/index name) so it cannot break out of the
+        /// surrounding SQL. Identifiers cannot be passed as bound parameters, so callers that build
+        /// SQL from identifiers must quote them; embedded double quotes are doubled per the SQLite
+        /// grammar.
+        /// </summary>
+        protected static string QuoteIdentifier(string identifier)
+        {
+            if (string.IsNullOrEmpty(identifier))
+                throw new ArgumentException("Identifier cannot be null or empty.", nameof(identifier));
+
+            return "\"" + identifier.Replace("\"", "\"\"") + "\"";
         }
 
         private static void AddParameters(SqliteCommand cmd, IEnumerable<KeyValuePair<string, object>> parameters)

--- a/src/ClassicUO.Client/Game/Managers/SqliteDatabase.cs
+++ b/src/ClassicUO.Client/Game/Managers/SqliteDatabase.cs
@@ -1,0 +1,407 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using ClassicUO.Utility.Logging;
+using Microsoft.Data.Sqlite;
+
+namespace ClassicUO.Game.Managers
+{
+    /// <summary>
+    /// Base class that removes the boilerplate of working with a SQLite database. Subclass it, pass a
+    /// database file name to the constructor, then use the declarative schema helpers
+    /// (<see cref="EnsureTableAsync"/>, <see cref="EnsureColumnsAsync"/>, <see cref="EnsureIndexAsync"/>)
+    /// and the row write helpers (<see cref="AddRowAsync"/>, <see cref="AddOrUpdateAsync"/>).
+    /// <para>
+    /// All operations are serialized behind a <see cref="SemaphoreSlim"/> and open a short-lived
+    /// connection per call, matching the conventions used by the other SQLite managers in the project.
+    /// Values are always bound as SQL parameters, never interpolated.
+    /// </para>
+    /// <example>
+    /// <code>
+    /// public class MyThingDb : SqliteDatabase
+    /// {
+    ///     public MyThingDb() : base("mything.db")
+    ///     {
+    ///         EnsureTableAsync("things",
+    ///             SqliteColumn.Int("id", primaryKey: true),
+    ///             SqliteColumn.Str("name", notNull: true, def: "''")
+    ///         ).GetAwaiter().GetResult();
+    ///     }
+    ///
+    ///     public Task SaveAsync(int id, string name) =>
+    ///         AddOrUpdateAsync("things", new SqliteRow { { "id", id }, { "name", name } });
+    /// }
+    /// </code>
+    /// </example>
+    /// </summary>
+    public abstract class SqliteDatabase : IDisposable
+    {
+        private const int MAX_BACKUPS = 3;
+
+        private readonly SemaphoreSlim _dbLock = new(1, 1);
+
+        /// <summary>The directory that contains the database file.</summary>
+        protected string DataDirectory { get; }
+
+        /// <summary>The full path to the database file on disk.</summary>
+        protected string DatabasePath { get; }
+
+        /// <summary>The connection string used to open connections to this database.</summary>
+        protected string ConnectionString { get; }
+
+        private bool _disposed;
+
+        /// <summary>
+        /// Creates the base database. The containing directory is created if it does not exist.
+        /// </summary>
+        /// <param name="dbFileName">The database file name, e.g. <c>"mything.db"</c>.</param>
+        /// <param name="dataDirectory">
+        /// The directory to place the database in. Defaults to the shared
+        /// <c>{ExecutablePath}/Data</c> directory used by the other managers. Provide an explicit
+        /// directory (e.g. a temp path) to make a subclass unit-testable.
+        /// </param>
+        protected SqliteDatabase(string dbFileName, string dataDirectory = null)
+        {
+            DataDirectory = dataDirectory ?? Path.Combine(CUOEnviroment.ExecutablePath, "Data");
+            DatabasePath = Path.Combine(DataDirectory, dbFileName);
+
+            if (!Directory.Exists(DataDirectory))
+                Directory.CreateDirectory(DataDirectory);
+
+            ConnectionString = new SqliteConnectionStringBuilder
+            {
+                DataSource = DatabasePath,
+                Mode = SqliteOpenMode.ReadWriteCreate,
+                Cache = SqliteCacheMode.Shared
+            }.ToString();
+        }
+
+        private async Task<SqliteConnection> OpenConnectionAsync()
+        {
+            SqliteConnection connection = new(ConnectionString);
+            await connection.OpenAsync().ConfigureAwait(false);
+            return connection;
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_disposed)
+                throw new ObjectDisposedException(GetType().Name);
+        }
+
+        /// <summary>
+        /// Ensures a table exists, creating it (<c>CREATE TABLE IF NOT EXISTS</c>) with the given
+        /// columns if necessary. If more than one column is flagged as a primary key, a composite
+        /// table-level PRIMARY KEY is emitted.
+        /// </summary>
+        /// <param name="tableName">The table name.</param>
+        /// <param name="columns">The columns that define the table.</param>
+        public async Task EnsureTableAsync(string tableName, params SqliteColumn[] columns)
+        {
+            ThrowIfDisposed();
+
+            if (columns == null || columns.Length == 0)
+                throw new ArgumentException("At least one column is required.", nameof(columns));
+
+            List<string> primaryKeys = new();
+            foreach (SqliteColumn c in columns)
+            {
+                if (c.PrimaryKey)
+                    primaryKeys.Add(c.Name);
+            }
+
+            // Inline "PRIMARY KEY" only works for a single-column key; otherwise use a table constraint.
+            bool compositeKey = primaryKeys.Count > 1;
+
+            StringBuilder sb = new();
+            sb.Append("CREATE TABLE IF NOT EXISTS ");
+            sb.Append(tableName);
+            sb.Append(" (");
+
+            for (int i = 0; i < columns.Length; i++)
+            {
+                if (i > 0)
+                    sb.Append(", ");
+
+                sb.Append(columns[i].ToDefinition(includePrimaryKey: !compositeKey));
+            }
+
+            if (compositeKey)
+            {
+                sb.Append(", PRIMARY KEY (");
+                sb.Append(string.Join(", ", primaryKeys));
+                sb.Append(')');
+            }
+
+            sb.Append(')');
+
+            await ExecuteNonQueryAsync(sb.ToString()).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Ensures each given column exists on a table, adding any that are missing via
+        /// <c>ALTER TABLE ... ADD COLUMN</c>. Columns that already exist are skipped silently, so this
+        /// is safe to call on every startup for schema migrations.
+        /// </summary>
+        /// <param name="tableName">The table to add columns to.</param>
+        /// <param name="columns">The columns to ensure exist.</param>
+        public async Task EnsureColumnsAsync(string tableName, params SqliteColumn[] columns)
+        {
+            ThrowIfDisposed();
+
+            if (columns == null || columns.Length == 0)
+                return;
+
+            await _dbLock.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                await using SqliteConnection connection = await OpenConnectionAsync().ConfigureAwait(false);
+
+                foreach (SqliteColumn column in columns)
+                {
+                    try
+                    {
+                        await using SqliteCommand cmd = connection.CreateCommand();
+                        // A primary key cannot be added via ALTER TABLE, so never inline it here.
+                        cmd.CommandText = $"ALTER TABLE {tableName} ADD COLUMN {column.ToDefinition(includePrimaryKey: false)}";
+                        await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
+                    }
+                    catch (SqliteException)
+                    {
+                        // Column already exists - ignore, this is the expected migration path.
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error($@"Error ensuring columns on table '{tableName}': {ex.Message}");
+            }
+            finally
+            {
+                _dbLock.Release();
+            }
+        }
+
+        /// <summary>
+        /// Ensures an index exists (<c>CREATE INDEX IF NOT EXISTS</c>) over the given columns.
+        /// </summary>
+        /// <param name="indexName">The index name.</param>
+        /// <param name="tableName">The table the index is on.</param>
+        /// <param name="columns">The columns to index.</param>
+        public async Task EnsureIndexAsync(string indexName, string tableName, params string[] columns)
+        {
+            ThrowIfDisposed();
+
+            if (columns == null || columns.Length == 0)
+                throw new ArgumentException("At least one column is required.", nameof(columns));
+
+            string sql = $"CREATE INDEX IF NOT EXISTS {indexName} ON {tableName} ({string.Join(", ", columns)})";
+            await ExecuteNonQueryAsync(sql).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Inserts a new row (<c>INSERT INTO</c>) built from the given <see cref="SqliteRow"/>.
+        /// </summary>
+        /// <param name="tableName">The table to insert into.</param>
+        /// <param name="row">The column/value pairs to insert.</param>
+        public Task AddRowAsync(string tableName, SqliteRow row) => WriteRowAsync(tableName, row, orReplace: false);
+
+        /// <summary>
+        /// Inserts or replaces a row (<c>INSERT OR REPLACE INTO</c>) built from the given
+        /// <see cref="SqliteRow"/>. Requires the table to have a PRIMARY KEY or UNIQUE constraint for
+        /// the replace to take effect.
+        /// </summary>
+        /// <param name="tableName">The table to write to.</param>
+        /// <param name="row">The column/value pairs to write.</param>
+        public Task AddOrUpdateAsync(string tableName, SqliteRow row) => WriteRowAsync(tableName, row, orReplace: true);
+
+        private async Task WriteRowAsync(string tableName, SqliteRow row, bool orReplace)
+        {
+            ThrowIfDisposed();
+
+            if (row.Count == 0)
+                throw new ArgumentException("Row has no columns.", nameof(row));
+
+            StringBuilder columnList = new();
+            StringBuilder valueList = new();
+            List<KeyValuePair<string, object>> parameters = new(row.Count);
+
+            int i = 0;
+            foreach (KeyValuePair<string, object> pair in row.Columns)
+            {
+                if (i > 0)
+                {
+                    columnList.Append(", ");
+                    valueList.Append(", ");
+                }
+
+                string paramName = $"$p{i}";
+                columnList.Append(pair.Key);
+                valueList.Append(paramName);
+                parameters.Add(new KeyValuePair<string, object>(paramName, pair.Value ?? DBNull.Value));
+                i++;
+            }
+
+            string verb = orReplace ? "INSERT OR REPLACE INTO" : "INSERT INTO";
+            string sql = $"{verb} {tableName} ({columnList}) VALUES ({valueList})";
+
+            await ExecuteNonQueryAsync(sql, parameters).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Executes a non-query statement (INSERT/UPDATE/DELETE/DDL) and returns the number of rows
+        /// affected. Available to subclasses for statements the helpers do not cover.
+        /// </summary>
+        protected async Task<int> ExecuteNonQueryAsync(string sql, IEnumerable<KeyValuePair<string, object>> parameters = null)
+        {
+            ThrowIfDisposed();
+
+            await _dbLock.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                await using SqliteConnection connection = await OpenConnectionAsync().ConfigureAwait(false);
+                await using SqliteCommand cmd = connection.CreateCommand();
+                cmd.CommandText = sql;
+                AddParameters(cmd, parameters);
+                return await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Log.Error($@"Error executing SQL '{sql}': {ex.Message}");
+                return 0;
+            }
+            finally
+            {
+                _dbLock.Release();
+            }
+        }
+
+        /// <summary>
+        /// Executes a query and returns the first column of the first row, or null. Available to
+        /// subclasses for simple scalar reads.
+        /// </summary>
+        protected async Task<object> ExecuteScalarAsync(string sql, IEnumerable<KeyValuePair<string, object>> parameters = null)
+        {
+            ThrowIfDisposed();
+
+            await _dbLock.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                await using SqliteConnection connection = await OpenConnectionAsync().ConfigureAwait(false);
+                await using SqliteCommand cmd = connection.CreateCommand();
+                cmd.CommandText = sql;
+                AddParameters(cmd, parameters);
+                object result = await cmd.ExecuteScalarAsync().ConfigureAwait(false);
+                return result == DBNull.Value ? null : result;
+            }
+            catch (Exception ex)
+            {
+                Log.Error($@"Error executing scalar SQL '{sql}': {ex.Message}");
+                return null;
+            }
+            finally
+            {
+                _dbLock.Release();
+            }
+        }
+
+        private static void AddParameters(SqliteCommand cmd, IEnumerable<KeyValuePair<string, object>> parameters)
+        {
+            if (parameters == null)
+                return;
+
+            foreach (KeyValuePair<string, object> p in parameters)
+                cmd.Parameters.AddWithValue(p.Key, p.Value ?? DBNull.Value);
+        }
+
+        /// <summary>
+        /// Rotates up to <see cref="MAX_BACKUPS"/> copies of the database file (<c>.db.1</c>,
+        /// <c>.db.2</c>, ...). Opt-in: a subclass may call this from its constructor before creating
+        /// its schema if it wants startup backups.
+        /// </summary>
+        protected void CreateBackups()
+        {
+            try
+            {
+                if (!File.Exists(DatabasePath))
+                    return;
+
+                // Rotate existing backups: .3 -> delete, .2 -> .3, .1 -> .2
+                for (int i = MAX_BACKUPS; i > 0; i--)
+                {
+                    string backupPath = $"{DatabasePath}.{i}";
+
+                    if (i == MAX_BACKUPS)
+                    {
+                        if (File.Exists(backupPath))
+                            File.Delete(backupPath);
+                    }
+                    else
+                    {
+                        string nextBackupPath = $"{DatabasePath}.{i + 1}";
+                        if (File.Exists(backupPath))
+                        {
+                            if (File.Exists(nextBackupPath))
+                                File.Delete(nextBackupPath);
+                            File.Move(backupPath, nextBackupPath);
+                        }
+                    }
+                }
+
+                string firstBackupPath = $"{DatabasePath}.1";
+                if (File.Exists(firstBackupPath))
+                    File.Delete(firstBackupPath);
+
+                File.Copy(DatabasePath, firstBackupPath);
+            }
+            catch (Exception ex)
+            {
+                Log.Error($@"Warning: Failed to create database backups for '{DatabasePath}': {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Runs an arbitrary operation against an open connection while holding the database lock. Use
+        /// this from a subclass for reads/queries that the built-in helpers do not cover (e.g. running
+        /// a <see cref="SqliteDataReader"/>). The connection is opened and disposed for you.
+        /// </summary>
+        protected async Task<T> ExecuteAsync<T>(Func<SqliteConnection, Task<T>> operation)
+        {
+            ThrowIfDisposed();
+
+            await _dbLock.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                await using SqliteConnection connection = await OpenConnectionAsync().ConfigureAwait(false);
+                return await operation(connection).ConfigureAwait(false);
+            }
+            finally
+            {
+                _dbLock.Release();
+            }
+        }
+
+        /// <summary>Releases resources used by the database.</summary>
+        public virtual void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _dbLock.Wait();
+            try
+            {
+                _disposed = true;
+            }
+            finally
+            {
+                _dbLock.Release();
+                _dbLock.Dispose();
+            }
+
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/ClassicUO.Client/Game/Managers/SqliteRow.cs
+++ b/src/ClassicUO.Client/Game/Managers/SqliteRow.cs
@@ -45,7 +45,11 @@ namespace ClassicUO.Game.Managers
             return this;
         }
 
-        /// <summary>Gets or sets the value for a column. The setter appends a new pair.</summary>
+        /// <summary>
+        /// Gets or sets the value for a column. The setter replaces the value in place if the column
+        /// already exists, otherwise it appends a new pair. (Use <see cref="Add"/> for append-always
+        /// semantics.)
+        /// </summary>
         public object this[string column]
         {
             readonly get
@@ -61,7 +65,21 @@ namespace ClassicUO.Game.Managers
 
                 return null;
             }
-            set => Add(column, value);
+            set
+            {
+                _columns ??= new List<KeyValuePair<string, object>>();
+
+                for (int i = 0; i < _columns.Count; i++)
+                {
+                    if (_columns[i].Key == column)
+                    {
+                        _columns[i] = new KeyValuePair<string, object>(column, value);
+                        return;
+                    }
+                }
+
+                _columns.Add(new KeyValuePair<string, object>(column, value));
+            }
         }
 
         public readonly IEnumerator<KeyValuePair<string, object>> GetEnumerator()

--- a/src/ClassicUO.Client/Game/Managers/SqliteRow.cs
+++ b/src/ClassicUO.Client/Game/Managers/SqliteRow.cs
@@ -1,0 +1,72 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace ClassicUO.Game.Managers
+{
+    /// <summary>
+    /// A lightweight, ordered set of column/value pairs used to add or update a database row without
+    /// writing SQL by hand. Supports collection-initializer syntax as well as a fluent API:
+    /// <code>
+    /// // collection initializer
+    /// var row = new SqliteRow { { "serial", 1 }, { "name", "foo" } };
+    ///
+    /// // fluent
+    /// var row = new SqliteRow().Set("serial", 1).Set("name", "foo");
+    /// </code>
+    /// Pass the row to <see cref="SqliteDatabase.AddRowAsync"/> or
+    /// <see cref="SqliteDatabase.AddOrUpdateAsync"/>. All values are bound as SQL parameters, so any
+    /// value type supported by Microsoft.Data.Sqlite is safe to use.
+    /// </summary>
+    public struct SqliteRow : IEnumerable<KeyValuePair<string, object>>
+    {
+        private List<KeyValuePair<string, object>> _columns;
+
+        /// <summary>The number of columns currently in this row.</summary>
+        public readonly int Count => _columns?.Count ?? 0;
+
+        /// <summary>The ordered column/value pairs that make up this row.</summary>
+        public readonly IReadOnlyList<KeyValuePair<string, object>> Columns
+            => (IReadOnlyList<KeyValuePair<string, object>>)_columns ?? System.Array.Empty<KeyValuePair<string, object>>();
+
+        /// <summary>
+        /// Adds a column/value pair. Enables collection-initializer syntax
+        /// (<c>new SqliteRow { { "col", value } }</c>).
+        /// </summary>
+        public void Add(string column, object value)
+        {
+            _columns ??= new List<KeyValuePair<string, object>>();
+            _columns.Add(new KeyValuePair<string, object>(column, value));
+        }
+
+        /// <summary>Adds a column/value pair and returns this row for fluent chaining.</summary>
+        public SqliteRow Set(string column, object value)
+        {
+            Add(column, value);
+            return this;
+        }
+
+        /// <summary>Gets or sets the value for a column. The setter appends a new pair.</summary>
+        public object this[string column]
+        {
+            readonly get
+            {
+                if (_columns != null)
+                {
+                    foreach (KeyValuePair<string, object> pair in _columns)
+                    {
+                        if (pair.Key == column)
+                            return pair.Value;
+                    }
+                }
+
+                return null;
+            }
+            set => Add(column, value);
+        }
+
+        public readonly IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+            => (_columns ?? new List<KeyValuePair<string, object>>()).GetEnumerator();
+
+        readonly IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/tests/ClassicUO.UnitTests/Game/Managers/SqliteDatabaseTest.cs
+++ b/tests/ClassicUO.UnitTests/Game/Managers/SqliteDatabaseTest.cs
@@ -1,0 +1,132 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using ClassicUO.Game.Managers;
+using FluentAssertions;
+using Xunit;
+
+namespace ClassicUO.UnitTests.Game.Managers
+{
+    public class SqliteDatabaseTest : IDisposable
+    {
+        // Concrete subclass exposing the protected scalar helper so tests can read values back.
+        private sealed class TestDatabase : SqliteDatabase
+        {
+            public TestDatabase(string directory) : base("test.db", directory) { }
+
+            public Task<object> ScalarAsync(string sql, string paramName = null, object paramValue = null)
+            {
+                if (paramName == null)
+                    return ExecuteScalarAsync(sql);
+
+                return ExecuteScalarAsync(sql, new[]
+                {
+                    new System.Collections.Generic.KeyValuePair<string, object>(paramName, paramValue)
+                });
+            }
+        }
+
+        private readonly string _tempDir;
+        private readonly TestDatabase _db;
+
+        public SqliteDatabaseTest()
+        {
+            _tempDir = Path.Combine(Path.GetTempPath(), "tazuo_sqlite_test_" + Guid.NewGuid().ToString("N"));
+            _db = new TestDatabase(_tempDir);
+        }
+
+        [Fact]
+        public void Constructor_CreatesDataDirectory()
+        {
+            Directory.Exists(_tempDir).Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task EnsureTable_And_EnsureColumns_AreIdempotent()
+        {
+            Func<Task> act = async () =>
+            {
+                await _db.EnsureTableAsync("things",
+                    SqliteColumn.Int("id", primaryKey: true),
+                    SqliteColumn.Str("name", notNull: true, def: "''"));
+
+                // Calling again must not throw.
+                await _db.EnsureTableAsync("things",
+                    SqliteColumn.Int("id", primaryKey: true),
+                    SqliteColumn.Str("name", notNull: true, def: "''"));
+
+                // Adding a new column, twice, must not throw (migration path).
+                await _db.EnsureColumnsAsync("things", SqliteColumn.Int("count", def: "0"));
+                await _db.EnsureColumnsAsync("things", SqliteColumn.Int("count", def: "0"));
+            };
+
+            await act.Should().NotThrowAsync();
+            File.Exists(Path.Combine(_tempDir, "test.db")).Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task AddRow_Then_AddOrUpdate_UpsertsByPrimaryKey()
+        {
+            await _db.EnsureTableAsync("things",
+                SqliteColumn.Int("id", primaryKey: true),
+                SqliteColumn.Str("name", notNull: true, def: "''"));
+
+            await _db.AddRowAsync("things", new SqliteRow { { "id", 1 }, { "name", "original" } });
+
+            object before = await _db.ScalarAsync("SELECT name FROM things WHERE id = $id", "$id", 1);
+            before.Should().Be("original");
+
+            // Same primary key with a changed value should update, not duplicate.
+            await _db.AddOrUpdateAsync("things", new SqliteRow { { "id", 1 }, { "name", "updated" } });
+
+            object after = await _db.ScalarAsync("SELECT name FROM things WHERE id = $id", "$id", 1);
+            after.Should().Be("updated");
+
+            object count = await _db.ScalarAsync("SELECT COUNT(*) FROM things");
+            Convert.ToInt64(count).Should().Be(1);
+        }
+
+        [Fact]
+        public async Task AddOrUpdate_WithCompositeKey_Works()
+        {
+            await _db.EnsureTableAsync("kv",
+                SqliteColumn.Str("scope", primaryKey: true, notNull: true),
+                SqliteColumn.Str("key", primaryKey: true, notNull: true),
+                SqliteColumn.Str("value", notNull: true, def: "''"));
+
+            await _db.AddOrUpdateAsync("kv", new SqliteRow { { "scope", "a" }, { "key", "x" }, { "value", "1" } });
+            await _db.AddOrUpdateAsync("kv", new SqliteRow { { "scope", "a" }, { "key", "x" }, { "value", "2" } });
+
+            object value = await _db.ScalarAsync("SELECT value FROM kv WHERE scope = 'a' AND key = 'x'");
+            value.Should().Be("2");
+
+            object count = await _db.ScalarAsync("SELECT COUNT(*) FROM kv");
+            Convert.ToInt64(count).Should().Be(1);
+        }
+
+        [Fact]
+        public async Task Operations_AfterDispose_Throw()
+        {
+            var db = new TestDatabase(_tempDir);
+            db.Dispose();
+
+            Func<Task> act = () => db.EnsureTableAsync("t", SqliteColumn.Int("id", primaryKey: true));
+            await act.Should().ThrowAsync<ObjectDisposedException>();
+        }
+
+        public void Dispose()
+        {
+            _db.Dispose();
+
+            try
+            {
+                if (Directory.Exists(_tempDir))
+                    Directory.Delete(_tempDir, true);
+            }
+            catch
+            {
+                // Best-effort cleanup.
+            }
+        }
+    }
+}

--- a/tests/ClassicUO.UnitTests/Game/Managers/SqliteDatabaseTest.cs
+++ b/tests/ClassicUO.UnitTests/Game/Managers/SqliteDatabaseTest.cs
@@ -105,6 +105,17 @@ namespace ClassicUO.UnitTests.Game.Managers
         }
 
         [Fact]
+        public void SqliteRow_Indexer_ReplacesValueInPlace()
+        {
+            var row = new SqliteRow();
+            row["id"] = 1;
+            row["id"] = 2;
+
+            row.Count.Should().Be(1);
+            row["id"].Should().Be(2);
+        }
+
+        [Fact]
         public async Task Operations_AfterDispose_Throw()
         {
             var db = new TestDatabase(_tempDir);


### PR DESCRIPTION
Introduces a reusable base class that removes the boilerplate the existing SQLite managers each duplicate (connection setup, locking, data-dir creation, table/column DDL). Uses the already-referenced Microsoft.Data.Sqlite package; no new dependencies.

- SqliteColumn: column definition struct with factory helpers and DDL builder
- SqliteRow: lightweight row struct supporting collection-initializer and fluent syntax for adding/updating rows without hand-written SQL
- SqliteDatabase: abstract base with EnsureTableAsync, EnsureColumnsAsync, EnsureIndexAsync, AddRowAsync, AddOrUpdateAsync, plus protected scalar/ non-query/connection helpers and opt-in backup rotation
- Unit tests covering table/column idempotency and upsert behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reusable SQLite database support for creating tables, updating schemas, managing indexes, and storing or updating records.
  * Added structured helpers for defining SQLite columns and composing database rows.
  * Added optional database backup rotation and safe operation handling.

* **Tests**
  * Added coverage for schema creation and migration, record upserts, composite keys, disposal behavior, and temporary database cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->