### PR TITLE
Fix tooltip overrides not applying to items in server gumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to TazUO will be recorded here.
 * Added an option to only apply the trees-to-stumps replacement to trees within the circle of transparency radius, leaving farther trees at their normal appearance - [P.R 765](https://github.com/PlayTazUO/TazUO/pull/765) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
+* Fixed tooltip overrides no longer applying to items shown in server-sent gumps (which aren't real world items, like vendor search results); the override now falls back to the item's OPL text instead of showing the raw tooltip - [P.R 767](https://github.com/PlayTazUO/TazUO/pull/767) ([bittiez](https://github.com/bittiez))
 * Fixed a FormatException crash when loading a world map marker file that contained a malformed line; malformed lines are now logged and skipped instead of crashing the client, and a warning is shown in-game noting how many lines were skipped - [P.R 763](https://github.com/PlayTazUO/TazUO/pull/763) ([bittiez](https://github.com/bittiez))
 * Fixed an IndexOutOfRangeException crash when the server sent a map change (ExtendedCommand 0x08) with an out-of-range map index while no map was loaded; the index is now clamped before the map is constructed - [P.R 762](https://github.com/PlayTazUO/TazUO/pull/762) ([bittiez](https://github.com/bittiez))
 

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.7.0</AssemblyVersion>
-    <FileVersion>5.7.0</FileVersion>
+    <AssemblyVersion>5.7.1</AssemblyVersion>
+    <FileVersion>5.7.1</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/Managers/ToolTipOverrideManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/ToolTipOverrideManager.cs
@@ -387,6 +387,31 @@ namespace ClassicUO.Game.Managers
             return BuildTooltip(itemPropertiesData);
         }
 
+        /// <summary>
+        /// Resolve the final tooltip text for a hovered object, applying any configured overrides.
+        /// Items that exist in the world are resolved by serial. Items shown in server-sent gumps
+        /// (and vendor search results) are referenced by serial but aren't real world items, so the
+        /// serial lookup returns null - in that case the override is applied to the raw OPL text
+        /// (<paramref name="rawHtml"/>) instead. Falls back to the raw text only when no override
+        /// produced any output.
+        /// </summary>
+        public static string ResolveTooltipText(World world, uint serial, string rawHtml)
+        {
+            string finalString = null;
+
+            if (SerialHelper.IsItem(serial))
+                finalString = ProcessTooltipText(world, serial);
+
+            //Fix for vendor search and items shown in server gumps that aren't real world items.
+            if (string.IsNullOrEmpty(finalString) && !string.IsNullOrEmpty(rawHtml))
+                finalString = ProcessTooltipText(rawHtml);
+
+            if (string.IsNullOrEmpty(finalString))
+                finalString = rawHtml;
+
+            return finalString;
+        }
+
         private static bool CheckLayers(TooltipLayers overrideLayer, byte itemLayer)
         {
             if (overrideLayer == TooltipLayers.Any)

--- a/src/ClassicUO.Client/Game/UI/Tooltip.cs
+++ b/src/ClassicUO.Client/Game/UI/Tooltip.cs
@@ -98,15 +98,18 @@ namespace ClassicUO.Game.UI
                         align = FontStashSharp.RichText.TextHorizontalAlignment.Center;
                 }
 
-                string finalString = _textHTML;
+                string finalString = null;
                 if (SerialHelper.IsItem(Serial))
-                {
                     finalString = Managers.ToolTipOverrideData.ProcessTooltipText(_world, Serial);
-                    finalString ??= _textHTML;
-                }
 
-                if (string.IsNullOrEmpty(finalString) && !string.IsNullOrEmpty(_textHTML)) //Fix for vendor search
+                //Fix for vendor search and items shown in server gumps that aren't real world items:
+                //the serial based lookup above returns null when the item isn't in world.Items, so
+                //apply the override using the raw OPL text instead of skipping it entirely.
+                if (string.IsNullOrEmpty(finalString) && !string.IsNullOrEmpty(_textHTML))
                     finalString = Managers.ToolTipOverrideData.ProcessTooltipText(_textHTML);
+
+                if (string.IsNullOrEmpty(finalString))
+                    finalString = _textHTML;
 
                 if (_item?.CustomName.NotNullNotEmpty() == true) //Add custom item name
                     finalString = $"[{_item.CustomName}]\n" + finalString;

--- a/src/ClassicUO.Client/Game/UI/Tooltip.cs
+++ b/src/ClassicUO.Client/Game/UI/Tooltip.cs
@@ -98,18 +98,7 @@ namespace ClassicUO.Game.UI
                         align = FontStashSharp.RichText.TextHorizontalAlignment.Center;
                 }
 
-                string finalString = null;
-                if (SerialHelper.IsItem(Serial))
-                    finalString = Managers.ToolTipOverrideData.ProcessTooltipText(_world, Serial);
-
-                //Fix for vendor search and items shown in server gumps that aren't real world items:
-                //the serial based lookup above returns null when the item isn't in world.Items, so
-                //apply the override using the raw OPL text instead of skipping it entirely.
-                if (string.IsNullOrEmpty(finalString) && !string.IsNullOrEmpty(_textHTML))
-                    finalString = Managers.ToolTipOverrideData.ProcessTooltipText(_textHTML);
-
-                if (string.IsNullOrEmpty(finalString))
-                    finalString = _textHTML;
+                string finalString = Managers.ToolTipOverrideData.ResolveTooltipText(_world, Serial, _textHTML);
 
                 if (_item?.CustomName.NotNullNotEmpty() == true) //Add custom item name
                     finalString = $"[{_item.CustomName}]\n" + finalString;

--- a/tests/ClassicUO.UnitTests/Game/Managers/ToolTipOverrideTest.cs
+++ b/tests/ClassicUO.UnitTests/Game/Managers/ToolTipOverrideTest.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using ClassicUO.Configuration;
+using ClassicUO.Game;
+using ClassicUO.Game.Data;
+using ClassicUO.Game.Managers;
+using FluentAssertions;
+using Xunit;
+
+namespace ClassicUO.UnitTests.Game.Managers
+{
+    /// <summary>
+    /// Tests for <see cref="ToolTipOverrideData"/> tooltip override resolution.
+    ///
+    /// These cover the two branches of <see cref="ToolTipOverrideData.ResolveTooltipText"/>:
+    /// the "item" branch (a serial that <see cref="SerialHelper.IsItem"/> recognizes) and the
+    /// "not item" branch (raw OPL text, e.g. vendor search results). Items shown in server-sent
+    /// gumps are referenced by serial but often aren't real entries in world.Items, so they must
+    /// still receive overrides via their raw OPL text - a case that was accidentally broken when
+    /// a failed serial lookup started returning the raw, un-overridden text instead of trying the
+    /// text based override.
+    /// </summary>
+    public class ToolTipOverrideTest : IDisposable
+    {
+        // Any serial in [0x40000000, 0x80000000) is treated as an item by SerialHelper.IsItem.
+        private const uint ITEM_SERIAL = 0x40000001;
+
+        // A distinctive token so we can prove the override was applied rather than the raw text shown.
+        private const string OVERRIDE_FORMAT = "FIRERES={1}";
+        private const string RAW_TOOLTIP = "Some Sword\nFire Resist 15";
+
+        public ToolTipOverrideTest() => SetCurrentProfile(CreateProfileWithFireResistOverride());
+
+        public void Dispose() => SetCurrentProfile(null);
+
+        #region "Not item" branch (raw OPL text / vendor search)
+
+        [Fact]
+        public void ProcessTooltipText_StringOverload_AppliesOverride()
+        {
+            string result = ToolTipOverrideData.ProcessTooltipText(RAW_TOOLTIP);
+
+            result.Should().Contain("FIRERES=15", "the configured override should rewrite the property line");
+            result.Should().NotContain("Fire Resist 15", "the original property line should have been replaced");
+        }
+
+        [Fact]
+        public void ResolveTooltipText_NonItemSerial_AppliesOverrideFromRawText()
+        {
+            var world = new World();
+
+            // serial 0 is not an item, so resolution must come from the raw OPL text.
+            string result = ToolTipOverrideData.ResolveTooltipText(world, 0, RAW_TOOLTIP);
+
+            result.Should().Contain("FIRERES=15");
+
+            world.Clear();
+        }
+
+        #endregion
+
+        #region "Item" branch (item shown in a server gump, not a real world item)
+
+        [Fact]
+        public void ResolveTooltipText_ItemSerialNotInWorld_AppliesOverrideFromRawText()
+        {
+            var world = new World();
+
+            // ITEM_SERIAL is a valid item serial (as sent in a server gump) but is NOT in world.Items,
+            // exactly like an item shown in a server-sent gump. The override must still be applied.
+            string result = ToolTipOverrideData.ResolveTooltipText(world, ITEM_SERIAL, RAW_TOOLTIP);
+
+            result.Should().Contain("FIRERES=15");
+
+            world.Clear();
+        }
+
+        [Fact]
+        public void ResolveTooltipText_ItemSerialNotInWorld_DoesNotReturnRawUnprocessedText()
+        {
+            var world = new World();
+
+            // Regression guard: when the serial lookup fails, resolution must fall through to the
+            // text based override instead of returning the raw, un-overridden tooltip.
+            string result = ToolTipOverrideData.ResolveTooltipText(world, ITEM_SERIAL, RAW_TOOLTIP);
+
+            result.Should().NotBe(RAW_TOOLTIP);
+            result.Should().NotContain("Fire Resist 15");
+
+            world.Clear();
+        }
+
+        [Fact]
+        public void ProcessTooltipText_ItemNotInWorld_ReturnsNull()
+        {
+            var world = new World();
+
+            // Documents why the raw-text fallback in ResolveTooltipText is required: the serial based
+            // lookup produces nothing for an item that isn't in world.Items.
+            string result = ToolTipOverrideData.ProcessTooltipText(world, ITEM_SERIAL);
+
+            result.Should().BeNull();
+
+            world.Clear();
+        }
+
+        #endregion
+
+        #region Fallback / no-override behaviour
+
+        [Fact]
+        public void ResolveTooltipText_NoOverrideConfigured_KeepsPropertyText()
+        {
+            SetCurrentProfile(CreateProfileWithNoOverrides());
+            var world = new World();
+
+            string result = ToolTipOverrideData.ResolveTooltipText(world, ITEM_SERIAL, RAW_TOOLTIP);
+
+            // With no overrides, the property line survives unchanged (no override token added).
+            result.Should().Contain("Fire Resist 15");
+            result.Should().NotContain("FIRERES=");
+
+            world.Clear();
+        }
+
+        [Fact]
+        public void ResolveTooltipText_EmptyRawTextAndNoWorldItem_ReturnsRawText()
+        {
+            var world = new World();
+
+            string result = ToolTipOverrideData.ResolveTooltipText(world, ITEM_SERIAL, string.Empty);
+
+            result.Should().BeEmpty();
+
+            world.Clear();
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private static Profile CreateProfileWithFireResistOverride()
+        {
+            Profile profile = CreateProfileWithNoOverrides();
+
+            profile.ToolTipOverride_SearchText = new List<string> { "Fire Resist" };
+            profile.ToolTipOverride_NewFormat = new List<string> { OVERRIDE_FORMAT };
+            profile.ToolTipOverride_MinVal1 = new List<int> { -1 };
+            profile.ToolTipOverride_MinVal2 = new List<int> { -1 };
+            profile.ToolTipOverride_MaxVal1 = new List<int> { 100 };
+            profile.ToolTipOverride_MaxVal2 = new List<int> { 100 };
+            profile.ToolTipOverride_Layer = new List<byte> { (byte)TooltipLayers.Any };
+
+            return profile;
+        }
+
+        private static Profile CreateProfileWithNoOverrides()
+        {
+            return new Profile
+            {
+                // Skip grid-highlight matching so the test doesn't depend on the highlight config/db.
+                GridHighlightProperties = false,
+                GridHighlightShowRuleName = false,
+                ToolTipOverride_SearchText = new List<string>(),
+                ToolTipOverride_NewFormat = new List<string>(),
+                ToolTipOverride_MinVal1 = new List<int>(),
+                ToolTipOverride_MinVal2 = new List<int>(),
+                ToolTipOverride_MaxVal1 = new List<int>(),
+                ToolTipOverride_MaxVal2 = new List<int>(),
+                ToolTipOverride_Layer = new List<byte>(),
+            };
+        }
+
+        private static void SetCurrentProfile(Profile profile)
+        {
+            PropertyInfo prop = typeof(ProfileManager).GetProperty(
+                nameof(ProfileManager.CurrentProfile),
+                BindingFlags.Public | BindingFlags.Static);
+
+            prop.SetValue(null, profile);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Items shown in server-sent gumps are referenced by serial but are often not real entries in world.Items (same as the vendor search case). For those, the serial based ProcessTooltipText lookup returns null.

The previous logic set finalString to the raw OPL text (via `finalString ??= _textHTML`) whenever the serial lookup failed, which made the subsequent text based override fallback skip itself because finalString was no longer empty. As a result the override was never applied to server gump items.

Reorder so the text based override is attempted when the serial lookup returns nothing, only falling back to the raw OPL text when no override produced output.