### PR TITLE
Fix ArgumentNullException in TrueTypeLoader.GetFont on null font name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to TazUO will be recorded here.
 * Added an option to draw overheads (names, health bars, overhead text) at a constant size regardless of the camera zoom - [P.R 730](https://github.com/PlayTazUO/TazUO/pull/730) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
+* Fixed an ArgumentNullException crash in TrueTypeLoader.GetFont when called with a null or empty font name; it now falls back to the default embedded font - [P.R 750](https://github.com/PlayTazUO/TazUO/pull/750) ([bittiez](https://github.com/bittiez))
 * Fixed a startup crash (IndexOutOfRangeException) in the animations loader when AnimationSequence.uop contained an out-of-range animation group index - [P.R 749](https://github.com/PlayTazUO/TazUO/pull/749) ([bittiez](https://github.com/bittiez))
 * Fixed a crash when a Legion Python script was stopped at the exact moment it was displaying an error, caused by a thread interrupt surfacing while IronPython formatted the exception - [P.R 748](https://github.com/PlayTazUO/TazUO/pull/748) ([bittiez](https://github.com/bittiez))
 * Fixed a crash when exporting grid highlight settings to an invalid or inaccessible file path; the client now shows an error message instead - [P.R 747](https://github.com/PlayTazUO/TazUO/pull/747) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Assets/TrueTypeLoader.cs
+++ b/src/ClassicUO.Assets/TrueTypeLoader.cs
@@ -422,21 +422,26 @@ public class TrueTypeLoader
     /// </returns>
     public SpriteFontBase GetFont(string name, float size)
     {
-        // Try standard fonts first
-        if (_fonts.TryGetValue(name, out FontSystem font))
-            return font.GetFont(size);
-
-        // If the font isn't present in the loaded ones but is available on the system, try to load it
-        if (_availableSystemFontFamilyNames.Contains(name))
+        // A null or empty name can't be looked up (Dictionary.TryGetValue throws on a null key),
+        // so skip straight to the fallback font below.
+        if (!string.IsNullOrEmpty(name))
         {
-            if (TryGetSystemFont(name, size, out SpriteFontBase sysFont))
-                return sysFont;
+            // Try standard fonts first
+            if (_fonts.TryGetValue(name, out FontSystem font))
+                return font.GetFont(size);
 
-            // This is to prevent repeated disk hits if a font is botched or otherwise unusable.
-            // We can also note in cache that this font family is problematic, but if we've gotten here,
-            // it means the initial cache population run concluded that this font is valid.
-            Log.Warn($"Could not load system font '{name}'. Family will be ignored");
-            _availableSystemFontFamilyNames.Remove(name);
+            // If the font isn't present in the loaded ones but is available on the system, try to load it
+            if (_availableSystemFontFamilyNames.Contains(name))
+            {
+                if (TryGetSystemFont(name, size, out SpriteFontBase sysFont))
+                    return sysFont;
+
+                // This is to prevent repeated disk hits if a font is botched or otherwise unusable.
+                // We can also note in cache that this font family is problematic, but if we've gotten here,
+                // it means the initial cache population run concluded that this font is valid.
+                Log.Warn($"Could not load system font '{name}'. Family will be ignored");
+                _availableSystemFontFamilyNames.Remove(name);
+            }
         }
 
         // Use the default embedded font as a fallback

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.4.6</AssemblyVersion>
-    <FileVersion>5.4.6</FileVersion>
+    <AssemblyVersion>5.4.7</AssemblyVersion>
+    <FileVersion>5.4.7</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
Dictionary.TryGetValue throws ArgumentNullException when passed a null key. When GetFont was called with a null (or empty) font name it crashed instead of falling back to the embedded Roboto font. Guard the lookups so a null/empty name skips straight to the fallback.