### PR TITLE
Guard against null string in GetPluralAdjustedString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to TazUO will be recorded here.
 * Added an option to draw overheads (names, health bars, overhead text) at a constant size regardless of the camera zoom - [P.R 730](https://github.com/PlayTazUO/TazUO/pull/730) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
+* Fixed a NullReferenceException crash in StringHelper.GetPluralAdjustedString when an item's data name was null (e.g. while adding items to a container); it now guards against null/empty input - [P.R 755](https://github.com/PlayTazUO/TazUO/pull/755) ([bittiez](https://github.com/bittiez))
 * Fixed an IndexOutOfRangeException crash in FontStashSharp caused by CustomToolTip building and measuring tooltip text on a background thread; the retry now runs on the main thread so the shared, non-thread-safe font caches aren't corrupted - [P.R 753](https://github.com/PlayTazUO/TazUO/pull/753) ([bittiez](https://github.com/bittiez))
 * Fixed an ArgumentNullException crash in TrueTypeLoader.GetFont when called with a null or empty font name; it now falls back to the default embedded font - [P.R 750](https://github.com/PlayTazUO/TazUO/pull/750) ([bittiez](https://github.com/bittiez))
 * Fixed a startup crash (IndexOutOfRangeException) in the animations loader when AnimationSequence.uop contained an out-of-range animation group index - [P.R 749](https://github.com/PlayTazUO/TazUO/pull/749) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.4.10</AssemblyVersion>
-    <FileVersion>5.4.10</FileVersion>
+    <AssemblyVersion>5.4.11</AssemblyVersion>
+    <FileVersion>5.4.11</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Utility/StringHelper.cs
+++ b/src/ClassicUO.Utility/StringHelper.cs
@@ -374,6 +374,11 @@ namespace ClassicUO.Utility
 
         public static string GetPluralAdjustedString(string str, bool plural = false)
         {
+            if (string.IsNullOrEmpty(str))
+            {
+                return str;
+            }
+
             if (str.Contains("%"))
             {
                 string[] parts = str.Split(new[] { '%' }, System.StringSplitOptions.RemoveEmptyEntries);


### PR DESCRIPTION
Fix a NullReferenceException in StringHelper.GetPluralAdjustedString when called with a null string. This occurred via Item.GetNormalizedName passing ItemData.Name (which can be null) while adding items to a container, crashing packet processing.