### PR TITLE
Move tooltip overrides to their own tooltip_overrides.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to TazUO will be recorded here.
 * Added a new reusable hotkey setting window, all hotkey assignment goes through this window now - [P.R 793](https://github.com/PlayTazUO/TazUO/pull/793) ([bittiez](https://github.com/bittiez))
 * Replaced the old Myra window style with a new themed one. Thank you NewYears! - [P.R 774](https://github.com/PlayTazUO/TazUO/pull/774) ([bittiez](https://github.com/bittiez))
 
+### Misc
+* Migrate tooltip override saves to its own json file - [P.R 798](https://github.com/PlayTazUO/TazUO/pull/798) ([bittiez](https://github.com/bittiez))
+
 ### Fixes
 * Fixed potential crashes with FSS text generation - ([bittiez](https://github.com/bittiez))
 

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.15.0</AssemblyVersion>
-    <FileVersion>5.15.0</FileVersion>
+    <AssemblyVersion>5.15.1</AssemblyVersion>
+    <FileVersion>5.15.1</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -1117,7 +1117,59 @@ namespace ClassicUO.Configuration
 
                 ProfileMigrationVersion++;
             }
+
+            if (ProfileMigrationVersion < 4) //3
+            {
+                MigrateToolTipOverrides();
+
+                ProfileMigrationVersion++;
+            }
         }
+
+        /// <summary>
+        /// Moves the legacy parallel <c>ToolTipOverride_*</c> lists into the dedicated
+        /// tooltip_overrides.json (see <see cref="TooltipOverridesConfig"/>) and clears them. The config
+        /// list is rebuilt (not appended) so re-running the migration - e.g. if the profile isn't saved
+        /// before the next launch - stays idempotent.
+        /// </summary>
+#pragma warning disable CS0618 // Reading the obsolete legacy lists is the whole point of migration.
+        private void MigrateToolTipOverrides()
+        {
+            int count = ToolTipOverride_SearchText.Count;
+            if (count == 0)
+                return;
+
+            var overrides = new List<ToolTipOverrideData>(count);
+
+            for (int i = 0; i < count; i++)
+            {
+                overrides.Add(new ToolTipOverrideData(
+                    i,
+                    ToolTipOverride_SearchText[i],
+                    ToolTipOverride_NewFormat.ElementAtOrDefault(i) ?? string.Empty,
+                    i < ToolTipOverride_MinVal1.Count ? ToolTipOverride_MinVal1[i] : -1,
+                    i < ToolTipOverride_MaxVal1.Count ? ToolTipOverride_MaxVal1[i] : 100,
+                    i < ToolTipOverride_MinVal2.Count ? ToolTipOverride_MinVal2[i] : -1,
+                    i < ToolTipOverride_MaxVal2.Count ? ToolTipOverride_MaxVal2[i] : 100,
+                    i < ToolTipOverride_Layer.Count ? ToolTipOverride_Layer[i] : (byte)TooltipLayers.Any,
+                    i < ToolTipOverride_BorderHue.Count ? ToolTipOverride_BorderHue[i] : -1));
+            }
+
+            TooltipOverridesConfig config = TooltipOverridesConfig.Current;
+            config.Overrides = overrides;
+            config.Save();
+
+            // Clear the legacy lists so tooltip overrides live only in tooltip_overrides.json going forward.
+            ToolTipOverride_SearchText.Clear();
+            ToolTipOverride_NewFormat.Clear();
+            ToolTipOverride_MinVal1.Clear();
+            ToolTipOverride_MinVal2.Clear();
+            ToolTipOverride_MaxVal1.Clear();
+            ToolTipOverride_MaxVal2.Clear();
+            ToolTipOverride_Layer.Clear();
+            ToolTipOverride_BorderHue.Clear();
+        }
+#pragma warning restore CS0618
 
         internal void Save(World world, string path, bool saveGumps = true)
         {

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -715,14 +715,28 @@ namespace ClassicUO.Configuration
         public int AdvancedSkillsGumpHeight { get; set => SetProperty(ref field, value); } = 510;
 
         #region ToolTip Overrides
+        // The ToolTipOverride_* parallel lists below are the legacy tooltip-override storage. They have been
+        // superseded by tooltip_overrides.json (see TooltipOverridesConfig) and are retained only so existing
+        // profiles can be migrated on load. Do not use them in new code. The defaults are kept so a fresh
+        // profile still migrates the standard resist/damage overrides into the new file.
+        private const string TooltipOverrideMigratedMessage = "Migrated to tooltip_overrides.json (TooltipOverridesConfig); retained only for one-time migration of existing profiles.";
+
+        [Obsolete(TooltipOverrideMigratedMessage)]
         public List<string> ToolTipOverride_SearchText { get; set => SetProperty(ref field, value); } = new List<string>() { "Physical Res", "Fire Resist", "Cold Resist", "Poison Resist", "Energy Resist", "Weapon Damage" };
+        [Obsolete(TooltipOverrideMigratedMessage)]
         public List<string> ToolTipOverride_NewFormat { get; set => SetProperty(ref field, value); } = new List<string>() { "/c[#8c733e]Physical Resist {1}%", "/c[red]Fire Resist {1}%", "/c[teal]Cold Resist {1}%", "/c[green]Poison Resist {1}%", "/c[purple]Energy Resist {1}%", "{0} /c[orange]{1}{4} /cd- /c[red]{2}{5}" };
+        [Obsolete(TooltipOverrideMigratedMessage)]
         public List<int> ToolTipOverride_MinVal1 { get; set => SetProperty(ref field, value); } = new List<int>() { -1, -1, -1, -1, -1, -1 };
+        [Obsolete(TooltipOverrideMigratedMessage)]
         public List<int> ToolTipOverride_MinVal2 { get; set => SetProperty(ref field, value); } = new List<int>() { -1, -1, -1, -1, -1, -1 };
+        [Obsolete(TooltipOverrideMigratedMessage)]
         public List<int> ToolTipOverride_MaxVal1 { get; set => SetProperty(ref field, value); } = new List<int>() { 100, 100, 100, 100, 100, 100 };
+        [Obsolete(TooltipOverrideMigratedMessage)]
         public List<int> ToolTipOverride_MaxVal2 { get; set => SetProperty(ref field, value); } = new List<int>() { 100, 100, 100, 100, 100, 100 };
+        [Obsolete(TooltipOverrideMigratedMessage)]
         public List<byte> ToolTipOverride_Layer { get; set => SetProperty(ref field, value); } = new List<byte>() { (byte)TooltipLayers.Any, (byte)TooltipLayers.Any, (byte)TooltipLayers.Any, (byte)TooltipLayers.Any, (byte)TooltipLayers.Any, (byte)TooltipLayers.Any };
         /// <summary>Optional per-override border hue drawn around the tooltip when the rule matches; -1 means no override.</summary>
+        [Obsolete(TooltipOverrideMigratedMessage)]
         public List<int> ToolTipOverride_BorderHue { get; set => SetProperty(ref field, value); } = new List<int>() { -1, -1, -1, -1, -1, -1 };
         /// <summary>When enabled, tooltip overrides are not applied to mobile tooltips.</summary>
         public bool ToolTipOverride_IgnoreMobiles { get; set => SetProperty(ref field, value); } = true;

--- a/src/ClassicUO.Client/Configuration/ProfileManager.cs
+++ b/src/ClassicUO.Client/Configuration/ProfileManager.cs
@@ -92,6 +92,12 @@ namespace ClassicUO.Configuration
                 ConfigurationResolver.Save(CurrentProfile, Path.Combine(ProfilePath, "profile.json"), ProfileJsonContext.DefaultToUse.Profile);
             }
 
+            // Load (or migrate from the legacy parallel-list profile storage) the tooltip overrides.
+            if (TooltipOverridesConfig.LoadForProfile(ProfilePath, CurrentProfile))
+            {
+                ConfigurationResolver.Save(CurrentProfile, Path.Combine(ProfilePath, "profile.json"), ProfileJsonContext.DefaultToUse.Profile);
+            }
+
             ValidateFields(CurrentProfile);
 
             CurrentProfile.AfterLoad();

--- a/src/ClassicUO.Client/Configuration/ProfileManager.cs
+++ b/src/ClassicUO.Client/Configuration/ProfileManager.cs
@@ -92,11 +92,9 @@ namespace ClassicUO.Configuration
                 ConfigurationResolver.Save(CurrentProfile, Path.Combine(ProfilePath, "profile.json"), ProfileJsonContext.DefaultToUse.Profile);
             }
 
-            // Load (or migrate from the legacy parallel-list profile storage) the tooltip overrides.
-            if (TooltipOverridesConfig.LoadForProfile(ProfilePath, CurrentProfile))
-            {
-                ConfigurationResolver.Save(CurrentProfile, Path.Combine(ProfilePath, "profile.json"), ProfileJsonContext.DefaultToUse.Profile);
-            }
+            // Load the tooltip overrides for this profile (migration from the legacy profile lists is
+            // handled in Profile.HandleMigration).
+            TooltipOverridesConfig.Load(ProfilePath);
 
             ValidateFields(CurrentProfile);
 

--- a/src/ClassicUO.Client/Configuration/TooltipOverridesConfig.cs
+++ b/src/ClassicUO.Client/Configuration/TooltipOverridesConfig.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using ClassicUO.Game.Data;
 using ClassicUO.Game.Managers;
 
 namespace ClassicUO.Configuration
@@ -12,7 +11,7 @@ namespace ClassicUO.Configuration
     /// <summary>
     /// JSON-backed store for tooltip override rules. Persisted to <c>tooltip_overrides.json</c> in the
     /// current profile's save location. Replaces the legacy parallel <c>ToolTipOverride_*</c> lists on
-    /// <see cref="Profile"/>, which are migrated on first load so existing overrides are preserved.
+    /// <see cref="Profile"/>, which are migrated across during profile migration.
     /// </summary>
     public sealed class TooltipOverridesConfig
     {
@@ -23,39 +22,25 @@ namespace ClassicUO.Configuration
         private static TooltipOverridesConfig _current;
 
         /// <summary>The tooltip-override config for the currently loaded profile.</summary>
-        public static TooltipOverridesConfig Current => _current ??= LoadForCurrentProfile();
+        public static TooltipOverridesConfig Current => _current ??= Load(ProfileManager.ProfilePath);
 
         private static string GetFilePath() =>
             string.IsNullOrEmpty(ProfileManager.ProfilePath) ? null : Path.Combine(ProfileManager.ProfilePath, FileName);
 
         /// <summary>
-        /// Loads (or migrates) the tooltip-override config for the given profile and sets it as
-        /// <see cref="Current"/>. Returns <see langword="true"/> when a migration from the legacy
-        /// <see cref="Profile"/> lists was performed (and those lists were cleared), signaling that
-        /// the profile itself should be re-saved.
+        /// Loads the tooltip-override config from <paramref name="profilePath"/> and sets it as
+        /// <see cref="Current"/>. Called on every profile load so the cache tracks the active profile.
         /// </summary>
-        public static bool LoadForProfile(string profilePath, Profile profile)
+        public static TooltipOverridesConfig Load(string profilePath)
         {
             string file = string.IsNullOrEmpty(profilePath) ? null : Path.Combine(profilePath, FileName);
 
-            if (file != null && File.Exists(file))
-            {
-                _current = ConfigurationResolver.Load<TooltipOverridesConfig>(file, TooltipOverridesJsonContext.DefaultToUse.TooltipOverridesConfig)
-                           ?? new TooltipOverridesConfig();
-                _current.Reindex();
-                return false;
-            }
+            _current = (file != null && File.Exists(file)
+                           ? ConfigurationResolver.Load<TooltipOverridesConfig>(file, TooltipOverridesJsonContext.DefaultToUse.TooltipOverridesConfig)
+                           : null)
+                       ?? new TooltipOverridesConfig();
 
-            bool migrated = MigrateFromProfile(profile, out TooltipOverridesConfig config);
-            _current = config;
             _current.Reindex();
-            _current.Save();
-            return migrated;
-        }
-
-        private static TooltipOverridesConfig LoadForCurrentProfile()
-        {
-            LoadForProfile(ProfileManager.ProfilePath, ProfileManager.CurrentProfile);
             return _current;
         }
 
@@ -118,51 +103,6 @@ namespace ClassicUO.Configuration
                     Overrides[i].Index = i;
             }
         }
-
-        /// <summary>
-        /// Builds a config from the legacy parallel <see cref="Profile"/> lists and clears them.
-        /// </summary>
-        /// <returns><see langword="true"/> when there was legacy data to migrate.</returns>
-#pragma warning disable CS0618 // Reading the obsolete legacy lists is the whole point of migration.
-        private static bool MigrateFromProfile(Profile profile, out TooltipOverridesConfig config)
-        {
-            config = new TooltipOverridesConfig();
-
-            if (profile == null)
-                return false;
-
-            int count = profile.ToolTipOverride_SearchText.Count;
-
-            for (int i = 0; i < count; i++)
-            {
-                config.Overrides.Add(new ToolTipOverrideData(
-                    i,
-                    profile.ToolTipOverride_SearchText[i],
-                    profile.ToolTipOverride_NewFormat.ElementAtOrDefault(i) ?? string.Empty,
-                    i < profile.ToolTipOverride_MinVal1.Count ? profile.ToolTipOverride_MinVal1[i] : -1,
-                    i < profile.ToolTipOverride_MaxVal1.Count ? profile.ToolTipOverride_MaxVal1[i] : 100,
-                    i < profile.ToolTipOverride_MinVal2.Count ? profile.ToolTipOverride_MinVal2[i] : -1,
-                    i < profile.ToolTipOverride_MaxVal2.Count ? profile.ToolTipOverride_MaxVal2[i] : 100,
-                    i < profile.ToolTipOverride_Layer.Count ? profile.ToolTipOverride_Layer[i] : (byte)TooltipLayers.Any,
-                    i < profile.ToolTipOverride_BorderHue.Count ? profile.ToolTipOverride_BorderHue[i] : -1));
-            }
-
-            if (count == 0)
-                return false;
-
-            // Clear the legacy lists so the parallel-list storage no longer persists in the profile.
-            profile.ToolTipOverride_SearchText.Clear();
-            profile.ToolTipOverride_NewFormat.Clear();
-            profile.ToolTipOverride_MinVal1.Clear();
-            profile.ToolTipOverride_MinVal2.Clear();
-            profile.ToolTipOverride_MaxVal1.Clear();
-            profile.ToolTipOverride_MaxVal2.Clear();
-            profile.ToolTipOverride_Layer.Clear();
-            profile.ToolTipOverride_BorderHue.Clear();
-
-            return true;
-        }
-#pragma warning restore CS0618
     }
 
     [JsonSerializable(typeof(TooltipOverridesConfig), GenerationMode = JsonSourceGenerationMode.Metadata)]

--- a/src/ClassicUO.Client/Configuration/TooltipOverridesConfig.cs
+++ b/src/ClassicUO.Client/Configuration/TooltipOverridesConfig.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ClassicUO.Game.Data;
+using ClassicUO.Game.Managers;
+
+namespace ClassicUO.Configuration
+{
+    /// <summary>
+    /// JSON-backed store for tooltip override rules. Persisted to <c>tooltip_overrides.json</c> in the
+    /// current profile's save location. Replaces the legacy parallel <c>ToolTipOverride_*</c> lists on
+    /// <see cref="Profile"/>, which are migrated on first load so existing overrides are preserved.
+    /// </summary>
+    public sealed class TooltipOverridesConfig
+    {
+        public const string FileName = "tooltip_overrides.json";
+
+        public List<ToolTipOverrideData> Overrides { get; set; } = new();
+
+        private static TooltipOverridesConfig _current;
+
+        /// <summary>The tooltip-override config for the currently loaded profile.</summary>
+        public static TooltipOverridesConfig Current => _current ??= LoadForCurrentProfile();
+
+        private static string GetFilePath() =>
+            string.IsNullOrEmpty(ProfileManager.ProfilePath) ? null : Path.Combine(ProfileManager.ProfilePath, FileName);
+
+        /// <summary>
+        /// Loads (or migrates) the tooltip-override config for the given profile and sets it as
+        /// <see cref="Current"/>. Returns <see langword="true"/> when a migration from the legacy
+        /// <see cref="Profile"/> lists was performed (and those lists were cleared), signaling that
+        /// the profile itself should be re-saved.
+        /// </summary>
+        public static bool LoadForProfile(string profilePath, Profile profile)
+        {
+            string file = string.IsNullOrEmpty(profilePath) ? null : Path.Combine(profilePath, FileName);
+
+            if (file != null && File.Exists(file))
+            {
+                _current = ConfigurationResolver.Load<TooltipOverridesConfig>(file, TooltipOverridesJsonContext.DefaultToUse.TooltipOverridesConfig)
+                           ?? new TooltipOverridesConfig();
+                _current.Reindex();
+                return false;
+            }
+
+            bool migrated = MigrateFromProfile(profile, out TooltipOverridesConfig config);
+            _current = config;
+            _current.Reindex();
+            _current.Save();
+            return migrated;
+        }
+
+        private static TooltipOverridesConfig LoadForCurrentProfile()
+        {
+            LoadForProfile(ProfileManager.ProfilePath, ProfileManager.CurrentProfile);
+            return _current;
+        }
+
+        public void Save()
+        {
+            string file = GetFilePath();
+            if (file == null)
+                return;
+
+            ConfigurationResolver.Save(this, file, TooltipOverridesJsonContext.DefaultToUse.TooltipOverridesConfig);
+        }
+
+        /// <summary>
+        /// Stores <paramref name="data"/> at its <see cref="ToolTipOverrideData.Index"/>. When the index
+        /// is out of range the entry is appended (and its index updated to its new position). Persists on
+        /// any change.
+        /// </summary>
+        public void Upsert(ToolTipOverrideData data)
+        {
+            if (data == null)
+                return;
+
+            if (data.Index >= 0 && data.Index < Overrides.Count)
+            {
+                Overrides[data.Index] = data;
+            }
+            else
+            {
+                data.Index = Overrides.Count;
+                Overrides.Add(data);
+            }
+
+            Save();
+        }
+
+        /// <summary>Removes the entry at <paramref name="index"/>, if present, reindexes and persists.</summary>
+        public void RemoveAt(int index)
+        {
+            if (index < 0 || index >= Overrides.Count)
+                return;
+
+            Overrides.RemoveAt(index);
+            Reindex();
+            Save();
+        }
+
+        /// <summary>Removes every override and persists.</summary>
+        public void Clear()
+        {
+            Overrides.Clear();
+            Save();
+        }
+
+        /// <summary>Keeps each entry's <see cref="ToolTipOverrideData.Index"/> in sync with its list position.</summary>
+        private void Reindex()
+        {
+            for (int i = 0; i < Overrides.Count; i++)
+            {
+                if (Overrides[i] != null)
+                    Overrides[i].Index = i;
+            }
+        }
+
+        /// <summary>
+        /// Builds a config from the legacy parallel <see cref="Profile"/> lists and clears them.
+        /// </summary>
+        /// <returns><see langword="true"/> when there was legacy data to migrate.</returns>
+#pragma warning disable CS0618 // Reading the obsolete legacy lists is the whole point of migration.
+        private static bool MigrateFromProfile(Profile profile, out TooltipOverridesConfig config)
+        {
+            config = new TooltipOverridesConfig();
+
+            if (profile == null)
+                return false;
+
+            int count = profile.ToolTipOverride_SearchText.Count;
+
+            for (int i = 0; i < count; i++)
+            {
+                config.Overrides.Add(new ToolTipOverrideData(
+                    i,
+                    profile.ToolTipOverride_SearchText[i],
+                    profile.ToolTipOverride_NewFormat.ElementAtOrDefault(i) ?? string.Empty,
+                    i < profile.ToolTipOverride_MinVal1.Count ? profile.ToolTipOverride_MinVal1[i] : -1,
+                    i < profile.ToolTipOverride_MaxVal1.Count ? profile.ToolTipOverride_MaxVal1[i] : 100,
+                    i < profile.ToolTipOverride_MinVal2.Count ? profile.ToolTipOverride_MinVal2[i] : -1,
+                    i < profile.ToolTipOverride_MaxVal2.Count ? profile.ToolTipOverride_MaxVal2[i] : 100,
+                    i < profile.ToolTipOverride_Layer.Count ? profile.ToolTipOverride_Layer[i] : (byte)TooltipLayers.Any,
+                    i < profile.ToolTipOverride_BorderHue.Count ? profile.ToolTipOverride_BorderHue[i] : -1));
+            }
+
+            if (count == 0)
+                return false;
+
+            // Clear the legacy lists so the parallel-list storage no longer persists in the profile.
+            profile.ToolTipOverride_SearchText.Clear();
+            profile.ToolTipOverride_NewFormat.Clear();
+            profile.ToolTipOverride_MinVal1.Clear();
+            profile.ToolTipOverride_MinVal2.Clear();
+            profile.ToolTipOverride_MaxVal1.Clear();
+            profile.ToolTipOverride_MaxVal2.Clear();
+            profile.ToolTipOverride_Layer.Clear();
+            profile.ToolTipOverride_BorderHue.Clear();
+
+            return true;
+        }
+#pragma warning restore CS0618
+    }
+
+    [JsonSerializable(typeof(TooltipOverridesConfig), GenerationMode = JsonSourceGenerationMode.Metadata)]
+    sealed partial class TooltipOverridesJsonContext : JsonSerializerContext
+    {
+        sealed class SnakeCaseNamingPolicy : JsonNamingPolicy
+        {
+            public static SnakeCaseNamingPolicy Instance { get; } = new SnakeCaseNamingPolicy();
+
+            public override string ConvertName(string name) =>
+                string.Concat(name.Select((x, i) => i > 0 && char.IsUpper(x) ? "_" + x.ToString() : x.ToString())).ToLower();
+        }
+
+        private static Lazy<JsonSerializerOptions> _jsonOptions { get; } = new Lazy<JsonSerializerOptions>(() =>
+        {
+            var options = new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                PropertyNamingPolicy = SnakeCaseNamingPolicy.Instance
+            };
+            return options;
+        });
+
+        public static TooltipOverridesJsonContext DefaultToUse { get; } = new TooltipOverridesJsonContext(_jsonOptions.Value);
+    }
+}

--- a/src/ClassicUO.Client/Game/Managers/ToolTipOverrideManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/ToolTipOverrideManager.cs
@@ -39,7 +39,13 @@ namespace ClassicUO.Game.Managers
             BorderHue = borderHue;
         }
 
-        public int Index { get; }
+        /// <summary>
+        /// Position of this override within <see cref="TooltipOverridesConfig.Overrides"/>. This is a
+        /// runtime index derived from list position, not part of the persisted file.
+        /// </summary>
+        [JsonIgnore]
+        public int Index { get; set; }
+
         public string SearchText { get; set; }
         public string FormattedText { get; set; }
         public int Min1 { get; set; }
@@ -61,126 +67,42 @@ namespace ClassicUO.Game.Managers
         /// <summary>Pixel width of the custom border drawn when <see cref="HasBorderHue"/> is set.</summary>
         public const int BorderWidth = 5;
 
+        [JsonIgnore]
         public bool IsNew { get; set; } = false;
 
         public static ToolTipOverrideData Get(int index)
         {
-            bool isNew = false;
-            if (ProfileManager.CurrentProfile != null)
+            if (ProfileManager.CurrentProfile == null)
+                return null;
+
+            List<ToolTipOverrideData> overrides = TooltipOverridesConfig.Current.Overrides;
+
+            if (index >= 0 && index < overrides.Count)
+                return overrides[index];
+
+            // Requesting an out-of-range index creates a new default override, persists it and returns it.
+            var data = new ToolTipOverrideData(index, "Weapon Damage", "DMG /c[orange]{1} /cd- /c[red]{2}", -1, 99, -1, 99, (byte)TooltipLayers.Any)
             {
-                string searchText = "Weapon Damage", formattedText = "DMG /c[orange]{1} /cd- /c[red]{2}";
-                int min1 = -1, max1 = 99, min2 = -1, max2 = 99;
-                byte layer = (byte)TooltipLayers.Any;
-                int borderHue = -1;
-
-                if (ProfileManager.CurrentProfile.ToolTipOverride_SearchText.Count > index)
-                    searchText = ProfileManager.CurrentProfile.ToolTipOverride_SearchText[index];
-                else isNew = true;
-
-                if (ProfileManager.CurrentProfile.ToolTipOverride_NewFormat.Count > index)
-                    formattedText = ProfileManager.CurrentProfile.ToolTipOverride_NewFormat[index];
-                else isNew = true;
-
-                if (ProfileManager.CurrentProfile.ToolTipOverride_MinVal1.Count > index)
-                    min1 = ProfileManager.CurrentProfile.ToolTipOverride_MinVal1[index];
-                else isNew = true;
-
-                if (ProfileManager.CurrentProfile.ToolTipOverride_MinVal2.Count > index)
-                    min2 = ProfileManager.CurrentProfile.ToolTipOverride_MinVal2[index];
-                else isNew = true;
-
-                if (ProfileManager.CurrentProfile.ToolTipOverride_MaxVal1.Count > index)
-                    max1 = ProfileManager.CurrentProfile.ToolTipOverride_MaxVal1[index];
-                else isNew = true;
-
-                if (ProfileManager.CurrentProfile.ToolTipOverride_MaxVal2.Count > index)
-                    max2 = ProfileManager.CurrentProfile.ToolTipOverride_MaxVal2[index];
-                else isNew = true;
-
-                if (ProfileManager.CurrentProfile.ToolTipOverride_Layer.Count > index)
-                    layer = ProfileManager.CurrentProfile.ToolTipOverride_Layer[index];
-                else isNew = true;
-
-                if (ProfileManager.CurrentProfile.ToolTipOverride_BorderHue.Count > index)
-                    borderHue = ProfileManager.CurrentProfile.ToolTipOverride_BorderHue[index];
-                else isNew = true;
-
-                var data = new ToolTipOverrideData(index, searchText, formattedText, min1, max1, min2, max2, layer, borderHue);
-
-                if (isNew)
-                {
-                    data.IsNew = true;
-                    data.Save();
-                }
-                return data;
-            }
-            return null;
+                IsNew = true
+            };
+            data.Save();
+            return data;
         }
 
         public void Save()
         {
-            if (ProfileManager.CurrentProfile.ToolTipOverride_SearchText.Count > Index)
-                ProfileManager.CurrentProfile.ToolTipOverride_SearchText[Index] = SearchText;
-            else ProfileManager.CurrentProfile.ToolTipOverride_SearchText.Add(SearchText);
+            if (ProfileManager.CurrentProfile == null)
+                return;
 
-            if (ProfileManager.CurrentProfile.ToolTipOverride_NewFormat.Count > Index)
-                ProfileManager.CurrentProfile.ToolTipOverride_NewFormat[Index] = FormattedText;
-            else ProfileManager.CurrentProfile.ToolTipOverride_NewFormat.Add(FormattedText);
-
-            if (ProfileManager.CurrentProfile.ToolTipOverride_MinVal1.Count > Index)
-                ProfileManager.CurrentProfile.ToolTipOverride_MinVal1[Index] = Min1;
-            else ProfileManager.CurrentProfile.ToolTipOverride_MinVal1.Add(Min1);
-
-            if (ProfileManager.CurrentProfile.ToolTipOverride_MinVal2.Count > Index)
-                ProfileManager.CurrentProfile.ToolTipOverride_MinVal2[Index] = Min2;
-            else ProfileManager.CurrentProfile.ToolTipOverride_MinVal2.Add(Min2);
-
-            if (ProfileManager.CurrentProfile.ToolTipOverride_MaxVal1.Count > Index)
-                ProfileManager.CurrentProfile.ToolTipOverride_MaxVal1[Index] = Max1;
-            else ProfileManager.CurrentProfile.ToolTipOverride_MaxVal1.Add(Max1);
-
-            if (ProfileManager.CurrentProfile.ToolTipOverride_MaxVal2.Count > Index)
-                ProfileManager.CurrentProfile.ToolTipOverride_MaxVal2[Index] = Max2;
-            else ProfileManager.CurrentProfile.ToolTipOverride_MaxVal2.Add(Max2);
-
-            if (ProfileManager.CurrentProfile.ToolTipOverride_Layer.Count > Index)
-                ProfileManager.CurrentProfile.ToolTipOverride_Layer[Index] = (byte)ItemLayer;
-            else ProfileManager.CurrentProfile.ToolTipOverride_Layer.Add((byte)ItemLayer);
-
-            if (ProfileManager.CurrentProfile.ToolTipOverride_BorderHue.Count > Index)
-                ProfileManager.CurrentProfile.ToolTipOverride_BorderHue[Index] = BorderHue;
-            else ProfileManager.CurrentProfile.ToolTipOverride_BorderHue.Add(BorderHue);
+            TooltipOverridesConfig.Current.Upsert(this);
         }
 
         public void Delete()
         {
-            if (Index < 0) return;
+            if (Index < 0 || ProfileManager.CurrentProfile == null)
+                return;
 
-            Profile profile = ProfileManager.CurrentProfile;
-
-            if (Index < profile.ToolTipOverride_SearchText.Count)
-                profile.ToolTipOverride_SearchText.RemoveAt(Index);
-
-            if (Index < profile.ToolTipOverride_NewFormat.Count)
-                profile.ToolTipOverride_NewFormat.RemoveAt(Index);
-
-            if (Index < profile.ToolTipOverride_MinVal1.Count)
-                profile.ToolTipOverride_MinVal1.RemoveAt(Index);
-
-            if (Index < profile.ToolTipOverride_MinVal2.Count)
-                profile.ToolTipOverride_MinVal2.RemoveAt(Index);
-
-            if (Index < profile.ToolTipOverride_MaxVal1.Count)
-                profile.ToolTipOverride_MaxVal1.RemoveAt(Index);
-
-            if (Index < profile.ToolTipOverride_MaxVal2.Count)
-                profile.ToolTipOverride_MaxVal2.RemoveAt(Index);
-
-            if (Index < profile.ToolTipOverride_Layer.Count)
-                profile.ToolTipOverride_Layer.RemoveAt(Index);
-
-            if (Index < profile.ToolTipOverride_BorderHue.Count)
-                profile.ToolTipOverride_BorderHue.RemoveAt(Index);
+            TooltipOverridesConfig.Current.RemoveAt(Index);
         }
 
         public static ToolTipOverrideData[] GetAllToolTipOverrides()
@@ -188,14 +110,7 @@ namespace ClassicUO.Game.Managers
             if (ProfileManager.CurrentProfile == null)
                 return null;
 
-            var result = new ToolTipOverrideData[ProfileManager.CurrentProfile.ToolTipOverride_SearchText.Count];
-
-            for (int i = 0; i < ProfileManager.CurrentProfile.ToolTipOverride_SearchText.Count; i++)
-            {
-                result[i] = Get(i);
-            }
-
-            return result;
+            return TooltipOverridesConfig.Current.Overrides.ToArray();
         }
 
         public static void ExportOverrideSettings(World world)
@@ -210,7 +125,7 @@ namespace ClassicUO.Game.Managers
                     return;
                 }
 
-                string result = JsonSerializer.Serialize(allData);
+                string result = JsonSerializer.Serialize(allData, ToolTipOverrideContext.Default.ToolTipOverrideDataArray);
                 string path = Path.Combine(p, "tooltip_overrides.json");
                 if (FileSystemHelper.WriteAllTextSafe(path, result))
                     GameActions.Print(World.Instance, $"The override file has been saved to [{path}]");
@@ -232,10 +147,10 @@ namespace ClassicUO.Game.Managers
                                                                     {
                                                                         string result = File.ReadAllText(p);
 
-                                                                        ToolTipOverrideData[] imported = JsonSerializer.Deserialize<ToolTipOverrideData[]>(result);
+                                                                        ToolTipOverrideData[] imported = JsonSerializer.Deserialize(result, ToolTipOverrideContext.Default.ToolTipOverrideDataArray);
 
                                                                         foreach (ToolTipOverrideData importedData in imported)
-                                                                            new ToolTipOverrideData(ProfileManager.CurrentProfile.ToolTipOverride_SearchText.Count, importedData.SearchText, importedData.FormattedText, importedData.Min1, importedData.Max1, importedData.Min2, importedData.Max2, (byte)importedData.ItemLayer, importedData.BorderHue).Save();
+                                                                            new ToolTipOverrideData(TooltipOverridesConfig.Current.Overrides.Count, importedData.SearchText, importedData.FormattedText, importedData.Min1, importedData.Max1, importedData.Min2, importedData.Max2, (byte)importedData.ItemLayer, importedData.BorderHue).Save();
 
                                                                         GameActions.Print(World.Instance, $"Imported {imported.Length} tooltip overrides!");
                                                                     }

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/TooltipOverrideWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/TooltipOverrideWindow.cs
@@ -1,6 +1,5 @@
 #nullable enable
 using System;
-using System.Collections.Generic;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.Managers;
@@ -109,7 +108,7 @@ public sealed class TooltipOverrideWindow : MyraControl
     {
         _rowsPanel.Widgets.Clear();
 
-        int count = ProfileManager.CurrentProfile?.ToolTipOverride_SearchText.Count ?? 0;
+        int count = ProfileManager.CurrentProfile == null ? 0 : TooltipOverridesConfig.Current.Overrides.Count;
 
         if (count == 0)
         {
@@ -302,7 +301,7 @@ public sealed class TooltipOverrideWindow : MyraControl
         if (ProfileManager.CurrentProfile == null)
             return;
 
-        ToolTipOverrideData.Get(ProfileManager.CurrentProfile.ToolTipOverride_SearchText.Count);
+        ToolTipOverrideData.Get(TooltipOverridesConfig.Current.Overrides.Count);
         BuildRows();
     }
 
@@ -326,17 +325,10 @@ public sealed class TooltipOverrideWindow : MyraControl
 
     private static void ClearAll()
     {
-        Profile? profile = ProfileManager.CurrentProfile;
-        if (profile == null)
+        if (ProfileManager.CurrentProfile == null)
             return;
 
-        profile.ToolTipOverride_SearchText = new List<string>();
-        profile.ToolTipOverride_NewFormat = new List<string>();
-        profile.ToolTipOverride_MinVal1 = new List<int>();
-        profile.ToolTipOverride_MinVal2 = new List<int>();
-        profile.ToolTipOverride_MaxVal1 = new List<int>();
-        profile.ToolTipOverride_MaxVal2 = new List<int>();
-        profile.ToolTipOverride_Layer = new List<byte>();
+        TooltipOverridesConfig.Current.Clear();
     }
 
     private void ShowSaved()

--- a/tests/ClassicUO.UnitTests/Game/Managers/ToolTipOverrideTest.cs
+++ b/tests/ClassicUO.UnitTests/Game/Managers/ToolTipOverrideTest.cs
@@ -30,9 +30,17 @@ namespace ClassicUO.UnitTests.Game.Managers
         private const string OVERRIDE_FORMAT = "FIRERES={1}";
         private const string RAW_TOOLTIP = "Some Sword\nFire Resist 15";
 
-        public ToolTipOverrideTest() => SetCurrentProfile(CreateProfileWithFireResistOverride());
+        public ToolTipOverrideTest()
+        {
+            SetCurrentProfile(CreateProfileWithNoOverrides());
+            SetTooltipOverrides(new ToolTipOverrideData(0, "Fire Resist", OVERRIDE_FORMAT, -1, 100, -1, 100, (byte)TooltipLayers.Any));
+        }
 
-        public void Dispose() => SetCurrentProfile(null);
+        public void Dispose()
+        {
+            SetCurrentProfile(null);
+            SetTooltipOverrides();
+        }
 
         #region "Not item" branch (raw OPL text / vendor search)
 
@@ -113,6 +121,7 @@ namespace ClassicUO.UnitTests.Game.Managers
         public void ResolveTooltipText_NoOverrideConfigured_KeepsPropertyText()
         {
             SetCurrentProfile(CreateProfileWithNoOverrides());
+            SetTooltipOverrides();
             var world = new World();
 
             string result = ToolTipOverrideData.ResolveTooltipText(world, ITEM_SERIAL, RAW_TOOLTIP);
@@ -140,21 +149,6 @@ namespace ClassicUO.UnitTests.Game.Managers
 
         #region Helpers
 
-        private static Profile CreateProfileWithFireResistOverride()
-        {
-            Profile profile = CreateProfileWithNoOverrides();
-
-            profile.ToolTipOverride_SearchText = new List<string> { "Fire Resist" };
-            profile.ToolTipOverride_NewFormat = new List<string> { OVERRIDE_FORMAT };
-            profile.ToolTipOverride_MinVal1 = new List<int> { -1 };
-            profile.ToolTipOverride_MinVal2 = new List<int> { -1 };
-            profile.ToolTipOverride_MaxVal1 = new List<int> { 100 };
-            profile.ToolTipOverride_MaxVal2 = new List<int> { 100 };
-            profile.ToolTipOverride_Layer = new List<byte> { (byte)TooltipLayers.Any };
-
-            return profile;
-        }
-
         private static Profile CreateProfileWithNoOverrides()
         {
             return new Profile
@@ -162,13 +156,6 @@ namespace ClassicUO.UnitTests.Game.Managers
                 // Skip grid-highlight matching so the test doesn't depend on the highlight config/db.
                 GridHighlightProperties = false,
                 GridHighlightShowRuleName = false,
-                ToolTipOverride_SearchText = new List<string>(),
-                ToolTipOverride_NewFormat = new List<string>(),
-                ToolTipOverride_MinVal1 = new List<int>(),
-                ToolTipOverride_MinVal2 = new List<int>(),
-                ToolTipOverride_MaxVal1 = new List<int>(),
-                ToolTipOverride_MaxVal2 = new List<int>(),
-                ToolTipOverride_Layer = new List<byte>(),
             };
         }
 
@@ -179,6 +166,22 @@ namespace ClassicUO.UnitTests.Game.Managers
                 BindingFlags.Public | BindingFlags.Static);
 
             prop.SetValue(null, profile);
+        }
+
+        /// <summary>
+        /// Replaces the cached <see cref="TooltipOverridesConfig"/> with one holding exactly the given
+        /// overrides. Tooltip overrides now live in tooltip_overrides.json (via TooltipOverridesConfig)
+        /// rather than the profile, so tests seed the config directly instead of the profile's lists.
+        /// </summary>
+        private static void SetTooltipOverrides(params ToolTipOverrideData[] overrides)
+        {
+            var config = new TooltipOverridesConfig { Overrides = new List<ToolTipOverrideData>(overrides) };
+
+            FieldInfo field = typeof(TooltipOverridesConfig).GetField(
+                "_current",
+                BindingFlags.NonPublic | BindingFlags.Static);
+
+            field.SetValue(null, config);
         }
 
         #endregion


### PR DESCRIPTION
Tooltip override rules previously lived in the profile as eight parallel ToolTipOverride_* lists. This moves them into a dedicated TooltipOverridesConfig persisted to tooltip_overrides.json in the profile directory, matching the existing pattern used by grid_highlights.json and cooldownbars.json.

- Add TooltipOverridesConfig backed by a single List<ToolTipOverrideData>, with load/save, upsert/remove/clear helpers and a source-generated JSON context.
- Migrate the legacy parallel lists on first profile load, then clear them so overrides live only in the new file going forward. The profile lists are kept (marked [Obsolete]) solely for one-time migration, preserving their defaults so fresh profiles still get the standard resist/damage rules.
- Rewire ToolTipOverrideData.Get/Save/Delete/GetAllToolTipOverrides and the Myra config window to read and write through the config.
- Use the existing ToolTipOverrideContext for export/import serialization.
- Update tests to seed the config directly instead of the profile lists.