### PR TITLE
Re-pathfind when a house is loaded via packet mid-walk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to TazUO will be recorded here.
 * Replaced the old Myra window style with a new themed one. Thank you NewYears! - [P.R 774](https://github.com/PlayTazUO/TazUO/pull/774) ([bittiez](https://github.com/bittiez))
 
 ### Misc
+* Pathfinding now re-plans when a house is loaded mid-walk and keeps a soft 1-tile buffer around houses so paths route around them better - [P.R 799](https://github.com/PlayTazUO/TazUO/pull/799) ([bittiez](https://github.com/bittiez))
 * Migrate tooltip override saves to its own json file - [P.R 798](https://github.com/PlayTazUO/TazUO/pull/798) ([bittiez](https://github.com/bittiez))
 
 ### Fixes

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.15.1</AssemblyVersion>
-    <FileVersion>5.15.1</FileVersion>
+    <AssemblyVersion>5.15.2</AssemblyVersion>
+    <FileVersion>5.15.2</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Configuration/SqlProfile.cs
+++ b/src/ClassicUO.Client/Configuration/SqlProfile.cs
@@ -34,6 +34,12 @@ public sealed partial class Profile
         [SqlSetting(SettingsScope.Global, Constants.SqlSettings.PATHFINDING_MAX_NODES, 150000)]
         public partial int PathfindingMaxNodes { get; set; }
 
+        // Extra A* cost applied to tiles bordering a house/multi wall, giving paths a soft 1-tile
+        // standoff from houses. 0 disables the buffer.
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, Constants.SqlSettings.PATHFINDING_MULTI_BUFFER, 4)]
+        public partial int PathfindingMultiBuffer { get; set; }
+
         // Maximum number of A* nodes the world map (long-distance) pathfinder will expand before giving up.
         [JsonIgnore]
         [SqlSetting(SettingsScope.Global, Constants.SqlSettings.WORLDMAP_PATH_MAX_NODES, 1000000)]

--- a/src/ClassicUO.Client/Game/Constants.cs
+++ b/src/ClassicUO.Client/Game/Constants.cs
@@ -131,6 +131,7 @@ public const string SCALE_PETS_ENABLED = "scale_pets_enabled";
             public const string IRC_AUTO_CONNECT = "irc_disable_auto_connect";
             public const string PATH_Z_LEVEL = "path_z_level";
             public const string PATHFINDING_MAX_NODES = "pathfinding_max_nodes";
+            public const string PATHFINDING_MULTI_BUFFER = "pathfinding_multi_buffer";
             public const string WORLDMAP_PATH_MAX_NODES = "worldmap_path_max_nodes";
             public const string WORLDMAP_PATH_MAX_RETRIES = "worldmap_path_max_retries";
             public const string WORLDMAP_PATH_TIMEOUT = "worldmap_path_timeout";

--- a/src/ClassicUO.Client/Game/GameObjects/Item.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Item.cs
@@ -411,6 +411,12 @@ namespace ClassicUO.Game.GameObjects
             if (World.HouseManager.EntityIntoHouse(Serial, World.Player)) GameScene.Instance?.UpdateMaxDrawZ(true);
 
             World.BoatMovingManager.ClearSteps(Serial);
+
+            // A multi (house/boat) just had its components placed on the map. If the player is
+            // auto-walking a path that was computed before this geometry existed, that path may
+            // now cut through the new blocker — re-pathfind from the current position so the
+            // walk routes around it.
+            World.Player?.Pathfinder?.RecalculatePath();
         }
 
         public override void CheckGraphicChange(byte animIndex = 0)

--- a/src/ClassicUO.Client/Game/Pathfinder.cs
+++ b/src/ClassicUO.Client/Game/Pathfinder.cs
@@ -1116,6 +1116,29 @@ namespace ClassicUO.Game
             return _path.Count != 0;
         }
 
+        /// <summary>
+        /// Recomputes the active auto-walk path from the player's current position to the
+        /// same target that <see cref="WalkTo"/> was last called with. Intended to be called
+        /// when world geometry changes underneath a walk in progress — most notably when a
+        /// house/multi is loaded via packet and its (previously absent) components now block
+        /// tiles the current path runs through. Re-running the A* search from where the player
+        /// stands lets it route around the newly-appeared blocker.
+        ///
+        /// No-op unless a local A* auto-walk is currently in progress. Computed paths
+        /// (WorldMap navigation via <see cref="StartComputedPath"/>) are skipped — they have
+        /// their own dynamic-block replanning via <see cref="OnComputedPathStepFailed"/>.
+        /// </summary>
+        public void RecalculatePath()
+        {
+            if (!AutoWalking || _computedPathActive || _world.Player == null || _world.Player.IsParalyzed)
+            {
+                return;
+            }
+
+            // Re-run from the player's present position to the previously requested target.
+            WalkTo(_endPoint.X, _endPoint.Y, _endPointZ, _pathfindDistance);
+        }
+
         public void ProcessAutoWalk()
         {
             if (AutoWalking && _world.InGame && _world.Player.Walker.StepsCount < Constants.MAX_STEP_COUNT && _world.Player.Walker.LastStepRequestTime <= Time.Ticks)

--- a/src/ClassicUO.Client/Game/Pathfinder.cs
+++ b/src/ClassicUO.Client/Game/Pathfinder.cs
@@ -56,6 +56,16 @@ namespace ClassicUO.Game
         private static int _endPointZ;
         private static readonly List<PathObject> _reusableList = new();
 
+        // Extra A* cost applied to tiles adjacent to an impassable multi (house wall), giving
+        // paths a soft 1-tile standoff from houses. 0 disables it. Cached per-search from the
+        // profile so it can't change mid-search.
+        private int _multiBufferPenalty;
+
+        // Per-search memoization of "does this tile hold a blocking multi component?" so the
+        // buffer check doesn't re-walk a tile's object list once per neighbouring node. Cleared
+        // by CleanupPathfinding at the start of every search.
+        private static readonly Dictionary<(int x, int y), bool> _blockingMultiCache = new();
+
         public Point StartPoint => _startPoint;
         public Point EndPoint => _endPoint;
         public int PathSize => _path.Count;
@@ -742,6 +752,63 @@ namespace ClassicUO.Game
             //return (Math.Abs(_endPoint.X - point.X) + Math.Abs(_endPoint.Y - point.Y)) * cost;
             Math.Max(Math.Abs(_endPoint.X - point.X), Math.Abs(_endPoint.Y - point.Y));
 
+        /// <summary>
+        /// True when the tile holds a multi component that blocks movement (a house wall or
+        /// other impassable piece). Floors/roofs are walkable surfaces and don't count, and
+        /// house-preview pieces are ignored. Memoized per search via <see cref="_blockingMultiCache"/>.
+        /// </summary>
+        private bool TileHasBlockingMulti(int x, int y)
+        {
+            (int x, int y) key = (x, y);
+
+            if (_blockingMultiCache.TryGetValue(key, out bool cached))
+            {
+                return cached;
+            }
+
+            bool result = false;
+            GameObject tile = _world.Map.GetTile(x, y, false);
+
+            if (tile != null)
+            {
+                GameObject obj = tile;
+
+                while (obj.TPrevious != null)
+                {
+                    obj = obj.TPrevious;
+                }
+
+                for (; obj != null; obj = obj.TNext)
+                {
+                    if (obj is Multi m && !m.IsHousePreview && (m.ItemData.IsImpassable || m.ItemData.IsWall))
+                    {
+                        result = true;
+                        break;
+                    }
+                }
+            }
+
+            _blockingMultiCache[key] = result;
+            return result;
+        }
+
+        /// <summary>
+        /// True when any of the eight tiles surrounding (x, y) holds a blocking multi, i.e. the
+        /// tile sits within a 1-tile buffer around a house. Used to add a soft avoidance cost.
+        /// </summary>
+        private bool IsWithinMultiBuffer(int x, int y)
+        {
+            for (int i = 0; i < 8; i++)
+            {
+                if (TileHasBlockingMulti(x + _offsetX[i], y + _offsetY[i]))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         private static int GetTurnPenalty(PathNode parent, int direction) =>
             // The turn penalty prevents unnecessary zig-zagging that takes extra
             // time (turning pauses movement briefly) and makes the movement look
@@ -770,6 +837,14 @@ namespace ClassicUO.Game
             // concern here to warrent the 8x cost.
             int turnPenalty = GetTurnPenalty(parent, direction);
             int newDistFromStart = parent.DistFromStartCost + cost + Math.Abs(z - parent.Z) + turnPenalty;
+
+            // Soft 1-tile buffer around houses: nudge the search away from tiles that border an
+            // impassable multi so paths don't scrape along house walls. It's a cost, not a block,
+            // so tight town streets and destinations right next to a house stay reachable.
+            if (_multiBufferPenalty > 0 && IsWithinMultiBuffer(x, y))
+            {
+                newDistFromStart += _multiBufferPenalty;
+            }
 
             var updatedNode = PathNode.Get();
 
@@ -1053,6 +1128,7 @@ namespace ClassicUO.Game
         public List<(int X, int Y, int Z)> GetPathTo(int x, int y, int z, int distance)
         {
             _zLevelDiff = ProfileManager.CurrentProfile.PathfindingZLevelDiff;
+            _multiBufferPenalty = ProfileManager.CurrentProfile.PathfindingMultiBuffer;
 
             CleanupPathfinding();
             _pointIndex = 0;
@@ -1088,6 +1164,7 @@ namespace ClassicUO.Game
             }
 
             _zLevelDiff = ProfileManager.CurrentProfile.PathfindingZLevelDiff;
+            _multiBufferPenalty = ProfileManager.CurrentProfile.PathfindingMultiBuffer;
 
             EventSink.InvokeOnPathFinding(null, new Vector4(x, y, z, distance));
 
@@ -1222,6 +1299,7 @@ namespace ClassicUO.Game
 
             _path.Clear();
             _goalNode = null;
+            _blockingMultiCache.Clear();
         }
 
         private enum PATH_STEP_STATE

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/PathfindingTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/PathfindingTabContent.cs
@@ -31,6 +31,17 @@ public static class PathfindingTabContent
 
         root.Widgets.Add(maxNodesWidget);
 
+        HorizontalStackPanel multiBufferSliderWidget = LabeledHorizontalSlider.SliderWithLabel(
+            "Pathfinding house buffer",
+            out LabeledHorizontalSlider multiBufferSlider,
+            v => { ProfileManager.CurrentProfile?.PathfindingMultiBuffer = (int)v; },
+            min: 0,
+            max: 50,
+            value: ProfileManager.CurrentProfile.PathfindingMultiBuffer);
+        multiBufferSlider.Tooltip = "Extra pathfinding cost for tiles next to a house/multi wall, keeping paths a tile away from houses when possible. 0 disables it; higher values avoid houses more strongly.";
+
+        root.Widgets.Add(multiBufferSliderWidget);
+
         HorizontalStackPanel wmMaxNodesWidget = MyraInputBox.NumberWithLabel(
             "World map pathfinding max nodes",
             value: ProfileManager.CurrentProfile.WorldMapPathfindingMaxNodes,

--- a/src/ClassicUO.Client/Network/PacketHandlers/CustomHouse.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers/CustomHouse.cs
@@ -108,5 +108,10 @@ internal static class CustomHouse
             Client.Game.GetScene<GameScene>()?.UpdateMaxDrawZ(true);
 
         world.BoatMovingManager.ClearSteps(serial);
+
+        // Custom house geometry just arrived/changed via packet. If the player is auto-walking a
+        // path computed before these components existed, re-pathfind from the current position so
+        // the walk can route around the newly-blocked tiles.
+        world.Player?.Pathfinder?.RecalculatePath();
     }
 }


### PR DESCRIPTION
When auto-walking a local A* path (WalkTo), the path is computed once from the player's position. If a house or other multi is streamed in via packet after the path was computed, its components can now block tiles the current path runs through, leaving the walker stuck against the newly-appeared geometry.

Add Pathfinder.RecalculatePath(), which re-runs the A* search from the player's current position to the same target. It is invoked when multi geometry is placed on the map (Item.LoadMulti) and when custom house data arrives (0xD8 handler). The A* search already accounts for house components (Multi objects are handled in CreateItemList), so recomputing lets the walk route around the house.

Computed WorldMap paths are skipped since they have their own dynamic-block replanning via OnComputedPathStepFailed.