### PR TITLE
Fix grid highlight not saving properly

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightProperties.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHighLightProperties.cs
@@ -191,8 +191,14 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
             nameInput.TextChangedByUser += (_, _) => property.Name = nameInput.Text ?? "";
 
             // Property picker: a suggestion dropdown that fills the editable name box next to it.
+            // Setting Text programmatically doesn't raise TextChangedByUser, so commit the value to
+            // the model here too or the picked property is shown but never saved.
             var propCell = new HorizontalStackPanel { Spacing = 4, VerticalAlignment = VerticalAlignment.Center };
-            propCell.Widgets.Add(SuggestionCombo(values, v => nameInput.Text = v));
+            propCell.Widgets.Add(SuggestionCombo(values, v =>
+            {
+                nameInput.Text = v;
+                property.Name = v;
+            }));
             propCell.Widgets.Add(nameInput);
             grid.AddWidget(propCell, row, 0);
 
@@ -354,8 +360,14 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
             var input = new MyraInputBox { Text = list[index] ?? "", Width = 230 };
             input.TextChangedByUser += (_, _) => list[index] = input.Text ?? "";
 
+            // Setting Text programmatically doesn't raise TextChangedByUser, so commit the value to
+            // the model here too or the picked value is shown but never saved.
             if (suggestions != null && suggestions.Length > 0)
-                row.Widgets.Add(SuggestionCombo(suggestions, v => input.Text = v));
+                row.Widgets.Add(SuggestionCombo(suggestions, v =>
+                {
+                    input.Text = v;
+                    list[index] = v;
+                }));
 
             row.Widgets.Add(input);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added options to strip IDs from chat usernames and scale overhead elements with camera zoom.
  * Expanded and reorganized settings, including improved search and miscellaneous option access.
  * Added automatic migration for existing settings.
* **Bug Fixes**
  * Prevented crashes caused by invalid animation data, missing fonts, interrupted scripts, and background font processing.
  * Improved grid highlight export error handling.
  * Corrected overhead text and health-bar positioning during zoom.
* **Chores**
  * Updated the application version to 5.4.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->