### PR TITLE
Fix FontStashSharp IndexOutOfRangeException from off-thread tooltip text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to TazUO will be recorded here.
 * Added an option to draw overheads (names, health bars, overhead text) at a constant size regardless of the camera zoom - [P.R 730](https://github.com/PlayTazUO/TazUO/pull/730) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
+* Fixed an IndexOutOfRangeException crash in FontStashSharp caused by CustomToolTip building and measuring tooltip text on a background thread; the retry now runs on the main thread so the shared, non-thread-safe font caches aren't corrupted - [P.R 753](https://github.com/PlayTazUO/TazUO/pull/753) ([bittiez](https://github.com/bittiez))
 * Fixed an ArgumentNullException crash in TrueTypeLoader.GetFont when called with a null or empty font name; it now falls back to the default embedded font - [P.R 750](https://github.com/PlayTazUO/TazUO/pull/750) ([bittiez](https://github.com/bittiez))
 * Fixed a startup crash (IndexOutOfRangeException) in the animations loader when AnimationSequence.uop contained an out-of-range animation group index - [P.R 749](https://github.com/PlayTazUO/TazUO/pull/749) ([bittiez](https://github.com/bittiez))
 * Fixed a crash when a Legion Python script was stopped at the exact moment it was displaying an error, caused by a thread interrupt surfacing while IronPython formatted the exception - [P.R 748](https://github.com/PlayTazUO/TazUO/pull/748) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.4.8</AssemblyVersion>
-    <FileVersion>5.4.8</FileVersion>
+    <AssemblyVersion>5.4.9</AssemblyVersion>
+    <FileVersion>5.4.9</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Gumps/CustomToolTip.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/CustomToolTip.cs
@@ -99,7 +99,12 @@ namespace ClassicUO.Game.UI.Gumps
                 {
                     Task.Delay(1500).Wait();
                     attempt++;
-                    LoadOPLData(attempt);
+                    // Re-run on the main thread: once the OPL data arrives, LoadOPLData builds and
+                    // measures a TextBox through FontStashSharp, whose shared font caches are not
+                    // thread-safe. Measuring here (a background task thread) while the main thread
+                    // measures/draws the same fonts corrupts those caches and crashes
+                    // (IndexOutOfRangeException in FontStashSharp's Int32Map).
+                    MainThreadQueue.InvokeOnMainThread(() => LoadOPLData(attempt));
                 });
             }
 


### PR DESCRIPTION
CustomToolTip.LoadOPLData retries via Task.Factory.StartNew when OPL data isn't ready yet. When the data later arrives, that retry ran the TextBox construction and measurement (TextBox.GetOne / MeasuredSize / Height) on a background task thread. FontStashSharp's shared per-font glyph/kerning caches (Int32Map) are not thread-safe, so measuring text there while the main thread measured or drew the same fonts corrupted the caches, surfacing as an IndexOutOfRangeException in Int32Map.Insert (e.g. from the main-thread chat message path).

Route the retry's re-invocation back to the main thread via MainThreadQueue.InvokeOnMainThread so all FontStashSharp text work stays on one thread, matching the existing pattern used elsewhere (e.g. the Python UI API).