### PR TITLE
Fix unvoted polls notification showing after voting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ All notable changes to TazUO will be recorded here.
 * Added a goto location input to the web map (accepts raw map or sextant coordinates) that sets the player's Go-To location - [P.R 708](https://github.com/PlayTazUO/TazUO/pull/708) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
+* Fixed the unvoted Firebase polls login notification showing even after you had already voted, caused by reading the in-memory voted-polls list before its asynchronous settings load had finished; the check now reads the persisted value directly ([bittiez](https://github.com/bittiez))
 * Fixed the nameplate overhead manager gump not resizing to fit all buttons and profile names, and now refreshes its buttons when a profile is renamed in the options window - [P.R 698](https://github.com/PlayTazUO/TazUO/pull/698) ([bittiez](https://github.com/bittiez))
 * Fixed client crash ("pointer being freed was not allocated") when deleting map markers in the marker manager, caused by leaked marker list controls whose graphics textures were freed off the render thread by the GC finalizer - [P.R 678](https://github.com/PlayTazUO/TazUO/pull/678) ([bittiez](https://github.com/bittiez))
 * Auto open doors no longer closes a door that is already open - [P.R 674](https://github.com/PlayTazUO/TazUO/pull/674) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/Game/Managers/FirebasePollsManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/FirebasePollsManager.cs
@@ -184,7 +184,7 @@ public static class FirebasePollsManager
         if (polls == null || polls.Count == 0)
             return null;
 
-        int unvoted = CountUnvoted(polls);
+        int unvoted = await CountUnvotedAsync(polls);
 
         if (unvoted <= 0)
             return null;
@@ -198,13 +198,10 @@ public static class FirebasePollsManager
                 unvoted);
     }
 
-    /// <summary>Counts how many of the given polls the current profile has not yet voted on.</summary>
-    private static int CountUnvoted(Dictionary<string, Poll> polls)
+    /// <summary>Counts how many of the given polls the user has not yet voted on.</summary>
+    private static async Task<int> CountUnvotedAsync(Dictionary<string, Poll> polls)
     {
-        Profile profile = ProfileManager.CurrentProfile;
-
-        var voted = new HashSet<string>((profile?.VotedPolls ?? string.Empty)
-            .Split(';', StringSplitOptions.RemoveEmptyEntries));
+        HashSet<string> voted = await GetVotedPollIdsAsync();
 
         int count = 0;
         foreach (string pollId in polls.Keys)
@@ -214,6 +211,30 @@ public static class FirebasePollsManager
         }
 
         return count;
+    }
+
+    /// <summary>
+    /// Returns the set of poll ids the user has already voted on, read straight from the settings store.
+    ///
+    /// This deliberately does not use the in-memory <see cref="Profile.VotedPolls"/> property: that value is
+    /// populated by an asynchronous, fire-and-forget load of the Global SQL settings kicked off when the
+    /// profile loads (see <see cref="Profile.AfterLoad"/>). Because the profile is loaded as the player is
+    /// created — essentially at the same moment the poll notification is computed on entering the world — that
+    /// load may not have completed yet, leaving <see cref="Profile.VotedPolls"/> empty and making already-voted
+    /// polls look unvoted. Reading the persisted value directly avoids that race. Falls back to the in-memory
+    /// property only if the settings store is unavailable.
+    /// </summary>
+    private static async Task<HashSet<string>> GetVotedPollIdsAsync()
+    {
+        string voted;
+
+        if (Client.Settings != null)
+            voted = await Client.Settings.GetAsync(SettingsScope.Global, Constants.SqlSettings.VOTED_POLLS, string.Empty);
+        else
+            voted = ProfileManager.CurrentProfile?.VotedPolls ?? string.Empty;
+
+        return new HashSet<string>((voted ?? string.Empty)
+            .Split(';', StringSplitOptions.RemoveEmptyEntries));
     }
 
     /// <summary>


### PR DESCRIPTION
The login "you have unvoted polls" notification read Profile.VotedPolls, which is populated by an asynchronous fire-and-forget load of the Global SQL settings kicked off in Profile.AfterLoad. Since the profile loads as the player is created (essentially when the notification is computed on entering the world), that load often had not completed yet, leaving VotedPolls empty and making already-voted polls count as unvoted.

Read the persisted voted-polls list directly from the settings store when computing the notification so it no longer depends on the in-memory property being loaded in time.