### PR TITLE
Recover from corrupt SQLite database instead of crashing at login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to TazUO will be recorded here.
 * Migrate tooltip override saves to its own json file - [P.R 798](https://github.com/PlayTazUO/TazUO/pull/798) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
+* Recover from a corrupt SQLite database instead of crashing at login; the bad file is quarantined and an empty database is recreated - [P.R 800](https://github.com/PlayTazUO/TazUO/pull/800) ([bittiez](https://github.com/bittiez))
 * Fixed Myra windows not closing with right click - ([bittiez](https://github.com/bittiez))
 * Fixed menu color that failed to get the new myrs colors - ([bittiez](https://github.com/bittiez))
 * Fixed potential crashes with FSS text generation - ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.15.3</AssemblyVersion>
-    <FileVersion>5.15.3</FileVersion>
+    <AssemblyVersion>5.15.4</AssemblyVersion>
+    <FileVersion>5.15.4</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/Managers/SqliteDatabase.cs
+++ b/src/ClassicUO.Client/Game/Managers/SqliteDatabase.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using ClassicUO.Utility.Logging;
 using Dapper;
 using Microsoft.Data.Sqlite;
 
@@ -90,9 +91,16 @@ namespace ClassicUO.Game.Managers
             await _dbLock.WaitAsync().ConfigureAwait(false);
             try
             {
-                await using SqliteConnection connection = new(ConnectionString);
-                await connection.OpenAsync().ConfigureAwait(false);
-                return await operation(connection).ConfigureAwait(false);
+                try
+                {
+                    return await OpenAndRunAsync(operation).ConfigureAwait(false);
+                }
+                catch (SqliteException ex) when (IsCorruptionError(ex) && QuarantineCorruptDatabase(ex))
+                {
+                    // The file was corrupt and has been quarantined; a fresh database will be created
+                    // on this retry. Only one retry is attempted - if it fails again the error propagates.
+                    return await OpenAndRunAsync(operation).ConfigureAwait(false);
+                }
             }
             finally
             {
@@ -105,21 +113,19 @@ namespace ClassicUO.Game.Managers
         /// connection is opened and disposed for you. Use this with Dapper's <c>ExecuteAsync</c> for
         /// writes/DDL.
         /// </summary>
-        protected async Task WithConnectionAsync(Func<SqliteConnection, Task> operation)
-        {
-            ThrowIfDisposed();
-
-            await _dbLock.WaitAsync().ConfigureAwait(false);
-            try
+        protected Task WithConnectionAsync(Func<SqliteConnection, Task> operation) =>
+            WithConnectionAsync(async connection =>
             {
-                await using SqliteConnection connection = new(ConnectionString);
-                await connection.OpenAsync().ConfigureAwait(false);
                 await operation(connection).ConfigureAwait(false);
-            }
-            finally
-            {
-                _dbLock.Release();
-            }
+                return true;
+            });
+
+        /// <summary>Opens a fresh connection, runs the operation, and disposes the connection.</summary>
+        private async Task<T> OpenAndRunAsync<T>(Func<SqliteConnection, Task<T>> operation)
+        {
+            await using SqliteConnection connection = new(ConnectionString);
+            await connection.OpenAsync().ConfigureAwait(false);
+            return await operation(connection).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -227,6 +233,80 @@ namespace ClassicUO.Game.Managers
         /// where a bound parameter or double-quoted identifier cannot be used).
         /// </summary>
         private static string QuoteLiteral(string value) => "'" + value.Replace("'", "''") + "'";
+
+        /// <summary>
+        /// Returns true if the exception indicates the database file itself is corrupt/unreadable
+        /// (a malformed schema or a file that is not a database) rather than a transient or usage error.
+        /// These are the only conditions that quarantining and recreating the file can recover from.
+        /// </summary>
+        private static bool IsCorruptionError(SqliteException ex) =>
+            ex.SqliteErrorCode == SQLITE_CORRUPT || ex.SqliteErrorCode == SQLITE_NOTADB;
+
+        // SQLite primary result codes (see https://www.sqlite.org/rescode.html). A malformed database
+        // schema, "database disk image is malformed" all report SQLITE_CORRUPT (11); a file whose header
+        // is not recognizable as a SQLite database reports SQLITE_NOTADB (26).
+        private const int SQLITE_CORRUPT = 11;
+        private const int SQLITE_NOTADB = 26;
+
+        /// <summary>
+        /// Moves a corrupt database file (and its WAL/SHM/journal sidecars) aside so a fresh, empty
+        /// database can be created in its place, letting the client keep running instead of crashing on
+        /// startup. The corrupt copy is preserved with a <c>.corrupt</c> suffix for later inspection.
+        /// Returns true only if the primary file was successfully moved out of the way, meaning the
+        /// caller can safely retry the operation against a clean database.
+        /// </summary>
+        private bool QuarantineCorruptDatabase(SqliteException ex)
+        {
+            try
+            {
+                // Pooled connections keep the file handle open; without clearing the pool the move/delete
+                // below fails on Windows because the file is still in use.
+                SqliteConnection.ClearAllPools();
+
+                if (!File.Exists(DatabasePath))
+                    return false;
+
+                string quarantinePath = DatabasePath + ".corrupt";
+
+                MoveAside(DatabasePath, quarantinePath);
+                // The sidecar files belong to the corrupt database; discard them so they cannot be
+                // paired with the new file. Best-effort - a fresh database recreates them as needed.
+                TryDelete(DatabasePath + "-wal");
+                TryDelete(DatabasePath + "-shm");
+                TryDelete(DatabasePath + "-journal");
+
+                Log.Warn($"Corrupt SQLite database '{DatabasePath}' detected ({ex.Message.Trim()}). " +
+                         $"Moved it to '{quarantinePath}' and recreating an empty database.");
+
+                return !File.Exists(DatabasePath);
+            }
+            catch (Exception cleanupEx)
+            {
+                Log.Error($"Failed to quarantine corrupt SQLite database '{DatabasePath}': {cleanupEx.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>Moves <paramref name="source"/> to <paramref name="destination"/>, overwriting any existing quarantine copy.</summary>
+        private static void MoveAside(string source, string destination)
+        {
+            TryDelete(destination);
+            File.Move(source, destination);
+        }
+
+        /// <summary>Best-effort deletion of a file that may or may not exist.</summary>
+        private static void TryDelete(string path)
+        {
+            try
+            {
+                if (File.Exists(path))
+                    File.Delete(path);
+            }
+            catch
+            {
+                // Best-effort - a leftover sidecar is harmless once the primary file is gone.
+            }
+        }
 
         /// <summary>
         /// Best-effort clearing of the read-only file attribute on an existing database file. A read-only

--- a/tests/ClassicUO.UnitTests/Game/Managers/SqliteDatabaseTest.cs
+++ b/tests/ClassicUO.UnitTests/Game/Managers/SqliteDatabaseTest.cs
@@ -145,6 +145,31 @@ namespace ClassicUO.UnitTests.Game.Managers
         }
 
         [Fact]
+        public async Task WithConnectionAsync_RecoversFromCorruptDatabaseFile()
+        {
+            // Release the fixture instance so it doesn't hold a pooled handle to the file we're about to
+            // clobber, then write bytes that SQLite cannot recognize as a database at all.
+            _db.Dispose();
+
+            string dbPath = Path.Combine(_tempDir, "test.db");
+            await File.WriteAllTextAsync(dbPath, "this is not a valid sqlite database");
+
+            using var db = new TestDatabase(_tempDir);
+
+            // The first operation should detect the corruption, move the bad file aside, and succeed
+            // against a freshly created database rather than throwing.
+            Func<Task> act = () => db.RunAsync(c => c.ExecuteAsync(
+                "CREATE TABLE IF NOT EXISTS things (id INTEGER PRIMARY KEY, name TEXT NOT NULL)"));
+            await act.Should().NotThrowAsync();
+
+            // The corrupt copy is preserved for inspection and the new database is usable.
+            File.Exists(dbPath + ".corrupt").Should().BeTrue();
+
+            long count = await db.RunAsync(c => c.ExecuteScalarAsync<long>("SELECT COUNT(*) FROM things"));
+            count.Should().Be(0);
+        }
+
+        [Fact]
         public async Task Constructor_ClearsReadOnlyAttribute_AndAllowsWrites()
         {
             await _db.RunAsync(c => c.ExecuteAsync(


### PR DESCRIPTION
A malformed/corrupt SQLite file (SQLite Error 11 SQLITE_CORRUPT, or Error 26 SQLITE_NOTADB) thrown during table initialization propagated all the way up through login and crashed the client. This centralizes recovery in the shared SqliteDatabase base class so every SQLite-backed manager (persistent vars, friendlies, gump positions, SQL-backed settings) heals itself: when an operation fails with a corruption error, the bad file (and its WAL/SHM/journal sidecars) is quarantined with a .corrupt suffix and the operation is retried once against a freshly created database.