### PR TITLE
Add General container tab with Container Style and Corpse Container style dropdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to TazUO will be recorded here.
 ## In Development
 
 ### Features
+* Reworked the container options into a new General tab with a "Container Style" dropdown (Grid/Original) and a "Corpse Container Style" dropdown (Grid/Original/Old Grid Loot/Old Grid Loot + Container), replacing the old "Enable grid containers" toggle and "Original Style Grid Loot" setting; moved "Default container view" to the Grid tab and migrated existing preferences - [P.R 761](https://github.com/PlayTazUO/TazUO/pull/761) ([bittiez](https://github.com/bittiez))
 * Added an option to only apply the trees-to-stumps replacement to trees within the circle of transparency radius, leaving farther trees at their normal appearance - [P.R 765](https://github.com/PlayTazUO/TazUO/pull/765) ([bittiez](https://github.com/bittiez))
 
 ### Fixes

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.6.0</AssemblyVersion>
-    <FileVersion>5.6.0</FileVersion>
+    <AssemblyVersion>5.7.0</AssemblyVersion>
+    <FileVersion>5.7.0</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -382,8 +382,6 @@ namespace ClassicUO.Configuration
 
         public uint GrabBagSerial { get; set => SetProperty(ref field, value); }
 
-        public int GridLootType { get; set => SetProperty(ref field, value); } // 0 = none, 1 = only grid, 2 = both
-
         public bool ReduceFPSWhenInactive { get; set => SetProperty(ref field, value); }
 
         public bool EnableVSync { get; set => SetProperty(ref field, value); } = true;
@@ -504,9 +502,30 @@ namespace ClassicUO.Configuration
         public uint SetFavoriteMoveBagSerial { get; set => SetProperty(ref field, value); }
 
         #region GRID CONTAINER
-        public bool UseGridLayoutContainerGumps { get; set => SetProperty(ref field, value); } = true;
+
+        /// <summary>
+        ///     Which container style newly opened (non-corpse) containers use. Persisted via the
+        ///     <see cref="ContainerStyleValue"/> SQL setting.
+        /// </summary>
+        [JsonIgnore]
+        public ContainerStyle ContainerStyle
+        {
+            get => (ContainerStyle)ContainerStyleValue;
+            set => ContainerStyleValue = (int)value;
+        }
+
+        /// <summary>
+        ///     Which container style corpses open in. Persisted via the
+        ///     <see cref="CorpseContainerStyleValue"/> SQL setting.
+        /// </summary>
+        [JsonIgnore]
+        public CorpseContainerStyle CorpseContainerStyle
+        {
+            get => (CorpseContainerStyle)CorpseContainerStyleValue;
+            set => CorpseContainerStyleValue = (int)value;
+        }
+
         public bool GridContainersDefaultToOldStyleView { get; set => SetProperty(ref field, value); } = false;
-        public CorpseContainerStyle CorpseContainerStyle { get; set => SetProperty(ref field, value); } = CorpseContainerStyle.Default;
         public int GridContainerViewMode { get; set => SetProperty(ref field, value); } = 0; // 0 = Grid, 1 = List
         public int GridContainerSearchMode { get; set => SetProperty(ref field, value); } = 0;
         public bool EnableGridContainerAnchor { get; set => SetProperty(ref field, value); } = false;
@@ -902,6 +921,19 @@ namespace ClassicUO.Configuration
         [JsonPropertyName("enable_a_sync_map_loading")]
         public bool OldEnableASyncMapLoading { get; set => SetProperty(ref field, value); } = true;
 
+        [Obsolete]
+        [JsonPropertyName("use_grid_layout_container_gumps")]
+        public bool OldUseGridLayoutContainerGumps { get; set => SetProperty(ref field, value); } = true;
+
+        [Obsolete]
+        [JsonPropertyName("grid_loot_type")]
+        public int OldGridLootType { get; set => SetProperty(ref field, value); } // 0 = none, 1 = only grid, 2 = both
+
+        // Stored as the old CorpseContainerStyle enum ordinal: 0 = Default, 1 = Grid, 2 = Original
+        [Obsolete]
+        [JsonPropertyName("corpse_container_style")]
+        public int OldCorpseContainerStyle { get; set => SetProperty(ref field, value); }
+
         private long lastSave;
 
         internal void AfterLoad()
@@ -952,6 +984,36 @@ namespace ClassicUO.Configuration
                 PostProcessingType = OldPostProcessingType;
                 ForcedHouseTransparency = OldForcedHouseTransparency;
                 HideHudGumpFlags = OldHideHudGumpFlags;
+
+                ProfileMigrationVersion++;
+            }
+
+            if (ProfileMigrationVersion < 2) //1
+            {
+                // The old "Enable grid containers" toggle becomes the new Container Style dropdown.
+                ContainerStyle = OldUseGridLayoutContainerGumps ? ContainerStyle.Grid : ContainerStyle.Original;
+
+                // The old grid loot type and corpse container style settings are merged into a single
+                // Corpse Container Style dropdown. Grid loot took precedence when it was enabled.
+                if (OldGridLootType == 1 || OldGridLootType == 2)
+                {
+                    CorpseContainerStyle = CorpseContainerStyle.OldGridLoot;
+                }
+                else
+                {
+                    switch (OldCorpseContainerStyle)
+                    {
+                        case 1: // old CorpseContainerStyle.Grid
+                            CorpseContainerStyle = CorpseContainerStyle.Grid;
+                            break;
+                        case 2: // old CorpseContainerStyle.Original
+                            CorpseContainerStyle = CorpseContainerStyle.Original;
+                            break;
+                        default: // old CorpseContainerStyle.Default followed the global container style
+                            CorpseContainerStyle = OldUseGridLayoutContainerGumps ? CorpseContainerStyle.Grid : CorpseContainerStyle.Original;
+                            break;
+                    }
+                }
 
                 ProfileMigrationVersion++;
             }

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -994,10 +994,15 @@ namespace ClassicUO.Configuration
                 ContainerStyle = OldUseGridLayoutContainerGumps ? ContainerStyle.Grid : ContainerStyle.Original;
 
                 // The old grid loot type and corpse container style settings are merged into a single
-                // Corpse Container Style dropdown. Grid loot took precedence when it was enabled.
-                if (OldGridLootType == 1 || OldGridLootType == 2)
+                // Corpse Container Style dropdown. Grid loot took precedence when it was enabled; the
+                // old "both" mode (2) is preserved as the combined loot-gump-plus-container style.
+                if (OldGridLootType == 1)
                 {
                     CorpseContainerStyle = CorpseContainerStyle.OldGridLoot;
+                }
+                else if (OldGridLootType == 2)
+                {
+                    CorpseContainerStyle = CorpseContainerStyle.OldGridLootAndContainer;
                 }
                 else
                 {

--- a/src/ClassicUO.Client/Configuration/SqlProfile.cs
+++ b/src/ClassicUO.Client/Configuration/SqlProfile.cs
@@ -182,4 +182,16 @@ public sealed partial class Profile
         [JsonIgnore]
         [SqlSetting(SettingsScope.Global, "auto_save_gump_positions", false)]
         public partial bool AutoSaveGumpPositions { get; set; }
+
+        // Which container style newly opened (non-corpse) containers use. Backing store for the
+        // <see cref="ContainerStyle"/> enum: 0 = Grid (default), 1 = Original.
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Char, "container_style", 0)]
+        public partial int ContainerStyleValue { get; set; }
+
+        // Which container style corpses open in. Backing store for the
+        // <see cref="CorpseContainerStyle"/> enum: 0 = Grid (default), 1 = Original, 2 = Old Grid Loot.
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Char, "corpse_container_style", 0)]
+        public partial int CorpseContainerStyleValue { get; set; }
 }

--- a/src/ClassicUO.Client/Configuration/SqlProfile.cs
+++ b/src/ClassicUO.Client/Configuration/SqlProfile.cs
@@ -186,12 +186,13 @@ public sealed partial class Profile
         // Which container style newly opened (non-corpse) containers use. Backing store for the
         // <see cref="ContainerStyle"/> enum: 0 = Grid (default), 1 = Original.
         [JsonIgnore]
-        [SqlSetting(SettingsScope.Char, "container_style", 0)]
+        [SqlSetting(SettingsScope.Global, "container_style", 0)]
         public partial int ContainerStyleValue { get; set; }
 
         // Which container style corpses open in. Backing store for the
-        // <see cref="CorpseContainerStyle"/> enum: 0 = Grid (default), 1 = Original, 2 = Old Grid Loot.
+        // <see cref="CorpseContainerStyle"/> enum: 0 = Grid (default), 1 = Original, 2 = Old Grid Loot,
+        // 3 = Old Grid Loot + Container.
         [JsonIgnore]
-        [SqlSetting(SettingsScope.Char, "corpse_container_style", 0)]
+        [SqlSetting(SettingsScope.Global, "corpse_container_style", 0)]
         public partial int CorpseContainerStyleValue { get; set; }
 }

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -5,7 +5,7 @@
 ; Missing keys are auto-appended with English defaults when
 ; this file's version is newer than the user's copy.
 ; -------------------------------------------------------
-_version=65
+_version=66
 accountname=Account Name
 accountcontextmenutooltip=Right click to select another account.
 music=Music
@@ -1799,8 +1799,9 @@ mog_tazuo_gridcontainersdefaulttooldstyleview=Open new containers in the origina
 mog_tazuo_corpsecontainerstyle=Corpse Container Style
 mog_tazuo_corpsestyleopt_grid=Grid
 mog_tazuo_corpsestyleopt_oldgridloot=Old Grid Loot
+mog_tazuo_corpsestyleopt_oldgridlootandcontainer=Old Grid Loot + Container
 mog_tazuo_corpsestyleopt_original=Original
-mog_tazuo_tooltipcorpsecontainerstyle=Choose which style corpses open in: grid container, original container, or the old grid loot gump.
+mog_tazuo_tooltipcorpsecontainerstyle=Choose which style corpses open in: grid container, original container, the old grid loot gump, or the old grid loot gump alongside the normal container.
 mog_tazuo_griddisabletargeting=Disable Targeting Grid Containers
 mog_tazuo_gridhighlightproperties=Show highlighted item properties in tooltip
 mog_tazuo_gridhighlightsettings=Grid highlight settings

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -5,7 +5,7 @@
 ; Missing keys are auto-appended with English defaults when
 ; this file's version is newer than the user's copy.
 ; -------------------------------------------------------
-_version=64
+_version=65
 accountname=Account Name
 accountcontextmenutooltip=Right click to select another account.
 music=Music
@@ -1076,6 +1076,7 @@ mog_containers_containerscale=Container scale
 mog_containers_description=These settings are for original container gumps, for grid container settings visit the TazUO section
 mog_containers_doubleclicktolootitemsinsidecontainers=Double click to loot items inside containers
 mog_containers_highlightcontainerongroundwhenmouseisoveracontainergump=Highlight container on ground when mouse is over a container gump
+mog_containers_labelgeneral=General
 mog_containers_labelgridcontainerhighlighting=Grid Container Highlighting
 mog_containers_labelgridcontainers=Grid
 mog_containers_labelgridcontainerstyling=Grid Container Styling
@@ -1091,6 +1092,8 @@ mog_containers_recolorcontainergumpbywithcontainerhue=Recolor container gump wit
 mog_containers_relativedraganddropitemsincontainers=Relative drag and drop items in containers
 mog_containers_remembereachcontainer=Remember each container
 mog_containers_uselargecontainergumps=Use large container gumps
+mog_containerstyleopt_grid=Grid
+mog_containerstyleopt_original=Original
 
 ; --- cooldowns ---
 mog_cooldowns_customcooldownbars=Custom cooldown bars
@@ -1187,6 +1190,7 @@ mog_general_corpseskipemptywarningtitle=Skip Empty Corpses
 mog_general_corpseskipemptywarning=This setting does not work on most servers, make sure to verify this is working if you enable it. If corpses are not opening, disable this.
 mog_general_cotdistance=Distance
 mog_general_cottype=Type
+mog_general_containerstyle=Container Style
 mog_general_cottypeoptfull=Full
 mog_general_cottypeoptgrad=Gradient
 mog_general_cottypeoptmodern=Modern
@@ -1792,11 +1796,11 @@ mog_tazuo_globalscale=Scale
 mog_tazuo_gridcontainers=Grid containers
 mog_tazuo_gridcontainerscale=Grid container scale
 mog_tazuo_gridcontainersdefaulttooldstyleview=Open new containers in the original view
-mog_tazuo_corpsecontainerstyle=Corpse container style
-mog_tazuo_corpsestyleopt_default=Follow global setting
+mog_tazuo_corpsecontainerstyle=Corpse Container Style
 mog_tazuo_corpsestyleopt_grid=Grid
+mog_tazuo_corpsestyleopt_oldgridloot=Old Grid Loot
 mog_tazuo_corpsestyleopt_original=Original
-mog_tazuo_tooltipcorpsecontainerstyle=Choose which container style corpses open in. This overrides the "Open new containers in the original view" option for corpses.
+mog_tazuo_tooltipcorpsecontainerstyle=Choose which style corpses open in: grid container, original container, or the old grid loot gump.
 mog_tazuo_griddisabletargeting=Disable Targeting Grid Containers
 mog_tazuo_gridhighlightproperties=Show highlighted item properties in tooltip
 mog_tazuo_gridhighlightsettings=Grid highlight settings

--- a/src/ClassicUO.Client/Game/GameObjects/Views/ItemView.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Views/ItemView.cs
@@ -7,6 +7,7 @@ using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.Scenes;
+using ClassicUO.Game.UI.Gumps;
 using ClassicUO.IO;
 using ClassicUO.Renderer;
 using Microsoft.Xna.Framework;
@@ -391,7 +392,7 @@ namespace ClassicUO.Game.GameObjects
                 }
                 else
                 {
-                    if ((ProfileManager.CurrentProfile.GridLootType > 0 || ProfileManager.CurrentProfile.UseGridLayoutContainerGumps) && SelectedObject.CorpseObject == owner)
+                    if (ProfileManager.CurrentProfile.CorpseContainerStyle != CorpseContainerStyle.Original && SelectedObject.CorpseObject == owner)
                     {
                         color = 0x0034;
                     }

--- a/src/ClassicUO.Client/Game/Managers/MacroManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/MacroManager.cs
@@ -2401,16 +2401,16 @@ namespace ClassicUO.Game.Managers
                     break;
 
                 case MacroType.CloseCorpses:
-                    int? gridLootType = ProfileManager.CurrentProfile?.GridLootType; // 0 = none, 1 = only grid, 2 = both
+                    CorpseContainerStyle corpseStyle = ProfileManager.CurrentProfile?.CorpseContainerStyle ?? CorpseContainerStyle.Grid;
 
-                    if (gridLootType == 0 || gridLootType == 2)
+                    if (corpseStyle == CorpseContainerStyle.Original)
                         UIManager.ForEach<ContainerGump>(g =>
                         {
                             if (g.Graphic == ContainerGump.CORPSES_GUMP)
                                 g.Dispose();
                         });
 
-                    if (gridLootType == 1 || gridLootType == 2)
+                    if (corpseStyle == CorpseContainerStyle.OldGridLoot)
                         UIManager.ForEach<GridLootGump>(g =>
                         {
                             g.Dispose();

--- a/src/ClassicUO.Client/Game/Managers/MacroManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/MacroManager.cs
@@ -2403,14 +2403,14 @@ namespace ClassicUO.Game.Managers
                 case MacroType.CloseCorpses:
                     CorpseContainerStyle corpseStyle = ProfileManager.CurrentProfile?.CorpseContainerStyle ?? CorpseContainerStyle.Grid;
 
-                    if (corpseStyle == CorpseContainerStyle.Original)
+                    if (corpseStyle is CorpseContainerStyle.Original or CorpseContainerStyle.OldGridLootAndContainer)
                         UIManager.ForEach<ContainerGump>(g =>
                         {
                             if (g.Graphic == ContainerGump.CORPSES_GUMP)
                                 g.Dispose();
                         });
 
-                    if (corpseStyle == CorpseContainerStyle.OldGridLoot)
+                    if (corpseStyle is CorpseContainerStyle.OldGridLoot or CorpseContainerStyle.OldGridLootAndContainer)
                         UIManager.ForEach<GridLootGump>(g =>
                         {
                             g.Dispose();

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/Enums/ContainerStyle.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/Enums/ContainerStyle.cs
@@ -1,0 +1,13 @@
+namespace ClassicUO.Game.UI.Gumps;
+
+/// <summary>
+///     Controls which container style newly opened containers use.
+/// </summary>
+public enum ContainerStyle
+{
+    /// <summary>Open containers as grid containers.</summary>
+    Grid,
+
+    /// <summary>Open containers as original-style containers.</summary>
+    Original
+}

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/Enums/CorpseContainerStyle.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/Enums/CorpseContainerStyle.cs
@@ -12,6 +12,9 @@ public enum CorpseContainerStyle
     /// <summary>Open corpses as original-style containers.</summary>
     Original,
 
-    /// <summary>Open corpses using the old grid loot gump.</summary>
-    OldGridLoot
+    /// <summary>Open corpses using the old grid loot gump only.</summary>
+    OldGridLoot,
+
+    /// <summary>Open corpses using the old grid loot gump alongside the normal container.</summary>
+    OldGridLootAndContainer
 }

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/Enums/CorpseContainerStyle.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/Enums/CorpseContainerStyle.cs
@@ -2,16 +2,16 @@ namespace ClassicUO.Game.UI.Gumps;
 
 /// <summary>
 ///     Controls which container style corpses open in, independent of the global
-///     <see cref="ClassicUO.Configuration.Profile.GridContainersDefaultToOldStyleView" /> preference.
+///     <see cref="ClassicUO.Configuration.Profile.ContainerStyle" /> preference.
 /// </summary>
 public enum CorpseContainerStyle
 {
-    /// <summary>Use the global default (the "Open new containers in the original view" setting).</summary>
-    Default,
-
-    /// <summary>Always open corpses as grid containers.</summary>
+    /// <summary>Open corpses as grid containers.</summary>
     Grid,
 
-    /// <summary>Always open corpses as original-style containers.</summary>
-    Original
+    /// <summary>Open corpses as original-style containers.</summary>
+    Original,
+
+    /// <summary>Open corpses using the old grid loot gump.</summary>
+    OldGridLoot
 }

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/GridContainer.cs
@@ -541,7 +541,7 @@ public partial class GridContainer : ResizableGump
                     {
                         case CorpseContainerStyle.Grid: return false;
                         case CorpseContainerStyle.Original: return true;
-                        // CorpseContainerStyle.Default falls through to the global default
+                        // CorpseContainerStyle.OldGridLoot falls through to the global default
                     }
                 }
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridLootGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridLootGump.cs
@@ -20,7 +20,7 @@ namespace ClassicUO.Game.UI.Gumps
         private const int MAX_WIDTH = 300;
         private const int MAX_HEIGHT = 420;
 
-        private static int _lastX = 100;
+        private static int _lastX = ProfileManager.CurrentProfile.CorpseContainerStyle == CorpseContainerStyle.OldGridLootAndContainer ? 200 : 100;
         private static int _lastY = 100;
         private readonly AlphaBlendControl _background;
         private readonly NiceButton _buttonPrev,

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridLootGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridLootGump.cs
@@ -20,7 +20,7 @@ namespace ClassicUO.Game.UI.Gumps
         private const int MAX_WIDTH = 300;
         private const int MAX_HEIGHT = 420;
 
-        private static int _lastX = ProfileManager.CurrentProfile.GridLootType == 2 ? 200 : 100;
+        private static int _lastX = 100;
         private static int _lastY = 100;
         private readonly AlphaBlendControl _background;
         private readonly NiceButton _buttonPrev,

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
@@ -532,17 +532,17 @@ namespace ClassicUO.Game.UI.Gumps
             (
                 c = new ComboBoxWithLabel
                 (World,
-                    TazLang.Get("mog_general_gridloot"), 0, ThemeSettings.COMBO_BOX_WIDTH,
+                    TazLang.Get("mog_tazuo_corpsecontainerstyle"), 0, ThemeSettings.COMBO_BOX_WIDTH,
                     new string[]
                     {
-                        TazLang.Get("mog_general_gridlootoptdisable"), TazLang.Get("mog_general_gridlootoptonly"),
-                        TazLang.Get("mog_general_gridlootoptboth")
-                    }, profile.GridLootType,
-                    (s, n) => { profile.GridLootType = s; }
+                        TazLang.Get("mog_tazuo_corpsestyleopt_grid"), TazLang.Get("mog_tazuo_corpsestyleopt_original"),
+                        TazLang.Get("mog_tazuo_corpsestyleopt_oldgridloot")
+                    }, (int)profile.CorpseContainerStyle,
+                    (s, n) => { profile.CorpseContainerStyle = (CorpseContainerStyle)s; }
                 ), true, page
             );
 
-            c.SetTooltip(TazLang.Get("mog_general_gridloottooltip"));
+            c.SetTooltip(TazLang.Get("mog_tazuo_tooltipcorpsecontainerstyle"));
 
             content.BlankLine();
 
@@ -3104,8 +3104,15 @@ namespace ClassicUO.Game.UI.Gumps
 
             content.AddToRight
             (
-                new CheckboxWithLabel(TazLang.Get("mog_tazuo_enablegridcontainers"), 0, profile.UseGridLayoutContainerGumps,
-                    (b) => { profile.UseGridLayoutContainerGumps = b; }), true, page
+                new ComboBoxWithLabel
+                (World,
+                    TazLang.Get("mog_general_containerstyle"), 0, ThemeSettings.COMBO_BOX_WIDTH,
+                    new string[]
+                    {
+                        TazLang.Get("mog_containerstyleopt_grid"), TazLang.Get("mog_containerstyleopt_original")
+                    }, (int)profile.ContainerStyle,
+                    (s, n) => { profile.ContainerStyle = (ContainerStyle)s; }
+                ), true, page
             );
 
             content.BlankLine();

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
@@ -536,7 +536,7 @@ namespace ClassicUO.Game.UI.Gumps
                     new string[]
                     {
                         TazLang.Get("mog_tazuo_corpsestyleopt_grid"), TazLang.Get("mog_tazuo_corpsestyleopt_original"),
-                        TazLang.Get("mog_tazuo_corpsestyleopt_oldgridloot")
+                        TazLang.Get("mog_tazuo_corpsestyleopt_oldgridloot"), TazLang.Get("mog_tazuo_corpsestyleopt_oldgridlootandcontainer")
                     }, (int)profile.CorpseContainerStyle,
                     (s, n) => { profile.CorpseContainerStyle = (CorpseContainerStyle)s; }
                 ), true, page

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/ContainersTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/ContainersTab.cs
@@ -22,6 +22,11 @@ public static class ContainersTab
 
         return new OptionTabGroup()
             .AddTab(
+                TazLang.Get("mog_containers_labelgeneral"),
+                GetGeneralContainerSection,
+                new SearchMetadata(TazLang.Get("mog_containers_labelgeneral"), Keywords: [TazLang.Get("mog_kw_general")])
+            )
+            .AddTab(
                 TazLang.Get("mog_containers_labeloriginalcontainers"),
                 GetStandardContainerSection,
                 new SearchMetadata(TazLang.Get("mog_containers_labeloriginalcontainers"), Keywords: [TazLang.Get("mog_kw_original"), TazLang.Get("mog_kw_standard")])
@@ -31,6 +36,29 @@ public static class ContainersTab
                 GetGridContainerSection,
                 new SearchMetadata(TazLang.Get("mog_containers_labelgridcontainers"), Keywords: [TazLang.Get("mog_kw_grid")])
             );
+    }
+
+    private static IOptionSource GetGeneralContainerSection()
+    {
+        Profile profile = ProfileManager.CurrentProfile;
+
+        return OptionsUi.VisualContainer(
+                new VisualContainerProps { LabelText = TazLang.Get("mog_containers_labelgeneral") },
+                Option.LComboBox(
+                    TazLang.Get("mog_general_containerstyle"),
+                    new Accessor<ContainerStyle>(() => profile.ContainerStyle, v => profile.ContainerStyle = v),
+                    "mog_containerstyleopt_",
+                    search: new SearchMetadata(TazLang.Get("mog_general_containerstyle"), Keywords: [TazLang.Get("mog_kw_container"), TazLang.Get("mog_kw_style")])
+                ),
+                Option.LComboBox(
+                    TazLang.Get("mog_tazuo_corpsecontainerstyle"),
+                    new Accessor<CorpseContainerStyle>(() => profile.CorpseContainerStyle, v => profile.CorpseContainerStyle = v),
+                    "mog_tazuo_corpsestyleopt_",
+                    TazLang.Get("mog_tazuo_tooltipcorpsecontainerstyle"),
+                    search: new SearchMetadata(TazLang.Get("mog_tazuo_corpsecontainerstyle"), Keywords: [TazLang.Get("mog_kw_corpse"), TazLang.Get("mog_kw_style"), TazLang.Get("mog_kw_container")])
+                )
+            )
+            .WithSearch(new SearchMetadata(TazLang.Get("mog_containers_labelgeneral"), Tags: [TazLang.Get("mog_kw_container")], Keywords: [TazLang.Get("mog_kw_container"), TazLang.Get("mog_kw_style")]));
     }
 
     private static IOptionSource GetStandardContainerSection()
@@ -167,53 +195,54 @@ public static class ContainersTab
                 LabelText = TazLang.Get("mog_containers_labelgridcontainerswiki"),
                 LabelLink = "https://tazuo.org/wiki/tazuogrid-containers/"
             },
-            OptionsUi.CheckBoxGroup(
-                new PropertyBinder(new Accessor<bool>(() => profile.UseGridLayoutContainerGumps), TazLang.Get("mog_tazuo_enablegridcontainers")),
-                Option.Checkbox(
-                    TazLang.Get("mog_tazuo_gridcontainersdefaulttooldstyleview"),
-                    new Accessor<bool>(() => profile.GridContainersDefaultToOldStyleView),
-                    search: new SearchMetadata(TazLang.Get("mog_tazuo_gridcontainersdefaulttooldstyleview"), Keywords: [TazLang.Get("mog_kw_old"), TazLang.Get("mog_kw_style"), TazLang.Get("mog_kw_view")])
+            Option.Checkbox(
+                TazLang.Get("mog_tazuo_gridcontainersdefaulttooldstyleview"),
+                new Accessor<bool>(() => profile.GridContainersDefaultToOldStyleView),
+                search: new SearchMetadata(TazLang.Get("mog_tazuo_gridcontainersdefaulttooldstyleview"), Keywords: [TazLang.Get("mog_kw_old"), TazLang.Get("mog_kw_style"), TazLang.Get("mog_kw_view")])
+            ),
+            Option.ComboBox(
+                TazLang.Get("gridcontainer_defaultview", "Default container view"),
+                profile.GridContainerViewMode,
+                [TazLang.Get("gridcontainer_view_grid_short", "Grid"), TazLang.Get("gridcontainer_view_list_short", "List")],
+                i =>
+                {
+                    profile.GridContainerViewMode = i;
+                    GridContainer.UpdateAllGridContainers();
+                },
+                search: new SearchMetadata(TazLang.Get("gridcontainer_defaultview", "Default container view"), Keywords: [TazLang.Get("mog_kw_view"), TazLang.Get("mog_kw_grid")])
+            ),
+            Option.ComboBox(
+                TazLang.Get("mog_tazuo_searchstyle"),
+                profile.GridContainerSearchMode,
+                [TazLang.Get("mog_tazuo_onlyshow"), TazLang.Get("mog_tazuo_highlight")],
+                i => profile.GridContainerSearchMode = i,
+                search: new SearchMetadata(TazLang.Get("mog_tazuo_searchstyle"), Keywords: [TazLang.Get("mog_kw_search"), TazLang.Get("mog_kw_style")])
+            ),
+            Option.Checkbox(
+                TazLang.Get("mog_tazuo_enablecontainerpreview"),
+                new Accessor<bool>(() => profile.GridEnableContPreview),
+                TazLang.Get("mog_tazuo_tooltippreview"),
+                search: new SearchMetadata(TazLang.Get("mog_tazuo_enablecontainerpreview"), Keywords: [TazLang.Get("mog_kw_preview")])
+            ),
+            Option.Checkbox(
+                TazLang.Get("mog_tazuo_makeanchorable"),
+                new Accessor<bool>(
+                    () => profile.EnableGridContainerAnchor,
+                    b =>
+                    {
+                        profile.EnableGridContainerAnchor = b;
+                        GridContainer.UpdateAllGridContainers();
+                    }
                 ),
-                Option.LComboBox(
-                    TazLang.Get("mog_tazuo_corpsecontainerstyle"),
-                    new Accessor<CorpseContainerStyle>(() => profile.CorpseContainerStyle, v => profile.CorpseContainerStyle = v),
-                    "mog_tazuo_corpsestyleopt_",
-                    TazLang.Get("mog_tazuo_tooltipcorpsecontainerstyle"),
-                    search: new SearchMetadata(TazLang.Get("mog_tazuo_corpsecontainerstyle"), Keywords: [TazLang.Get("mog_kw_corpse"), TazLang.Get("mog_kw_style"), TazLang.Get("mog_kw_container")])
-                ),
-                Option.ComboBox(
-                    TazLang.Get("mog_tazuo_searchstyle"),
-                    profile.GridContainerSearchMode,
-                    [TazLang.Get("mog_tazuo_onlyshow"), TazLang.Get("mog_tazuo_highlight")],
-                    i => profile.GridContainerSearchMode = i,
-                    search: new SearchMetadata(TazLang.Get("mog_tazuo_searchstyle"), Keywords: [TazLang.Get("mog_kw_search"), TazLang.Get("mog_kw_style")])
-                ),
-                Option.Checkbox(
-                    TazLang.Get("mog_tazuo_enablecontainerpreview"),
-                    new Accessor<bool>(() => profile.GridEnableContPreview),
-                    TazLang.Get("mog_tazuo_tooltippreview"),
-                    search: new SearchMetadata(TazLang.Get("mog_tazuo_enablecontainerpreview"), Keywords: [TazLang.Get("mog_kw_preview")])
-                ),
-                Option.Checkbox(
-                    TazLang.Get("mog_tazuo_makeanchorable"),
-                    new Accessor<bool>(
-                        () => profile.EnableGridContainerAnchor,
-                        b =>
-                        {
-                            profile.EnableGridContainerAnchor = b;
-                            GridContainer.UpdateAllGridContainers();
-                        }
-                    ),
-                    TazLang.Get("mog_tazuo_tooltipgridanchor"),
-                    search: new SearchMetadata(TazLang.Get("mog_tazuo_makeanchorable"), Keywords: [TazLang.Get("mog_kw_anchor")])
-                ),
-                Option.Checkbox(
-                    TazLang.Get("mog_tazuo_griddisabletargeting"),
-                    new Accessor<bool>(() => profile.DisableTargetingGridContainers),
-                    search: new SearchMetadata(TazLang.Get("mog_tazuo_griddisabletargeting"), Keywords: [TazLang.Get("mog_kw_targeting"), TazLang.Get("mog_kw_disable")])
-                ),
-                GetGridContainerStylingSection()
-            ).WithSearch(new SearchMetadata(TazLang.Get("mog_containers_labelgridcontainers"), Tags: [TazLang.Get("mog_kw_container"), TazLang.Get("mog_kw_grid")], Keywords: [TazLang.Get("mog_kw_grid"), TazLang.Get("mog_kw_container")]))
+                TazLang.Get("mog_tazuo_tooltipgridanchor"),
+                search: new SearchMetadata(TazLang.Get("mog_tazuo_makeanchorable"), Keywords: [TazLang.Get("mog_kw_anchor")])
+            ),
+            Option.Checkbox(
+                TazLang.Get("mog_tazuo_griddisabletargeting"),
+                new Accessor<bool>(() => profile.DisableTargetingGridContainers),
+                search: new SearchMetadata(TazLang.Get("mog_tazuo_griddisabletargeting"), Keywords: [TazLang.Get("mog_kw_targeting"), TazLang.Get("mog_kw_disable")])
+            ),
+            GetGridContainerStylingSection()
         );
     }
 

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/MiscTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/MiscTab.cs
@@ -15,11 +15,7 @@ namespace ClassicUO.Game.UI.MyraWindows.Options.Tabs;
 public static class MiscTab
 {
     /// <summary>Returns the paged option group containing miscellaneous settings pages</summary>
-    internal static IOptionSource GetContent() =>
-        OptionsUi.Horizontal(
-            GetGridLoot(),
-            GetPages()
-        );
+    internal static IOptionSource GetContent() => GetPages();
 
     private static OptionPageGroup GetPages() => new(
         new SearchMetadata(Keywords: [TazLang.Get("mog_kw_misc"), TazLang.Get("mog_kw_miscellaneous"), TazLang.Get("mog_kw_other")],
@@ -268,39 +264,4 @@ public static class MiscTab
             Keywords: [TazLang.Get("mog_kw_experimental"), TazLang.Get("mog_kw_beta"), TazLang.Get("mog_kw_test")], Tags: [TazLang.Get("mog_kw_experimental")]));
     }
 
-    private static OptionFragment GetGridLoot()
-    {
-        Profile profile = ProfileManager.CurrentProfile;
-
-        return OptionsUi.VisualContainer(
-                new VisualContainerProps { LabelText = TazLang.Get("mog_misctab_oldstylegridloot_label") },
-                Option.ComboBox(
-                    TazLang.Get("mog_general_gridloot"),
-                    profile.GridLootType,
-                    [
-                        TazLang.Get("mog_general_gridlootoptdisable"),
-                        TazLang.Get("mog_general_gridlootoptonly"),
-                        TazLang.Get("mog_general_gridlootoptboth")
-                    ],
-                    newValue => profile.GridLootType = newValue,
-                    TazLang.Get("mog_general_gridlootoptonlytooltip"),
-                    new SearchMetadata(TazLang.Get("mog_general_gridloot"), Keywords: [TazLang.Get("mog_kw_grid"), TazLang.Get("mog_kw_loot")])
-                ),
-                Option.ComboBox(
-                    TazLang.Get("gridcontainer_defaultview", "Default container view"),
-                    profile.GridContainerViewMode,
-                    [TazLang.Get("gridcontainer_view_grid_short", "Grid"), TazLang.Get("gridcontainer_view_list_short", "List")],
-                    i =>
-                    {
-                        profile.GridContainerViewMode = i;
-                        GridContainer.UpdateAllGridContainers();
-                    },
-                    search: new SearchMetadata(TazLang.Get("gridcontainer_defaultview", "Default container view"),
-                        Keywords: [TazLang.Get("mog_kw_view"), TazLang.Get("mog_kw_grid")])
-                )
-            )
-            .AsSearchGroup()
-            .WithSearch(new SearchMetadata(TazLang.Get("mog_misctab_oldstylegridloot_label"),
-                Keywords: [TazLang.Get("mog_kw_grid"), TazLang.Get("mog_kw_loot"), TazLang.Get("mog_kw_view")]));
-    }
 }

--- a/src/ClassicUO.Client/LegionScripting/docs/API.py
+++ b/src/ClassicUO.Client/LegionScripting/docs/API.py
@@ -107,7 +107,7 @@ class ApiItem(ApiEntity):
 
     def GetContainerGump(self) -> "ApiUiBaseControl":
         """
-         If this item is a container ( item.IsContainer ) and is open, this will return the grid container or container gump for it.
+         If this item is a container ( item.IsContainer ) and is open, this will return the grid container, container gump, or grid loot gump for it.
         
         """
         pass

--- a/src/ClassicUO.Client/LegionScripting/docs/ApiItem.md
+++ b/src/ClassicUO.Client/LegionScripting/docs/ApiItem.md
@@ -90,7 +90,7 @@ description:  Represents a Python-accessible item in the game world.  Inherits e
 
 ### GetContainerGump
 
- If this item is a container ( item.IsContainer ) and is open, this will return the grid container or container gump for it.
+ If this item is a container ( item.IsContainer ) and is open, this will return the grid container, container gump, or grid loot gump for it.
 
 
 **Return Type:** `ApiUiBaseControl`

--- a/src/ClassicUO.Client/Network/PacketHandlers/DeleteObject.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers/DeleteObject.cs
@@ -72,8 +72,7 @@ internal static class DeleteObject
                 if (top != null && top.Graphic == 0x2006)
                 {
                     UIManager.GetGump<NearbyLootGump>()?.RequestUpdateContents();
-                    if (ProfileManager.CurrentProfile.GridLootType == 1 ||
-                        ProfileManager.CurrentProfile.GridLootType == 2)
+                    if (ProfileManager.CurrentProfile.CorpseContainerStyle == CorpseContainerStyle.OldGridLoot)
                         UIManager.GetGump<GridLootGump>(cont)?.RequestUpdateContents();
                 }
 

--- a/src/ClassicUO.Client/Network/PacketHandlers/DeleteObject.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers/DeleteObject.cs
@@ -72,7 +72,7 @@ internal static class DeleteObject
                 if (top != null && top.Graphic == 0x2006)
                 {
                     UIManager.GetGump<NearbyLootGump>()?.RequestUpdateContents();
-                    if (ProfileManager.CurrentProfile.CorpseContainerStyle == CorpseContainerStyle.OldGridLoot)
+                    if (ProfileManager.CurrentProfile.CorpseContainerStyle is CorpseContainerStyle.OldGridLoot or CorpseContainerStyle.OldGridLootAndContainer)
                         UIManager.GetGump<GridLootGump>(cont)?.RequestUpdateContents();
                 }
 

--- a/src/ClassicUO.Client/Network/PacketHandlers/Helpers/ItemHelpers.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers/Helpers/ItemHelpers.cs
@@ -120,7 +120,7 @@ internal static class ItemHelpers
 
                     #endregion
 
-                    if (ProfileManager.CurrentProfile.CorpseContainerStyle == CorpseContainerStyle.OldGridLoot)
+                    if (ProfileManager.CurrentProfile.CorpseContainerStyle is CorpseContainerStyle.OldGridLoot or CorpseContainerStyle.OldGridLootAndContainer)
                     {
                         GridLootGump grid_gump = UIManager.GetGump<GridLootGump>(
                             containerSerial

--- a/src/ClassicUO.Client/Network/PacketHandlers/Helpers/ItemHelpers.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers/Helpers/ItemHelpers.cs
@@ -120,7 +120,7 @@ internal static class ItemHelpers
 
                     #endregion
 
-                    if (ProfileManager.CurrentProfile.GridLootType > 0)
+                    if (ProfileManager.CurrentProfile.CorpseContainerStyle == CorpseContainerStyle.OldGridLoot)
                     {
                         GridLootGump grid_gump = UIManager.GetGump<GridLootGump>(
                             containerSerial

--- a/src/ClassicUO.Client/Network/PacketHandlers/OpenContainer.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers/OpenContainer.cs
@@ -15,6 +15,25 @@ namespace ClassicUO.Network.PacketHandlers;
 
 internal static class OpenContainer
 {
+    /// <summary>Whether the given corpse style opens the old grid loot gump (on its own or alongside a container).</summary>
+    private static bool CorpseUsesOldGridLoot(CorpseContainerStyle style) =>
+        style is CorpseContainerStyle.OldGridLoot or CorpseContainerStyle.OldGridLootAndContainer;
+
+    /// <summary>
+    ///     Determines whether a newly opened container/corpse should use a grid container gump.
+    ///     Corpses follow their dedicated <see cref="CorpseContainerStyle"/>; the "old grid loot + container"
+    ///     mode falls back to the global <see cref="ContainerStyle"/> for the accompanying container.
+    /// </summary>
+    private static bool ShouldUseGridContainer(Profile profile, bool isCorpse) =>
+        isCorpse
+            ? profile.CorpseContainerStyle switch
+            {
+                CorpseContainerStyle.Grid => true,
+                CorpseContainerStyle.Original => false,
+                _ => profile.ContainerStyle == ContainerStyle.Grid
+            }
+            : profile.ContainerStyle == ContainerStyle.Grid;
+
     public static void Receive(World world, ref StackDataReader p)
     {
         if (world.Player == null)
@@ -130,15 +149,17 @@ internal static class OpenContainer
             {
                 if (!NearbyLootGump.IsCorpseRequested(serial))
                 {
-                    if (
-                        item.IsCorpse
-                        && ProfileManager.CurrentProfile.CorpseContainerStyle == CorpseContainerStyle.OldGridLoot
-                    )
+                    CorpseContainerStyle corpseStyle = ProfileManager.CurrentProfile.CorpseContainerStyle;
+
+                    if (item.IsCorpse && CorpseUsesOldGridLoot(corpseStyle))
                     {
                         UIManager.GetGump<GridLootGump>(serial)?.Dispose();
                         UIManager.Add(new GridLootGump(world, serial));
                         Helpers.SharedStore.RequestedGridLoot = serial;
-                        return;
+
+                        // "Old grid loot only" shows just the loot gump; the combined mode also opens the container.
+                        if (corpseStyle == CorpseContainerStyle.OldGridLoot)
+                            return;
                     }
 
                     if (
@@ -148,9 +169,7 @@ internal static class OpenContainer
                     )
                         UpdateLargeContainerGraphics(ref graphic);
 
-                    bool useGridContainer = item.IsCorpse
-                        ? ProfileManager.CurrentProfile.CorpseContainerStyle == CorpseContainerStyle.Grid
-                        : ProfileManager.CurrentProfile.ContainerStyle == ContainerStyle.Grid;
+                    bool useGridContainer = ShouldUseGridContainer(ProfileManager.CurrentProfile, item.IsCorpse);
 
                     if (useGridContainer && graphic != 0x091A)
                         GridContainer.OpenOrUpdate(serial, graphic);
@@ -313,15 +332,17 @@ internal static class OpenContainer
             {
                 if (!NearbyLootGump.IsCorpseRequested(serial))
                 {
-                    if (
-                        item.IsCorpse
-                        && ProfileManager.CurrentProfile.CorpseContainerStyle == CorpseContainerStyle.OldGridLoot
-                    )
+                    CorpseContainerStyle corpseStyle = ProfileManager.CurrentProfile.CorpseContainerStyle;
+
+                    if (item.IsCorpse && CorpseUsesOldGridLoot(corpseStyle))
                     {
                         UIManager.GetGump<GridLootGump>(serial)?.Dispose();
                         UIManager.Add(new GridLootGump(world, serial));
                         Helpers.SharedStore.RequestedGridLoot = serial;
-                        return;
+
+                        // "Old grid loot only" shows just the loot gump; the combined mode also opens the container.
+                        if (corpseStyle == CorpseContainerStyle.OldGridLoot)
+                            return;
                     }
                     bool canuse = graphic == 1009 || graphic == 1081 || graphic == 1278 || graphic == 2417 || (graphic >= 1060 && graphic <= 1068) || (graphic >= 1071 && graphic <= 1079) || (graphic >= 1258 && graphic <= 1270) || (graphic >= 1282 && graphic <= 1291) || (graphic >= 1071 && graphic <= 1079);
 
@@ -344,9 +365,7 @@ internal static class OpenContainer
 
                     }
 
-                    bool useGridContainer = item.IsCorpse
-                        ? ProfileManager.CurrentProfile.CorpseContainerStyle == CorpseContainerStyle.Grid
-                        : ProfileManager.CurrentProfile.ContainerStyle == ContainerStyle.Grid;
+                    bool useGridContainer = ShouldUseGridContainer(ProfileManager.CurrentProfile, item.IsCorpse);
 
                     if (useGridContainer && !canuse && !isvendor && graphic != 0x091A)
                     {

--- a/src/ClassicUO.Client/Network/PacketHandlers/OpenContainer.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers/OpenContainer.cs
@@ -132,18 +132,13 @@ internal static class OpenContainer
                 {
                     if (
                         item.IsCorpse
-                        && (
-                            ProfileManager.CurrentProfile.GridLootType == 1
-                            || ProfileManager.CurrentProfile.GridLootType == 2
-                        )
+                        && ProfileManager.CurrentProfile.CorpseContainerStyle == CorpseContainerStyle.OldGridLoot
                     )
                     {
                         UIManager.GetGump<GridLootGump>(serial)?.Dispose();
                         UIManager.Add(new GridLootGump(world, serial));
                         Helpers.SharedStore.RequestedGridLoot = serial;
-
-                        if (ProfileManager.CurrentProfile.GridLootType == 1)
-                            return;
+                        return;
                     }
 
                     if (
@@ -153,8 +148,11 @@ internal static class OpenContainer
                     )
                         UpdateLargeContainerGraphics(ref graphic);
 
+                    bool useGridContainer = item.IsCorpse
+                        ? ProfileManager.CurrentProfile.CorpseContainerStyle == CorpseContainerStyle.Grid
+                        : ProfileManager.CurrentProfile.ContainerStyle == ContainerStyle.Grid;
 
-                    if (ProfileManager.CurrentProfile.UseGridLayoutContainerGumps && graphic != 0x091A)
+                    if (useGridContainer && graphic != 0x091A)
                         GridContainer.OpenOrUpdate(serial, graphic);
                     else
                     {
@@ -317,18 +315,13 @@ internal static class OpenContainer
                 {
                     if (
                         item.IsCorpse
-                        && (
-                            ProfileManager.CurrentProfile.GridLootType == 1
-                            || ProfileManager.CurrentProfile.GridLootType == 2
-                        )
+                        && ProfileManager.CurrentProfile.CorpseContainerStyle == CorpseContainerStyle.OldGridLoot
                     )
                     {
                         UIManager.GetGump<GridLootGump>(serial)?.Dispose();
                         UIManager.Add(new GridLootGump(world, serial));
                         Helpers.SharedStore.RequestedGridLoot = serial;
-
-                        if (ProfileManager.CurrentProfile.GridLootType == 1)
-                            return;
+                        return;
                     }
                     bool canuse = graphic == 1009 || graphic == 1081 || graphic == 1278 || graphic == 2417 || (graphic >= 1060 && graphic <= 1068) || (graphic >= 1071 && graphic <= 1079) || (graphic >= 1258 && graphic <= 1270) || (graphic >= 1282 && graphic <= 1291) || (graphic >= 1071 && graphic <= 1079);
 
@@ -351,7 +344,11 @@ internal static class OpenContainer
 
                     }
 
-                    if (ProfileManager.CurrentProfile.UseGridLayoutContainerGumps && !canuse && !isvendor && graphic != 0x091A)
+                    bool useGridContainer = item.IsCorpse
+                        ? ProfileManager.CurrentProfile.CorpseContainerStyle == CorpseContainerStyle.Grid
+                        : ProfileManager.CurrentProfile.ContainerStyle == ContainerStyle.Grid;
+
+                    if (useGridContainer && !canuse && !isvendor && graphic != 0x091A)
                     {
                         GridContainer.OpenOrUpdate(serial, graphic);
                     }


### PR DESCRIPTION
Replace the "Enable grid containers" toggle with a "Container Style" dropdown (Grid/Original, Grid default) and the "Original Style Grid Loot" combobox plus the old corpse container style setting with a single "Corpse Container Style" dropdown (Grid/Original/Old Grid Loot). Both are persisted in SqlProfile.cs and applied wherever containers and corpses are opened.

- New General tab at the start of Interface > Containers hosting both dropdowns
- Move "Default container view" (Grid/List) from Misc to the Grid tab
- Remove the Misc "Old Style Grid Loot" section
- Migrate existing profiles' old preferences to the new settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate style selections for regular containers and corpse containers.
  * Added Grid and Original presentation options for containers.
  * Added Grid, Original, and Old Grid Loot options for corpses.
  * Updated container settings with clearer controls and organization.

* **Bug Fixes**
  * Existing profiles now migrate automatically to the new container style settings.
  * Container and corpse windows consistently honor the selected styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->