### PR TITLE
Add string-based ContextMenu overload to Legion API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to TazUO will be recorded here.
 ---
 ## In Development
 
+### Legion
+* Added a string-based `API.ContextMenu(serial, entry)` overload that selects a context menu entry by its text - [P.R 808](https://github.com/PlayTazUO/TazUO/pull/808) ([bittiez](https://github.com/bittiez))
+
 ### Features
 * Added journal triggers for macros - [P.R 802](https://github.com/PlayTazUO/TazUO/pull/802) ([bittiez](https://github.com/bittiez))
 * Added .bmp support to external images loader - [P.R 796](https://github.com/PlayTazUO/TazUO/pull/796) ([credzba](https://github.com/credzba))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.17.3</AssemblyVersion>
-    <FileVersion>5.17.3</FileVersion>
+    <AssemblyVersion>5.17.4</AssemblyVersion>
+    <FileVersion>5.17.4</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Gumps/PopupMenuGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/PopupMenuGump.cs
@@ -15,6 +15,8 @@ namespace ClassicUO.Game.UI.Gumps
         private ushort _selectedItem;
         private readonly PopupMenuData _data;
 
+        public PopupMenuData Data => _data;
+
         public PopupMenuGump(World world, PopupMenuData data) : base(world, 0, 0)
         {
             if (CloseNext != uint.MaxValue && data.Serial == CloseNext)

--- a/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
@@ -816,6 +816,62 @@ namespace ClassicUO.LegionScripting
         );
 
         /// <summary>
+        /// Send a context menu(right click menu) response by matching the entry text.
+        /// This opens the menu, finds the entry whose text matches, and responds with the correct index.
+        /// The match is case-insensitive and matches the first entry that contains the given text.
+        /// Example:
+        /// ```py
+        /// API.ContextMenu(API.Player, "Open Paperdoll")
+        /// ```
+        /// </summary>
+        /// <param name="serial"></param>
+        /// <param name="entry">The text of the menu entry to select</param>
+        /// <param name="timeout">Seconds to wait for the menu to appear</param>
+        /// <returns>True if a matching entry was found and a response was sent</returns>
+        public bool ContextMenu(uint serial, string entry, double timeout = 5)
+        {
+            if (string.IsNullOrEmpty(entry))
+                return false;
+
+            OnMain(() => AsyncNetClient.Socket.Send_RequestPopupMenu(serial));
+
+            DateTime expire = DateTime.UtcNow.AddSeconds(timeout);
+
+            while (DateTime.UtcNow < expire)
+            {
+                // null = menu not ready yet (keep waiting), true = matched & sent, false = menu open but no match
+                bool? result = OnMain<bool?>(() =>
+                {
+                    PopupMenuGump gump = UIManager.PopupMenu;
+
+                    if (gump == null || gump.IsDisposed || gump.Data == null || gump.Data.Serial != serial)
+                        return null;
+
+                    foreach (PopupMenuItem item in gump.Data.Items)
+                    {
+                        string text = Client.Game.UO.FileManager.Clilocs.GetString(item.Cliloc);
+
+                        if (!string.IsNullOrEmpty(text) && text.IndexOf(entry, StringComparison.OrdinalIgnoreCase) >= 0)
+                        {
+                            AsyncNetClient.Socket.Send_PopupMenuSelection(serial, item.Index);
+                            gump.Dispose();
+                            return true;
+                        }
+                    }
+
+                    // Menu is open for this serial but no matching entry exists; stop waiting.
+                    gump.Dispose();
+                    return false;
+                });
+
+                if (result.HasValue)
+                    return result.Value;
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Send a response to the currently open menu (uses the latest MenuGump).
         /// Useful when menu IDs change every time (e.g., Tracking skill).
         /// Returns true if a menu was found and a response was sent.

--- a/src/ClassicUO.Client/LegionScripting/docs/API.py
+++ b/src/ClassicUO.Client/LegionScripting/docs/API.py
@@ -1366,7 +1366,20 @@ def ContextMenu(serial: "int", entry: "int") -> None:
      ```py
      API.ContextMenu(API.Player, 1)
      ```
-    
+
+    """
+    pass
+
+def ContextMenu(serial: "int", entry: "str", timeout: "float" = 5) -> "bool":
+    """
+     Send a context menu(right click menu) response by matching the entry text.
+     This opens the menu, finds the entry whose text matches, and responds with the correct index.
+     The match is case-insensitive and matches the first entry that contains the given text.
+     Example:
+     ```py
+     API.ContextMenu(API.Player, "Open Paperdoll")
+     ```
+
     """
     pass
 

--- a/src/ClassicUO.Client/LegionScripting/docs/LegionAPI.md
+++ b/src/ClassicUO.Client/LegionScripting/docs/LegionAPI.md
@@ -21,7 +21,7 @@ You can now type `-updateapi` in game to download the latest API.py file.
 
 [Additional notes](../notes/)  
 
-*This was generated on `7/26/26`.*
+*This was generated on `7/27/26`.*
 
 ## Properties
 ### `Events`
@@ -527,6 +527,29 @@ You can now type `-updateapi` in game to download the latest API.py file.
 | `entry` | `ushort` | ❌ No | Entries start at 0, the top entry will be 0, then 1, 2, etc. (Usually) |
 
 **Return Type:** `void` *(Does not return anything)*
+
+---
+
+### ContextMenu
+`(serial, entry, timeout)`
+ Send a context menu(right click menu) response by matching the entry text.
+ This opens the menu, finds the entry whose text matches, and responds with the correct index.
+ The match is case-insensitive and matches the first entry that contains the given text.
+ Example:
+ ```py
+ API.ContextMenu(API.Player, "Open Paperdoll")
+ ```
+
+
+**Parameters:**
+
+| Name | Type | Optional | Description |
+| --- | --- | --- | --- |
+| `serial` | `uint` | ❌ No |  |
+| `entry` | `string` | ❌ No | The text of the menu entry to select |
+| `timeout` | `double` | ✅ Yes | Seconds to wait for the menu to appear |
+
+**Return Type:** `bool`
 
 ---
 


### PR DESCRIPTION
Adds an API.ContextMenu(serial, entry) overload that accepts the entry text instead of an index. It opens the context menu, resolves each entry's cliloc text, and responds with the correct index for the first entry whose text matches (case-insensitive contains). Returns true when a matching entry was found and a response was sent.

Exposes PopupMenuData via PopupMenuGump.Data so the API can read the menu entries after the server sends them.