### PR TITLE
Add hysteresis buffer to tree-to-stumps radius to prevent flashing

### DIFF
--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.9.9</AssemblyVersion>
-    <FileVersion>5.9.9</FileVersion>
+    <AssemblyVersion>5.9.10</AssemblyVersion>
+    <FileVersion>5.9.10</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/Data/StaticFilters.cs
+++ b/src/ClassicUO.Client/Game/Data/StaticFilters.cs
@@ -479,7 +479,7 @@ namespace ClassicUO.Game.Data
         /// between tree and stump every frame. A tree only becomes a stump once inside the radius
         /// and only reverts once beyond the radius plus this buffer.
         /// </summary>
-        private const int STUMP_RADIUS_BUFFER = 10;
+        private const int STUMP_RADIUS_BUFFER = 50;
 
         /// <summary>
         /// Determines whether an object at the given screen position falls within the configured

--- a/src/ClassicUO.Client/Game/Data/StaticFilters.cs
+++ b/src/ClassicUO.Client/Game/Data/StaticFilters.cs
@@ -473,16 +473,40 @@ namespace ClassicUO.Game.Data
         }
 
         /// <summary>
+        /// Buffer (in screen pixels) applied as a hysteresis deadband around the tree-to-stumps
+        /// radius. The player's screen position bobs up and down slightly during walk/run
+        /// animations, so without a buffer trees sitting right at the radius boundary would flip
+        /// between tree and stump every frame. A tree only becomes a stump once inside the radius
+        /// and only reverts once beyond the radius plus this buffer.
+        /// </summary>
+        private const int STUMP_RADIUS_BUFFER = 10;
+
+        /// <summary>
         /// Determines whether an object at the given screen position falls within the configured
         /// circle of transparency radius from the player. Used to optionally limit the
-        /// tree-to-stumps replacement to nearby trees only.
+        /// tree-to-stumps replacement to nearby trees only. Applies a hysteresis buffer via
+        /// <paramref name="withinRadius"/> so trees near the boundary don't flash as the player's
+        /// animated screen position bobs slightly.
         /// </summary>
+        /// <param name="objectScreenPos">The object's screen position.</param>
+        /// <param name="playerScreenPos">The player's screen position.</param>
+        /// <param name="withinRadius">
+        /// The object's current within-radius state. Read to determine the active threshold and
+        /// updated in place with the new state.
+        /// </param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsWithinStumpRadius(Vector2 objectScreenPos, Vector2 playerScreenPos)
+        public static bool IsWithinStumpRadius(Vector2 objectScreenPos, Vector2 playerScreenPos, ref bool withinRadius)
         {
             int radius = ProfileManager.CurrentProfile?.CircleOfTransparencyRadius ?? 0;
 
-            return Vector2.Distance(objectScreenPos, playerScreenPos) <= radius;
+            // Use the outer threshold when already inside so a small bob past the radius doesn't
+            // immediately revert the tree; use the inner threshold when outside so it only converts
+            // once genuinely within the radius.
+            int threshold = withinRadius ? radius + STUMP_RADIUS_BUFFER : radius;
+
+            withinRadius = Vector2.Distance(objectScreenPos, playerScreenPos) <= threshold;
+
+            return withinRadius;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/ClassicUO.Client/Game/GameObjects/GameObject.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/GameObject.cs
@@ -122,6 +122,14 @@ namespace ClassicUO.Game.GameObjects
             }
         }
         public Vector3 Offset;
+
+        /// <summary>
+        /// Tracks whether this object is currently treated as within the tree-to-stumps radius.
+        /// Used to apply hysteresis so trees near the radius boundary don't flash when the
+        /// player's screen position bobs slightly during walk/run animations.
+        /// </summary>
+        public bool WithinStumpRadius;
+
         public short PriorityZ;
         public GameObject TNext;
         public GameObject TPrevious;

--- a/src/ClassicUO.Client/Game/GameObjects/Views/StaticView.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Views/StaticView.cs
@@ -29,7 +29,7 @@ namespace ClassicUO.Game.GameObjects
             {
                 if (_profile.TreeToStumpsWithinRadius
                     && World.Player != null
-                    && !StaticFilters.IsWithinStumpRadius(GetScreenPosition(), World.Player.GetScreenPosition()))
+                    && !StaticFilters.IsWithinStumpRadius(GetScreenPosition(), World.Player.GetScreenPosition(), ref WithinStumpRadius))
                 {
                     return graphic;
                 }

--- a/src/ClassicUO.Client/Game/Scenes/GameSceneDrawingSorting.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameSceneDrawingSorting.cs
@@ -505,7 +505,7 @@ namespace ClassicUO.Game.Scenes
 
             if (profile.TreeToStumpsWithinRadius)
             {
-                return StaticFilters.IsWithinStumpRadius(obj.GetScreenPosition(), playerScreePos);
+                return StaticFilters.IsWithinStumpRadius(obj.GetScreenPosition(), playerScreePos, ref obj.WithinStumpRadius);
             }
 
             return true;


### PR DESCRIPTION
Trees near the circle-of-transparency radius boundary flashed between tree and stump because the player's screen position bobs slightly up and down during walk/run animations, causing the distance to oscillate across the threshold each frame.

Apply a 10px hysteresis deadband: a tree only becomes a stump once inside the radius, and only reverts once beyond radius + 10px. The per-object state is tracked on GameObject.WithinStumpRadius.