### PR TITLE
Use clipboard for grid highlight import/export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to TazUO will be recorded here.
 * Replaced the old Myra window style with a new themed one. Thank you NewYears! - [P.R 774](https://github.com/PlayTazUO/TazUO/pull/774) ([bittiez](https://github.com/bittiez))
 
 ### Misc
+* Changed grid highlight import/export to use the clipboard instead of the file browser - [P.R 806](https://github.com/PlayTazUO/TazUO/pull/806) ([bittiez](https://github.com/bittiez))
 * Added a new PrivateSay macro option(Only you can see it) - [P.R 803](https://github.com/PlayTazUO/TazUO/pull/803) ([bittiez](https://github.com/bittiez))
 * Pathfinding now re-plans when a house is loaded mid-walk and keeps a soft 1-tile buffer around houses so paths route around them better - [P.R 799](https://github.com/PlayTazUO/TazUO/pull/799) ([bittiez](https://github.com/bittiez))
 * Migrate tooltip override saves to its own json file - [P.R 798](https://github.com/PlayTazUO/TazUO/pull/798) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.17.1</AssemblyVersion>
-    <FileVersion>5.17.1</FileVersion>
+    <AssemblyVersion>5.17.2</AssemblyVersion>
+    <FileVersion>5.17.2</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Configuration/GridHighlightsConfig.cs
+++ b/src/ClassicUO.Client/Configuration/GridHighlightsConfig.cs
@@ -97,6 +97,7 @@ namespace ClassicUO.Configuration
     }
 
     [JsonSerializable(typeof(GridHighlightsConfig), GenerationMode = JsonSourceGenerationMode.Metadata)]
+    [JsonSerializable(typeof(List<GridHighlightSetupEntry>), GenerationMode = JsonSourceGenerationMode.Metadata)]
     sealed partial class GridHighlightsJsonContext : JsonSerializerContext
     {
         sealed class SnakeCaseNamingPolicy : JsonNamingPolicy

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -150,10 +150,9 @@ gridhighlight_up=Up
 gridhighlight_up_tooltip=Move this up in the list
 gridhighlight_down=Down
 gridhighlight_down_tooltip=Move this down in the list
-gridhighlight_export_dialog=Save grid highlight settings
-gridhighlight_export_success=Saved highlight export to: {0}
-gridhighlight_import_dialog=Import grid highlight settings
-gridhighlight_import_success=Imported highlight config from: {0}
+gridhighlight_export_success=Copied highlight settings to clipboard
+gridhighlight_import_success=Imported highlight config from clipboard
+gridhighlight_import_empty=Clipboard is empty, nothing to import
 gridhighlight_import_error=Error importing highlight config
 gridhighlight_export_error=Error exporting highlight config
 

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -150,9 +150,9 @@ gridhighlight_up=Up
 gridhighlight_up_tooltip=Move this up in the list
 gridhighlight_down=Down
 gridhighlight_down_tooltip=Move this down in the list
-gridhighlight_export_success=Copied highlight settings to clipboard
-gridhighlight_import_success=Imported highlight config from clipboard
-gridhighlight_import_empty=Clipboard is empty, nothing to import
+gridhighlight_export_clipboard_success=Copied highlight settings to clipboard
+gridhighlight_import_clipboard_success=Imported highlight config from clipboard
+gridhighlight_import_clipboard_empty=Clipboard is empty, nothing to import
 gridhighlight_import_error=Error importing highlight config
 gridhighlight_export_error=Error exporting highlight config
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHightlightMenu.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHightlightMenu.cs
@@ -3,10 +3,10 @@ using ClassicUO.Game.Managers;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Game.UI.MyraWindows;
 using ClassicUO.Game.UI.MyraWindows.Widgets;
+using ClassicUO.Utility;
 using ClassicUO.Utility.Logging;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Text.Json;
 using Microsoft.Xna.Framework;
 using Myra.Graphics2D.Brushes;
@@ -168,44 +168,33 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
 
         private static void ExportGridHighlightSettings(World world)
         {
-            List<GridHighlightSetupEntry> data = GridHighlightsConfig.Current.Highlights;
-
-            RunFileDialog(world, true, TazLang.Get("gridhighlight_export_dialog"), file =>
+            try
             {
-                try
-                {
-                    if (Directory.Exists(file))
-                    {
-                        // If the path is a directory, append default filename
-                        file = Path.Combine(file, "highlights.json");
-                    }
-                    else if (!Path.HasExtension(file))
-                    {
-                        // If it's not a directory and has no extension, assume they meant a file name
-                        file += ".json";
-                    }
+                List<GridHighlightSetupEntry> data = GridHighlightsConfig.Current.Highlights;
 
-                    string json = JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true });
-                    File.WriteAllText(file, json);
-                    GameActions.Print(world, TazLang.Get("gridhighlight_export_success", [file]));
-                }
-                catch (Exception ex)
-                {
-                    GameActions.Print(world, TazLang.Get("gridhighlight_export_error"), Constants.HUE_ERROR);
-                    Log.Error(ex.ToString());
-                }
-            });
+                string json = JsonSerializer.Serialize(data, GridHighlightsJsonContext.DefaultToUse.ListGridHighlightSetupEntry);
+                Clipboard.SetClipboardText(json);
+                GameActions.Print(world, TazLang.Get("gridhighlight_export_success"));
+            }
+            catch (Exception ex)
+            {
+                GameActions.Print(world, TazLang.Get("gridhighlight_export_error"), Constants.HUE_ERROR);
+                Log.Error(ex.ToString());
+            }
         }
 
-        private static void ImportGridHighlightSettings(World world) => RunFileDialog(world, false, TazLang.Get("gridhighlight_import_dialog"), file =>
+        private static void ImportGridHighlightSettings(World world)
         {
             try
             {
-                if (!File.Exists(file))
+                string json = Clipboard.GetClipboardText();
+                if (string.IsNullOrWhiteSpace(json))
+                {
+                    GameActions.Print(world, TazLang.Get("gridhighlight_import_empty"), Constants.HUE_ERROR);
                     return;
+                }
 
-                string json = File.ReadAllText(file);
-                List<GridHighlightSetupEntry> imported = JsonSerializer.Deserialize<List<GridHighlightSetupEntry>>(json);
+                List<GridHighlightSetupEntry> imported = JsonSerializer.Deserialize(json, GridHighlightsJsonContext.DefaultToUse.ListGridHighlightSetupEntry);
                 if (imported != null)
                 {
                     GridHighlightsConfig.Current.Highlights.AddRange(imported);
@@ -221,7 +210,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
                         }
                     }
 
-                    GameActions.Print(world, TazLang.Get("gridhighlight_import_success", [file]));
+                    GameActions.Print(world, TazLang.Get("gridhighlight_import_success"));
                 }
             }
             catch (Exception ex)
@@ -229,8 +218,6 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
                 GameActions.Print(world, TazLang.Get("gridhighlight_import_error"), Constants.HUE_ERROR);
                 Log.Error(ex.ToString());
             }
-        });
-
-        private static void RunFileDialog(World world, bool save, string title, Action<string> onResult) => FileSelector.ShowFileBrowser(world, save ? FileSelectorType.Directory : FileSelectorType.File, null, save ? null : ["*.json"], onResult, title);
+        }
     }
 }

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHightlightMenu.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridHighLight/GridHightlightMenu.cs
@@ -174,7 +174,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
 
                 string json = JsonSerializer.Serialize(data, GridHighlightsJsonContext.DefaultToUse.ListGridHighlightSetupEntry);
                 Clipboard.SetClipboardText(json);
-                GameActions.Print(world, TazLang.Get("gridhighlight_export_success"));
+                GameActions.Print(world, TazLang.Get("gridhighlight_export_clipboard_success"));
             }
             catch (Exception ex)
             {
@@ -190,7 +190,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
                 string json = Clipboard.GetClipboardText();
                 if (string.IsNullOrWhiteSpace(json))
                 {
-                    GameActions.Print(world, TazLang.Get("gridhighlight_import_empty"), Constants.HUE_ERROR);
+                    GameActions.Print(world, TazLang.Get("gridhighlight_import_clipboard_empty"), Constants.HUE_ERROR);
                     return;
                 }
 
@@ -210,7 +210,7 @@ namespace ClassicUO.Game.UI.Gumps.GridHighLight
                         }
                     }
 
-                    GameActions.Print(world, TazLang.Get("gridhighlight_import_success"));
+                    GameActions.Print(world, TazLang.Get("gridhighlight_import_clipboard_success"));
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
Replace the file browser dialog with clipboard copy/paste for exporting and importing grid highlight settings. Export now serializes the highlights to JSON and copies them to the clipboard; import reads and deserializes JSON from the clipboard. Uses the Clipboard helper from the utility project and a source-generated JSON context for the highlight list.