### PR TITLE
Fix ThreadInterruptedException crash when stopping an errored Python script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to TazUO will be recorded here.
 ## In Development
 
 ### Fixes
+* Fixed a crash when a Legion Python script was stopped at the exact moment it was displaying an error, caused by a thread interrupt surfacing while IronPython formatted the exception - [P.R 748](https://github.com/PlayTazUO/TazUO/pull/748) ([bittiez](https://github.com/bittiez))
 * Fixed a crash when exporting grid highlight settings to an invalid or inaccessible file path; the client now shows an error message instead - [P.R 747](https://github.com/PlayTazUO/TazUO/pull/747) ([bittiez](https://github.com/bittiez))
 
 ## V5.4.0

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.4.3</AssemblyVersion>
-    <FileVersion>5.4.3</FileVersion>
+    <AssemblyVersion>5.4.4</AssemblyVersion>
+    <FileVersion>5.4.4</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
@@ -482,7 +482,16 @@ namespace ClassicUO.LegionScripting
             catch (OperationCanceledException) { }
             catch (Exception e)
             {
-                ShowScriptError(script, e);
+                try
+                {
+                    ShowScriptError(script, e);
+                }
+                // Formatting the error runs IronPython dynamic code that takes internal locks.
+                // If the script is stopped at that exact moment (StopScript -> Thread.Interrupt),
+                // the interrupt surfaces here as a ThreadInterruptedException/ThreadAbortException.
+                // Swallow it so tearing down an already-errored script never crashes the client.
+                catch (ThreadInterruptedException) { }
+                catch (ThreadAbortException) { }
             }
 
             MainThreadQueue.EnqueueAction(() => { StopScript(script); });


### PR DESCRIPTION
When a Legion Python script throws, ExecutePythonScript's general catch calls ShowScriptError, which formats the exception via IronPython. That runs dynamic Python code that acquires internal Monitor locks. If the script is stopped at that instant (StopScript -> ScriptThread.Interrupt), the interrupt surfaces as a ThreadInterruptedException inside the lock acquisition, escapes the catch block, and crashes the client as an unhandled exception on the script thread.

Guard the ShowScriptError call so a ThreadInterruptedException/ ThreadAbortException raised while formatting the error is swallowed, matching how the surrounding execution path already handles interrupts.


Original Crash:
```
Exception:
System.Threading.ThreadInterruptedException: Thread was interrupted from a waiting state.
   at System.Threading.Monitor.Enter_Slowpath(Object obj)
   at System.Threading.Monitor.Enter(Object obj, Boolean& lockTaken)
   at IronPython.Runtime.Binding.MetaPythonType.FastGetBinderHelper.GetBinding()
   at IronPython.Runtime.Types.PythonType.IronPython.Runtime.Binding.IFastGettable.MakeGetBinding[T](CallSite`1 site, PythonGetMemberBinder binder, CodeContext context, String name)
   at IronPython.Runtime.Binding.PythonGetMemberBinder.BindDelegate[T](CallSite`1 site, Object[] args)
   at System.Runtime.CompilerServices.CallSiteBinder.BindCore[T](CallSite`1 site, Object[] args)
   at System.Dynamic.UpdateDelegates.UpdateAndExecute2[T0,T1,TRet](CallSite site, T0 arg0, T1 arg1)
   at IronPython.Runtime.Types.PythonType.TryGetBoundAttr(CodeContext context, Object o, String name, Object& ret)
   at IronPython.Runtime.Operations.PythonOps.TryGetBoundAttr(CodeContext context, Object o, String name, Object& ret)
   at IronPython.Runtime.Operations.PythonOps.TryGetBoundAttr(Object o, String name, Object& ret)
   at IronPython.Runtime.PythonContext.GetPythonExceptionClassName(Object pythonException)
   at IronPython.Runtime.PythonContext.FormatPythonException(Object pythonException)
   at IronPython.Runtime.PythonContext.FormatException(Exception exception)
   at Microsoft.Scripting.Hosting.ExceptionOperations.FormatException(Exception exception)
   at ClassicUO.LegionScripting.LegionScripting.ShowScriptError(ScriptFile script, Exception e) in D:\a\TazUO\TazUO\src\ClassicUO.Client\LegionScripting\LegionScripting.cs:line 541
   at ClassicUO.LegionScripting.LegionScripting.ExecutePythonScript(ScriptFile script) in D:\a\TazUO\TazUO\src\ClassicUO.Client\LegionScripting\LegionScripting.cs:line 485
   at ClassicUO.LegionScripting.LegionScripting.<>c__DisplayClass36_0.<PlayScript>b__1() in D:\a\TazUO\TazUO\src\ClassicUO.Client\LegionScripting\LegionScripting.cs:line 458
   at System.Threading.Thread.StartHelper.Callback(Object state)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
```