### PR TITLE
Allow Bitmap gumps and other external image enhancements

### DIFF
--- a/src/ClassicUO.Assets/ExternalImageLoader.cs
+++ b/src/ClassicUO.Assets/ExternalImageLoader.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
@@ -9,7 +9,7 @@ using ClassicUO.Utility.Logging;
 
 namespace ClassicUO.Assets
 {
-    public class PNGLoader
+    public class ExternalImageLoader
     {
         private const string IMAGES_FOLDER = "ExternalImages", GUMP_EXTERNAL_FOLDER = "gumps", ART_EXTERNAL_FOLDER = "art";
 
@@ -20,16 +20,16 @@ namespace ClassicUO.Assets
         private Dictionary<string, Texture2D> _zipNamedTextures = new Dictionary<string, Texture2D>();
         private Texture2D _emptyTexture;
 
-        private uint[] gump_availableIDs;
+        private Dictionary<uint, string> gump_availableFilePaths = new Dictionary<uint, string>();
         private Dictionary<uint, (uint[] pixels, int width, int height)> gump_textureCache = new Dictionary<uint, (uint[], int, int)>();
 
-        private uint[] art_availableIDs;
+        private Dictionary<uint, string> art_availableFilePaths = new Dictionary<uint, string>();
         private Dictionary<uint, (uint[] pixels, int width, int height)> art_textureCache = new Dictionary<uint, (uint[], int, int)>();
 
         public GraphicsDevice GraphicsDevice { set; get; }
 
-        public static PNGLoader _instance;
-        public static PNGLoader Instance => _instance ?? (_instance = new PNGLoader());
+        public static ExternalImageLoader _instance;
+        public static ExternalImageLoader Instance => _instance ?? (_instance = new ExternalImageLoader());
 
         public bool TryGetEmbeddedTexture(string name, out Texture2D texture)
         {
@@ -81,12 +81,7 @@ namespace ClassicUO.Assets
 
         public GumpInfo LoadGumpTexture(uint graphic)
         {
-            if (gump_availableIDs == null)
-                return new GumpInfo();
-
-            int index = Array.IndexOf(gump_availableIDs, graphic);
-
-            if (index == -1)
+            if (!gump_availableFilePaths.TryGetValue(graphic, out string fullImagePath))
                 return new GumpInfo();
 
             if (gump_textureCache.TryGetValue(graphic, out (uint[] pixels, int width, int height) cached))
@@ -99,15 +94,20 @@ namespace ClassicUO.Assets
                 };
             }
 
-            if (exePath != null && GraphicsDevice != null)
+            if (GraphicsDevice != null && File.Exists(fullImagePath))
             {
-                string fullImagePath = Path.Combine(exePath, IMAGES_FOLDER, GUMP_EXTERNAL_FOLDER, ((int)graphic).ToString() + ".png");
-
-                if (File.Exists(fullImagePath))
+                try
                 {
-                    FileStream titleStream = File.OpenRead(fullImagePath);
-                    var tempTexture = Texture2D.FromStream(GraphicsDevice, titleStream);
-                    titleStream.Close();
+                    Texture2D tempTexture;
+                    if (fullImagePath.EndsWith(".bmp", StringComparison.OrdinalIgnoreCase))
+                    {
+                        tempTexture = LoadBmp(GraphicsDevice, fullImagePath);
+                    }
+                    else
+                    {
+                        using FileStream titleStream = File.OpenRead(fullImagePath);
+                        tempTexture = Texture2D.FromStream(GraphicsDevice, titleStream);
+                    }
 
                     if (tempTexture == null)
                         return new GumpInfo();
@@ -127,6 +127,10 @@ namespace ClassicUO.Assets
                         Height = height
                     };
                 }
+                catch (Exception ex)
+                {
+                    Log.Error($"Failed to load gump image '{fullImagePath}': {ex.Message}");
+                }
             }
 
             return new GumpInfo();
@@ -134,12 +138,7 @@ namespace ClassicUO.Assets
 
         public ArtInfo LoadArtTexture(uint graphic)
         {
-            if (art_availableIDs == null)
-                return new ArtInfo();
-
-            int index = Array.IndexOf(art_availableIDs, graphic);
-
-            if (index == -1)
+            if (!art_availableFilePaths.TryGetValue(graphic, out string fullImagePath))
                 return new ArtInfo();
 
             if (art_textureCache.TryGetValue(graphic, out (uint[] pixels, int width, int height) cached))
@@ -152,16 +151,18 @@ namespace ClassicUO.Assets
                 };
             }
 
-            if (exePath != null && GraphicsDevice != null)
+            if (GraphicsDevice != null && File.Exists(fullImagePath))
             {
-                uint fileGraphic = graphic - 0x4000;
-                string fullImagePath = Path.Combine(exePath, IMAGES_FOLDER, ART_EXTERNAL_FOLDER, fileGraphic.ToString() + ".png");
-
-                if (File.Exists(fullImagePath))
+                try
                 {
                     Texture2D tempTexture;
-                    using (FileStream titleStream = File.OpenRead(fullImagePath))
+                    if (fullImagePath.EndsWith(".bmp", StringComparison.OrdinalIgnoreCase))
                     {
+                        tempTexture = LoadBmp(GraphicsDevice, fullImagePath);
+                    }
+                    else
+                    {
+                        using FileStream titleStream = File.OpenRead(fullImagePath);
                         tempTexture = Texture2D.FromStream(GraphicsDevice, titleStream);
                     }
 
@@ -183,9 +184,65 @@ namespace ClassicUO.Assets
                         Height = height
                     };
                 }
+                catch (Exception ex)
+                {
+                    Log.Error($"Failed to load art image '{fullImagePath}': {ex.Message}");
+                }
             }
 
             return new ArtInfo();
+        }
+
+        private static Texture2D LoadBmp(GraphicsDevice gd, string path)
+        {
+            byte[] file = File.ReadAllBytes(path);
+            if (file.Length < 54 || file[0] != 'B' || file[1] != 'M')
+                return null;
+
+            int dataOffset = BitConverter.ToInt32(file, 10);
+            int headerSize = BitConverter.ToInt32(file, 14);
+            if (headerSize < 40)
+                return null;
+
+            int width = BitConverter.ToInt32(file, 18);
+            int rawHeight = BitConverter.ToInt32(file, 22);
+            bool topDown = rawHeight < 0;
+            int height = Math.Abs(rawHeight);
+            short bpp = BitConverter.ToInt16(file, 28);
+
+            if (bpp != 24 && bpp != 32)
+            {
+                Log.Error($"Unsupported BMP bit depth {bpp} in '{path}'");
+                return null;
+            }
+
+            int bytesPerPixel = bpp / 8;
+            int rowStride = width * bytesPerPixel;
+            int rowPadding = (4 - (rowStride % 4)) % 4;
+            int rowBytes = rowStride + rowPadding;
+
+            var texture = new Texture2D(gd, width, height);
+            var pixels = new Color[width * height];
+
+            for (int y = 0; y < height; y++)
+            {
+                int srcRow = topDown ? y : (height - 1 - y);
+                int srcOffset = dataOffset + srcRow * rowBytes;
+
+                for (int x = 0; x < width; x++)
+                {
+                    int srcIdx = srcOffset + x * bytesPerPixel;
+                    byte b = file[srcIdx];
+                    byte g = file[srcIdx + 1];
+                    byte r = file[srcIdx + 2];
+                    byte a = (bytesPerPixel == 4) ? file[srcIdx + 3] : (byte)255;
+
+                    pixels[y * width + x] = new Color(r, g, b, a);
+                }
+            }
+
+            texture.SetData(pixels);
+            return texture;
         }
 
         private uint[] GetPixels(Texture2D texture)
@@ -207,6 +264,14 @@ namespace ClassicUO.Assets
             return pixels;
         }
 
+        private static string[] FindImageFiles(string directory)
+        {
+            var results = new List<string>();
+            results.AddRange(Directory.GetFiles(directory, "*.png", SearchOption.AllDirectories));
+            results.AddRange(Directory.GetFiles(directory, "*.bmp", SearchOption.AllDirectories));
+            return results.ToArray();
+        }
+
         public void Load(string uoDirectory = null)
         {
             exePath = AppContext.BaseDirectory;
@@ -216,13 +281,14 @@ namespace ClassicUO.Assets
 
             if (Directory.Exists(gumpPath))
             {
-                string[] files = Directory.GetFiles(gumpPath, "*.png", SearchOption.TopDirectoryOnly);
-                gump_availableIDs = new uint[files.Length];
+                string[] files = FindImageFiles(gumpPath);
 
                 for (int i = 0; i < files.Length; i++)
                 {
                     string fname = Path.GetFileName(files[i]);
-                    uint.TryParse(fname.Substring(0, fname.Length - 4), out gump_availableIDs[i]);
+                    string baseName = Path.GetFileNameWithoutExtension(fname);
+                    if (TryParseId(baseName, out uint id))
+                        gump_availableFilePaths[id] = files[i];
                 }
             }
             else
@@ -234,16 +300,16 @@ namespace ClassicUO.Assets
 
             if (Directory.Exists(artPath))
             {
-                string[] files = Directory.GetFiles(artPath, "*.png", SearchOption.TopDirectoryOnly);
-                art_availableIDs = new uint[files.Length];
+                string[] files = FindImageFiles(artPath);
 
                 for (int i = 0; i < files.Length; i++)
                 {
                     string fname = Path.GetFileName(files[i]);
+                    string baseName = Path.GetFileNameWithoutExtension(fname);
 
-                    if (uint.TryParse(fname.Substring(0, fname.Length - 4), out uint gfx))
+                    if (TryParseId(baseName, out uint gfx))
                     {
-                        art_availableIDs[i] = gfx + 0x4000;
+                        art_availableFilePaths[gfx + 0x4000] = files[i];
                     }
                 }
             }
@@ -317,7 +383,8 @@ namespace ClassicUO.Assets
 
             foreach (ZipArchiveEntry entry in archive.Entries)
             {
-                if (!entry.Name.EndsWith(".png", StringComparison.OrdinalIgnoreCase)) continue;
+                if (!entry.Name.EndsWith(".png", StringComparison.OrdinalIgnoreCase)
+                && !entry.Name.EndsWith(".bmp", StringComparison.OrdinalIgnoreCase)) continue;
 
                 byte[] bytes;
                 using (var ms = new MemoryStream())
@@ -338,16 +405,16 @@ namespace ClassicUO.Assets
                 if (parts.Length >= 2)
                 {
                     string folder = parts[parts.Length - 2];
-                    string baseName = entry.Name.Substring(0, entry.Name.Length - 4);
+                    string baseName = Path.GetFileNameWithoutExtension(entry.Name);
 
                     if (folder.Equals(GUMP_EXTERNAL_FOLDER, StringComparison.OrdinalIgnoreCase))
                     {
-                        if (uint.TryParse(baseName, out uint id) && !gump_textureCache.ContainsKey(id))
+                        if (TryParseId(baseName, out uint id) && !gump_textureCache.ContainsKey(id))
                             RegisterGumpFromBytes(id, bytes);
                     }
                     else if (folder.Equals(ART_EXTERNAL_FOLDER, StringComparison.OrdinalIgnoreCase))
                     {
-                        if (uint.TryParse(baseName, out uint fileId))
+                        if (TryParseId(baseName, out uint fileId))
                         {
                             uint graphicId = fileId + 0x4000;
                             if (!art_textureCache.ContainsKey(graphicId))
@@ -401,7 +468,8 @@ namespace ClassicUO.Assets
                 foreach (ZipArchiveEntry entry in archive.Entries)
                 {
                     if (string.IsNullOrEmpty(entry.Name)) continue;
-                    if (!entry.Name.EndsWith(".png", StringComparison.OrdinalIgnoreCase)) continue;
+                    if (!entry.Name.EndsWith(".png", StringComparison.OrdinalIgnoreCase)
+                    && !entry.Name.EndsWith(".bmp", StringComparison.OrdinalIgnoreCase)) continue;
                     if (ShouldSkipEntry(entry.FullName)) continue;
 
                     byte[] bytes;
@@ -421,7 +489,7 @@ namespace ClassicUO.Assets
                             if (tex == null) continue;
                             FixPNGAlpha(ref tex);
                             if (EmbeddedArt.TryGetValue(entry.Name, out Texture2D old)
-                                && old != null && !old.IsDisposed)
+                            && old != null && !old.IsDisposed)
                                 old.Dispose();
                             EmbeddedArt[entry.Name] = tex;
                             Log.Debug($"tuoassets.zip overrode embedded asset: {entry.Name}");
@@ -489,9 +557,9 @@ namespace ClassicUO.Assets
                 gump_textureCache[id] = (pixels, width, height);
                 tex.Dispose();
 
-                AppendToAvailableIDs(ref gump_availableIDs, id);
+                gump_availableFilePaths.TryAdd(id, $"0x{id:X}");
             }
-            catch (Exception ex) { Log.Error($"Error registering zip gump PNG {id}: {ex.Message}"); }
+            catch (Exception ex) { Log.Error($"Error registering zip gump image {id}: {ex.Message}"); }
         }
 
         private void RegisterArtFromBytes(uint id, byte[] bytes)
@@ -508,21 +576,9 @@ namespace ClassicUO.Assets
                 art_textureCache[id] = (pixels, width, height);
                 tex.Dispose();
 
-                AppendToAvailableIDs(ref art_availableIDs, id);
+                art_availableFilePaths.TryAdd(id, $"0x{id:X}");
             }
             catch (Exception ex) { Log.Error($"Error registering zip art PNG {id}: {ex.Message}"); }
-        }
-
-        private static void AppendToAvailableIDs(ref uint[] arr, uint id)
-        {
-            if (arr == null)
-            {
-                arr = [id];
-                return;
-            }
-            if (Array.IndexOf(arr, id) >= 0) return;
-            Array.Resize(ref arr, arr.Length + 1);
-            arr[arr.Length - 1] = id;
         }
 
         public void ClearArtPixelCache(uint graphic) => art_textureCache.Remove(graphic);

--- a/src/ClassicUO.Assets/UOFileManager.cs
+++ b/src/ClassicUO.Assets/UOFileManager.cs
@@ -168,7 +168,7 @@ namespace ClassicUO.Assets
             TileArt.Load();
             StringDictionary.Load();
 
-            PNGLoader.Instance.Load(BasePath);
+            ExternalImageLoader.Instance.Load(BasePath);
             //TrueTypeLoader.Instance.Load();
 
             ReadArtDefFile();

--- a/src/ClassicUO.Client/Game/Data/ModernUIConstants.cs
+++ b/src/ClassicUO.Client/Game/Data/ModernUIConstants.cs
@@ -9,7 +9,7 @@ public static class ModernUIConstants
     /// Standard Modern UI Panel. Used for a general gump background.
     /// Recommended to use with the NineSliceGump class.
     /// </summary>
-    public static Texture2D ModernUIPanel { get { PNGLoader.Instance.TryGetEmbeddedTexture("TUOGumpBg.png", out Texture2D texture); return texture; } }
+    public static Texture2D ModernUIPanel { get { ExternalImageLoader.Instance.TryGetEmbeddedTexture("TUOGumpBg.png", out Texture2D texture); return texture; } }
 
     /// <summary>
     /// Border size of the modern ui panel, used for the NineSliceGump class.
@@ -21,22 +21,22 @@ public static class ModernUIConstants
     /// See ModernUIButtonDown for "clicked" texture.
     /// Recommended to use with the NineSliceGump class.
     /// </summary>
-    public static Texture2D ModernUIButtonUp { get { PNGLoader.Instance.TryGetEmbeddedTexture("TUOUIButtonUp.png", out Texture2D texture); return texture; } }
-    public static Texture2D ModernUIButtonDown { get { PNGLoader.Instance.TryGetEmbeddedTexture("TUOUIButtonDown.png", out Texture2D texture); return texture; } }
-    public static Texture2D ModernUIButtonDangerUp { get { PNGLoader.Instance.TryGetEmbeddedTexture("TUOUIButtonDangerUp.png", out Texture2D texture); return texture; } }
-    public static Texture2D ModernUIButtonDangerDown { get { PNGLoader.Instance.TryGetEmbeddedTexture("TUOUIButtonDangerDown.png", out Texture2D texture); return texture; } }
-    public static Texture2D ModernUICheckBoxChecked { get { PNGLoader.Instance.TryGetEmbeddedTexture("TUOUICheckBoxChecked.png", out Texture2D texture); return texture; } }
-    public static Texture2D ModernUICheckBoxUnChecked { get { PNGLoader.Instance.TryGetEmbeddedTexture("TUOUICheckBoxUnChecked.png", out Texture2D texture); return texture; } }
+    public static Texture2D ModernUIButtonUp { get { ExternalImageLoader.Instance.TryGetEmbeddedTexture("TUOUIButtonUp.png", out Texture2D texture); return texture; } }
+    public static Texture2D ModernUIButtonDown { get { ExternalImageLoader.Instance.TryGetEmbeddedTexture("TUOUIButtonDown.png", out Texture2D texture); return texture; } }
+    public static Texture2D ModernUIButtonDangerUp { get { ExternalImageLoader.Instance.TryGetEmbeddedTexture("TUOUIButtonDangerUp.png", out Texture2D texture); return texture; } }
+    public static Texture2D ModernUIButtonDangerDown { get { ExternalImageLoader.Instance.TryGetEmbeddedTexture("TUOUIButtonDangerDown.png", out Texture2D texture); return texture; } }
+    public static Texture2D ModernUICheckBoxChecked { get { ExternalImageLoader.Instance.TryGetEmbeddedTexture("TUOUICheckBoxChecked.png", out Texture2D texture); return texture; } }
+    public static Texture2D ModernUICheckBoxUnChecked { get { ExternalImageLoader.Instance.TryGetEmbeddedTexture("TUOUICheckBoxUnChecked.png", out Texture2D texture); return texture; } }
 
-    public static Texture2D ModernUISkillUp { get { PNGLoader.Instance.TryGetEmbeddedTexture("upicon.png", out Texture2D texture); return texture; } }
-    public static Texture2D ModernUISkillDown { get { PNGLoader.Instance.TryGetEmbeddedTexture("downicon.png", out Texture2D texture); return texture; } }
-    public static Texture2D ModernUISkillLock { get { PNGLoader.Instance.TryGetEmbeddedTexture("lockicon.png", out Texture2D texture); return texture; } }
+    public static Texture2D ModernUISkillUp { get { ExternalImageLoader.Instance.TryGetEmbeddedTexture("upicon.png", out Texture2D texture); return texture; } }
+    public static Texture2D ModernUISkillDown { get { ExternalImageLoader.Instance.TryGetEmbeddedTexture("downicon.png", out Texture2D texture); return texture; } }
+    public static Texture2D ModernUISkillLock { get { ExternalImageLoader.Instance.TryGetEmbeddedTexture("lockicon.png", out Texture2D texture); return texture; } }
 
     public const int ModernUIButton_BorderSize = 4;
 
-    public static Texture2D ModernUIVerticalScrollbar { get { PNGLoader.Instance.TryGetEmbeddedTexture("scroll-vertical.png", out Texture2D texture); return texture; } }
-    public static Texture2D ModernUIVerticalScrollbarKnob { get { PNGLoader.Instance.TryGetEmbeddedTexture("scroll-knob-vertical.png", out Texture2D texture); return texture; } }
+    public static Texture2D ModernUIVerticalScrollbar { get { ExternalImageLoader.Instance.TryGetEmbeddedTexture("scroll-vertical.png", out Texture2D texture); return texture; } }
+    public static Texture2D ModernUIVerticalScrollbarKnob { get { ExternalImageLoader.Instance.TryGetEmbeddedTexture("scroll-knob-vertical.png", out Texture2D texture); return texture; } }
 
-    public static Texture2D ModernUIHorizontalScrollbar { get { PNGLoader.Instance.TryGetEmbeddedTexture("scroll-horizontal.png", out Texture2D texture); return texture; } }
-    public static Texture2D ModernUIHorizontalScrollbarKnob { get { PNGLoader.Instance.TryGetEmbeddedTexture("scroll-knob-horizontal.png", out Texture2D texture); return texture; } }
+    public static Texture2D ModernUIHorizontalScrollbar { get { ExternalImageLoader.Instance.TryGetEmbeddedTexture("scroll-horizontal.png", out Texture2D texture); return texture; } }
+    public static Texture2D ModernUIHorizontalScrollbarKnob { get { ExternalImageLoader.Instance.TryGetEmbeddedTexture("scroll-knob-horizontal.png", out Texture2D texture); return texture; } }
 }

--- a/src/ClassicUO.Client/Game/UI/Controls/LegionTexturePic.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/LegionTexturePic.cs
@@ -34,7 +34,7 @@ public class LegionTexturePic : Control
 
     private void TryApplyNaturalSize()
     {
-        if (PNGLoader.Instance.TryGetNamedZipTexture(_textureName, out Texture2D tex) && tex != null && !tex.IsDisposed)
+        if (ExternalImageLoader.Instance.TryGetNamedZipTexture(_textureName, out Texture2D tex) && tex != null && !tex.IsDisposed)
         {
             if (Width <= 0)  Width  = tex.Width;
             if (Height <= 0) Height = tex.Height;
@@ -45,7 +45,7 @@ public class LegionTexturePic : Control
     {
         if (IsDisposed) return false;
 
-        if (!PNGLoader.Instance.TryGetNamedZipTexture(_textureName, out Texture2D tex) || tex == null || tex.IsDisposed)
+        if (!ExternalImageLoader.Instance.TryGetNamedZipTexture(_textureName, out Texture2D tex) || tex == null || tex.IsDisposed)
             return false;
 
         Vector3 hueVector = ShaderHueTranslator.GetHueVector(0, false, Alpha, true);

--- a/src/ClassicUO.Client/Game/UI/Gumps/Login/CampfireCharacterSelectionGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/Login/CampfireCharacterSelectionGump.cs
@@ -42,7 +42,7 @@ namespace ClassicUO.Game.UI.Gumps.Login
 
             ResolveInitialSelection(loginScene);
 
-            PNGLoader.Instance.TryGetEmbeddedTexture("CharSelectBG.png", out Microsoft.Xna.Framework.Graphics.Texture2D upTexture);
+            ExternalImageLoader.Instance.TryGetEmbeddedTexture("CharSelectBG.png", out Microsoft.Xna.Framework.Graphics.Texture2D upTexture);
             Add
             (
                 new EmbeddedGumpPic(AREA_X, AREA_Y, upTexture),

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernPaperdoll.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernPaperdoll.cs
@@ -1,4 +1,4 @@
-﻿using ClassicUO.Assets;
+using ClassicUO.Assets;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.GameObjects;
@@ -30,7 +30,7 @@ namespace ClassicUO.Game.UI.Gumps
         {
             if (MordernPaperdollGump == null)
             {
-                PNGLoader.Instance.TryGetEmbeddedTexture("modern-paperdollgump.png", out MordernPaperdollGump);
+                ExternalImageLoader.Instance.TryGetEmbeddedTexture("modern-paperdollgump.png", out MordernPaperdollGump);
             }
         }
         #endregion

--- a/src/ClassicUO.Client/Game/UI/Gumps/SpellBar/SpellBar.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/SpellBar/SpellBar.cs
@@ -127,10 +127,10 @@ public class SpellBar : Gump
         rowLabel.Y = (Height - rowLabel.Height) >> 1;
         Add(rowLabel);
 
-        PNGLoader.Instance.TryGetEmbeddedTexture("upicon.png", out Microsoft.Xna.Framework.Graphics.Texture2D upTexture);
+        ExternalImageLoader.Instance.TryGetEmbeddedTexture("upicon.png", out Microsoft.Xna.Framework.Graphics.Texture2D upTexture);
         var up = new EmbeddedGumpPic(Width - 31, 0, upTexture, 148);
         up.MouseUp += (sender, e) => { ChangeRow(false); };
-        PNGLoader.Instance.TryGetEmbeddedTexture("downicon.png", out Microsoft.Xna.Framework.Graphics.Texture2D downTexture);
+        ExternalImageLoader.Instance.TryGetEmbeddedTexture("downicon.png", out Microsoft.Xna.Framework.Graphics.Texture2D downTexture);
         var down = new EmbeddedGumpPic(Width - 31, Height - 16, downTexture, 148);
         down.MouseUp += (sender, e) => { ChangeRow(true); };
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/Supporters.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/Supporters.cs
@@ -1,4 +1,4 @@
-﻿using ClassicUO.Assets;
+using ClassicUO.Assets;
 using ClassicUO.Configuration;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Renderer;
@@ -25,7 +25,7 @@ namespace ClassicUO.Game.UI.Gumps
         };
         private AlphaBlendControl _background;
 
-        private Texture2D image = PNGLoader.Instance.GetImageTexture(Path.Combine(CUOEnviroment.ExecutablePath, "ExternalImages", "tazuo.png"));
+        private Texture2D image = ExternalImageLoader.Instance.GetImageTexture(Path.Combine(CUOEnviroment.ExecutablePath, "ExternalImages", "tazuo.png"));
 
         private Label[] supporterLabels = new Label[SUPPORTERS.Length];
 

--- a/src/ClassicUO.Client/Game/Weather.cs
+++ b/src/ClassicUO.Client/Game/Weather.cs
@@ -17,7 +17,7 @@ namespace ClassicUO.Game
         private const float SIMULATION_TIME = 37.0f;
 
         private readonly WeatherEffect[] _effects = new WeatherEffect[MAX_WEATHER_EFFECT];
-        private readonly Texture2D _rainImage = PNGLoader.Instance.GetImageTexture(
+        private readonly Texture2D _rainImage = ExternalImageLoader.Instance.GetImageTexture(
             System.IO.Path.Combine(CUOEnviroment.ExecutablePath, "ExternalImages", "rain.png"));
 
         public Weather(World world) : base(world)

--- a/src/ClassicUO.Client/GameController.cs
+++ b/src/ClassicUO.Client/GameController.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: BSD-2-Clause
+// SPDX-License-Identifier: BSD-2-Clause
 
 using ClassicUO.Assets;
 using ClassicUO.Configuration;
@@ -204,8 +204,8 @@ namespace ClassicUO
 #else
             UO.Load(this);
 
-            PNGLoader.Instance.GraphicsDevice = GraphicsDevice;
-            PNGLoader.Instance.LoadResourceAssets(Client.Game.UO.Gumps.GetGumpsLoader);
+            ExternalImageLoader.Instance.GraphicsDevice = GraphicsDevice;
+            ExternalImageLoader.Instance.LoadResourceAssets(Client.Game.UO.Gumps.GetGumpsLoader);
 
             MyraEnvironment.Game = this;
             MyraEnvironment.SetMouseCursorFromWidget = false;

--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiNineSliceGump.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiNineSliceGump.cs
@@ -152,7 +152,7 @@ internal class ModernNineSliceGump : NineSliceGump
     /// <param name="borderSize"></param>
     public void SetLegionTexture(string texture, int borderSize)
     {
-        if (PNGLoader.Instance.TryGetNamedZipTexture(texture, out Texture2D tex) && tex != null && !tex.IsDisposed)
+        if (ExternalImageLoader.Instance.TryGetNamedZipTexture(texture, out Texture2D tex) && tex != null && !tex.IsDisposed)
         {
             borderSize = Math.Clamp(borderSize, 1, tex.Width);
             borderSize = Math.Clamp(borderSize, 1, tex.Height);

--- a/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -254,7 +254,7 @@ namespace ClassicUO.LegionScripting
         {
             try
             {
-                using var archive = ZipFile.OpenRead(zipPath);
+                using ZipArchive archive = ZipFile.OpenRead(zipPath);
 
                 foreach (ZipArchiveEntry entry in archive.Entries)
                 {
@@ -285,7 +285,7 @@ namespace ClassicUO.LegionScripting
                     loadedScripts.Add(syntheticKey);
                 }
 
-                ClassicUO.Assets.PNGLoader.Instance.RegisterZipPNGs(archive);
+                ClassicUO.Assets.ExternalImageLoader.Instance.RegisterZipPNGs(archive);
             }
             catch (Exception ex)
             {

--- a/src/ClassicUO.Renderer/Arts/Art.cs
+++ b/src/ClassicUO.Renderer/Arts/Art.cs
@@ -46,7 +46,7 @@ namespace ClassicUO.Renderer.Arts
 
             if (loadedFromPNG)
             {
-                PNGLoader.Instance.ClearArtPixelCache(loadedIdx);
+                ExternalImageLoader.Instance.ClearArtPixelCache(loadedIdx);
             }
 
             return artInfo;
@@ -54,7 +54,7 @@ namespace ClassicUO.Renderer.Arts
 
         private ArtInfo LoadSourceArtInfo(uint idx, out bool loadedFromPNG)
         {
-            ArtInfo artInfo = PNGLoader.Instance.LoadArtTexture(idx);
+            ArtInfo artInfo = ExternalImageLoader.Instance.LoadArtTexture(idx);
             loadedFromPNG = !artInfo.Pixels.IsEmpty;
 
             if (artInfo.Pixels.IsEmpty)
@@ -98,7 +98,7 @@ namespace ClassicUO.Renderer.Arts
                     // Clear the pixel cache from PNG Loader since it's now in the atlas
                     if (loadedFromPNG)
                     {
-                        PNGLoader.Instance.ClearArtPixelCache(idx);
+                        ExternalImageLoader.Instance.ClearArtPixelCache(idx);
                     }
 
                     if (idx > 0x4000)

--- a/src/ClassicUO.Renderer/Gumps/Gump.cs
+++ b/src/ClassicUO.Renderer/Gumps/Gump.cs
@@ -28,7 +28,7 @@ namespace ClassicUO.Renderer.Gumps
 
             if (spriteInfo.Texture == null)
             {
-                GumpInfo gumpInfo = PNGLoader.Instance.LoadGumpTexture(idx);
+                GumpInfo gumpInfo = ExternalImageLoader.Instance.LoadGumpTexture(idx);
                 bool loadedFromPNG = !gumpInfo.Pixels.IsEmpty;
 
                 if (gumpInfo.Pixels.IsEmpty)
@@ -49,7 +49,7 @@ namespace ClassicUO.Renderer.Gumps
                     // Clear the pixel cache from PNG Loader since it's now in the atlas
                     if (loadedFromPNG)
                     {
-                        PNGLoader.Instance.ClearGumpPixelCache(idx);
+                        ExternalImageLoader.Instance.ClearGumpPixelCache(idx);
                     }
                 }
             }


### PR DESCRIPTION
## Description
- Rename PNGLoader → ExternalImageLoader
- Support hex filenames (e.g. 0x1A2B.png)
- Add BMP format loading (24/32-bit)
- Recursive directory search for external images
- Graceful error handling with try-catch on file loads
- Add bounds checking in MultiMap to reject invalid dimensions

## Type of Change
- [X ] New feature


## Testing
add subdirectories (Ability  Bushido  Chivalry  Magery  Necromancy  Ninjitsu  Spellweaving) to ExternalImages and populated them with bmp files in format 0x8C0.bmp. 
Ran the client with gumps displaying the changed gump, and it appeared as the bmp. 

## Screenshots (if applicable)
<img width="150" height="91" alt="image" src="https://github.com/user-attachments/assets/11eb0367-2988-45ab-ad5e-daabf4427807" />

## Additional Notes
Many of the old gump images were stored in bmp format and used a filename in hex instead of decimal. 
This change does not preclude png format, nor decimal filenaming, rather it just extends the existing code to also support bmp and 0x#### format files.  It does this by detecting the .bmp suffix, and the 0x prefix. 
