### PR TITLE
Fix modern buff bar saving position slightly too high on logout

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/ImprovedBuffGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ImprovedBuffGump.cs
@@ -169,7 +169,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             writer.WriteAttributeString("type", ((int)GumpType).ToString());
             writer.WriteAttributeString("x", X.ToString());
-            writer.WriteAttributeString("y", (_direction ? Y : Bounds.Bottom - _background.Height - 7).ToString());
+            writer.WriteAttributeString("y", (_direction ? Y : Bounds.Bottom - PADDING_HANDLE).ToString());
             writer.WriteAttributeString("serial", LocalSerial.ToString());
             writer.WriteAttributeString("serverSerial", ServerSerial.ToString());
             writer.WriteAttributeString("isLocked", IsLocked.ToString());

--- a/src/ClassicUO.Client/Game/UI/Gumps/ImprovedBuffGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ImprovedBuffGump.cs
@@ -28,6 +28,11 @@ namespace ClassicUO.Game.UI.Gumps
             CanMove = true;
             CanCloseWithRightClick = true;
             AcceptMouseInput = false;
+            // This gump manages its own Width/Height in UpdateSize(). Leaving the base
+            // auto-size on would let the child graphics (toggle button/background) grow the
+            // empty-bar height past PADDING_HANDLE, which shifts the saved bottom anchor and
+            // makes the bar creep up/down a few pixels each logout.
+            WantUpdateSize = false;
 
             BuildGump();
         }


### PR DESCRIPTION
When the modern buff bar grows upward (buffs added on top of the handle), the bottom edge is the fixed anchor: as buffs are added, Y moves up so the handle stays put. On restore the bar starts empty (Height = PADDING_HANDLE) and the loader assigns the saved Y directly, anchoring the bottom at savedY + PADDING_HANDLE.

The save path stored Bounds.Bottom - _background.Height - 7, which only matches that restore anchor if the handle graphic were 6px tall. Graphic 2091 is taller, so the saved Y was a few pixels too small and the bar crept upward each logout. Save Bounds.Bottom - PADDING_HANDLE so the bottom edge round-trips exactly.