### PR TITLE
Load SQL profile settings before saved gumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to TazUO will be recorded here.
 * Migrate tooltip override saves to its own json file - [P.R 798](https://github.com/PlayTazUO/TazUO/pull/798) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
+* Load SQL profile settings before saved gumps are restored at login, so gumps use the correct setting values - [P.R 804](https://github.com/PlayTazUO/TazUO/pull/804) ([bittiez](https://github.com/bittiez))
 * Restore default cooldown duration and hue - [P.R 802](https://github.com/PlayTazUO/TazUO/pull/802) ([bittiez](https://github.com/bittiez))
 * Recover from a corrupt SQLite database instead of crashing at login; the bad file is quarantined and an empty database is recreated - [P.R 800](https://github.com/PlayTazUO/TazUO/pull/800) ([bittiez](https://github.com/bittiez))
 * Fixed Myra windows not closing with right click - ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.16.1</AssemblyVersion>
-    <FileVersion>5.16.1</FileVersion>
+    <AssemblyVersion>5.16.2</AssemblyVersion>
+    <FileVersion>5.16.2</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -1064,23 +1064,22 @@ namespace ClassicUO.Configuration
             Task<Dictionary<string, string>> serverTask = Client.Settings.GetAllAsync(SettingsScope.Server);
             Task<Dictionary<string, string>> charTask = Client.Settings.GetAllAsync(SettingsScope.Char);
 
-            // Wait for the database reads to finish, then apply the settings on the main thread and
-            // block until that is done. This must complete synchronously here (before AfterLoad
-            // returns) because saved gumps are read later during login (see LoginComplete/ReadGumps)
-            // and they need the SQL settings to already be in place. Previously the apply was queued
-            // via MainThreadQueue.EnqueueAction, so it ran on a later frame - after the gumps had
-            // already been created with stale/default setting values.
+            // Wait for the database reads to finish, then apply the settings inline. AfterLoad already
+            // runs on the main thread (the FNA game loop's Update dispatches network packets, one of
+            // which -> World.CreatePlayer -> ProfileManager.Load -> here), so we can apply directly.
+            // This must complete synchronously before AfterLoad returns because saved gumps are read
+            // later during login (see LoginComplete/ReadGumps) and they need the SQL settings to
+            // already be in place. Previously the apply was queued via MainThreadQueue.EnqueueAction,
+            // so it ran on a later frame - after the gumps had already been created with stale/default
+            // setting values.
             if (Task.WhenAll(globalTask, accountTask, serverTask, charTask).Wait(10000))
             {
-                MainThreadQueue.BubblingInvokeOnMainThread(() =>
-                {
-                    LoadGeneratedGlobalSqlSettings(globalTask.Result);
-                    LoadGeneratedAccountSqlSettings(accountTask.Result);
-                    LoadGeneratedServerSqlSettings(serverTask.Result);
-                    LoadGeneratedCharSqlSettings(charTask.Result);
+                LoadGeneratedGlobalSqlSettings(globalTask.Result);
+                LoadGeneratedAccountSqlSettings(accountTask.Result);
+                LoadGeneratedServerSqlSettings(serverTask.Result);
+                LoadGeneratedCharSqlSettings(charTask.Result);
 
-                    HandleMigration();
-                });
+                HandleMigration();
             }
             else
             {

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -1064,9 +1064,15 @@ namespace ClassicUO.Configuration
             Task<Dictionary<string, string>> serverTask = Client.Settings.GetAllAsync(SettingsScope.Server);
             Task<Dictionary<string, string>> charTask = Client.Settings.GetAllAsync(SettingsScope.Char);
 
-            Task.WhenAll(globalTask, accountTask, serverTask, charTask).ContinueWith(_ =>
+            // Wait for the database reads to finish, then apply the settings on the main thread and
+            // block until that is done. This must complete synchronously here (before AfterLoad
+            // returns) because saved gumps are read later during login (see LoginComplete/ReadGumps)
+            // and they need the SQL settings to already be in place. Previously the apply was queued
+            // via MainThreadQueue.EnqueueAction, so it ran on a later frame - after the gumps had
+            // already been created with stale/default setting values.
+            if (Task.WhenAll(globalTask, accountTask, serverTask, charTask).Wait(10000))
             {
-                MainThreadQueue.EnqueueAction(() =>
+                MainThreadQueue.BubblingInvokeOnMainThread(() =>
                 {
                     LoadGeneratedGlobalSqlSettings(globalTask.Result);
                     LoadGeneratedAccountSqlSettings(accountTask.Result);
@@ -1075,7 +1081,11 @@ namespace ClassicUO.Configuration
 
                     HandleMigration();
                 });
-            }).Wait(10000);
+            }
+            else
+            {
+                Log.Error("SQL settings failed to load within the timeout; using defaults.");
+            }
 
             MyraStyle.SetDefault(); //Also loaded here in case profile settings affect styling
 


### PR DESCRIPTION
AfterLoad waited for the SQL setting database reads but then queued the actual apply via MainThreadQueue.EnqueueAction, so the settings were only applied on a later frame. That happened after login read the saved XML gumps (LoginComplete/ReadGumps), meaning gumps were created with stale or default setting values.

Apply the settings synchronously on the main thread before AfterLoad returns so the settings are in place before any saved gumps load.
