### PR TITLE
Allow target cursor to select bag via grid container top/label section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to TazUO will be recorded here.
 ## In Development
 
 ### Features
+* The grid container top/label section now accepts target cursors to select the container (bag) itself, matching how clicking an empty grid slot behaves - [P.R 781](https://github.com/PlayTazUO/TazUO/pull/781) ([bittiez](https://github.com/bittiez))
 * Added named auto loot lists so you can quickly swap between multiple loot configurations; a "Loot Lists" selector with New/Rename/Delete controls was added to the Auto Loot agent, existing entries are migrated into a "Default" list, and at least one list is always kept - [P.R 766](https://github.com/PlayTazUO/TazUO/pull/766) ([bittiez](https://github.com/bittiez))
 * Replaced the tooltip override configuration gump with a new Myra window, and added an optional per-rule custom tooltip border color (drawn as a thick border around the tooltip when the rule matches) - [P.R 768](https://github.com/PlayTazUO/TazUO/pull/768) ([bittiez](https://github.com/bittiez))
 * Reworked the container options into a new General tab with a "Container Style" dropdown (Grid/Original) and a "Corpse Container Style" dropdown (Grid/Original/Old Grid Loot/Old Grid Loot + Container), replacing the old "Enable grid containers" toggle and "Original Style Grid Loot" setting; moved "Default container view" to the Grid tab and migrated existing preferences - [P.R 761](https://github.com/PlayTazUO/TazUO/pull/761) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.9.7</AssemblyVersion>
-    <FileVersion>5.9.7</FileVersion>
+    <AssemblyVersion>5.9.8</AssemblyVersion>
+    <FileVersion>5.9.8</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/GridContainer.cs
@@ -888,23 +888,30 @@ public partial class GridContainer : ResizableGump
         /// <param name="e">The mouse event's arguments</param>
         private void OnBackgroundMouseUp(object sender, MouseEventArgs e)
         {
-            // Check whether we're trying to drop an item on the background
-            if (e.Button != MouseButtonType.Left || !Client.Game.UO.GameCursor.ItemHold.Enabled)
+            if (e.Button != MouseButtonType.Left)
                 return;
 
             // Verify the sender is actually what we expect it to be
             if (sender is not Control { MouseIsOver: true })
                 return;
 
-            // Issue a direct drop item command and let the underlying `UpdateContainerItem`
-            // mechanisms take care of actual placement
-            GameActions.DropItem(
-                Client.Game.UO.GameCursor.ItemHold.Serial,
-                0xFFFF,
-                0xFFFF,
-                0,
-                LocalSerial
-            );
+            if (Client.Game.UO.GameCursor.ItemHold.Enabled)
+            {
+                // Issue a direct drop item command and let the underlying `UpdateContainerItem`
+                // mechanisms take care of actual placement
+                GameActions.DropItem(
+                    Client.Game.UO.GameCursor.ItemHold.Serial,
+                    0xFFFF,
+                    0xFFFF,
+                    0,
+                    LocalSerial
+                );
+            }
+            else if (World.TargetManager.IsTargeting && !ProfileManager.CurrentProfile.DisableTargetingGridContainers)
+            {
+                // Let a target cursor pick the bag itself, matching how an empty grid slot behaves
+                World.TargetManager.Target(LocalSerial);
+            }
         }
 
         protected override void OnMouseExit(int x, int y)


### PR DESCRIPTION
The top section of a grid container (holding the container name label and background strip) previously only accepted item drops. Now, when a target cursor is active, clicking that section targets the container itself, matching how clicking an empty grid slot already behaves (and respecting the DisableTargetingGridContainers profile option).