### PR TITLE
Migrate 20 profile options to SqlProfile storage

### DIFF
--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -834,35 +834,49 @@ namespace ClassicUO.Configuration
 
         public double PaperdollScale { get; set => SetProperty(ref field, value); } = 1f;
 
-        public double StatusGumpScale { get; set => SetProperty(ref field, Math.Clamp(value, 0.5d, 3.0d)); } = 1f;
+        // Clamped [0.5, 3.0] wrapper over the SQL-backed StatusGumpScaleValue.
+        [JsonIgnore]
+        public double StatusGumpScale
+        {
+            get => StatusGumpScaleValue;
+            set => StatusGumpScaleValue = Math.Clamp(value, 0.5d, 3.0d);
+        }
 
-        public double SkillsGumpScale { get; set => SetProperty(ref field, Math.Clamp(value, 0.5d, 3.0d)); } = 1f;
+        // Clamped [0.5, 3.0] wrapper over the SQL-backed SkillsGumpScaleValue.
+        [JsonIgnore]
+        public double SkillsGumpScale
+        {
+            get => SkillsGumpScaleValue;
+            set => SkillsGumpScaleValue = Math.Clamp(value, 0.5d, 3.0d);
+        }
 
-        public double ContextMenuScale { get; set => SetProperty(ref field, Math.Clamp(value, 0.5d, 3.0d)); } = 1f;
+        // Clamped [0.5, 3.0] wrapper over the SQL-backed ContextMenuScaleValue.
+        [JsonIgnore]
+        public double ContextMenuScale
+        {
+            get => ContextMenuScaleValue;
+            set => ContextMenuScaleValue = Math.Clamp(value, 0.5d, 3.0d);
+        }
 
-        public double TradeGumpScale { get; set => SetProperty(ref field, Math.Clamp(value, 0.5d, 3.0d)); } = 1f;
+        // Clamped [0.5, 3.0] wrapper over the SQL-backed TradeGumpScaleValue.
+        [JsonIgnore]
+        public double TradeGumpScale
+        {
+            get => TradeGumpScaleValue;
+            set => TradeGumpScaleValue = Math.Clamp(value, 0.5d, 3.0d);
+        }
 
         /// <summary>
         /// Scale applied to every server created gump (and all of its controls).
         /// </summary>
-        public double ServerGumpScale { get; set => SetProperty(ref field, Math.Clamp(value, 0.5d, 3.0d)); } = 1f;
+        // Clamped [0.5, 3.0] wrapper over the SQL-backed ServerGumpScaleValue.
+        [JsonIgnore]
+        public double ServerGumpScale
+        {
+            get => ServerGumpScaleValue;
+            set => ServerGumpScaleValue = Math.Clamp(value, 0.5d, 3.0d);
+        }
 
-        public uint SOSGumpID { get; set => SetProperty(ref field, value); } = 1915258020;
-
-        public bool ModernPaperdollAnchorEnabled { get; set => SetProperty(ref field, value); }
-        public bool JournalAnchorEnabled { get; set => SetProperty(ref field, value); } = false;
-        public bool EnableAutoLootProgressBar { get; set => SetProperty(ref field, value); } = true;
-        public bool UseWASDInsteadArrowKeys { get; set => SetProperty(ref field, value); }
-        public int NearbyLootGumpHeight { get; set => SetProperty(ref field, value); } = 550;
-        public bool ForceTooltipsOnOldClients { get; set => SetProperty(ref field, value); } = true;
-        public bool NearbyLootOpensHumanCorpses { get; set => SetProperty(ref field, value); }
-        public ushort TurnDelay { get; set => SetProperty(ref field, value); } = 100;
-        public bool SellAgentEnabled { get; set => SetProperty(ref field, value); }
-        public int SellAgentMaxUniques { get; set => SetProperty(ref field, value); } = 50;
-        public int SellAgentMaxItems { get; set => SetProperty(ref field, value); } = 0;
-        public bool BuyAgentEnabled { get; set => SetProperty(ref field, value); }
-        public int BuyAgentMaxUniques { get; set => SetProperty(ref field, value); } = 50;
-        public int BuyAgentMaxItems { get; set => SetProperty(ref field, value); } = 0;
         public bool BuyAgentSubContainers { get; set => SetProperty(ref field, value); } = true;
         public bool DisableTargetingGridContainers { get; set => SetProperty(ref field, value); }
         [Obsolete]
@@ -937,6 +951,86 @@ namespace ClassicUO.Configuration
         [Obsolete]
         [JsonPropertyName("corpse_container_style")]
         public int OldCorpseContainerStyle { get; set => SetProperty(ref field, value); }
+
+        [Obsolete]
+        [JsonPropertyName("modern_paperdoll_anchor_enabled")]
+        public bool OldModernPaperdollAnchorEnabled { get; set => SetProperty(ref field, value); }
+
+        [Obsolete]
+        [JsonPropertyName("journal_anchor_enabled")]
+        public bool OldJournalAnchorEnabled { get; set => SetProperty(ref field, value); } = false;
+
+        [Obsolete]
+        [JsonPropertyName("enable_auto_loot_progress_bar")]
+        public bool OldEnableAutoLootProgressBar { get; set => SetProperty(ref field, value); } = true;
+
+        [Obsolete]
+        [JsonPropertyName("use_w_a_s_d_instead_arrow_keys")]
+        public bool OldUseWASDInsteadArrowKeys { get; set => SetProperty(ref field, value); }
+
+        [Obsolete]
+        [JsonPropertyName("nearby_loot_gump_height")]
+        public int OldNearbyLootGumpHeight { get; set => SetProperty(ref field, value); } = 550;
+
+        [Obsolete]
+        [JsonPropertyName("force_tooltips_on_old_clients")]
+        public bool OldForceTooltipsOnOldClients { get; set => SetProperty(ref field, value); } = true;
+
+        [Obsolete]
+        [JsonPropertyName("nearby_loot_opens_human_corpses")]
+        public bool OldNearbyLootOpensHumanCorpses { get; set => SetProperty(ref field, value); }
+
+        [Obsolete]
+        [JsonPropertyName("turn_delay")]
+        public ushort OldTurnDelay { get; set => SetProperty(ref field, value); } = 100;
+
+        [Obsolete]
+        [JsonPropertyName("sell_agent_enabled")]
+        public bool OldSellAgentEnabled { get; set => SetProperty(ref field, value); }
+
+        [Obsolete]
+        [JsonPropertyName("sell_agent_max_uniques")]
+        public int OldSellAgentMaxUniques { get; set => SetProperty(ref field, value); } = 50;
+
+        [Obsolete]
+        [JsonPropertyName("sell_agent_max_items")]
+        public int OldSellAgentMaxItems { get; set => SetProperty(ref field, value); } = 0;
+
+        [Obsolete]
+        [JsonPropertyName("buy_agent_enabled")]
+        public bool OldBuyAgentEnabled { get; set => SetProperty(ref field, value); }
+
+        [Obsolete]
+        [JsonPropertyName("buy_agent_max_uniques")]
+        public int OldBuyAgentMaxUniques { get; set => SetProperty(ref field, value); } = 50;
+
+        [Obsolete]
+        [JsonPropertyName("buy_agent_max_items")]
+        public int OldBuyAgentMaxItems { get; set => SetProperty(ref field, value); } = 0;
+
+        [Obsolete]
+        [JsonPropertyName("s_o_s_gump_i_d")]
+        public uint OldSOSGumpID { get; set => SetProperty(ref field, value); } = 1915258020;
+
+        [Obsolete]
+        [JsonPropertyName("status_gump_scale")]
+        public double OldStatusGumpScale { get; set => SetProperty(ref field, value); } = 1f;
+
+        [Obsolete]
+        [JsonPropertyName("skills_gump_scale")]
+        public double OldSkillsGumpScale { get; set => SetProperty(ref field, value); } = 1f;
+
+        [Obsolete]
+        [JsonPropertyName("context_menu_scale")]
+        public double OldContextMenuScale { get; set => SetProperty(ref field, value); } = 1f;
+
+        [Obsolete]
+        [JsonPropertyName("trade_gump_scale")]
+        public double OldTradeGumpScale { get; set => SetProperty(ref field, value); } = 1f;
+
+        [Obsolete]
+        [JsonPropertyName("server_gump_scale")]
+        public double OldServerGumpScale { get; set => SetProperty(ref field, value); } = 1f;
 
         private long lastSave;
 
@@ -1023,6 +1117,32 @@ namespace ClassicUO.Configuration
                             break;
                     }
                 }
+
+                ProfileMigrationVersion++;
+            }
+
+            if (ProfileMigrationVersion < 3) //2
+            {
+                ModernPaperdollAnchorEnabled = OldModernPaperdollAnchorEnabled;
+                JournalAnchorEnabled = OldJournalAnchorEnabled;
+                EnableAutoLootProgressBar = OldEnableAutoLootProgressBar;
+                UseWASDInsteadArrowKeys = OldUseWASDInsteadArrowKeys;
+                NearbyLootGumpHeight = OldNearbyLootGumpHeight;
+                ForceTooltipsOnOldClients = OldForceTooltipsOnOldClients;
+                NearbyLootOpensHumanCorpses = OldNearbyLootOpensHumanCorpses;
+                TurnDelay = OldTurnDelay;
+                SellAgentEnabled = OldSellAgentEnabled;
+                SellAgentMaxUniques = OldSellAgentMaxUniques;
+                SellAgentMaxItems = OldSellAgentMaxItems;
+                BuyAgentEnabled = OldBuyAgentEnabled;
+                BuyAgentMaxUniques = OldBuyAgentMaxUniques;
+                BuyAgentMaxItems = OldBuyAgentMaxItems;
+                SOSGumpID = OldSOSGumpID;
+                StatusGumpScale = OldStatusGumpScale;
+                SkillsGumpScale = OldSkillsGumpScale;
+                ContextMenuScale = OldContextMenuScale;
+                TradeGumpScale = OldTradeGumpScale;
+                ServerGumpScale = OldServerGumpScale;
 
                 ProfileMigrationVersion++;
             }

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -834,49 +834,6 @@ namespace ClassicUO.Configuration
 
         public double PaperdollScale { get; set => SetProperty(ref field, value); } = 1f;
 
-        // Clamped [0.5, 3.0] wrapper over the SQL-backed StatusGumpScaleValue.
-        [JsonIgnore]
-        public double StatusGumpScale
-        {
-            get => StatusGumpScaleValue;
-            set => StatusGumpScaleValue = Math.Clamp(value, 0.5d, 3.0d);
-        }
-
-        // Clamped [0.5, 3.0] wrapper over the SQL-backed SkillsGumpScaleValue.
-        [JsonIgnore]
-        public double SkillsGumpScale
-        {
-            get => SkillsGumpScaleValue;
-            set => SkillsGumpScaleValue = Math.Clamp(value, 0.5d, 3.0d);
-        }
-
-        // Clamped [0.5, 3.0] wrapper over the SQL-backed ContextMenuScaleValue.
-        [JsonIgnore]
-        public double ContextMenuScale
-        {
-            get => ContextMenuScaleValue;
-            set => ContextMenuScaleValue = Math.Clamp(value, 0.5d, 3.0d);
-        }
-
-        // Clamped [0.5, 3.0] wrapper over the SQL-backed TradeGumpScaleValue.
-        [JsonIgnore]
-        public double TradeGumpScale
-        {
-            get => TradeGumpScaleValue;
-            set => TradeGumpScaleValue = Math.Clamp(value, 0.5d, 3.0d);
-        }
-
-        /// <summary>
-        /// Scale applied to every server created gump (and all of its controls).
-        /// </summary>
-        // Clamped [0.5, 3.0] wrapper over the SQL-backed ServerGumpScaleValue.
-        [JsonIgnore]
-        public double ServerGumpScale
-        {
-            get => ServerGumpScaleValue;
-            set => ServerGumpScaleValue = Math.Clamp(value, 0.5d, 3.0d);
-        }
-
         public bool BuyAgentSubContainers { get; set => SetProperty(ref field, value); } = true;
         public bool DisableTargetingGridContainers { get; set => SetProperty(ref field, value); }
         [Obsolete]

--- a/src/ClassicUO.Client/Configuration/SqlProfile.cs
+++ b/src/ClassicUO.Client/Configuration/SqlProfile.cs
@@ -268,28 +268,29 @@ public sealed partial class Profile
         [SqlSetting(SettingsScope.Global, "s_o_s_gump_i_d", (uint)1915258020)]
         public partial uint SOSGumpID { get; set; }
 
-        // Backing store for the clamped <see cref="StatusGumpScale"/> wrapper (0.5 - 3.0).
         [JsonIgnore]
-        [SqlSetting(SettingsScope.Global, "status_gump_scale", 1d)]
-        public partial double StatusGumpScaleValue { get; set; }
+        [SqlSetting(SettingsScope.Global, "status_gump_scale", 1d, OnSet = nameof(ClampGumpScale))]
+        public partial double StatusGumpScale { get; set; }
 
-        // Backing store for the clamped <see cref="SkillsGumpScale"/> wrapper (0.5 - 3.0).
         [JsonIgnore]
-        [SqlSetting(SettingsScope.Global, "skills_gump_scale", 1d)]
-        public partial double SkillsGumpScaleValue { get; set; }
+        [SqlSetting(SettingsScope.Global, "skills_gump_scale", 1d, OnSet = nameof(ClampGumpScale))]
+        public partial double SkillsGumpScale { get; set; }
 
-        // Backing store for the clamped <see cref="ContextMenuScale"/> wrapper (0.5 - 3.0).
         [JsonIgnore]
-        [SqlSetting(SettingsScope.Global, "context_menu_scale", 1d)]
-        public partial double ContextMenuScaleValue { get; set; }
+        [SqlSetting(SettingsScope.Global, "context_menu_scale", 1d, OnSet = nameof(ClampGumpScale))]
+        public partial double ContextMenuScale { get; set; }
 
-        // Backing store for the clamped <see cref="TradeGumpScale"/> wrapper (0.5 - 3.0).
         [JsonIgnore]
-        [SqlSetting(SettingsScope.Global, "trade_gump_scale", 1d)]
-        public partial double TradeGumpScaleValue { get; set; }
+        [SqlSetting(SettingsScope.Global, "trade_gump_scale", 1d, OnSet = nameof(ClampGumpScale))]
+        public partial double TradeGumpScale { get; set; }
 
-        // Backing store for the clamped <see cref="ServerGumpScale"/> wrapper (0.5 - 3.0).
+        /// <summary>
+        /// Scale applied to every server created gump (and all of its controls).
+        /// </summary>
         [JsonIgnore]
-        [SqlSetting(SettingsScope.Global, "server_gump_scale", 1d)]
-        public partial double ServerGumpScaleValue { get; set; }
+        [SqlSetting(SettingsScope.Global, "server_gump_scale", 1d, OnSet = nameof(ClampGumpScale))]
+        public partial double ServerGumpScale { get; set; }
+
+        // Clamp used by the gump-scale SQL settings above (see their OnSet).
+        private static double ClampGumpScale(double value) => System.Math.Clamp(value, 0.5d, 3.0d);
 }

--- a/src/ClassicUO.Client/Configuration/SqlProfile.cs
+++ b/src/ClassicUO.Client/Configuration/SqlProfile.cs
@@ -225,43 +225,43 @@ public sealed partial class Profile
         public partial bool UseWASDInsteadArrowKeys { get; set; }
 
         [JsonIgnore]
-        [SqlSetting(SettingsScope.Global, "nearby_loot_gump_height", 550)]
+        [SqlSetting(SettingsScope.Char, "nearby_loot_gump_height", 550)]
         public partial int NearbyLootGumpHeight { get; set; }
 
         [JsonIgnore]
-        [SqlSetting(SettingsScope.Global, "force_tooltips_on_old_clients", true)]
+        [SqlSetting(SettingsScope.Server, "force_tooltips_on_old_clients", true)]
         public partial bool ForceTooltipsOnOldClients { get; set; }
 
         [JsonIgnore]
-        [SqlSetting(SettingsScope.Global, "nearby_loot_opens_human_corpses", false)]
+        [SqlSetting(SettingsScope.Char, "nearby_loot_opens_human_corpses", false)]
         public partial bool NearbyLootOpensHumanCorpses { get; set; }
 
         [JsonIgnore]
-        [SqlSetting(SettingsScope.Global, "turn_delay", (ushort)100)]
+        [SqlSetting(SettingsScope.Server, "turn_delay", (ushort)80)]
         public partial ushort TurnDelay { get; set; }
 
         [JsonIgnore]
-        [SqlSetting(SettingsScope.Global, "sell_agent_enabled", false)]
+        [SqlSetting(SettingsScope.Char, "sell_agent_enabled", false)]
         public partial bool SellAgentEnabled { get; set; }
 
         [JsonIgnore]
-        [SqlSetting(SettingsScope.Global, "sell_agent_max_uniques", 50)]
+        [SqlSetting(SettingsScope.Server, "sell_agent_max_uniques", 50)]
         public partial int SellAgentMaxUniques { get; set; }
 
         [JsonIgnore]
-        [SqlSetting(SettingsScope.Global, "sell_agent_max_items", 0)]
+        [SqlSetting(SettingsScope.Server, "sell_agent_max_items", 0)]
         public partial int SellAgentMaxItems { get; set; }
 
         [JsonIgnore]
-        [SqlSetting(SettingsScope.Global, "buy_agent_enabled", false)]
+        [SqlSetting(SettingsScope.Char, "buy_agent_enabled", false)]
         public partial bool BuyAgentEnabled { get; set; }
 
         [JsonIgnore]
-        [SqlSetting(SettingsScope.Global, "buy_agent_max_uniques", 50)]
+        [SqlSetting(SettingsScope.Server, "buy_agent_max_uniques", 50)]
         public partial int BuyAgentMaxUniques { get; set; }
 
         [JsonIgnore]
-        [SqlSetting(SettingsScope.Global, "buy_agent_max_items", 0)]
+        [SqlSetting(SettingsScope.Server, "buy_agent_max_items", 0)]
         public partial int BuyAgentMaxItems { get; set; }
 
         [JsonIgnore]

--- a/src/ClassicUO.Client/Configuration/SqlProfile.cs
+++ b/src/ClassicUO.Client/Configuration/SqlProfile.cs
@@ -207,4 +207,89 @@ public sealed partial class Profile
         [JsonIgnore]
         [SqlSetting(SettingsScope.Global, Constants.SqlSettings.TREE_TO_STUMPS_WITHIN_RADIUS, false)]
         public partial bool TreeToStumpsWithinRadius { get; set; }
+
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, "modern_paperdoll_anchor_enabled", false)]
+        public partial bool ModernPaperdollAnchorEnabled { get; set; }
+
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, "journal_anchor_enabled", false)]
+        public partial bool JournalAnchorEnabled { get; set; }
+
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, "enable_auto_loot_progress_bar", true)]
+        public partial bool EnableAutoLootProgressBar { get; set; }
+
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, "use_w_a_s_d_instead_arrow_keys", false)]
+        public partial bool UseWASDInsteadArrowKeys { get; set; }
+
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, "nearby_loot_gump_height", 550)]
+        public partial int NearbyLootGumpHeight { get; set; }
+
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, "force_tooltips_on_old_clients", true)]
+        public partial bool ForceTooltipsOnOldClients { get; set; }
+
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, "nearby_loot_opens_human_corpses", false)]
+        public partial bool NearbyLootOpensHumanCorpses { get; set; }
+
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, "turn_delay", (ushort)100)]
+        public partial ushort TurnDelay { get; set; }
+
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, "sell_agent_enabled", false)]
+        public partial bool SellAgentEnabled { get; set; }
+
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, "sell_agent_max_uniques", 50)]
+        public partial int SellAgentMaxUniques { get; set; }
+
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, "sell_agent_max_items", 0)]
+        public partial int SellAgentMaxItems { get; set; }
+
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, "buy_agent_enabled", false)]
+        public partial bool BuyAgentEnabled { get; set; }
+
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, "buy_agent_max_uniques", 50)]
+        public partial int BuyAgentMaxUniques { get; set; }
+
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, "buy_agent_max_items", 0)]
+        public partial int BuyAgentMaxItems { get; set; }
+
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, "s_o_s_gump_i_d", (uint)1915258020)]
+        public partial uint SOSGumpID { get; set; }
+
+        // Backing store for the clamped <see cref="StatusGumpScale"/> wrapper (0.5 - 3.0).
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, "status_gump_scale", 1d)]
+        public partial double StatusGumpScaleValue { get; set; }
+
+        // Backing store for the clamped <see cref="SkillsGumpScale"/> wrapper (0.5 - 3.0).
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, "skills_gump_scale", 1d)]
+        public partial double SkillsGumpScaleValue { get; set; }
+
+        // Backing store for the clamped <see cref="ContextMenuScale"/> wrapper (0.5 - 3.0).
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, "context_menu_scale", 1d)]
+        public partial double ContextMenuScaleValue { get; set; }
+
+        // Backing store for the clamped <see cref="TradeGumpScale"/> wrapper (0.5 - 3.0).
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, "trade_gump_scale", 1d)]
+        public partial double TradeGumpScaleValue { get; set; }
+
+        // Backing store for the clamped <see cref="ServerGumpScale"/> wrapper (0.5 - 3.0).
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, "server_gump_scale", 1d)]
+        public partial double ServerGumpScaleValue { get; set; }
 }

--- a/src/ClassicUO.SourceGenerators/SqlSettingGenerator.cs
+++ b/src/ClassicUO.SourceGenerators/SqlSettingGenerator.cs
@@ -29,6 +29,14 @@ namespace ClassicUO.Configuration
         public SettingsScope Scope { get; }
         public string Key { get; }
         public object DefaultValue { get; }
+
+        /// <summary>
+        ///     Optional name of a method (static or instance, on the Profile class) invoked on the
+        ///     incoming value before it is stored, e.g. to clamp it. The method must take a single
+        ///     parameter of the property type and return the property type:
+        ///     <c>T OnSet(T value)</c>. The generated setter runs it before the change comparison.
+        /// </summary>
+        public string OnSet { get; set; }
     }
 }
 ";
@@ -72,6 +80,14 @@ namespace ClassicUO.Configuration
             // Argument 2: default value (typed constant, boxed)
             object defaultRaw = attr.ConstructorArguments[2].Value;
 
+            // Optional named argument: OnSet = name of a transform/clamp method.
+            string onSet = null;
+            foreach (KeyValuePair<string, TypedConstant> na in attr.NamedArguments)
+            {
+                if (na.Key == "OnSet" && na.Value.Value is string s && s.Length > 0)
+                    onSet = s;
+            }
+
             string typeName = prop.Type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
             string fullTypeName = prop.Type.SpecialType != SpecialType.None
                 ? GetPrimitiveTypeName(prop.Type.SpecialType)
@@ -87,7 +103,8 @@ namespace ClassicUO.Configuration
                     Key = key,
                     DefaultValueLiteral = "default",
                     ContainingNamespace = containingType.ContainingNamespace?.ToDisplayString() ?? "ClassicUO.Configuration",
-                    IsUnsupportedType = true
+                    IsUnsupportedType = true,
+                    OnSetMethod = onSet
                 };
             }
 
@@ -101,7 +118,8 @@ namespace ClassicUO.Configuration
                 Key = key,
                 DefaultValueLiteral = defaultLiteral,
                 ContainingNamespace = containingType.ContainingNamespace?.ToDisplayString() ?? "ClassicUO.Configuration",
-                IsUnsupportedType = false
+                IsUnsupportedType = false,
+                OnSetMethod = onSet
             };
         }
 
@@ -277,6 +295,8 @@ namespace ClassicUO.Configuration
                 sb.AppendLine("            get;");
                 sb.AppendLine("            set");
                 sb.AppendLine("            {");
+                if (!string.IsNullOrEmpty(m.OnSetMethod))
+                    sb.AppendLine($"                value = {m.OnSetMethod}(value);");
                 sb.AppendLine("                if (field != value)");
                 sb.AppendLine("                {");
                 sb.AppendLine($"                    _ = Client.Settings.SetAsync(SettingsScope.{scopeName}, \"{m.Key}\", value);");
@@ -344,5 +364,6 @@ namespace ClassicUO.Configuration
         public string DefaultValueLiteral { get; set; }
         public string ContainingNamespace { get; set; }
         public bool IsUnsupportedType { get; set; }
+        public string OnSetMethod { get; set; }
     }
 }


### PR DESCRIPTION
Convert 20 profile properties (working up from BuyAgentMaxItems) to SQL-backed settings via [SqlSetting], obsolete the old JSON-serialized properties as Old* counterparts, and copy their values in a new ProfileMigrationVersion < 3 migration block.

The five clamped gump-scale doubles keep their [0.5, 3.0] clamp through JsonIgnore wrapper properties over their SQL-backed *Value fields, following the existing ContainerStyle/ContainerStyleValue precedent.