### PR TITLE
Fix cooldown bars flashing a border for one frame then vanishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to TazUO will be recorded here.
 * Migrate tooltip override saves to its own json file - [P.R 798](https://github.com/PlayTazUO/TazUO/pull/798) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
+* Restore default cooldown duration and hue - [P.R 802](https://github.com/PlayTazUO/TazUO/pull/802) ([bittiez](https://github.com/bittiez))
 * Recover from a corrupt SQLite database instead of crashing at login; the bad file is quarantined and an empty database is recreated - [P.R 800](https://github.com/PlayTazUO/TazUO/pull/800) ([bittiez](https://github.com/bittiez))
 * Fixed Myra windows not closing with right click - ([bittiez](https://github.com/bittiez))
 * Fixed menu color that failed to get the new myrs colors - ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.15.4</AssemblyVersion>
-    <FileVersion>5.15.4</FileVersion>
+    <AssemblyVersion>5.15.5</AssemblyVersion>
+    <FileVersion>5.15.5</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Gumps/CoolDownBar.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/CoolDownBar.cs
@@ -116,7 +116,10 @@ namespace ClassicUO.Game.UI.Gumps
                 return false;
 
             if (DateTime.Now >= expire)
+            {
                 Dispose();
+                return false;
+            }
 
             TimeSpan remaing = expire - DateTime.Now;
 

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/CooldownBars/CooldownBarRule.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/CooldownBars/CooldownBarRule.cs
@@ -39,10 +39,10 @@ public class CooldownBarRule : IRule, INotifyPropertyChanged
     public string Name { get; set => SetField(ref field, value); } = string.Empty;
 
     /// <summary>Duration of the cooldown bar in seconds</summary>
-    public uint Cooldown { get; set => SetField(ref field, value); }
+    public uint Cooldown { get; set => SetField(ref field, value); } = 10;
 
     /// <summary>The cooldown bar's hue (color)</summary>
-    public ushort Hue { get; set => SetField(ref field, value); }
+    public ushort Hue { get; set => SetField(ref field, value); } = 42;
 
     /// <summary>The message substring that triggers this cooldown bar when received</summary>
     public string TriggerMessage { get; set => SetField(ref field, value); } = string.Empty;


### PR DESCRIPTION
New cooldown-bar rules created through the redesigned (Myra) options were seeded with a 0-second duration. CooldownBarRule.Cooldown is a uint with no initializer, so `new CooldownBarRule()` (used by the rulebase "add" flow) produced Cooldown = 0 and persisted it via ToEntry(). The legacy CoolDownConditionData defaulted this to 10, so this was a regression from the options overhaul.

A 0-second bar has `expire == DateTime.Now`, so on its very first Draw the `DateTime.Now >= expire` check disposes it. Because the disposal happened inline and Draw still ran the border DrawRectangle calls afterward (while base.Draw skipped the now-disposed children), the user saw only the border for a single frame before the gump was removed.

- Restore sensible defaults on CooldownBarRule (Cooldown = 10, Hue = 42) to match the persisted CooldownBarConfigEntry defaults and legacy behavior.
- Bail out of CoolDownBar.Draw immediately after disposing an expired bar so no stray border is drawn for a frame.