### PR TITLE
Fix IndexOutOfRangeException in TextEdit.Undo/Redo with stale history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to TazUO will be recorded here.
 * Fixed Myra windows not closing with right click - ([bittiez](https://github.com/bittiez))
 * Fixed menu color that failed to get the new myrs colors - ([bittiez](https://github.com/bittiez))
 * Fixed potential crashes with FSS text generation - ([bittiez](https://github.com/bittiez))
+* Fixed an IndexOutOfRangeException crash when pressing Undo/Redo in a text box whose contents had been changed outside the undo system (e.g. set directly, refreshed by the server, or truncated by a max length); stale undo/redo history is now discarded instead of indexing past the end of the text - [P.R 805](https://github.com/PlayTazUO/TazUO/pull/805) ([bittiez](https://github.com/bittiez))
 
 ## V5.12.0
 

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.17.0</AssemblyVersion>
-    <FileVersion>5.17.0</FileVersion>
+    <AssemblyVersion>5.17.1</AssemblyVersion>
+    <FileVersion>5.17.1</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Utility/StbTextedit/TextEdit.cs
+++ b/src/ClassicUO.Utility/StbTextedit/TextEdit.cs
@@ -844,13 +844,7 @@ namespace StbTextEditSharp
             u = s.undo_rec[s.undo_point - 1];
             int rpos = s.redo_point - 1;
 
-            // The undo record stores positions into the text buffer at the time
-            // the edit was made. If the text was replaced or trimmed outside of
-            // the undo system (e.g. the Text property was set directly, or a max
-            // length truncated an insert) the record can point past the end of
-            // the current text, and applying it would throw. Likewise rpos would
-            // be negative if there is no room left for a redo record. In either
-            // case the history is inconsistent, so discard it instead of crashing.
+            // Discard stale/inconsistent history instead of indexing past the end of the text.
             if (rpos < 0 || u.where < 0 || u.where > Length || u.where + u.delete_length > Length)
             {
                 s.Reset();
@@ -925,9 +919,7 @@ namespace StbTextEditSharp
             int upos = s.undo_point;
             r = s.undo_rec[s.redo_point];
 
-            // Guard against a redo record whose stored positions no longer match
-            // the current text buffer (see the matching check in Undo). Applying
-            // a stale record would index outside the text, so drop the history.
+            // Discard stale/inconsistent history instead of indexing past the end of the text.
             if (upos >= s.undo_rec.Length || r.where < 0 || r.where > Length || r.where + r.delete_length > Length)
             {
                 s.Reset();

--- a/src/ClassicUO.Utility/StbTextedit/TextEdit.cs
+++ b/src/ClassicUO.Utility/StbTextedit/TextEdit.cs
@@ -844,6 +844,20 @@ namespace StbTextEditSharp
             u = s.undo_rec[s.undo_point - 1];
             int rpos = s.redo_point - 1;
 
+            // The undo record stores positions into the text buffer at the time
+            // the edit was made. If the text was replaced or trimmed outside of
+            // the undo system (e.g. the Text property was set directly, or a max
+            // length truncated an insert) the record can point past the end of
+            // the current text, and applying it would throw. Likewise rpos would
+            // be negative if there is no room left for a redo record. In either
+            // case the history is inconsistent, so discard it instead of crashing.
+            if (rpos < 0 || u.where < 0 || u.where > Length || u.where + u.delete_length > Length)
+            {
+                s.Reset();
+
+                return;
+            }
+
             s.undo_rec[rpos].char_storage = -1;
 
             s.undo_rec[rpos].insert_length = u.delete_length;
@@ -910,6 +924,16 @@ namespace StbTextEditSharp
 
             int upos = s.undo_point;
             r = s.undo_rec[s.redo_point];
+
+            // Guard against a redo record whose stored positions no longer match
+            // the current text buffer (see the matching check in Undo). Applying
+            // a stale record would index outside the text, so drop the history.
+            if (upos >= s.undo_rec.Length || r.where < 0 || r.where > Length || r.where + r.delete_length > Length)
+            {
+                s.Reset();
+
+                return;
+            }
 
             s.undo_rec[upos].delete_length = r.insert_length;
 

--- a/src/ClassicUO.Utility/StbTextedit/UndoState.cs
+++ b/src/ClassicUO.Utility/StbTextedit/UndoState.cs
@@ -19,6 +19,17 @@ namespace StbTextEditSharp
             redo_char_point = 999;
         }
 
+        // Clears all undo/redo history. Used when the recorded history can no
+        // longer be trusted (for example, the text buffer was replaced outside
+        // of the undo system) and applying it would index outside the text.
+        public void Reset()
+        {
+            undo_point = 0;
+            undo_char_point = 0;
+            redo_point = 99;
+            redo_char_point = 999;
+        }
+
         public void DiscardUndo()
         {
             if (undo_point > 0)

--- a/src/ClassicUO.Utility/StbTextedit/UndoState.cs
+++ b/src/ClassicUO.Utility/StbTextedit/UndoState.cs
@@ -19,9 +19,7 @@ namespace StbTextEditSharp
             redo_char_point = 999;
         }
 
-        // Clears all undo/redo history. Used when the recorded history can no
-        // longer be trusted (for example, the text buffer was replaced outside
-        // of the undo system) and applying it would index outside the text.
+        // Clears all undo/redo history when it can no longer be trusted.
         public void Reset()
         {
             undo_point = 0;

--- a/tests/ClassicUO.UnitTests/Utility/StbTextedit/UndoStaleRecordTests.cs
+++ b/tests/ClassicUO.UnitTests/Utility/StbTextedit/UndoStaleRecordTests.cs
@@ -6,8 +6,7 @@ namespace ClassicUO.UnitTests.Utility.StbTextedit
 {
     public class UndoStaleRecordTests
     {
-        // Minimal handler backed by a plain string. It mimics a text box that can
-        // have its text replaced from outside the undo system.
+        // Minimal string-backed handler whose text can be replaced outside the undo system.
         private sealed class TestHandler : ITextEditHandler
         {
             public string Text { get; set; } = string.Empty;
@@ -28,22 +27,17 @@ namespace ClassicUO.UnitTests.Utility.StbTextedit
             var handler = new TestHandler();
             var edit = new TextEdit(handler) { SingleLine = true };
 
-            // Type some text through the edit so undo records are created.
+            // Type text so undo records are created.
             foreach (char c in "hello world")
             {
                 edit.InputChar(c);
             }
 
-            // Replace the buffer with a much shorter string, bypassing the undo
-            // system. The stored undo records now reference positions past the end
-            // of the current text - the exact condition that used to crash.
+            // Replace the buffer with a shorter string, leaving undo records pointing past the end.
             handler.Text = "hi";
 
-            // Should not throw IndexOutOfRangeException.
-            edit.Key(ControlKeys.Undo);
-
-            // History is discarded, so a second undo is also safe and a no-op.
-            edit.Key(ControlKeys.Undo);
+            edit.Key(ControlKeys.Undo); // Must not throw IndexOutOfRangeException.
+            edit.Key(ControlKeys.Undo); // History discarded, so this is a safe no-op.
 
             handler.Text.Should().Be("hi");
         }
@@ -59,12 +53,9 @@ namespace ClassicUO.UnitTests.Utility.StbTextedit
                 edit.InputChar(c);
             }
 
-            // Create a redo record by undoing once while the buffer is still valid.
-            edit.Key(ControlKeys.Undo);
+            edit.Key(ControlKeys.Undo); // Create a redo record while the buffer is still valid.
 
-            // Now corrupt the buffer and attempt a redo.
-            handler.Text = "hi";
-
+            handler.Text = "hi"; // Corrupt the buffer, then attempt a redo.
             edit.Key(ControlKeys.Redo);
 
             handler.Text.Should().Be("hi");
@@ -83,9 +74,8 @@ namespace ClassicUO.UnitTests.Utility.StbTextedit
 
             handler.Text.Should().Be("abc");
 
-            edit.Key(ControlKeys.Undo);
+            edit.Key(ControlKeys.Undo); // Undoes the most recent single-character insert.
 
-            // The most recent single-character insert should have been undone.
             handler.Text.Should().Be("ab");
         }
     }

--- a/tests/ClassicUO.UnitTests/Utility/StbTextedit/UndoStaleRecordTests.cs
+++ b/tests/ClassicUO.UnitTests/Utility/StbTextedit/UndoStaleRecordTests.cs
@@ -1,0 +1,92 @@
+using FluentAssertions;
+using StbTextEditSharp;
+using Xunit;
+
+namespace ClassicUO.UnitTests.Utility.StbTextedit
+{
+    public class UndoStaleRecordTests
+    {
+        // Minimal handler backed by a plain string. It mimics a text box that can
+        // have its text replaced from outside the undo system.
+        private sealed class TestHandler : ITextEditHandler
+        {
+            public string Text { get; set; } = string.Empty;
+
+            public int Length => Text?.Length ?? 0;
+
+            public TextEditRow LayoutRow(int startIndex) => new TextEditRow
+            {
+                num_chars = Length - startIndex
+            };
+
+            public float GetWidth(int index) => 1f;
+        }
+
+        [Fact]
+        public void Undo_Does_Not_Throw_When_Text_Replaced_Externally()
+        {
+            var handler = new TestHandler();
+            var edit = new TextEdit(handler) { SingleLine = true };
+
+            // Type some text through the edit so undo records are created.
+            foreach (char c in "hello world")
+            {
+                edit.InputChar(c);
+            }
+
+            // Replace the buffer with a much shorter string, bypassing the undo
+            // system. The stored undo records now reference positions past the end
+            // of the current text - the exact condition that used to crash.
+            handler.Text = "hi";
+
+            // Should not throw IndexOutOfRangeException.
+            edit.Key(ControlKeys.Undo);
+
+            // History is discarded, so a second undo is also safe and a no-op.
+            edit.Key(ControlKeys.Undo);
+
+            handler.Text.Should().Be("hi");
+        }
+
+        [Fact]
+        public void Redo_Does_Not_Throw_When_Text_Replaced_Externally()
+        {
+            var handler = new TestHandler();
+            var edit = new TextEdit(handler) { SingleLine = true };
+
+            foreach (char c in "hello world")
+            {
+                edit.InputChar(c);
+            }
+
+            // Create a redo record by undoing once while the buffer is still valid.
+            edit.Key(ControlKeys.Undo);
+
+            // Now corrupt the buffer and attempt a redo.
+            handler.Text = "hi";
+
+            edit.Key(ControlKeys.Redo);
+
+            handler.Text.Should().Be("hi");
+        }
+
+        [Fact]
+        public void Undo_Still_Works_For_Valid_History()
+        {
+            var handler = new TestHandler();
+            var edit = new TextEdit(handler) { SingleLine = true };
+
+            foreach (char c in "abc")
+            {
+                edit.InputChar(c);
+            }
+
+            handler.Text.Should().Be("abc");
+
+            edit.Key(ControlKeys.Undo);
+
+            // The most recent single-character insert should have been undone.
+            handler.Text.Should().Be("ab");
+        }
+    }
+}


### PR DESCRIPTION
The undo/redo records store absolute positions into the text buffer at the time each edit was made. When the text buffer is replaced or trimmed outside of the undo system - for example when the Text property is assigned directly, a server update rewrites the field, or a max-length truncates an insert - the stored records can reference positions past the end of the current text.

Applying such a record made Undo() read `text[u.where + i]` beyond the end of the string, throwing System.IndexOutOfRangeException and crashing the client on Ctrl+Z (and the symmetric case in Redo).

Undo() and Redo() now validate each record against the current text length (and guard the redo/undo slot index) before applying it. If the history is inconsistent it is discarded via UndoState.Reset() rather than crashing, so a subsequent undo is simply a no-op. Valid history continues to work unchanged.

Adds unit tests covering the external-replacement crash for both undo and redo plus a regression test that normal undo still works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved undo and redo stability when text content changes externally.
  * Prevented invalid history records from causing errors or corrupting the current text.
  * Automatically clears unusable undo/redo history so editing can continue safely.

* **Tests**
  * Added coverage for externally replaced or corrupted text and valid undo/redo scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->