### PR TITLE
Add Layer sort mode to GridContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to TazUO will be recorded here.
 ## In Development
 
 ### Features
+* Added a "Sort by Layer" option to the grid container sort menu, ordering items by their equipment layer (graphic and hue as tiebreakers) - [P.R 785](https://github.com/PlayTazUO/TazUO/pull/785) ([bittiez](https://github.com/bittiez))
 * Added an optional toggle (enabled by default) to ignore tooltip overrides for mobiles, so their raw tooltip text is shown instead of override-formatted text - [P.R 784](https://github.com/PlayTazUO/TazUO/pull/784) ([bittiez](https://github.com/bittiez))
 * The grid container top/label section now accepts target cursors to select the container (bag) itself, matching how clicking an empty grid slot behaves - [P.R 781](https://github.com/PlayTazUO/TazUO/pull/781) ([bittiez](https://github.com/bittiez))
 * Added named auto loot lists so you can quickly swap between multiple loot configurations; a "Loot Lists" selector with New/Rename/Delete controls was added to the Auto Loot agent, existing entries are migrated into a "Default" list, and at least one list is always kept - [P.R 766](https://github.com/PlayTazUO/TazUO/pull/766) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.10.0</AssemblyVersion>
-    <FileVersion>5.10.0</FileVersion>
+    <AssemblyVersion>5.11.0</AssemblyVersion>
+    <FileVersion>5.11.0</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/Enums/GridSortMode.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/Enums/GridSortMode.cs
@@ -3,5 +3,6 @@ namespace ClassicUO.Game.UI.Gumps;
 public enum GridSortMode
 {
     GraphicAndHue = 0,
-    Name = 1
+    Name = 1,
+    Layer = 2
 }

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/GridContainer.cs
@@ -110,7 +110,12 @@ public partial class GridContainer : ResizableGump
             get
             {
                 string status = GetEnabledDisabledText(_autoSortContainer);
-                string sortModeText = _sortMode == GridSortMode.Name ? TazLang.Get("gridcontainer_sortmode_name", "Name") : TazLang.Get("gridcontainer_sortmode_graphichue", "Graphic + Hue");
+                string sortModeText = _sortMode switch
+                {
+                    GridSortMode.Name => TazLang.Get("gridcontainer_sortmode_name", "Name"),
+                    GridSortMode.Layer => TazLang.Get("gridcontainer_sortmode_layer", "Layer"),
+                    _ => TazLang.Get("gridcontainer_sortmode_graphichue", "Graphic + Hue")
+                };
                 return TazLang.Get("gridcontainer_sort_tooltip", new string[] { sortModeText, status });
             }
         }
@@ -706,6 +711,15 @@ public partial class GridContainer : ResizableGump
                 UpdateItems(true);
                 _gridContainerEntry.UpdateSaveDataEntry(this);
             }, true, _sortMode == GridSortMode.Name));
+
+            control.Add(new ContextMenuItemEntry(TazLang.Get("gridcontainer_sortbylayer", "Sort by Layer"), () =>
+            {
+                _sortMode = GridSortMode.Layer;
+                _sortContents.ContextMenu = GenSortContextMenu();
+                _sortContents.SetTooltip(SortButtonTooltip);
+                UpdateItems(true);
+                _gridContainerEntry.UpdateSaveDataEntry(this);
+            }, true, _sortMode == GridSortMode.Layer));
 
             return control;
         }

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/GridSlotManager.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/GridSlotManager.cs
@@ -358,6 +358,10 @@ namespace ClassicUO.Game.UI.Gumps.GridContainers;
                 {
                     return contents.OrderBy(GetItemName).ThenBy(((x) => x.Amount)).ToList();
                 }
+                else if (sortMode == GridSortMode.Layer) // Sort by layer
+                {
+                    return contents.OrderBy((x) => x.ItemData.Layer).ThenBy((x) => x.Graphic).ThenBy((x) => x.Hue).ToList();
+                }
                 else // Default: Sort by graphic + hue
                 {
                     return contents.OrderBy((x) => x.Graphic).ThenBy((x) => x.Hue).ToList();


### PR DESCRIPTION
Adds a new "Sort by Layer" option to the grid container sort context menu. Items are ordered by their equipment layer, then graphic and hue as tiebreakers. Includes the enum value, sort logic, context menu entry, and tooltip text.