### PR TITLE
Add toggle to ignore tooltip overrides for mobiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to TazUO will be recorded here.
 ## In Development
 
 ### Features
+* Added an optional toggle (enabled by default) to ignore tooltip overrides for mobiles, so their raw tooltip text is shown instead of override-formatted text - [P.R 784](https://github.com/PlayTazUO/TazUO/pull/784) ([bittiez](https://github.com/bittiez))
 * The grid container top/label section now accepts target cursors to select the container (bag) itself, matching how clicking an empty grid slot behaves - [P.R 781](https://github.com/PlayTazUO/TazUO/pull/781) ([bittiez](https://github.com/bittiez))
 * Added named auto loot lists so you can quickly swap between multiple loot configurations; a "Loot Lists" selector with New/Rename/Delete controls was added to the Auto Loot agent, existing entries are migrated into a "Default" list, and at least one list is always kept - [P.R 766](https://github.com/PlayTazUO/TazUO/pull/766) ([bittiez](https://github.com/bittiez))
 * Replaced the tooltip override configuration gump with a new Myra window, and added an optional per-rule custom tooltip border color (drawn as a thick border around the tooltip when the rule matches) - [P.R 768](https://github.com/PlayTazUO/TazUO/pull/768) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.9.10</AssemblyVersion>
-    <FileVersion>5.9.10</FileVersion>
+    <AssemblyVersion>5.10.0</AssemblyVersion>
+    <FileVersion>5.10.0</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -724,6 +724,8 @@ namespace ClassicUO.Configuration
         public List<byte> ToolTipOverride_Layer { get; set => SetProperty(ref field, value); } = new List<byte>() { (byte)TooltipLayers.Any, (byte)TooltipLayers.Any, (byte)TooltipLayers.Any, (byte)TooltipLayers.Any, (byte)TooltipLayers.Any, (byte)TooltipLayers.Any };
         /// <summary>Optional per-override border hue drawn around the tooltip when the rule matches; -1 means no override.</summary>
         public List<int> ToolTipOverride_BorderHue { get; set => SetProperty(ref field, value); } = new List<int>() { -1, -1, -1, -1, -1, -1 };
+        /// <summary>When enabled, tooltip overrides are not applied to mobile tooltips.</summary>
+        public bool ToolTipOverride_IgnoreMobiles { get; set => SetProperty(ref field, value); } = true;
         #endregion
 
         public string TooltipHeaderFormat { get; set => SetProperty(ref field, value); } = "/c[yellow]{0}";

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -1881,6 +1881,7 @@ mog_tazuo_hpopacity=HP opacity
 mog_tazuo_importfromurl=Import from url
 mog_tazuo_infobarfont=Infobar font
 mog_tazuo_inputrequesturl=Enter the url for the spell config. \n/c[red]This will override your current config.
+mog_tazuo_ignoretooltipoverridesformobiles=Ignore tooltip overrides for mobiles
 mog_tazuo_journal=Journal
 mog_tazuo_journalbackgroundcolor=Background color
 mog_tazuo_journalfont=Journal font

--- a/src/ClassicUO.Client/Game/Managers/ToolTipOverrideManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/ToolTipOverrideManager.cs
@@ -463,6 +463,10 @@ namespace ClassicUO.Game.Managers
             borderHue = -1;
             string finalString = null;
 
+            // Optionally skip overrides entirely for mobiles, returning their raw tooltip text.
+            if (SerialHelper.IsMobile(serial) && ProfileManager.CurrentProfile is { ToolTipOverride_IgnoreMobiles: true })
+                return rawHtml;
+
             if (SerialHelper.IsItem(serial))
                 finalString = ProcessTooltipText(world, serial, out borderHue);
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
@@ -4340,6 +4340,12 @@ namespace ClassicUO.Game.UI.Gumps
             content.BlankLine();
 
             content.AddToRight
+            (new CheckboxWithLabel(TazLang.Get("mog_tazuo_ignoretooltipoverridesformobiles"), 0, profile.ToolTipOverride_IgnoreMobiles, b => { profile.ToolTipOverride_IgnoreMobiles = b; }),
+                true, page);
+
+            content.BlankLine();
+
+            content.AddToRight
             (new HttpClickableLink("Tooltip Overrides Wiki", "https://github.com/PlayTazUO/TazUO/wiki/TazUO.Tooltip-Override", ThemeSettings.TEXT_FONT_COLOR),
                 true, page);
 

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/TooltipsTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/TooltipsTab.cs
@@ -65,6 +65,11 @@ public static class TooltipsTab
                     LabelText = TazLang.Get("mog_tooltips_labeltooltipoverrides"),
                     LabelLink = "https://tazuo.org/wiki/tooltip-override/"
                 },
+                Option.Checkbox(
+                    TazLang.Get("mog_tazuo_ignoretooltipoverridesformobiles"),
+                    new Accessor<bool>(() => profile.ToolTipOverride_IgnoreMobiles),
+                    search: new SearchMetadata(TazLang.Get("mog_tazuo_ignoretooltipoverridesformobiles"), Keywords: [TazLang.Get("mog_kw_override"), TazLang.Get("mog_kw_mobile")])
+                ),
                 Option.Button(
                     TazLang.Get("mog_tooltips_labelopenoverridesconfig"),
                     () => TooltipOverrideWindow.Show(World.Instance),


### PR DESCRIPTION
Adds an optional profile setting (enabled by default) that skips applying tooltip overrides to mobile tooltips, returning their raw text instead. Exposed as a checkbox in both the modern and Myra options tooltip settings.