### PR TITLE
Add option to only apply trees-to-stumps within circle of transparency radius

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to TazUO will be recorded here.
 ---
 ## In Development
 
+### Features
+* Added an option to only apply the trees-to-stumps replacement to trees within the circle of transparency radius, leaving farther trees at their normal appearance - [P.R 765](https://github.com/PlayTazUO/TazUO/pull/765) ([bittiez](https://github.com/bittiez))
+
 ### Fixes
 * Fixed a FormatException crash when loading a world map marker file that contained a malformed line; malformed lines are now logged and skipped instead of crashing the client, and a warning is shown in-game noting how many lines were skipped - [P.R 763](https://github.com/PlayTazUO/TazUO/pull/763) ([bittiez](https://github.com/bittiez))
 * Fixed an IndexOutOfRangeException crash when the server sent a map change (ExtendedCommand 0x08) with an out-of-range map index while no map was loaded; the index is now clamped before the map is constructed - [P.R 762](https://github.com/PlayTazUO/TazUO/pull/762) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.6.2</AssemblyVersion>
-    <FileVersion>5.6.2</FileVersion>
+    <AssemblyVersion>5.6.0</AssemblyVersion>
+    <FileVersion>5.6.0</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.5.2</AssemblyVersion>
-    <FileVersion>5.5.2</FileVersion>
+    <AssemblyVersion>5.6.2</AssemblyVersion>
+    <FileVersion>5.6.2</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -199,6 +199,7 @@ namespace ClassicUO.Configuration
         public bool ShowMobileHealthbar { get; set => SetProperty(ref field, value); } // Draws a small healthbar directly under each mobile
         public bool ShowMobileNameOverhead { get; set => SetProperty(ref field, value); } // Always draws the mobile's name/title above their head
         public bool TreeToStumps { get; set => SetProperty(ref field, value); }
+        public bool TreeToStumpsWithinRadius { get; set => SetProperty(ref field, value); } // Only replace trees within the circle of transparency radius
         public bool EnableCaveBorder { get; set => SetProperty(ref field, value); }
         public bool HideVegetation { get; set => SetProperty(ref field, value); }
         public bool DisableGargoyleFlyingAnimation { get; set => SetProperty(ref field, value); }

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -199,7 +199,6 @@ namespace ClassicUO.Configuration
         public bool ShowMobileHealthbar { get; set => SetProperty(ref field, value); } // Draws a small healthbar directly under each mobile
         public bool ShowMobileNameOverhead { get; set => SetProperty(ref field, value); } // Always draws the mobile's name/title above their head
         public bool TreeToStumps { get; set => SetProperty(ref field, value); }
-        public bool TreeToStumpsWithinRadius { get; set => SetProperty(ref field, value); } // Only replace trees within the circle of transparency radius
         public bool EnableCaveBorder { get; set => SetProperty(ref field, value); }
         public bool HideVegetation { get; set => SetProperty(ref field, value); }
         public bool DisableGargoyleFlyingAnimation { get; set => SetProperty(ref field, value); }

--- a/src/ClassicUO.Client/Configuration/SqlProfile.cs
+++ b/src/ClassicUO.Client/Configuration/SqlProfile.cs
@@ -182,4 +182,10 @@ public sealed partial class Profile
         [JsonIgnore]
         [SqlSetting(SettingsScope.Global, "auto_save_gump_positions", false)]
         public partial bool AutoSaveGumpPositions { get; set; }
+
+        // When enabled (alongside TreeToStumps), trees are only rendered as stumps while they
+        // are within the circle of transparency radius from the player.
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, Constants.SqlSettings.TREE_TO_STUMPS_WITHIN_RADIUS, false)]
+        public partial bool TreeToStumpsWithinRadius { get; set; }
 }

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -5,7 +5,7 @@
 ; Missing keys are auto-appended with English defaults when
 ; this file's version is newer than the user's copy.
 ; -------------------------------------------------------
-_version=64
+_version=65
 accountname=Account Name
 accountcontextmenutooltip=Right click to select another account.
 music=Music
@@ -1150,6 +1150,7 @@ mog_gameplaytab_terrain_hidevegetation=Hide vegetation
 mog_gameplaytab_terrain_label=Terrain & Statics
 mog_gameplaytab_terrain_magicfieldtype=Magic field type
 mog_gameplaytab_terrain_treestostump=Vegetation to stumps
+mog_gameplaytab_terrain_treestostumpradius=Only within circle of transparency radius
 mog_gameplaytab_misc_label=Misc
 
 ; --- general ---
@@ -1263,6 +1264,7 @@ mog_general_singleclickpathfind=Single click for pathfinding
 mog_general_smoothboat=Smooth boat movements
 mog_general_textfade=Enable text fading
 mog_general_treestostump=Change trees to stumps
+mog_general_treestostumpradius=Only within circle of transparency radius
 
 ; --- gumpstab ---
 mog_gumpstab_altforanchorsgumps=Require alt to close anchored gumps

--- a/src/ClassicUO.Client/Game/Constants.cs
+++ b/src/ClassicUO.Client/Game/Constants.cs
@@ -147,6 +147,7 @@ public const string SCALE_PETS_ENABLED = "scale_pets_enabled";
             public const string BANDAGE_JOURNAL_MESSAGES = "bandage_journal_messages";
             public const string VOTED_POLLS = "voted_polls";
             public const string OVERHEADS_SCALE_WITH_ZOOM = "overheads_scale_with_zoom";
+            public const string TREE_TO_STUMPS_WITHIN_RADIUS = "tree_to_stumps_within_radius";
         }
     }
 }

--- a/src/ClassicUO.Client/Game/Data/StaticFilters.cs
+++ b/src/ClassicUO.Client/Game/Data/StaticFilters.cs
@@ -346,6 +346,19 @@ namespace ClassicUO.Game.Data
             return false;
         }
 
+        /// <summary>
+        /// Determines whether an object at the given screen position falls within the configured
+        /// circle of transparency radius from the player. Used to optionally limit the
+        /// tree-to-stumps replacement to nearby trees only.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsWithinStumpRadius(Vector2 objectScreenPos, Vector2 playerScreenPos)
+        {
+            int radius = ProfileManager.CurrentProfile?.CircleOfTransparencyRadius ?? 0;
+
+            return Vector2.Distance(objectScreenPos, playerScreenPos) <= radius;
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsVegetation(ushort g) => (_filteredTiles[g] & STATIC_TILES_FILTER_FLAGS.STFF_VEGETATION) != 0;
 

--- a/src/ClassicUO.Client/Game/GameObjects/Views/StaticView.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Views/StaticView.cs
@@ -27,6 +27,13 @@ namespace ClassicUO.Game.GameObjects
         {
             if (StaticFilters.IsTree(graphic, out _) && _profile?.TreeToStumps == true)
             {
+                if (_profile.TreeToStumpsWithinRadius
+                    && World.Player != null
+                    && !StaticFilters.IsWithinStumpRadius(GetScreenPosition(), World.Player.GetScreenPosition()))
+                {
+                    return graphic;
+                }
+
                 return Constants.TREE_REPLACE_GRAPHIC;
             }
             return graphic;

--- a/src/ClassicUO.Client/Game/Scenes/GameSceneDrawingSorting.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameSceneDrawingSorting.cs
@@ -490,6 +490,27 @@ namespace ClassicUO.Game.Scenes
             return false;
         }
 
+        /// <summary>
+        /// Determines whether a foliage object should be hidden as part of the tree-to-stumps
+        /// feature. When <see cref="Profile.TreeToStumpsWithinRadius"/> is enabled the foliage is
+        /// only hidden while it is within the circle of transparency radius from the player.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool HideFoliageForStumps(GameObject obj, Profile profile, ref Vector2 playerScreePos)
+        {
+            if (!profile.TreeToStumps)
+            {
+                return false;
+            }
+
+            if (profile.TreeToStumpsWithinRadius)
+            {
+                return StaticFilters.IsWithinStumpRadius(obj.GetScreenPosition(), playerScreePos);
+            }
+
+            return true;
+        }
+
         private static bool CalculateAlpha(ref byte alphaHue, int maxAlpha)
         {
             if (
@@ -745,7 +766,7 @@ namespace ClassicUO.Game.Scenes
                             }
 
                             //we avoid to hide impassable foliage or bushes, if present...
-                            if (itemData.IsFoliage && profile.TreeToStumps)
+                            if (itemData.IsFoliage && HideFoliageForStumps(obj, profile, ref playerScreePos))
                             {
                                 continue;
                             }
@@ -834,7 +855,7 @@ namespace ClassicUO.Game.Scenes
 
                             if (!itemData.IsMultiMovable)
                             {
-                                if (itemData.IsFoliage && profile.TreeToStumps)
+                                if (itemData.IsFoliage && HideFoliageForStumps(obj, profile, ref playerScreePos))
                                 {
                                     continue;
                                 }
@@ -981,7 +1002,7 @@ namespace ClassicUO.Game.Scenes
                             if (
                                 !itemData.IsMultiMovable
                                 && itemData.IsFoliage
-                                && profile.TreeToStumps
+                                && HideFoliageForStumps(obj, profile, ref playerScreePos)
                             )
                             {
                                 continue;

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
@@ -772,6 +772,12 @@ namespace ClassicUO.Game.UI.Gumps
             (new CheckboxWithLabel(TazLang.Get("mog_general_treestostump"), isChecked: profile.TreeToStumps, valueChanged: (b) => { profile.TreeToStumps = b; }),
                 true, page);
 
+            content.Indent();
+            content.AddToRight
+            (new CheckboxWithLabel(TazLang.Get("mog_general_treestostumpradius"), isChecked: profile.TreeToStumpsWithinRadius, valueChanged: (b) => { profile.TreeToStumpsWithinRadius = b; }),
+                true, page);
+            content.RemoveIndent();
+
             content.BlankLine();
 
             content.AddToRight

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/GameplayTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/GameplayTab.cs
@@ -85,6 +85,11 @@ public static class GameplayTab
                 search: new SearchMetadata(TazLang.Get("mog_gameplaytab_terrain_treestostump"), Keywords: [TazLang.Get("mog_kw_tree"), TazLang.Get("mog_kw_stump")])
             ),
             Option.Checkbox(
+                TazLang.Get("mog_gameplaytab_terrain_treestostumpradius"),
+                new Accessor<bool>(() => profile.TreeToStumpsWithinRadius),
+                search: new SearchMetadata(TazLang.Get("mog_gameplaytab_terrain_treestostumpradius"), Keywords: [TazLang.Get("mog_kw_tree"), TazLang.Get("mog_kw_stump")])
+            ),
+            Option.Checkbox(
                 TazLang.Get("mog_gameplaytab_terrain_hidevegetation"),
                 new Accessor<bool>(() => profile.HideVegetation),
                 search: new SearchMetadata(TazLang.Get("mog_gameplaytab_terrain_hidevegetation"), Keywords: [TazLang.Get("mog_kw_vegetation")])


### PR DESCRIPTION

Introduces a TreeToStumpsWithinRadius profile sub-option. When enabled alongside TreeToStumps, tree trunks are only replaced with stumps and their foliage canopy is only hidden while the tree is within the circle of transparency radius from the player; trees outside the radius keep their normal appearance.
