### PR TITLE
Move grid highlights to grid_highlights.json

### DIFF
--- a/src/ClassicUO.Client/Configuration/GridHighlightsConfig.cs
+++ b/src/ClassicUO.Client/Configuration/GridHighlightsConfig.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ClassicUO.Game.UI.Gumps.GridHighLight;
+
+namespace ClassicUO.Configuration
+{
+    /// <summary>
+    /// JSON-backed store for grid-highlight rules. Persisted to <c>grid_highlights.json</c> in the
+    /// current profile's save location. Replaces the in-profile <see cref="Profile.GridHighlightSetup"/>
+    /// storage, which is migrated on first load so existing highlights are preserved.
+    /// </summary>
+    public sealed class GridHighlightsConfig
+    {
+        public const string FileName = "grid_highlights.json";
+
+        public List<GridHighlightSetupEntry> Highlights { get; set; } = new();
+
+        private static GridHighlightsConfig _current;
+
+        /// <summary>The grid-highlight config for the currently loaded profile.</summary>
+        public static GridHighlightsConfig Current => _current ??= LoadForCurrentProfile();
+
+        private static string GetFilePath() =>
+            string.IsNullOrEmpty(ProfileManager.ProfilePath) ? null : Path.Combine(ProfileManager.ProfilePath, FileName);
+
+        /// <summary>
+        /// Loads (or migrates) the grid-highlight config for the given profile and sets it as
+        /// <see cref="Current"/>. Returns <see langword="true"/> when a migration from the legacy
+        /// <see cref="Profile.GridHighlightSetup"/> storage was performed (and that list was cleared),
+        /// signaling that the profile itself should be re-saved.
+        /// </summary>
+        public static bool LoadForProfile(string profilePath, Profile profile)
+        {
+            string file = string.IsNullOrEmpty(profilePath) ? null : Path.Combine(profilePath, FileName);
+
+            if (file != null && File.Exists(file))
+            {
+                _current = ConfigurationResolver.Load<GridHighlightsConfig>(file, GridHighlightsJsonContext.DefaultToUse.GridHighlightsConfig)
+                           ?? new GridHighlightsConfig();
+                return false;
+            }
+
+            bool migrated = MigrateFromProfile(profile, out GridHighlightsConfig config);
+            _current = config;
+            _current.Save();
+            return migrated;
+        }
+
+        private static GridHighlightsConfig LoadForCurrentProfile()
+        {
+            LoadForProfile(ProfileManager.ProfilePath, ProfileManager.CurrentProfile);
+            return _current;
+        }
+
+        public void Save()
+        {
+            string file = GetFilePath();
+            if (file == null)
+                return;
+
+            ConfigurationResolver.Save(this, file, GridHighlightsJsonContext.DefaultToUse.GridHighlightsConfig);
+        }
+
+        /// <summary>
+        /// Moves the highlights parsed into <see cref="Profile.GridHighlightSetup"/> (migrating from the even
+        /// older parallel <c>GridHighlight_*</c> lists first, when needed) into a standalone config and clears
+        /// the profile-side storage.
+        /// </summary>
+        /// <returns><see langword="true"/> when there was data to migrate.</returns>
+#pragma warning disable CS0618 // Reading the obsolete GridHighlightSetup is the whole point of migration.
+        private static bool MigrateFromProfile(Profile profile, out GridHighlightsConfig config)
+        {
+            config = new GridHighlightsConfig();
+
+            if (profile == null)
+                return false;
+
+            // Pull the even-older per-list storage into GridHighlightSetup first, if that hasn't happened yet.
+            if (profile.GridHighlightSetup.Count == 0)
+                GridHighLightProfile.MigrateGridHighlightToSetup(profile);
+
+            if (profile.GridHighlightSetup.Count == 0)
+                return false;
+
+            config.Highlights = new List<GridHighlightSetupEntry>(profile.GridHighlightSetup);
+
+            // Clear the in-profile storage so grid highlights live only in grid_highlights.json going forward.
+            profile.GridHighlightSetup.Clear();
+
+            return true;
+        }
+#pragma warning restore CS0618
+    }
+
+    [JsonSerializable(typeof(GridHighlightsConfig), GenerationMode = JsonSourceGenerationMode.Metadata)]
+    sealed partial class GridHighlightsJsonContext : JsonSerializerContext
+    {
+        sealed class SnakeCaseNamingPolicy : JsonNamingPolicy
+        {
+            public static SnakeCaseNamingPolicy Instance { get; } = new SnakeCaseNamingPolicy();
+
+            public override string ConvertName(string name) =>
+                string.Concat(name.Select((x, i) => i > 0 && char.IsUpper(x) ? "_" + x.ToString() : x.ToString())).ToLower();
+        }
+
+        private static Lazy<JsonSerializerOptions> _jsonOptions { get; } = new Lazy<JsonSerializerOptions>(() =>
+        {
+            var options = new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                PropertyNamingPolicy = SnakeCaseNamingPolicy.Instance
+            };
+            return options;
+        });
+
+        public static GridHighlightsJsonContext DefaultToUse { get; } = new GridHighlightsJsonContext(_jsonOptions.Value);
+    }
+}

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -613,6 +613,10 @@ namespace ClassicUO.Configuration
         public List<List<bool>> GridHighlight_IsOptionalProperties { get; set => SetProperty(ref field, value); } = new List<List<bool>>();
         public List<List<string>> GridHighlight_ExcludeNegatives { get; set => SetProperty(ref field, value); } = new List<List<string>>();
         public List<List<string>> GridHighlight_RequiredRarities { get; set => SetProperty(ref field, value); } = new();
+
+        // GridHighlightSetup has been superseded by grid_highlights.json (see GridHighlightsConfig) and is
+        // retained only so existing profiles can be migrated on load. Do not use it in new code.
+        [Obsolete("Migrated to grid_highlights.json (GridHighlightsConfig); retained only for one-time migration of existing profiles.")]
         public List<GridHighlightSetupEntry> GridHighlightSetup { get; set => SetProperty(ref field, value); } = new();
         public List<string> ConfigurableProperties { get; set => SetProperty(ref field, value); } = new();
         public List<string> ConfigurableResistances { get; set => SetProperty(ref field, value); } = new();
@@ -1051,6 +1055,11 @@ namespace ClassicUO.Configuration
 
             // Save profile settings
             ConfigurationResolver.Save(this, filePath, ProfileJsonContext.DefaultToUse.Profile);
+
+            // Grid highlights live in a separate grid_highlights.json (see GridHighlightsConfig); persist
+            // them alongside the profile so in-place rule edits are saved on the same cadence as before.
+            if (ReferenceEquals(this, ProfileManager.CurrentProfile))
+                GridHighlightsConfig.Current.Save();
 
             // Save opened gumps
             if (saveGumps)

--- a/src/ClassicUO.Client/Configuration/ProfileManager.cs
+++ b/src/ClassicUO.Client/Configuration/ProfileManager.cs
@@ -90,9 +90,9 @@ namespace ClassicUO.Configuration
             CurrentProfile.ServerName = servername;
             CurrentProfile.CharacterName = charactername;
 
-            if (CurrentProfile.GridHighlightSetup.Count == 0)
+            // Load (or migrate from the in-profile GridHighlightSetup / legacy per-list storage) the grid highlights.
+            if (GridHighlightsConfig.LoadForProfile(ProfilePath, CurrentProfile))
             {
-                GridHighLightProfile.MigrateGridHighlightToSetup(CurrentProfile);
                 ConfigurationResolver.Save(CurrentProfile, Path.Combine(ProfilePath, "profile.json"), ProfileJsonContext.DefaultToUse.Profile);
             }
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightData.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightData.cs
@@ -336,9 +336,10 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
 
             if (data == null)
             {
-                list.Add(new GridHighlightSetupEntry());
+                var newEntry = new GridHighlightSetupEntry();
+                list.Add(newEntry);
                 GridHighlightsConfig.Current.Save();
-                data = new GridHighlightData(list[index]);
+                data = new GridHighlightData(newEntry);
             }
 
             return data;

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightData.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightData.cs
@@ -29,7 +29,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
                 if (allConfigs != null)
                     return allConfigs;
 
-                List<GridHighlightSetupEntry> setup = ProfileManager.CurrentProfile.GridHighlightSetup;
+                List<GridHighlightSetupEntry> setup = GridHighlightsConfig.Current.Highlights;
                 allConfigs = setup.Select(entry => new GridHighlightData(entry)).ToArray();
                 return allConfigs;
             }
@@ -201,13 +201,14 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
 
         public void Delete()
         {
-            ProfileManager.CurrentProfile.GridHighlightSetup.Remove(_entry);
+            GridHighlightsConfig.Current.Highlights.Remove(_entry);
+            GridHighlightsConfig.Current.Save();
             allConfigs = null;
         }
 
         public void Move(bool up)
         {
-            List<GridHighlightSetupEntry> list = ProfileManager.CurrentProfile.GridHighlightSetup;
+            List<GridHighlightSetupEntry> list = GridHighlightsConfig.Current.Highlights;
             int index = list.IndexOf(_entry);
             if (index == -1) return; // Not found
 
@@ -217,6 +218,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
 
             list.RemoveAt(index);
             list.Insert(up ? index - 1 : index + 1, _entry);
+            GridHighlightsConfig.Current.Save();
         }
 
         public static void Unload()
@@ -329,12 +331,13 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
 
         public static GridHighlightData GetGridHighlightData(int index)
         {
-            List<GridHighlightSetupEntry> list = ProfileManager.CurrentProfile.GridHighlightSetup;
+            List<GridHighlightSetupEntry> list = GridHighlightsConfig.Current.Highlights;
             GridHighlightData data = index >= 0 && index < list.Count ? new GridHighlightData(list[index]) : null;
 
             if (data == null)
             {
                 list.Add(new GridHighlightSetupEntry());
+                GridHighlightsConfig.Current.Save();
                 data = new GridHighlightData(list[index]);
             }
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightMigration.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightMigration.cs
@@ -10,6 +10,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
 {
     public class GridHighLightProfile
     {
+#pragma warning disable CS0618 // Populating the obsolete GridHighlightSetup is a one-time migration step toward grid_highlights.json.
         public static void MigrateGridHighlightToSetup(Profile profile)
         {
             profile.GridHighlightSetup.Clear();
@@ -56,5 +57,6 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
             profile.GridHighlight_ExcludeNegatives.Clear();
             profile.GridHighlight_RequiredRarities.Clear();
         }
+#pragma warning restore CS0618
     }
 }

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHightlightMenu.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHightlightMenu.cs
@@ -67,7 +67,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
             toolbar.Widgets.Add(new MyraButton(TazLang.Get("gridhighlight_add"), () =>
             {
                 // Passing the current count appends a fresh entry, then we redraw the list.
-                GridHighlightData.GetGridHighlightData(ProfileManager.CurrentProfile.GridHighlightSetup.Count);
+                GridHighlightData.GetGridHighlightData(GridHighlightsConfig.Current.Highlights.Count);
                 RebuildList();
             }));
 
@@ -88,7 +88,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
         {
             _listPanel.Widgets.Clear();
 
-            int count = ProfileManager.CurrentProfile.GridHighlightSetup.Count;
+            int count = GridHighlightsConfig.Current.Highlights.Count;
             if (count == 0)
             {
                 _listPanel.Widgets.Add(new MyraLabel(TazLang.Get("gridhighlight_settings_desc"), MyraLabel.TextStyle.P));
@@ -168,7 +168,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
 
         private static void ExportGridHighlightSettings(World world)
         {
-            List<GridHighlightSetupEntry> data = ProfileManager.CurrentProfile.GridHighlightSetup;
+            List<GridHighlightSetupEntry> data = GridHighlightsConfig.Current.Highlights;
 
             RunFileDialog(world, true, TazLang.Get("gridhighlight_export_dialog"), file =>
             {
@@ -200,7 +200,8 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
                 List<GridHighlightSetupEntry> imported = JsonSerializer.Deserialize<List<GridHighlightSetupEntry>>(json);
                 if (imported != null)
                 {
-                    ProfileManager.CurrentProfile.GridHighlightSetup.AddRange(imported);
+                    GridHighlightsConfig.Current.Highlights.AddRange(imported);
+                    GridHighlightsConfig.Current.Save();
                     SaveProfile();
 
                     foreach (IGui gump in UIManager.Gumps)


### PR DESCRIPTION
Grid highlight rules were stored inline in profile.json via the Profile.GridHighlightSetup list. This relocates them into a dedicated grid_highlights.json (GridHighlightsConfig), mirroring the existing cooldownbars.json pattern.

Existing highlights are preserved: on first load for a profile without grid_highlights.json, the rules parsed into Profile.GridHighlightSetup (itself migrated from the even older GridHighlight_* parallel lists when needed) are copied into the new file and the in-profile list is cleared. The now-legacy GridHighlightSetup property is marked obsolete and kept only for that one-time migration.

Consumers (GridHighlightData, GridHighlightMenu) now read/write the config, which is saved on rule mutations and alongside the current profile so in-place edits persist on the same cadence as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Grid highlight settings are now stored in a dedicated configuration file for each profile.
  * Existing grid highlight settings are automatically migrated to the new format.
  * Grid highlight imports, exports, additions, deletions, and reordering now use the dedicated configuration.

* **Bug Fixes**
  * Grid highlight changes are saved consistently alongside other profile settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->