### PR TITLE
Prevent Myra render NullReferenceException from crashing the client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to TazUO will be recorded here.
 * Migrate tooltip override saves to its own json file - [P.R 798](https://github.com/PlayTazUO/TazUO/pull/798) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
+* Prevent a Myra render NullReferenceException from crashing the client when a widget is detached from the desktop mid-render - [P.R 807](https://github.com/PlayTazUO/TazUO/pull/807) ([bittiez](https://github.com/bittiez))
 * Load SQL profile settings before saved gumps are restored at login, so gumps use the correct setting values - [P.R 804](https://github.com/PlayTazUO/TazUO/pull/804) ([bittiez](https://github.com/bittiez))
 * Restore default cooldown duration and hue - [P.R 802](https://github.com/PlayTazUO/TazUO/pull/802) ([bittiez](https://github.com/bittiez))
 * Recover from a corrupt SQLite database instead of crashing at login; the bad file is quarantined and an empty database is recreated - [P.R 800](https://github.com/PlayTazUO/TazUO/pull/800) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.17.2</AssemblyVersion>
-    <FileVersion>5.17.2</FileVersion>
+    <AssemblyVersion>5.17.3</AssemblyVersion>
+    <FileVersion>5.17.3</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Controls/MyraControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/MyraControl.cs
@@ -303,12 +303,7 @@ public class MyraControl : IGui
         }
         catch (Exception ex)
         {
-            // Myra's render traversal walks a cached ChildrenCopy snapshot. If a widget is
-            // detached from the desktop mid-pass (e.g. a child removed while rebuilding the
-            // tree), its Desktop becomes null and Widget.Render throws a NullReferenceException
-            // while it is still referenced by that stale snapshot. A rendering fault must never
-            // take down the entire client, so swallow it here and keep the game running.
-            // Log only once per control to avoid flooding the log at frame rate.
+            // A Myra render fault (e.g. a widget detached from the desktop mid-pass) must not crash the client; log once per control to avoid frame-rate flooding.
             if (!_renderErrorLogged)
             {
                 _renderErrorLogged = true;

--- a/src/ClassicUO.Client/Game/UI/Controls/MyraControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/MyraControl.cs
@@ -6,6 +6,7 @@ using ClassicUO.Game.UI.Controls.ResizableComponents;
 using ClassicUO.Game.UI.MyraWindows;
 using ClassicUO.Input;
 using ClassicUO.Renderer;
+using ClassicUO.Utility.Logging;
 using Microsoft.Xna.Framework;
 using Myra.Events;
 using Myra.Graphics2D;
@@ -121,6 +122,7 @@ public class MyraControl : IGui
     #region Fields
     protected Rectangle _bounds = new();
     protected bool _disposeRequested = false;
+    private bool _renderErrorLogged = false;
     protected readonly Queue<Action> _deferredActions = new();
     #endregion
 
@@ -287,14 +289,31 @@ public class MyraControl : IGui
         // the click is passed through to Myra on the same frame, and hover frames keep Myra's mouse
         // baseline fresh so the down-edge is detected. Only one window is ever MouseOverControl
         // (front-most hit), so this does not cause click-through to overlapped windows.
-        if (IsTopMost || ReferenceEquals(UIManager.MouseOverControl, this))
+        try
         {
-            _desktop.Render();
+            if (IsTopMost || ReferenceEquals(UIManager.MouseOverControl, this))
+            {
+                _desktop.Render();
+            }
+            else
+            {
+                _desktop.UpdateLayout();
+                _desktop.RenderVisual();
+            }
         }
-        else
+        catch (Exception ex)
         {
-            _desktop.UpdateLayout();
-            _desktop.RenderVisual();
+            // Myra's render traversal walks a cached ChildrenCopy snapshot. If a widget is
+            // detached from the desktop mid-pass (e.g. a child removed while rebuilding the
+            // tree), its Desktop becomes null and Widget.Render throws a NullReferenceException
+            // while it is still referenced by that stale snapshot. A rendering fault must never
+            // take down the entire client, so swallow it here and keep the game running.
+            // Log only once per control to avoid flooding the log at frame rate.
+            if (!_renderErrorLogged)
+            {
+                _renderErrorLogged = true;
+                Log.Error($"Exception while rendering Myra window '{_rootWindow?.Title}': {ex}");
+            }
         }
 
         DrawDebug(batcher, x, y);


### PR DESCRIPTION
A NullReferenceException could propagate out of Myra's Widget.Render during Desktop rendering and take down the entire client (Desktop.RenderVisual -> Widget.Render). This happens when a widget is detached from the desktop mid-render pass: Myra's render traversal walks a cached ChildrenCopy snapshot, and a widget removed from its parent during that pass has its Desktop set to null while still referenced by the stale snapshot. Its Render then dereferences the null Desktop and throws.

Guard the desktop render calls in MyraControl.Draw so a rendering fault is logged (once per control to avoid frame-rate log flooding) and swallowed instead of crashing the game.