### PR TITLE
Enable bmp external files, and hex filename format (same as pr in dev) 

### DIFF
--- a/src/ClassicUO.Assets/ExternalImageLoader.cs
+++ b/src/ClassicUO.Assets/ExternalImageLoader.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace ClassicUO.Assets
 {
-    public class PNGLoader
+    public class ExternalImageLoader
     {
         private const string IMAGES_FOLDER = "ExternalImages", GUMP_EXTERNAL_FOLDER = "gumps", ART_EXTERNAL_FOLDER = "art";
 
@@ -16,16 +16,16 @@ namespace ClassicUO.Assets
         private Dictionary<string, Texture2D> EmbeddedArt = new Dictionary<string, Texture2D>();
         private Texture2D _emptyTexture;
 
-        private uint[] gump_availableIDs;
+        private Dictionary<uint, string> gump_availableFilePaths = new Dictionary<uint, string>();
         private Dictionary<uint, (uint[] pixels, int width, int height)> gump_textureCache = new Dictionary<uint, (uint[], int, int)>();
 
-        private uint[] art_availableIDs;
+        private Dictionary<uint, string> art_availableFilePaths = new Dictionary<uint, string>();
         private Dictionary<uint, (uint[] pixels, int width, int height)> art_textureCache = new Dictionary<uint, (uint[], int, int)>();
 
         public GraphicsDevice GraphicsDevice { set; get; }
 
-        public static PNGLoader _instance;
-        public static PNGLoader Instance => _instance ?? (_instance = new PNGLoader());
+        public static ExternalImageLoader _instance;
+        public static ExternalImageLoader Instance => _instance ?? (_instance = new ExternalImageLoader());
 
         public bool TryGetEmbeddedTexture(string name, out Texture2D texture)
         {
@@ -65,10 +65,8 @@ namespace ClassicUO.Assets
 
         public GumpInfo LoadGumpTexture(uint graphic)
         {
-            if (gump_availableIDs == null)
+            if (!gump_availableFilePaths.TryGetValue(graphic, out string fullImagePath))
                 return new GumpInfo();
-            int index = Array.IndexOf(gump_availableIDs, graphic);
-            if (index == -1) return new GumpInfo();
 
             if (gump_textureCache.TryGetValue(graphic, out var cached))
             {
@@ -80,15 +78,25 @@ namespace ClassicUO.Assets
                 };
             }
 
-            if (exePath != null && GraphicsDevice != null)
+            if (GraphicsDevice != null && File.Exists(fullImagePath))
             {
-                string fullImagePath = Path.Combine(exePath, IMAGES_FOLDER, GUMP_EXTERNAL_FOLDER, ((int)graphic).ToString() + ".png");
-
-                if (File.Exists(fullImagePath))
+                try
                 {
-                    FileStream titleStream = File.OpenRead(fullImagePath);
-                    Texture2D tempTexture = Texture2D.FromStream(GraphicsDevice, titleStream);
-                    titleStream.Close();
+                    Texture2D tempTexture;
+                    if (fullImagePath.EndsWith(".bmp", StringComparison.OrdinalIgnoreCase))
+                    {
+                        tempTexture = LoadBmp(GraphicsDevice, fullImagePath);
+                    }
+                    else
+                    {
+                        FileStream titleStream = File.OpenRead(fullImagePath);
+                        tempTexture = Texture2D.FromStream(GraphicsDevice, titleStream);
+                        titleStream.Close();
+                    }
+
+                    if (tempTexture == null)
+                        return new GumpInfo();
+
                     FixPNGAlpha(ref tempTexture);
 
                     uint[] pixels = GetPixels(tempTexture);
@@ -104,6 +112,10 @@ namespace ClassicUO.Assets
                         Height = height
                     };
                 }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Failed to load gump image '{fullImagePath}': {ex.Message}");
+                }
             }
 
             return new GumpInfo();
@@ -111,11 +123,8 @@ namespace ClassicUO.Assets
 
         public ArtInfo LoadArtTexture(uint graphic)
         {
-            if (art_availableIDs == null)
+            if (!art_availableFilePaths.TryGetValue(graphic, out string fullImagePath))
                 return new ArtInfo();
-
-            int index = Array.IndexOf(art_availableIDs, graphic);
-            if (index == -1) return new ArtInfo();
 
             if (art_textureCache.TryGetValue(graphic, out var cached))
             {
@@ -127,18 +136,26 @@ namespace ClassicUO.Assets
                 };
             }
 
-            if (exePath != null && GraphicsDevice != null)
+            if (GraphicsDevice != null && File.Exists(fullImagePath))
             {
-                uint fileGraphic = graphic - 0x4000;
-                string fullImagePath = Path.Combine(exePath, IMAGES_FOLDER, ART_EXTERNAL_FOLDER, fileGraphic.ToString() + ".png");
-
-                if (File.Exists(fullImagePath))
+                try
                 {
                     Texture2D tempTexture;
-                    using (FileStream titleStream = File.OpenRead(fullImagePath))
+                    if (fullImagePath.EndsWith(".bmp", StringComparison.OrdinalIgnoreCase))
                     {
-                        tempTexture = Texture2D.FromStream(GraphicsDevice, titleStream);
+                        tempTexture = LoadBmp(GraphicsDevice, fullImagePath);
                     }
+                    else
+                    {
+                        using (FileStream titleStream = File.OpenRead(fullImagePath))
+                        {
+                            tempTexture = Texture2D.FromStream(GraphicsDevice, titleStream);
+                        }
+                    }
+
+                    if (tempTexture == null)
+                        return new ArtInfo();
+
                     FixPNGAlpha(ref tempTexture);
 
                     uint[] pixels = GetPixels(tempTexture);
@@ -154,9 +171,65 @@ namespace ClassicUO.Assets
                         Height = height
                     };
                 }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Failed to load art image '{fullImagePath}': {ex.Message}");
+                }
             }
 
             return new ArtInfo();
+        }
+
+        private static Texture2D LoadBmp(GraphicsDevice gd, string path)
+        {
+            byte[] file = File.ReadAllBytes(path);
+            if (file.Length < 54 || file[0] != 'B' || file[1] != 'M')
+                return null;
+
+            int dataOffset = BitConverter.ToInt32(file, 10);
+            int headerSize = BitConverter.ToInt32(file, 14);
+            if (headerSize < 40)
+                return null;
+
+            int width = BitConverter.ToInt32(file, 18);
+            int rawHeight = BitConverter.ToInt32(file, 22);
+            bool topDown = rawHeight < 0;
+            int height = Math.Abs(rawHeight);
+            short bpp = BitConverter.ToInt16(file, 28);
+
+            if (bpp != 24 && bpp != 32)
+            {
+                Console.WriteLine($"Unsupported BMP bit depth {bpp} in '{path}'");
+                return null;
+            }
+
+            int bytesPerPixel = bpp / 8;
+            int rowStride = width * bytesPerPixel;
+            int rowPadding = (4 - (rowStride % 4)) % 4;
+            int rowBytes = rowStride + rowPadding;
+
+            var texture = new Texture2D(gd, width, height);
+            var pixels = new Color[width * height];
+
+            for (int y = 0; y < height; y++)
+            {
+                int srcRow = topDown ? y : (height - 1 - y);
+                int srcOffset = dataOffset + srcRow * rowBytes;
+
+                for (int x = 0; x < width; x++)
+                {
+                    int srcIdx = srcOffset + x * bytesPerPixel;
+                    byte b = file[srcIdx];
+                    byte g = file[srcIdx + 1];
+                    byte r = file[srcIdx + 2];
+                    byte a = (bytesPerPixel == 4) ? file[srcIdx + 3] : (byte)255;
+
+                    pixels[y * width + x] = new Color(r, g, b, a);
+                }
+            }
+
+            texture.SetData(pixels);
+            return texture;
         }
 
         private uint[] GetPixels(Texture2D texture)
@@ -178,6 +251,21 @@ namespace ClassicUO.Assets
             return pixels;
         }
 
+        private static string[] FindImageFiles(string directory)
+        {
+            var results = new List<string>();
+            results.AddRange(Directory.GetFiles(directory, "*.png", SearchOption.AllDirectories));
+            results.AddRange(Directory.GetFiles(directory, "*.bmp", SearchOption.AllDirectories));
+            return results.ToArray();
+        }
+
+        private static bool TryParseId(string value, out uint result)
+        {
+            if (value.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+                return uint.TryParse(value.Substring(2), System.Globalization.NumberStyles.HexNumber, null, out result);
+            return uint.TryParse(value, out result);
+        }
+
         public void Load()
         {
             string strExeFilePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
@@ -186,13 +274,14 @@ namespace ClassicUO.Assets
             string gumpPath = Path.Combine(exePath, IMAGES_FOLDER, GUMP_EXTERNAL_FOLDER);
             if (Directory.Exists(gumpPath))
             {
-                string[] files = Directory.GetFiles(gumpPath, "*.png", SearchOption.TopDirectoryOnly);
-                gump_availableIDs = new uint[files.Length];
+                string[] files = FindImageFiles(gumpPath);
 
                 for (int i = 0; i < files.Length; i++)
                 {
                     string fname = Path.GetFileName(files[i]);
-                    uint.TryParse(fname.Substring(0, fname.Length - 4), out gump_availableIDs[i]);
+                    string baseName = Path.GetFileNameWithoutExtension(fname);
+                    if (TryParseId(baseName, out uint id))
+                        gump_availableFilePaths[id] = files[i];
                 }
             }
             else
@@ -203,15 +292,15 @@ namespace ClassicUO.Assets
             string artPath = Path.Combine(exePath, IMAGES_FOLDER, ART_EXTERNAL_FOLDER);
             if (Directory.Exists(artPath))
             {
-                string[] files = Directory.GetFiles(artPath, "*.png", SearchOption.TopDirectoryOnly);
-                art_availableIDs = new uint[files.Length];
+                string[] files = FindImageFiles(artPath);
 
                 for (int i = 0; i < files.Length; i++)
                 {
                     string fname = Path.GetFileName(files[i]);
-                    if (uint.TryParse(fname.Substring(0, fname.Length - 4), out uint gfx))
+                    string baseName = Path.GetFileNameWithoutExtension(fname);
+                    if (TryParseId(baseName, out uint gfx))
                     {
-                        art_availableIDs[i] = gfx + 0x4000;
+                        art_availableFilePaths[gfx + 0x4000] = files[i];
                     }
                 }
             }
@@ -264,17 +353,8 @@ namespace ClassicUO.Assets
 
 
                                 //Increase available gump id's
-                                if (gump_availableIDs != null)
-                                {
-                                    uint[] availableIDs = new uint[gump_availableIDs.Length + 1];
-                                    gump_availableIDs.CopyTo(availableIDs, 0);
-                                    availableIDs[availableIDs.Length - 1] = i;
-                                    gump_availableIDs = availableIDs;
-                                }
-                                else
-                                {
-                                    gump_availableIDs = [i];
-                                }
+                                if (!gump_availableFilePaths.ContainsKey(i))
+                                    gump_availableFilePaths[i] = $"0x{i:X}";
 
                                 stream.Dispose();
                             }

--- a/src/ClassicUO.Assets/UOFileManager.cs
+++ b/src/ClassicUO.Assets/UOFileManager.cs
@@ -1,4 +1,4 @@
-﻿#region license
+#region license
 
 // Copyright (c) 2021, andreakarasho
 // All rights reserved.
@@ -129,7 +129,7 @@ namespace ClassicUO.Assets
                 Log.Panic("Loading files timeout.");
             }
 
-            PNGLoader.Instance.Load();
+            ExternalImageLoader.Instance.Load();
 
             Read_Art_def();
 

--- a/src/ClassicUO.Client/Game/Data/ModernUIConstants.cs
+++ b/src/ClassicUO.Client/Game/Data/ModernUIConstants.cs
@@ -9,7 +9,7 @@ public static class ModernUIConstants
     /// Standard Modern UI Panel. Used for a general gump background.
     /// Recommended to use with the NineSliceGump class.
     /// </summary>
-    public static Texture2D ModernUIPanel { get { PNGLoader.Instance.TryGetEmbeddedTexture("TUOGumpBg.png", out var texture); return texture; } }
+    public static Texture2D ModernUIPanel { get { ExternalImageLoader.Instance.TryGetEmbeddedTexture("TUOGumpBg.png", out var texture); return texture; } }
 
     /// <summary>
     /// Border size of the modern ui panel, used for the NineSliceGump class.
@@ -21,8 +21,8 @@ public static class ModernUIConstants
     /// See ModernUIButtonDown for "clicked" texture.
     /// Recommended to use with the NineSliceGump class.
     /// </summary>
-    public static Texture2D ModernUIButtonUp { get { PNGLoader.Instance.TryGetEmbeddedTexture("TUOUIButtonUp.png", out var texture); return texture; } }
-    public static Texture2D ModernUIButtonDown { get { PNGLoader.Instance.TryGetEmbeddedTexture("TUOUIButtonDown.png", out var texture); return texture; } }
+    public static Texture2D ModernUIButtonUp { get { ExternalImageLoader.Instance.TryGetEmbeddedTexture("TUOUIButtonUp.png", out var texture); return texture; } }
+    public static Texture2D ModernUIButtonDown { get { ExternalImageLoader.Instance.TryGetEmbeddedTexture("TUOUIButtonDown.png", out var texture); return texture; } }
 
     public const int ModernUIButton_BorderSize = 4;
 }

--- a/src/ClassicUO.Client/Game/UI/Gumps/DiscordGump/DiscordGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/DiscordGump/DiscordGump.cs
@@ -88,7 +88,7 @@ public class DiscordGump : Gump
     {
         AcceptMouseInput = true;
 
-        PNGLoader.Instance.TryGetEmbeddedTexture("Discord-Symbol-Blurple-SM.png", out var discordTexture);
+        ExternalImageLoader.Instance.TryGetEmbeddedTexture("Discord-Symbol-Blurple-SM.png", out var discordTexture);
         _discordLogo = new(LEFT_WIDTH / 2 - 66, HEIGHT / 2 - 50, discordTexture);
         Add(_discordLogo);
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/DiscordGump/DiscordUserListItem.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/DiscordGump/DiscordUserListItem.cs
@@ -111,7 +111,7 @@ public class DiscordUserListItem : Control
 
         if(user.GameActivity() != null) //In TUO
         {
-            PNGLoader.Instance.TryGetEmbeddedTexture("TazUOSM.png", out var tuoTexture);
+            ExternalImageLoader.Instance.TryGetEmbeddedTexture("TazUOSM.png", out var tuoTexture);
             var tuo = new EmbeddedGumpPic(Width - 75, 2, tuoTexture);
             Add(tuo);
         }

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernPaperdoll.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernPaperdoll.cs
@@ -1,4 +1,4 @@
-﻿using ClassicUO.Assets;
+using ClassicUO.Assets;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.GameObjects;
@@ -29,7 +29,7 @@ namespace ClassicUO.Game.UI.Gumps
         {
             if (MordernPaperdollGump == null)
             {
-                PNGLoader.Instance.TryGetEmbeddedTexture("modern-paperdollgump.png", out MordernPaperdollGump);
+                ExternalImageLoader.Instance.TryGetEmbeddedTexture("modern-paperdollgump.png", out MordernPaperdollGump);
             }
         }
         #endregion

--- a/src/ClassicUO.Client/Game/UI/Gumps/SpellBar/SpellBar.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/SpellBar/SpellBar.cs
@@ -115,10 +115,10 @@ public class SpellBar : Gump
         rowLabel.Y = (Height - rowLabel.Height) >> 1;
         Add(rowLabel);
 
-        PNGLoader.Instance.TryGetEmbeddedTexture("upicon.png", out var upTexture);
+        ExternalImageLoader.Instance.TryGetEmbeddedTexture("upicon.png", out var upTexture);
         var up = new EmbeddedGumpPic(Width - 31, 0, upTexture, 148);
         up.MouseUp += (sender, e) => { ChangeRow(false); };
-        PNGLoader.Instance.TryGetEmbeddedTexture("downicon.png", out var downTexture);
+        ExternalImageLoader.Instance.TryGetEmbeddedTexture("downicon.png", out var downTexture);
         var down = new EmbeddedGumpPic(Width - 31, Height - 16, downTexture, 148);
         down.MouseUp += (sender, e) => { ChangeRow(true); };
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/Supporters.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/Supporters.cs
@@ -1,4 +1,4 @@
-﻿using ClassicUO.Assets;
+using ClassicUO.Assets;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Renderer;
@@ -26,7 +26,7 @@ namespace ClassicUO.Game.UI.Gumps
         };
         private AlphaBlendControl _background;
 
-        private Texture2D image = PNGLoader.Instance.GetImageTexture(Path.Combine(CUOEnviroment.ExecutablePath, "ExternalImages", "tazuo.png"));
+        private Texture2D image = ExternalImageLoader.Instance.GetImageTexture(Path.Combine(CUOEnviroment.ExecutablePath, "ExternalImages", "tazuo.png"));
 
         private Label[] supporterLabels = new Label[SUPPORTERS.Length];
 

--- a/src/ClassicUO.Client/Game/Weather.cs
+++ b/src/ClassicUO.Client/Game/Weather.cs
@@ -1,4 +1,4 @@
-﻿#region license
+#region license
 
 // Copyright (c) 2021, andreakarasho
 // All rights reserved.
@@ -69,7 +69,7 @@ namespace ClassicUO.Game
         public byte CurrentCount { get; private set; }
         public byte Temperature{ get; private set; }
         public sbyte Wind { get; private set; }
-        private Texture2D rainImage = PNGLoader.Instance.GetImageTexture(System.IO.Path.Combine(CUOEnviroment.ExecutablePath, "ExternalImages", "rain.png"));
+        private Texture2D rainImage = ExternalImageLoader.Instance.GetImageTexture(System.IO.Path.Combine(CUOEnviroment.ExecutablePath, "ExternalImages", "rain.png"));
 
 
         private static float SinOscillate(float freq, int range, uint current_tick)

--- a/src/ClassicUO.Client/GameController.cs
+++ b/src/ClassicUO.Client/GameController.cs
@@ -1,4 +1,4 @@
-﻿#region license
+#region license
 
 // Copyright (c) 2021, andreakarasho
 // All rights reserved.
@@ -206,8 +206,8 @@ namespace ClassicUO
 
             Fonts.Initialize(GraphicsDevice);
             SolidColorTextureCache.Initialize(GraphicsDevice);
-            PNGLoader.Instance.GraphicsDevice = GraphicsDevice;
-            System.Threading.Tasks.Task loadResourceAssets = PNGLoader.Instance.LoadResourceAssets();
+            ExternalImageLoader.Instance.GraphicsDevice = GraphicsDevice;
+            System.Threading.Tasks.Task loadResourceAssets = ExternalImageLoader.Instance.LoadResourceAssets();
 
             Animations = new Renderer.Animations.Animations(GraphicsDevice);
             Arts = new Renderer.Arts.Art(GraphicsDevice);

--- a/src/ClassicUO.Renderer/Arts/Art.cs
+++ b/src/ClassicUO.Renderer/Arts/Art.cs
@@ -37,7 +37,7 @@ namespace ClassicUO.Renderer.Arts
 
             if (spriteInfo.Texture == null)
             {
-                ArtInfo artInfo = PNGLoader.Instance.LoadArtTexture(idx);
+                ArtInfo artInfo = ExternalImageLoader.Instance.LoadArtTexture(idx);
                 bool loadedFromPNG = artInfo.Pixels != null && !artInfo.Pixels.IsEmpty;
 
                 if (artInfo.Pixels == null || artInfo.Pixels.IsEmpty)
@@ -67,7 +67,7 @@ namespace ClassicUO.Renderer.Arts
                     // Clear the pixel cache from PNG Loader since it's now in the atlas
                     if (loadedFromPNG)
                     {
-                        PNGLoader.Instance.ClearArtPixelCache(idx);
+                        ExternalImageLoader.Instance.ClearArtPixelCache(idx);
                     }
 
                     if (idx > 0x4000)

--- a/src/ClassicUO.Renderer/Gumps/Gump.cs
+++ b/src/ClassicUO.Renderer/Gumps/Gump.cs
@@ -24,7 +24,7 @@ namespace ClassicUO.Renderer.Gumps
 
             if (spriteInfo.Texture == null)
             {
-                var gumpInfo = PNGLoader.Instance.LoadGumpTexture(idx);
+                var gumpInfo = ExternalImageLoader.Instance.LoadGumpTexture(idx);
                 bool loadedFromPNG = gumpInfo.Pixels != null && !gumpInfo.Pixels.IsEmpty;
 
                 if (gumpInfo.Pixels == null || gumpInfo.Pixels.IsEmpty)
@@ -45,7 +45,7 @@ namespace ClassicUO.Renderer.Gumps
                     // Clear the pixel cache from PNG Loader since it's now in the atlas
                     if (loadedFromPNG)
                     {
-                        PNGLoader.Instance.ClearGumpPixelCache(idx);
+                        ExternalImageLoader.Instance.ClearGumpPixelCache(idx);
                     }
                 }
             }

--- a/src/ClassicUO.Renderer/MultiMaps/MultiMap.cs
+++ b/src/ClassicUO.Renderer/MultiMaps/MultiMap.cs
@@ -23,7 +23,7 @@ namespace ClassicUO.Renderer.MultiMaps
                 MultiMapLoader.Instance.LoadFacet(facet.Value, width, height, startX, startY, endX, endY) :
                 MultiMapLoader.Instance.LoadMap(width, height, startX, startY, endX, endY);
 
-            if (multiMapInfo.Pixels.IsEmpty)
+            if (multiMapInfo.Pixels.IsEmpty || multiMapInfo.Width <= 0 || multiMapInfo.Height <= 0 || multiMapInfo.Width > 8192 || multiMapInfo.Height > 8192)
                 return default;
 
             var texture = new Texture2D(_device, multiMapInfo.Width, multiMapInfo.Height, false, SurfaceFormat.Color);


### PR DESCRIPTION
## Description
- Rename PNGLoader → ExternalImageLoader
- Support hex filenames (e.g. 0x1A2B.png)
- Add BMP format loading (24/32-bit)
- Recursive directory search for external images
- Graceful error handling with try-catch on file loads
- Add bounds checking in MultiMap to reject invalid dimensions

## Type of Change
- [X ] New feature


## Testing
add subdirectories (Ability  Bushido  Chivalry  Magery  Necromancy  Ninjitsu  Spellweaving) to ExternalImages and populated them with bmp files in format 0x8C0.bmp. 
Ran the client with gumps displaying the changed gump, and it appeared as the bmp. 

## Screenshots (if applicable)
<img width="150" height="91" alt="image" src="https://github.com/user-attachments/assets/11eb0367-2988-45ab-ad5e-daabf4427807" />

## Additional Notes
Many of the old gump images were stored in bmp format and used a filename in hex instead of decimal. 
This change does not preclude png format, nor decimal filenaming, rather it just extends the existing code to also support bmp and 0x#### format files.  It does this by detecting the .bmp suffix, and the 0x prefix. 
