### PR TITLE
Fix IndexOutOfRangeException on out-of-range map change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to TazUO will be recorded here.
 
 ---
+## In Development
+
+### Fixes
+* Fixed an IndexOutOfRangeException crash when the server sent a map change (ExtendedCommand 0x08) with an out-of-range map index while no map was loaded; the index is now clamped before the map is constructed - [P.R 762](https://github.com/PlayTazUO/TazUO/pull/762) ([bittiez](https://github.com/bittiez))
+
 ## V5.5.0
 
 ### Features

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.5.0</AssemblyVersion>
-    <FileVersion>5.5.0</FileVersion>
+    <AssemblyVersion>5.5.1</AssemblyVersion>
+    <FileVersion>5.5.1</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/World.cs
+++ b/src/ClassicUO.Client/Game/World.cs
@@ -194,6 +194,14 @@ namespace ClassicUO.Game
                         return;
                     }
 
+                    // Clamp to a valid map index. The server may send an out-of-range
+                    // index (map change is a single byte, so 0-255), which would throw
+                    // IndexOutOfRangeException when the Map is constructed.
+                    if (value < 0 || value >= MapLoader.MAPS_COUNT)
+                    {
+                        value = 0;
+                    }
+
                     if (Map != null)
                     {
                         if (MapIndex >= 0)
@@ -206,11 +214,6 @@ namespace ClassicUO.Game
                         sbyte z = Player.Z;
 
                         Map = null;
-
-                        if (value >= MapLoader.MAPS_COUNT)
-                        {
-                            value = 0;
-                        }
 
                         Client.Game.UO.FileManager.Maps.LoadMap(value, ClientFeatures.Flags.HasFlag(CharacterListFlags.CLF_UNLOCK_FELUCCA_AREAS));
                         Map = new Map.Map(this, value);


### PR DESCRIPTION
The map index clamp only ran in the branch where a Map already existed. When the server sent a map change (ExtendedCommand 0x08) with an index
>= MAPS_COUNT while World.Map was null, the unclamped value was passed
straight to the Map constructor, which indexed MapBlocksSize[Index, 0] and threw IndexOutOfRangeException.

Hoist the clamp above both branches so any out-of-range index (the map change value is a single byte, 0-255) is normalized to 0 before the Map is loaded and constructed.