### PR TITLE
Add gump position manager window with permanent SQL-backed positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to TazUO will be recorded here.
 ## In Development
 
 ### Features
+* Added a Gump Position Manager (More > Tools > Gump Positions) to permanently save server gump positions in a database, with per-gump save/center/identify actions, a "save all gumps automatically" option, and a list of saved positions to delete - [P.R 752](https://github.com/PlayTazUO/TazUO/pull/752) ([bittiez](https://github.com/bittiez))
 * Added an option to strip the leading "<id>" prefix from chat usernames (e.g. "<36475858>username" -> "username") - [P.R 751](https://github.com/PlayTazUO/TazUO/pull/751) ([bittiez](https://github.com/bittiez))
 * Added an option to draw overheads (names, health bars, overhead text) at a constant size regardless of the camera zoom - [P.R 730](https://github.com/PlayTazUO/TazUO/pull/730) ([bittiez](https://github.com/bittiez))
 

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.4.9</AssemblyVersion>
-    <FileVersion>5.4.9</FileVersion>
+    <AssemblyVersion>5.4.10</AssemblyVersion>
+    <FileVersion>5.4.10</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -1174,6 +1174,10 @@ namespace ClassicUO.Configuration
             var gumps = new List<Gump>();
             List<(Gump gump, GumpType type, int x, int y, uint serial, uint parent, XmlElement xml)> nestedGumps = new();
 
+            // Seed the in-memory gump position cache from the permanent (database-backed) positions so
+            // pinned gumps reopen at their saved location. Seeded before the XML gumps are restored below.
+            UIManager.LoadPersistentPositions();
+
             // load skillsgroup
             world.SkillsGroupManager.Load();
 

--- a/src/ClassicUO.Client/Configuration/SqlProfile.cs
+++ b/src/ClassicUO.Client/Configuration/SqlProfile.cs
@@ -176,4 +176,10 @@ public sealed partial class Profile
         [JsonIgnore]
         [SqlSetting(SettingsScope.Global, "strip_chat_username_id", false)]
         public partial bool StripChatUsernameId { get; set; }
+
+        // When true, every server gump's position is permanently saved automatically (see the Gump
+        // Position Manager). The backing database is global, so this setting is global too.
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, "auto_save_gump_positions", false)]
+        public partial bool AutoSaveGumpPositions { get; set; }
 }

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -5,7 +5,7 @@
 ; Missing keys are auto-appended with English defaults when
 ; this file's version is newer than the user's copy.
 ; -------------------------------------------------------
-_version=62
+_version=63
 accountname=Account Name
 accountcontextmenutooltip=Right click to select another account.
 music=Music
@@ -805,6 +805,7 @@ topbargump_tools=Tools
 topbargump_spellquickcast=Spell quick cast
 topbargump_openboatcontrol=Open boat control
 topbargump_nearbyloot=Nearby loot
+topbargump_gumppositions=Gump Positions
 topbargump_retrievegumps=Retrieve gumps
 topbargump_developer=Developer
 topbargump_tinkerer=Tinkerer

--- a/src/ClassicUO.Client/Game/Managers/CommandManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/CommandManager.cs
@@ -249,6 +249,8 @@ namespace ClassicUO.Game.Managers
                 Task.Run(() => SpellDefinition.SaveAllSpellsToJson(_world));
             });
 
+            Register("gumppositions", (s) => Game.UI.MyraWindows.GumpPositionManagerWindow.Show());
+
             Register("setinscreen", (s) =>
             {
                 for (LinkedListNode<IGui> last = UIManager.Gumps.Last; last != null; last = last.Previous)

--- a/src/ClassicUO.Client/Game/Managers/GumpPositionSQLManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/GumpPositionSQLManager.cs
@@ -55,8 +55,10 @@ namespace ClassicUO.Game.Managers
             public int X { get; set; }
             public int Y { get; set; }
 
-            /// <summary>When this position was last saved/seen, as Unix time in seconds.</summary>
-            public long LastSeen { get; set; }
+            // Dapper.Contrib maps a property straight onto a column of the same name (there is no
+            // column-rename attribute in 2.0.78), so this property is named to match the "last_seen"
+            // column exactly. When this position was last saved/seen, as Unix time in seconds.
+            public long last_seen { get; set; }
         }
 
         private const string DB_FILE = "gump_positions.db";
@@ -111,13 +113,13 @@ namespace ClassicUO.Game.Managers
 
                 foreach (GumpPositionRecord row in rows)
                 {
-                    if (row.LastSeen == 0)
+                    if (row.last_seen == 0)
                     {
                         // Row predates the last_seen column; treat it as just seen rather than ancient.
-                        row.LastSeen = now;
+                        row.last_seen = now;
                         await connection.UpdateAsync(row).ConfigureAwait(false);
                     }
-                    else if (row.LastSeen < cutoff)
+                    else if (row.last_seen < cutoff)
                     {
                         await connection.DeleteAsync(row).ConfigureAwait(false);
                     }
@@ -135,7 +137,7 @@ namespace ClassicUO.Game.Managers
             {
                 await WithConnectionAsync(async connection =>
                 {
-                    GumpPositionRecord record = new() { Serial = serial, Name = name ?? string.Empty, X = x, Y = y, LastSeen = NowUnix() };
+                    GumpPositionRecord record = new() { Serial = serial, Name = name ?? string.Empty, X = x, Y = y, last_seen = NowUnix() };
                     GumpPositionRecord existing = await connection.GetAsync<GumpPositionRecord>((long)serial).ConfigureAwait(false);
 
                     if (existing == null)
@@ -167,7 +169,7 @@ namespace ClassicUO.Game.Managers
 
                     existing.X = x;
                     existing.Y = y;
-                    existing.LastSeen = NowUnix();
+                    existing.last_seen = NowUnix();
                     await connection.UpdateAsync(existing).ConfigureAwait(false);
                 }).ConfigureAwait(false);
             }

--- a/src/ClassicUO.Client/Game/Managers/GumpPositionSQLManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/GumpPositionSQLManager.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using ClassicUO.Utility.Logging;
+using Dapper;
+
+namespace ClassicUO.Game.Managers
+{
+    /// <summary>
+    /// A single permanently-saved gump position: the gump's cache key (server serial / item serial),
+    /// a human friendly name for display, and the on-screen location it should reopen at.
+    /// </summary>
+    public readonly struct SavedGumpPosition
+    {
+        public SavedGumpPosition(uint serial, string name, int x, int y)
+        {
+            Serial = serial;
+            Name = name;
+            X = x;
+            Y = y;
+        }
+
+        public uint Serial { get; }
+        public string Name { get; }
+        public int X { get; }
+        public int Y { get; }
+    }
+
+    /// <summary>
+    /// Backing SQLite store for the permanent gump-position feature. Mirrors the in-memory
+    /// <see cref="UIManager"/> gump position cache for the subset of gumps the user has chosen to pin,
+    /// so those gumps reopen at their pinned location across restarts. The database lives alongside the
+    /// other managers in the shared <c>{ExecutablePath}/Data</c> directory.
+    /// </summary>
+    public class GumpPositionSQLManager : SqliteDatabase
+    {
+        public static GumpPositionSQLManager Instance
+        {
+            get
+            {
+                if (field == null)
+                    field = new();
+                return field;
+            }
+            private set => field = value;
+        }
+
+        private const string DB_FILE = "gump_positions.db";
+
+        private static readonly SqliteTableSchema PositionsSchema = new("gump_positions",
+            SqliteColumn.Int("serial", primaryKey: true),
+            SqliteColumn.Str("name"),
+            SqliteColumn.Int("x", notNull: true, def: "0"),
+            SqliteColumn.Int("y", notNull: true, def: "0"));
+
+        public GumpPositionSQLManager() : base(DB_FILE)
+        {
+            InitializeAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+        }
+
+        private async Task InitializeAsync()
+        {
+            try
+            {
+                await EnsureTableAsync(PositionsSchema).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Log.Error($@"Error initializing GumpPositionSQLManager: {ex.Message}");
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Inserts or updates a pinned gump position. Existing rows keep their key and are overwritten
+        /// with the supplied name and coordinates.
+        /// </summary>
+        public async Task SaveAsync(uint serial, string name, int x, int y)
+        {
+            try
+            {
+                await WithConnectionAsync(connection => connection.ExecuteAsync(
+                    """
+                    INSERT INTO gump_positions (serial, name, x, y)
+                    VALUES (@Serial, @Name, @X, @Y)
+                    ON CONFLICT(serial) DO UPDATE SET name = excluded.name, x = excluded.x, y = excluded.y
+                    """,
+                    new { Serial = (long)serial, Name = name ?? string.Empty, X = x, Y = y })).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Log.Error($@"Error saving gump position {serial}: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Updates only the coordinates of an already-pinned gump (used when the user drags/moves a
+        /// gump whose position is being tracked). Does nothing if the serial is not already stored.
+        /// </summary>
+        public async Task UpdatePositionAsync(uint serial, int x, int y)
+        {
+            try
+            {
+                await WithConnectionAsync(connection => connection.ExecuteAsync(
+                    "UPDATE gump_positions SET x = @X, y = @Y WHERE serial = @Serial",
+                    new { Serial = (long)serial, X = x, Y = y })).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Log.Error($@"Error updating gump position {serial}: {ex.Message}");
+            }
+        }
+
+        /// <summary>Removes a pinned gump position by serial.</summary>
+        public async Task RemoveAsync(uint serial)
+        {
+            try
+            {
+                await WithConnectionAsync(connection => connection.ExecuteAsync(
+                    "DELETE FROM gump_positions WHERE serial = @Serial",
+                    new { Serial = (long)serial })).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Log.Error($@"Error removing gump position {serial}: {ex.Message}");
+            }
+        }
+
+        /// <summary>Retrieves every pinned gump position.</summary>
+        public async Task<List<SavedGumpPosition>> GetAllAsync()
+        {
+            try
+            {
+                return await WithConnectionAsync(async connection =>
+                {
+                    IEnumerable<PositionRow> rows = await connection.QueryAsync<PositionRow>(
+                        "SELECT serial AS Serial, name AS Name, x AS X, y AS Y FROM gump_positions").ConfigureAwait(false);
+
+                    return rows.Select(r => new SavedGumpPosition((uint)r.Serial, r.Name, r.X, r.Y)).ToList();
+                }).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Log.Error($@"Error getting all gump positions: {ex.Message}");
+                return new List<SavedGumpPosition>();
+            }
+        }
+
+        /// <summary>
+        /// Synchronous convenience wrapper around <see cref="GetAllAsync"/> for the one-time startup
+        /// seed of the in-memory cache, mirroring the blocking pattern used by the other SQLite managers.
+        /// </summary>
+        public List<SavedGumpPosition> GetAll() =>
+            GetAllAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+
+        public override void Dispose()
+        {
+            base.Dispose();
+
+            if (ReferenceEquals(Instance, this))
+                Instance = null;
+        }
+
+        // Dapper materialization target; the public API exposes the immutable SavedGumpPosition instead.
+        private sealed class PositionRow
+        {
+            public long Serial { get; set; }
+            public string Name { get; set; }
+            public int X { get; set; }
+            public int Y { get; set; }
+        }
+    }
+}

--- a/src/ClassicUO.Client/Game/Managers/GumpPositionSQLManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/GumpPositionSQLManager.cs
@@ -54,20 +54,29 @@ namespace ClassicUO.Game.Managers
             public string Name { get; set; }
             public int X { get; set; }
             public int Y { get; set; }
+
+            /// <summary>When this position was last saved/seen, as Unix time in seconds.</summary>
+            public long LastSeen { get; set; }
         }
 
         private const string DB_FILE = "gump_positions.db";
+
+        // Pinned positions untouched for this long are purged on startup.
+        private const long RETENTION_SECONDS = 120L * 24 * 60 * 60;
 
         private static readonly SqliteTableSchema PositionsSchema = new("gump_positions",
             SqliteColumn.Int("serial", primaryKey: true),
             SqliteColumn.Str("name"),
             SqliteColumn.Int("x", notNull: true, def: "0"),
-            SqliteColumn.Int("y", notNull: true, def: "0"));
+            SqliteColumn.Int("y", notNull: true, def: "0"),
+            SqliteColumn.Int("last_seen", notNull: true, def: "0"));
 
         public GumpPositionSQLManager() : base(DB_FILE)
         {
             InitializeAsync().ConfigureAwait(false).GetAwaiter().GetResult();
         }
+
+        private static long NowUnix() => DateTimeOffset.UtcNow.ToUnixTimeSeconds();
 
         // Table creation/migration goes through the base class's schema reconciliation; row-level CRUD
         // below goes through Dapper.Contrib's typed helpers (Get/GetAll/Insert/Update/Delete) instead of
@@ -77,12 +86,43 @@ namespace ClassicUO.Game.Managers
             try
             {
                 await EnsureTableAsync(PositionsSchema).ConfigureAwait(false);
+                await BackfillAndPurgeAsync().ConfigureAwait(false);
             }
             catch (Exception ex)
             {
                 Log.Error($@"Error initializing GumpPositionSQLManager: {ex.Message}");
                 throw;
             }
+        }
+
+        /// <summary>
+        /// One-time housekeeping run at startup: stamps a "last seen" on rows migrated from the old
+        /// schema (so an upgrade doesn't instantly purge them) and deletes any pinned position that has
+        /// not been seen within the retention window.
+        /// </summary>
+        private Task BackfillAndPurgeAsync()
+        {
+            long now = NowUnix();
+            long cutoff = now - RETENTION_SECONDS;
+
+            return WithConnectionAsync(async connection =>
+            {
+                List<GumpPositionRecord> rows = (await connection.GetAllAsync<GumpPositionRecord>().ConfigureAwait(false)).ToList();
+
+                foreach (GumpPositionRecord row in rows)
+                {
+                    if (row.LastSeen == 0)
+                    {
+                        // Row predates the last_seen column; treat it as just seen rather than ancient.
+                        row.LastSeen = now;
+                        await connection.UpdateAsync(row).ConfigureAwait(false);
+                    }
+                    else if (row.LastSeen < cutoff)
+                    {
+                        await connection.DeleteAsync(row).ConfigureAwait(false);
+                    }
+                }
+            });
         }
 
         /// <summary>
@@ -95,7 +135,7 @@ namespace ClassicUO.Game.Managers
             {
                 await WithConnectionAsync(async connection =>
                 {
-                    GumpPositionRecord record = new() { Serial = serial, Name = name ?? string.Empty, X = x, Y = y };
+                    GumpPositionRecord record = new() { Serial = serial, Name = name ?? string.Empty, X = x, Y = y, LastSeen = NowUnix() };
                     GumpPositionRecord existing = await connection.GetAsync<GumpPositionRecord>((long)serial).ConfigureAwait(false);
 
                     if (existing == null)
@@ -127,6 +167,7 @@ namespace ClassicUO.Game.Managers
 
                     existing.X = x;
                     existing.Y = y;
+                    existing.LastSeen = NowUnix();
                     await connection.UpdateAsync(existing).ConfigureAwait(false);
                 }).ConfigureAwait(false);
             }

--- a/src/ClassicUO.Client/Game/Managers/GumpPositionSQLManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/GumpPositionSQLManager.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using ClassicUO.Utility.Logging;
-using Dapper;
+using Dapper.Contrib.Extensions;
 
 namespace ClassicUO.Game.Managers
 {
@@ -46,6 +46,16 @@ namespace ClassicUO.Game.Managers
             private set => field = value;
         }
 
+        [Table("gump_positions")]
+        private sealed class GumpPositionRecord
+        {
+            [ExplicitKey]
+            public long Serial { get; set; }
+            public string Name { get; set; }
+            public int X { get; set; }
+            public int Y { get; set; }
+        }
+
         private const string DB_FILE = "gump_positions.db";
 
         private static readonly SqliteTableSchema PositionsSchema = new("gump_positions",
@@ -59,6 +69,9 @@ namespace ClassicUO.Game.Managers
             InitializeAsync().ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
+        // Table creation/migration goes through the base class's schema reconciliation; row-level CRUD
+        // below goes through Dapper.Contrib's typed helpers (Get/GetAll/Insert/Update/Delete) instead of
+        // hand-written SQL, matching the FriendliesSQLManager conventions.
         private async Task InitializeAsync()
         {
             try
@@ -80,13 +93,16 @@ namespace ClassicUO.Game.Managers
         {
             try
             {
-                await WithConnectionAsync(connection => connection.ExecuteAsync(
-                    """
-                    INSERT INTO gump_positions (serial, name, x, y)
-                    VALUES (@Serial, @Name, @X, @Y)
-                    ON CONFLICT(serial) DO UPDATE SET name = excluded.name, x = excluded.x, y = excluded.y
-                    """,
-                    new { Serial = (long)serial, Name = name ?? string.Empty, X = x, Y = y })).ConfigureAwait(false);
+                await WithConnectionAsync(async connection =>
+                {
+                    GumpPositionRecord record = new() { Serial = serial, Name = name ?? string.Empty, X = x, Y = y };
+                    GumpPositionRecord existing = await connection.GetAsync<GumpPositionRecord>((long)serial).ConfigureAwait(false);
+
+                    if (existing == null)
+                        await connection.InsertAsync(record).ConfigureAwait(false);
+                    else
+                        await connection.UpdateAsync(record).ConfigureAwait(false);
+                }).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -102,9 +118,17 @@ namespace ClassicUO.Game.Managers
         {
             try
             {
-                await WithConnectionAsync(connection => connection.ExecuteAsync(
-                    "UPDATE gump_positions SET x = @X, y = @Y WHERE serial = @Serial",
-                    new { Serial = (long)serial, X = x, Y = y })).ConfigureAwait(false);
+                await WithConnectionAsync(async connection =>
+                {
+                    GumpPositionRecord existing = await connection.GetAsync<GumpPositionRecord>((long)serial).ConfigureAwait(false);
+
+                    if (existing == null)
+                        return;
+
+                    existing.X = x;
+                    existing.Y = y;
+                    await connection.UpdateAsync(existing).ConfigureAwait(false);
+                }).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -117,9 +141,8 @@ namespace ClassicUO.Game.Managers
         {
             try
             {
-                await WithConnectionAsync(connection => connection.ExecuteAsync(
-                    "DELETE FROM gump_positions WHERE serial = @Serial",
-                    new { Serial = (long)serial })).ConfigureAwait(false);
+                await WithConnectionAsync(connection =>
+                    connection.DeleteAsync(new GumpPositionRecord { Serial = serial })).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -134,9 +157,7 @@ namespace ClassicUO.Game.Managers
             {
                 return await WithConnectionAsync(async connection =>
                 {
-                    IEnumerable<PositionRow> rows = await connection.QueryAsync<PositionRow>(
-                        "SELECT serial AS Serial, name AS Name, x AS X, y AS Y FROM gump_positions").ConfigureAwait(false);
-
+                    IEnumerable<GumpPositionRecord> rows = await connection.GetAllAsync<GumpPositionRecord>().ConfigureAwait(false);
                     return rows.Select(r => new SavedGumpPosition((uint)r.Serial, r.Name, r.X, r.Y)).ToList();
                 }).ConfigureAwait(false);
             }
@@ -160,15 +181,6 @@ namespace ClassicUO.Game.Managers
 
             if (ReferenceEquals(Instance, this))
                 Instance = null;
-        }
-
-        // Dapper materialization target; the public API exposes the immutable SavedGumpPosition instead.
-        private sealed class PositionRow
-        {
-            public long Serial { get; set; }
-            public string Name { get; set; }
-            public int X { get; set; }
-            public int Y { get; set; }
         }
     }
 }

--- a/src/ClassicUO.Client/Game/Managers/GumpPositionSQLManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/GumpPositionSQLManager.cs
@@ -88,7 +88,7 @@ namespace ClassicUO.Game.Managers
             try
             {
                 await EnsureTableAsync(PositionsSchema).ConfigureAwait(false);
-                await BackfillAndPurgeAsync().ConfigureAwait(false);
+                await PurgeStaleAsync().ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -98,14 +98,12 @@ namespace ClassicUO.Game.Managers
         }
 
         /// <summary>
-        /// One-time housekeeping run at startup: stamps a "last seen" on rows migrated from the old
-        /// schema (so an upgrade doesn't instantly purge them) and deletes any pinned position that has
-        /// not been seen within the retention window.
+        /// Startup housekeeping: deletes any pinned position that has not been seen within the retention
+        /// window (120 days).
         /// </summary>
-        private Task BackfillAndPurgeAsync()
+        private Task PurgeStaleAsync()
         {
-            long now = NowUnix();
-            long cutoff = now - RETENTION_SECONDS;
+            long cutoff = NowUnix() - RETENTION_SECONDS;
 
             return WithConnectionAsync(async connection =>
             {
@@ -113,16 +111,8 @@ namespace ClassicUO.Game.Managers
 
                 foreach (GumpPositionRecord row in rows)
                 {
-                    if (row.last_seen == 0)
-                    {
-                        // Row predates the last_seen column; treat it as just seen rather than ancient.
-                        row.last_seen = now;
-                        await connection.UpdateAsync(row).ConfigureAwait(false);
-                    }
-                    else if (row.last_seen < cutoff)
-                    {
+                    if (row.last_seen < cutoff)
                         await connection.DeleteAsync(row).ConfigureAwait(false);
-                    }
                 }
             });
         }

--- a/src/ClassicUO.Client/Game/Managers/UIManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/UIManager.cs
@@ -311,19 +311,30 @@ namespace ClassicUO.Game.Managers
 
             // Keep the on-disk copy in sync whenever a pinned gump is moved, so its permanent
             // position always reflects where the user last left it.
-            if (_persistentPositionSerials.Contains(serverSerial))
+            if (_persistentPositionSerials.ContainsKey(serverSerial))
                 _ = GumpPositionSQLManager.Instance.UpdatePositionAsync(serverSerial, point.X, point.Y);
         }
 
-        public static bool RemovePosition(uint serverSerial) => _gumpPositionCache.Remove(serverSerial, out _);
+        public static bool RemovePosition(uint serverSerial)
+        {
+            // A permanently pinned position must survive transient "forget this position" requests
+            // (e.g. a non-movable server gump closing). Removing the cache entry here would let the next
+            // open re-seed it with the server default and overwrite the saved position in the database.
+            if (_persistentPositionSerials.ContainsKey(serverSerial))
+                return false;
+
+            return _gumpPositionCache.Remove(serverSerial, out _);
+        }
 
         public static bool GetGumpCachePosition(uint id, out Point pos) => _gumpPositionCache.TryGetValue(id, out pos);
 
         #region Persistent gump positions
 
-        // Serials whose positions are permanently saved to the GumpPositionSQLManager database and are
-        // reloaded into the in-memory position cache on startup.
-        private static readonly HashSet<uint> _persistentPositionSerials = new();
+        // Serials whose positions are permanently saved to the GumpPositionSQLManager database, mapped to
+        // their friendly display name. This is the authoritative in-memory view of the saved set (kept in
+        // sync on every change) so the manager UI never has to block on the database to render its list.
+        // Seeded from the database on startup.
+        private static readonly Dictionary<uint, string> _persistentPositionSerials = new();
 
         /// <summary>
         /// Seeds the in-memory gump position cache from the permanent database. Idempotent - safe to call
@@ -336,7 +347,7 @@ namespace ClassicUO.Game.Managers
             {
                 foreach (SavedGumpPosition saved in GumpPositionSQLManager.Instance.GetAll())
                 {
-                    _persistentPositionSerials.Add(saved.Serial);
+                    _persistentPositionSerials[saved.Serial] = saved.Name;
                     _gumpPositionCache[saved.Serial] = new Point(saved.X, saved.Y);
                 }
             }
@@ -347,7 +358,24 @@ namespace ClassicUO.Game.Managers
         }
 
         /// <summary>Whether the given gump serial currently has a permanently saved position.</summary>
-        public static bool IsPositionPersistent(uint serial) => _persistentPositionSerials.Contains(serial);
+        public static bool IsPositionPersistent(uint serial) => _persistentPositionSerials.ContainsKey(serial);
+
+        /// <summary>
+        /// Snapshot of every permanently saved position, built from in-memory state (name + current cached
+        /// location) so callers get an immediately consistent view without a blocking database read.
+        /// </summary>
+        public static List<SavedGumpPosition> GetPersistentPositions()
+        {
+            var list = new List<SavedGumpPosition>(_persistentPositionSerials.Count);
+
+            foreach ((uint serial, string name) in _persistentPositionSerials)
+            {
+                Point point = _gumpPositionCache.TryGetValue(serial, out Point p) ? p : Point.Zero;
+                list.Add(new SavedGumpPosition(serial, name, point.X, point.Y));
+            }
+
+            return list;
+        }
 
         /// <summary>A friendly display name for a gump used when persisting its position.</summary>
         public static string GetGumpDisplayName(Gump gump) =>
@@ -365,7 +393,7 @@ namespace ClassicUO.Game.Managers
             if (ProfileManager.CurrentProfile?.AutoSaveGumpPositions != true)
                 return;
 
-            if (_persistentPositionSerials.Contains(gump.ServerSerial))
+            if (_persistentPositionSerials.ContainsKey(gump.ServerSerial))
                 return;
 
             SetPositionPersistent(gump.ServerSerial, GetGumpDisplayName(gump), gump.Location);
@@ -380,7 +408,7 @@ namespace ClassicUO.Game.Managers
             if (serial == 0)
                 return;
 
-            _persistentPositionSerials.Add(serial);
+            _persistentPositionSerials[serial] = name;
             _gumpPositionCache[serial] = point;
             _ = GumpPositionSQLManager.Instance.SaveAsync(serial, name, point.X, point.Y);
         }

--- a/src/ClassicUO.Client/Game/Managers/UIManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/UIManager.cs
@@ -305,11 +305,75 @@ namespace ClassicUO.Game.Managers
 
         public static IGui LastControlMouseDown(MouseButtonType button) => _mouseDownControls[(int)button];
 
-        public static void SavePosition(uint serverSerial, Point point) => _gumpPositionCache[serverSerial] = point;
+        public static void SavePosition(uint serverSerial, Point point)
+        {
+            _gumpPositionCache[serverSerial] = point;
+
+            // Keep the on-disk copy in sync whenever a pinned gump is moved, so its permanent
+            // position always reflects where the user last left it.
+            if (_persistentPositionSerials.Contains(serverSerial))
+                _ = GumpPositionSQLManager.Instance.UpdatePositionAsync(serverSerial, point.X, point.Y);
+        }
 
         public static bool RemovePosition(uint serverSerial) => _gumpPositionCache.Remove(serverSerial, out _);
 
         public static bool GetGumpCachePosition(uint id, out Point pos) => _gumpPositionCache.TryGetValue(id, out pos);
+
+        #region Persistent gump positions
+
+        // Serials whose positions are permanently saved to the GumpPositionSQLManager database and are
+        // reloaded into the in-memory position cache on startup.
+        private static readonly HashSet<uint> _persistentPositionSerials = new();
+
+        /// <summary>
+        /// Seeds the in-memory gump position cache from the permanent database. Idempotent - safe to call
+        /// on each profile load. Pinned positions become the cache values so the affected gumps reopen at
+        /// their saved location.
+        /// </summary>
+        public static void LoadPersistentPositions()
+        {
+            try
+            {
+                foreach (SavedGumpPosition saved in GumpPositionSQLManager.Instance.GetAll())
+                {
+                    _persistentPositionSerials.Add(saved.Serial);
+                    _gumpPositionCache[saved.Serial] = new Point(saved.X, saved.Y);
+                }
+            }
+            catch (Exception ex)
+            {
+                ClassicUO.Utility.Logging.Log.Error($"Failed loading persistent gump positions: {ex.Message}");
+            }
+        }
+
+        /// <summary>Whether the given gump serial currently has a permanently saved position.</summary>
+        public static bool IsPositionPersistent(uint serial) => _persistentPositionSerials.Contains(serial);
+
+        /// <summary>
+        /// Permanently saves a gump's position under a friendly name, updating both the in-memory cache
+        /// and the backing database.
+        /// </summary>
+        public static void SetPositionPersistent(uint serial, string name, Point point)
+        {
+            if (serial == 0)
+                return;
+
+            _persistentPositionSerials.Add(serial);
+            _gumpPositionCache[serial] = point;
+            _ = GumpPositionSQLManager.Instance.SaveAsync(serial, name, point.X, point.Y);
+        }
+
+        /// <summary>
+        /// Removes a gump's permanently saved position from the database. The current in-memory cache
+        /// entry is left untouched so the gump keeps its position for the rest of the session.
+        /// </summary>
+        public static void RemovePersistentPosition(uint serial)
+        {
+            if (_persistentPositionSerials.Remove(serial))
+                _ = GumpPositionSQLManager.Instance.RemoveAsync(serial);
+        }
+
+        #endregion
 
         public static void ShowContextMenu(ContextMenuShowMenu menu)
         {

--- a/src/ClassicUO.Client/Game/Managers/UIManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/UIManager.cs
@@ -349,6 +349,28 @@ namespace ClassicUO.Game.Managers
         /// <summary>Whether the given gump serial currently has a permanently saved position.</summary>
         public static bool IsPositionPersistent(uint serial) => _persistentPositionSerials.Contains(serial);
 
+        /// <summary>A friendly display name for a gump used when persisting its position.</summary>
+        public static string GetGumpDisplayName(Gump gump) =>
+            gump.GumpType != Game.UI.Gumps.GumpType.None ? gump.GumpType.ToString() : gump.GetType().Name;
+
+        /// <summary>
+        /// When the "save all gumps automatically" profile option is enabled, permanently saves an open
+        /// server gump's position (once). No-op for non-server gumps or gumps already saved.
+        /// </summary>
+        public static void AutoSaveGumpPositionIfEnabled(Gump gump)
+        {
+            if (gump == null || gump.ServerSerial == 0)
+                return;
+
+            if (ProfileManager.CurrentProfile?.AutoSaveGumpPositions != true)
+                return;
+
+            if (_persistentPositionSerials.Contains(gump.ServerSerial))
+                return;
+
+            SetPositionPersistent(gump.ServerSerial, GetGumpDisplayName(gump), gump.Location);
+        }
+
         /// <summary>
         /// Permanently saves a gump's position under a friendly name, updating both the in-memory cache
         /// and the backing database.

--- a/src/ClassicUO.Client/Game/UI/Gumps/TopBarGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/TopBarGump.cs
@@ -257,6 +257,7 @@ namespace ClassicUO.Game.UI.Gumps
             submenu.Add(new ContextMenuItemEntry(TazLang.Get("topbargump_openboatcontrol", "Open boat control"), () => { UIManager.Add(new BoatControl(World) { X = 200, Y = 200 }); }));
             submenu.Add(new ContextMenuItemEntry(TazLang.Get("topbargump_nearbyloot", "Nearby loot"), () => { UIManager.Add(new NearbyLootGump(World)); }));
             submenu.Add(new ContextMenuItemEntry(TazLang.Get("healthbarcollector_title", "Healthbar Collector"), () => { UIManager.Add(new HealthbarCollectorGump(World) { X = 100, Y = 100 }); }));
+            submenu.Add(new ContextMenuItemEntry(TazLang.Get("topbargump_gumppositions", "Gump Positions"), MyraWindows.GumpPositionManagerWindow.Show));
             submenu.Add(new ContextMenuItemEntry(TazLang.Get("topbargump_retrievegumps", "Retrieve gumps"), () =>
             {
                 for (LinkedListNode<IGui> last = UIManager.Gumps.Last; last != null; last = last.Previous)

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/GumpPositionManagerWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/GumpPositionManagerWindow.cs
@@ -61,7 +61,7 @@ public sealed class GumpPositionManagerWindow : MyraControl
     {
         var root = new VerticalStackPanel { Spacing = MyraStyle.STANDARD_SPACING, Width = 460 };
 
-        _openHeader = new MyraLabel("Currently Open Gumps", MyraLabel.TextStyle.H4);
+        _openHeader = new MyraLabel("Open Server Gumps", MyraLabel.TextStyle.H4);
         _savedHeader = new MyraLabel("Saved Gump Positions", MyraLabel.TextStyle.H4);
 
         _openTable = new RulebaseTableView<OpenGumpRow>(_openColumns, _openStyle);
@@ -195,16 +195,16 @@ public sealed class GumpPositionManagerWindow : MyraControl
             if (gui is not Gump gump || gump.IsDisposed)
                 continue;
 
-            uint key = gump.ServerSerial != 0 ? gump.ServerSerial : gump.LocalSerial;
-            if (key == 0)
+            // Only server gumps participate in the server-serial position cache this feature manages.
+            if (gump.ServerSerial == 0)
                 continue;
 
             string name = gump.GumpType != Gumps.GumpType.None ? gump.GumpType.ToString() : gump.GetType().Name;
-            rows.Add(new OpenGumpRow(gump, key, name));
+            rows.Add(new OpenGumpRow(gump, gump.ServerSerial, name));
         }
 
         _openTable.SetRules(rows);
-        _openHeader.Text = $"Currently Open Gumps ({rows.Count})";
+        _openHeader.Text = $"Open Server Gumps ({rows.Count})";
     }
 
     private void RefreshSavedList()

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/GumpPositionManagerWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/GumpPositionManagerWindow.cs
@@ -34,7 +34,7 @@ public sealed class GumpPositionManagerWindow : MyraControl
     // Identify blink state: toggles _identifyGump.IsVisible on/off IDENTIFY_TOGGLES times, one toggle
     // every IDENTIFY_STEP_MS, driven off Time.Ticks from this window's Update().
     private const int IDENTIFY_TOGGLES = 10; // 5 off/on cycles
-    private const int IDENTIFY_STEP_MS = 300; // 10 * 300ms = 3 seconds
+    private const int IDENTIFY_STEP_MS = 150; // 10 * 150ms = 1.5 seconds
     private Gump? _identifyGump;
     private int _identifyTogglesLeft;
     private uint _identifyNextToggle;

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/GumpPositionManagerWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/GumpPositionManagerWindow.cs
@@ -31,6 +31,14 @@ public sealed class GumpPositionManagerWindow : MyraControl
     private MyraLabel _openHeader = null!;
     private MyraLabel _savedHeader = null!;
 
+    // Identify blink state: toggles _identifyGump.IsVisible on/off IDENTIFY_TOGGLES times, one toggle
+    // every IDENTIFY_STEP_MS, driven off Time.Ticks from this window's Update().
+    private const int IDENTIFY_TOGGLES = 10; // 5 off/on cycles
+    private const int IDENTIFY_STEP_MS = 300; // 10 * 300ms = 3 seconds
+    private Gump? _identifyGump;
+    private int _identifyTogglesLeft;
+    private uint _identifyNextToggle;
+
     public GumpPositionManagerWindow() : base("Gump Position Manager")
     {
         BuildColumns();
@@ -77,9 +85,19 @@ public sealed class GumpPositionManagerWindow : MyraControl
 
         root.Widgets.Add(toolbar);
         root.Widgets.Add(_openHeader);
-        root.Widgets.Add(new ScrollViewer { MaxHeight = 230, Content = _openTable });
+        root.Widgets.Add(new ScrollViewer
+        {
+            MaxHeight = 230,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            Content = _openTable
+        });
         root.Widgets.Add(_savedHeader);
-        root.Widgets.Add(new ScrollViewer { MaxHeight = 230, Content = _savedTable });
+        root.Widgets.Add(new ScrollViewer
+        {
+            MaxHeight = 230,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            Content = _savedTable
+        });
 
         SetRootContent(root);
     }
@@ -122,6 +140,14 @@ public sealed class GumpPositionManagerWindow : MyraControl
             Proportion = new Proportion(ProportionType.Auto),
             CellContentAlignment = HorizontalAlignment.Center,
             CellFactory = row => new MyraButton("Center", () => CenterGump(row))
+        });
+        _openColumns.Add(new RulebaseColumn<OpenGumpRow>
+        {
+            Header = "Identify",
+            HeaderTooltip = "Flash this gump on and off so you can spot it",
+            Proportion = new Proportion(ProportionType.Auto),
+            CellContentAlignment = HorizontalAlignment.Center,
+            CellFactory = row => new MyraButton("Identify", () => StartIdentify(row.Gump))
         });
 
         _savedColumns.Add(new RulebaseColumn<SavedGumpRow>
@@ -182,7 +208,62 @@ public sealed class GumpPositionManagerWindow : MyraControl
         RefreshOpenList();
     }
 
+    /// <summary>Begins the identify blink for a gump (finishing any blink already in progress first).</summary>
+    private void StartIdentify(Gump gump)
+    {
+        // Restore any previously blinking gump before switching targets.
+        if (_identifyGump != null && !_identifyGump.IsDisposed)
+            _identifyGump.IsVisible = true;
+
+        _identifyGump = gump;
+        _identifyTogglesLeft = IDENTIFY_TOGGLES;
+        _identifyNextToggle = Time.Ticks;
+    }
+
     #endregion
+
+    /// <summary>Drives the identify blink off the game clock so it needs no background thread.</summary>
+    public override void Update()
+    {
+        base.Update();
+
+        if (IsDisposed)
+            return;
+
+        if (_identifyGump == null)
+            return;
+
+        if (_identifyGump.IsDisposed)
+        {
+            _identifyGump = null;
+            return;
+        }
+
+        if (Time.Ticks < _identifyNextToggle)
+            return;
+
+        if (_identifyTogglesLeft <= 0)
+        {
+            // Always leave the gump visible when the blink finishes.
+            _identifyGump.IsVisible = true;
+            _identifyGump = null;
+            return;
+        }
+
+        _identifyGump.IsVisible = !_identifyGump.IsVisible;
+        _identifyTogglesLeft--;
+        _identifyNextToggle = Time.Ticks + IDENTIFY_STEP_MS;
+    }
+
+    public override void Dispose()
+    {
+        // Don't leave a gump hidden if the window is closed mid-blink.
+        if (_identifyGump != null && !_identifyGump.IsDisposed)
+            _identifyGump.IsVisible = true;
+
+        _identifyGump = null;
+        base.Dispose();
+    }
 
     #region Refresh
 

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/GumpPositionManagerWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/GumpPositionManagerWindow.cs
@@ -1,0 +1,268 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using ClassicUO.Game.Managers;
+using ClassicUO.Game.UI.Controls;
+using ClassicUO.Game.UI.Gumps;
+using ClassicUO.Game.UI.MyraWindows.Options.Editors.Rulebase;
+using ClassicUO.Game.UI.MyraWindows.Widgets;
+using Microsoft.Xna.Framework;
+using Myra.Graphics2D.UI;
+
+namespace ClassicUO.Game.UI.MyraWindows;
+
+/// <summary>
+/// Myra window for managing gump positions. The top section lists the gumps currently open, each with
+/// a checkbox that permanently saves its position to the database and a button to re-center it in the
+/// game viewport. The bottom section lists every permanently saved position with a delete action.
+/// Both lists are rendered with the Rulebase table-view UI system for a consistent look.
+/// </summary>
+public sealed class GumpPositionManagerWindow : MyraControl
+{
+    private readonly RulebaseStyleOptions _openStyle = new();
+    private readonly RulebaseStyleOptions _savedStyle = new();
+
+    private readonly List<RulebaseColumn<OpenGumpRow>> _openColumns = new();
+    private readonly List<RulebaseColumn<SavedGumpRow>> _savedColumns = new();
+
+    private RulebaseTableView<OpenGumpRow> _openTable = null!;
+    private RulebaseTableView<SavedGumpRow> _savedTable = null!;
+
+    private MyraLabel _openHeader = null!;
+    private MyraLabel _savedHeader = null!;
+
+    public GumpPositionManagerWindow() : base("Gump Position Manager")
+    {
+        BuildColumns();
+        Build();
+        RefreshOpenList();
+        RefreshSavedList();
+        CenterInViewPort();
+    }
+
+    /// <summary>Opens the window, focusing an existing instance instead of stacking duplicates.</summary>
+    public static void Show()
+    {
+        foreach (IGui gump in UIManager.Gumps)
+        {
+            if (gump is GumpPositionManagerWindow w && !w.IsDisposed)
+            {
+                w.BringOnTop();
+                return;
+            }
+        }
+
+        UIManager.Add(new GumpPositionManagerWindow());
+    }
+
+    #region Layout
+
+    private void Build()
+    {
+        var root = new VerticalStackPanel { Spacing = MyraStyle.STANDARD_SPACING, Width = 460 };
+
+        _openHeader = new MyraLabel("Currently Open Gumps", MyraLabel.TextStyle.H4);
+        _savedHeader = new MyraLabel("Saved Gump Positions", MyraLabel.TextStyle.H4);
+
+        _openTable = new RulebaseTableView<OpenGumpRow>(_openColumns, _openStyle);
+        _savedTable = new RulebaseTableView<SavedGumpRow>(_savedColumns, _savedStyle);
+
+        var toolbar = new HorizontalStackPanel { Spacing = 4, VerticalAlignment = VerticalAlignment.Center };
+        toolbar.Widgets.Add(new MyraButton("Refresh", () =>
+        {
+            RefreshOpenList();
+            RefreshSavedList();
+        }));
+        toolbar.Widgets.Add(new MyraLabel("Tick a gump to keep its position permanently.", MyraLabel.TextStyle.P));
+
+        root.Widgets.Add(toolbar);
+        root.Widgets.Add(_openHeader);
+        root.Widgets.Add(new ScrollViewer { MaxHeight = 230, Content = _openTable });
+        root.Widgets.Add(_savedHeader);
+        root.Widgets.Add(new ScrollViewer { MaxHeight = 230, Content = _savedTable });
+
+        SetRootContent(root);
+    }
+
+    private void BuildColumns()
+    {
+        _openColumns.Add(new RulebaseColumn<OpenGumpRow>
+        {
+            Header = "Gump",
+            Proportion = new Proportion(ProportionType.Fill, 1),
+            CellFactory = row => new MyraLabel(row.Name, MyraLabel.TextStyle.P) { Tooltip = row.Name }
+        });
+        _openColumns.Add(new RulebaseColumn<OpenGumpRow>
+        {
+            Header = "Serial",
+            Proportion = new Proportion(ProportionType.Auto),
+            CellFactory = row => new MyraLabel($"0x{row.Serial:X}", MyraLabel.TextStyle.P)
+        });
+        _openColumns.Add(new RulebaseColumn<OpenGumpRow>
+        {
+            Header = "Position",
+            Proportion = new Proportion(ProportionType.Auto),
+            CellFactory = row => new MyraLabel($"{row.Gump.X}, {row.Gump.Y}", MyraLabel.TextStyle.P)
+        });
+        _openColumns.Add(new RulebaseColumn<OpenGumpRow>
+        {
+            Header = "Saved",
+            HeaderTooltip = "Permanently save this gump's position",
+            Proportion = new Proportion(ProportionType.Auto),
+            CellContentAlignment = HorizontalAlignment.Center,
+            CellFactory = row => MyraCheckButton.CreateWithCallback(
+                UIManager.IsPositionPersistent(row.Serial),
+                isChecked => TogglePersistent(row, isChecked),
+                tooltip: "Permanently save this gump's position")
+        });
+        _openColumns.Add(new RulebaseColumn<OpenGumpRow>
+        {
+            Header = "Center",
+            HeaderTooltip = "Center this gump in the game viewport",
+            Proportion = new Proportion(ProportionType.Auto),
+            CellContentAlignment = HorizontalAlignment.Center,
+            CellFactory = row => new MyraButton("Center", () => CenterGump(row))
+        });
+
+        _savedColumns.Add(new RulebaseColumn<SavedGumpRow>
+        {
+            Header = "Gump",
+            Proportion = new Proportion(ProportionType.Fill, 1),
+            CellFactory = row => new MyraLabel(row.Name, MyraLabel.TextStyle.P) { Tooltip = row.Name }
+        });
+        _savedColumns.Add(new RulebaseColumn<SavedGumpRow>
+        {
+            Header = "Serial",
+            Proportion = new Proportion(ProportionType.Auto),
+            CellFactory = row => new MyraLabel($"0x{row.Serial:X}", MyraLabel.TextStyle.P)
+        });
+        _savedColumns.Add(new RulebaseColumn<SavedGumpRow>
+        {
+            Header = "Position",
+            Proportion = new Proportion(ProportionType.Auto),
+            CellFactory = row => new MyraLabel($"{row.X}, {row.Y}", MyraLabel.TextStyle.P)
+        });
+        _savedColumns.Add(new RulebaseColumn<SavedGumpRow>
+        {
+            Header = "",
+            Proportion = new Proportion(ProportionType.Auto),
+            CellContentAlignment = HorizontalAlignment.Center,
+            CellFactory = row => (MyraButton)MyraStyle.ApplyButtonDangerStyle(
+                new MyraButton("Delete", () => DeleteSaved(row)))
+        });
+    }
+
+    #endregion
+
+    #region Actions
+
+    private void TogglePersistent(OpenGumpRow row, bool isChecked)
+    {
+        if (isChecked)
+            UIManager.SetPositionPersistent(row.Serial, row.Name, new Point(row.Gump.X, row.Gump.Y));
+        else
+            UIManager.RemovePersistentPosition(row.Serial);
+
+        RefreshSavedList();
+    }
+
+    private void CenterGump(OpenGumpRow row)
+    {
+        row.Gump.CenterInViewPort();
+        // Persist the new location (only actually written to the DB when the gump is pinned).
+        UIManager.SavePosition(row.Serial, new Point(row.Gump.X, row.Gump.Y));
+        RefreshOpenList();
+    }
+
+    private void DeleteSaved(SavedGumpRow row)
+    {
+        UIManager.RemovePersistentPosition(row.Serial);
+        RefreshSavedList();
+        // A checkbox in the open list may reflect this entry, so refresh it too.
+        RefreshOpenList();
+    }
+
+    #endregion
+
+    #region Refresh
+
+    private void RefreshOpenList()
+    {
+        var rows = new List<OpenGumpRow>();
+
+        foreach (IGui gui in UIManager.Gumps)
+        {
+            if (gui is not Gump gump || gump.IsDisposed)
+                continue;
+
+            uint key = gump.ServerSerial != 0 ? gump.ServerSerial : gump.LocalSerial;
+            if (key == 0)
+                continue;
+
+            string name = gump.GumpType != Gumps.GumpType.None ? gump.GumpType.ToString() : gump.GetType().Name;
+            rows.Add(new OpenGumpRow(gump, key, name));
+        }
+
+        _openTable.SetRules(rows);
+        _openHeader.Text = $"Currently Open Gumps ({rows.Count})";
+    }
+
+    private void RefreshSavedList()
+    {
+        List<SavedGumpRow> rows = GumpPositionSQLManager.Instance.GetAll()
+            .OrderBy(s => s.Name)
+            .Select(s => new SavedGumpRow(s.Serial, s.Name, s.X, s.Y))
+            .ToList();
+
+        _savedTable.SetRules(rows);
+        _savedHeader.Text = $"Saved Gump Positions ({rows.Count})";
+    }
+
+    #endregion
+
+    #region Row models
+
+    /// <summary>A live open gump displayed in the top table.</summary>
+    private sealed class OpenGumpRow : IRule
+    {
+        public OpenGumpRow(Gump gump, uint serial, string name)
+        {
+            Gump = gump;
+            Serial = serial;
+            Name = name;
+        }
+
+        public Gump Gump { get; }
+        public uint Serial { get; }
+        public string Name { get; }
+
+        public uint Order { get; set; }
+        public bool Enabled { get; set; } = true;
+        public bool CanEdit { get; set; }
+        public bool CanDelete { get; set; }
+    }
+
+    /// <summary>A permanently saved position displayed in the bottom table.</summary>
+    private sealed class SavedGumpRow : IRule
+    {
+        public SavedGumpRow(uint serial, string name, int x, int y)
+        {
+            Serial = serial;
+            Name = name;
+            X = x;
+            Y = y;
+        }
+
+        public uint Serial { get; }
+        public string Name { get; }
+        public int X { get; }
+        public int Y { get; }
+
+        public uint Order { get; set; }
+        public bool Enabled { get; set; } = true;
+        public bool CanEdit { get; set; }
+        public bool CanDelete { get; set; } = true;
+    }
+
+    #endregion
+}

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/GumpPositionManagerWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/GumpPositionManagerWindow.cs
@@ -42,6 +42,10 @@ public sealed class GumpPositionManagerWindow : MyraControl
 
     public GumpPositionManagerWindow() : base("Gump Position Manager")
     {
+        // The title-bar close button disposes via base.Update()/PreDraw() without routing through this
+        // window's Dispose() override, so restore any blinking gump the moment a close is requested.
+        _rootWindow.Closed += (_, _) => RestoreIdentifyGump();
+
         BuildColumns();
         Build();
         RefreshOpenList();
@@ -144,10 +148,7 @@ public sealed class GumpPositionManagerWindow : MyraControl
             HeaderTooltip = "Permanently save this gump's position",
             Proportion = new Proportion(ProportionType.Auto),
             CellContentAlignment = HorizontalAlignment.Center,
-            CellFactory = row => MyraCheckButton.CreateWithCallback(
-                UIManager.IsPositionPersistent(row.Serial),
-                isChecked => TogglePersistent(row, isChecked),
-                tooltip: "Permanently save this gump's position")
+            CellFactory = BuildSavedCheckbox
         });
         _openColumns.Add(new RulebaseColumn<OpenGumpRow>
         {
@@ -198,6 +199,25 @@ public sealed class GumpPositionManagerWindow : MyraControl
 
     #region Actions
 
+    private Widget BuildSavedCheckbox(OpenGumpRow row)
+    {
+        // While "save all gumps automatically" is on it re-pins every server gump, so per-gump control
+        // would be overridden anyway - show it locked on rather than letting the user toggle it futilely.
+        if (ProfileManager.CurrentProfile?.AutoSaveGumpPositions == true)
+        {
+            return new MyraCheckButton(true)
+            {
+                Enabled = false,
+                Tooltip = "Managed by \"Save all gumps automatically\""
+            };
+        }
+
+        return MyraCheckButton.CreateWithCallback(
+            UIManager.IsPositionPersistent(row.Serial),
+            isChecked => TogglePersistent(row, isChecked),
+            tooltip: "Permanently save this gump's position");
+    }
+
     private void TogglePersistent(OpenGumpRow row, bool isChecked)
     {
         if (isChecked)
@@ -233,6 +253,8 @@ public sealed class GumpPositionManagerWindow : MyraControl
         // Persist the new location (only actually written to the DB when the gump is pinned).
         UIManager.SavePosition(row.Serial, new Point(row.Gump.X, row.Gump.Y));
         RefreshOpenList();
+        // The saved-list position for a pinned gump just changed, so refresh it too.
+        RefreshSavedList();
     }
 
     private void DeleteSaved(SavedGumpRow row)
@@ -253,6 +275,15 @@ public sealed class GumpPositionManagerWindow : MyraControl
         _identifyGump = gump;
         _identifyTogglesLeft = IDENTIFY_TOGGLES;
         _identifyNextToggle = Time.Ticks;
+    }
+
+    /// <summary>Leaves the currently blinking gump visible and clears the blink state.</summary>
+    private void RestoreIdentifyGump()
+    {
+        if (_identifyGump != null && !_identifyGump.IsDisposed)
+            _identifyGump.IsVisible = true;
+
+        _identifyGump = null;
     }
 
     #endregion
@@ -293,10 +324,7 @@ public sealed class GumpPositionManagerWindow : MyraControl
     public override void Dispose()
     {
         // Don't leave a gump hidden if the window is closed mid-blink.
-        if (_identifyGump != null && !_identifyGump.IsDisposed)
-            _identifyGump.IsVisible = true;
-
-        _identifyGump = null;
+        RestoreIdentifyGump();
         base.Dispose();
     }
 
@@ -315,8 +343,7 @@ public sealed class GumpPositionManagerWindow : MyraControl
             if (gump.ServerSerial == 0)
                 continue;
 
-            string name = gump.GumpType != Gumps.GumpType.None ? gump.GumpType.ToString() : gump.GetType().Name;
-            rows.Add(new OpenGumpRow(gump, gump.ServerSerial, name));
+            rows.Add(new OpenGumpRow(gump, gump.ServerSerial, UIManager.GetGumpDisplayName(gump)));
         }
 
         _openTable.SetRules(rows);
@@ -325,7 +352,9 @@ public sealed class GumpPositionManagerWindow : MyraControl
 
     private void RefreshSavedList()
     {
-        List<SavedGumpRow> rows = GumpPositionSQLManager.Instance.GetAll()
+        // Read from UIManager's in-memory snapshot rather than the database: it is always consistent
+        // with the writes just made (which persist asynchronously) and needs no blocking DB read.
+        List<SavedGumpRow> rows = UIManager.GetPersistentPositions()
             .OrderBy(s => s.Name)
             .Select(s => new SavedGumpRow(s.Serial, s.Name, s.X, s.Y))
             .ToList();

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/GumpPositionManagerWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/GumpPositionManagerWindow.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System.Collections.Generic;
 using System.Linq;
+using ClassicUO.Configuration;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Game.UI.Gumps;
@@ -83,7 +84,22 @@ public sealed class GumpPositionManagerWindow : MyraControl
         }));
         toolbar.Widgets.Add(new MyraLabel("Tick a gump to keep its position permanently.", MyraLabel.TextStyle.P));
 
+        bool autoSave = ProfileManager.CurrentProfile?.AutoSaveGumpPositions == true;
+        var autoSaveCheck = MyraCheckButton.CreateWithCallback(
+            autoSave,
+            OnToggleAutoSaveAll,
+            "Save all gumps automatically");
+
+        var warning = new MyraLabel(
+            "Some servers may send a significant amount of unique gumps, use with caution",
+            MyraLabel.TextStyle.P)
+        {
+            TextColor = new Color(230, 170, 60)
+        };
+
         root.Widgets.Add(toolbar);
+        root.Widgets.Add(autoSaveCheck);
+        root.Widgets.Add(warning);
         root.Widgets.Add(_openHeader);
         root.Widgets.Add(new ScrollViewer
         {
@@ -190,6 +206,25 @@ public sealed class GumpPositionManagerWindow : MyraControl
             UIManager.RemovePersistentPosition(row.Serial);
 
         RefreshSavedList();
+    }
+
+    private void OnToggleAutoSaveAll(bool enabled)
+    {
+        if (ProfileManager.CurrentProfile != null)
+            ProfileManager.CurrentProfile.AutoSaveGumpPositions = enabled;
+
+        // Enabling it immediately pins every server gump that is already open.
+        if (enabled)
+        {
+            foreach (IGui gui in UIManager.Gumps)
+            {
+                if (gui is Gump { IsDisposed: false } gump)
+                    UIManager.AutoSaveGumpPositionIfEnabled(gump);
+            }
+        }
+
+        RefreshSavedList();
+        RefreshOpenList();
     }
 
     private void CenterGump(OpenGumpRow row)

--- a/src/ClassicUO.Client/Network/PacketHandlers/Helpers/GumpHelpers.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers/Helpers/GumpHelpers.cs
@@ -584,6 +584,9 @@ internal static class GumpHelpers
         gump.Update();
         gump.SetInScreen();
 
+        // Persist this server gump's position immediately if the user opted to save all gumps.
+        UIManager.AutoSaveGumpPositionIfEnabled(gump);
+
         if (CUOEnviroment.Debug)
             GameActions.Print(world, $"GumpID: {gumpID}");
 


### PR DESCRIPTION
Adds a Myra window (opened via the "gumppositions" command) that lists the currently open gumps with a checkbox to permanently save each gump's position and a button to center it in the viewport, plus a list of all saved positions with a delete action. Both lists use the Rulebase table-view UI system.

Permanent positions are stored in a new SQLite database (gump_positions.db) in the Data folder, modeled on FriendliesSQLManager. On profile load the saved positions seed the in-memory gump position cache so pinned gumps reopen at their saved location, and moving a pinned gump keeps its stored position in sync.