### PR TITLE
Expose SetTooltip and SetItemTooltip on Legion API base control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to TazUO will be recorded here.
 ## In Development
 
 ### Legion
+* Added `SetTooltip(text)`, `SetEntityTooltip(serial)` and `ClearTooltip()` to the base UI control so scripts can attach plain-text or entity-property tooltips to any control - [P.R 810](https://github.com/PlayTazUO/TazUO/pull/810) ([bittiez](https://github.com/bittiez))
 * Added `API.ListRunningScripts()` and `API.IsScriptRunning(path)`, and switched `API.PlayScript`, `API.StopScript` and `API.ToggleScript` to match scripts by their path relative to the LegionScripts folder so scripts sharing a file name are no longer ambiguous - [P.R 809](https://github.com/PlayTazUO/TazUO/pull/809) ([bittiez](https://github.com/bittiez))
 * Added a string-based `API.ContextMenu(serial, entry)` overload that selects a context menu entry by its text - [P.R 808](https://github.com/PlayTazUO/TazUO/pull/808) ([bittiez](https://github.com/bittiez))
 

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.17.5</AssemblyVersion>
-    <FileVersion>5.17.5</FileVersion>
+    <AssemblyVersion>5.17.6</AssemblyVersion>
+    <FileVersion>5.17.6</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiBaseControl.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiBaseControl.cs
@@ -161,6 +161,26 @@ public class ApiUiBaseControl(Control control)
     public ApiUiBaseControl SetAlpha(float alpha) => SetPropFluent(() => control.Alpha = alpha);
 
     /// <summary>
+    /// Sets a plain text tooltip that is shown when hovering this control.
+    /// Used in python API
+    /// </summary>
+    /// <param name="text">The tooltip text to display. Pass an empty string to clear the tooltip.</param>
+    public ApiUiBaseControl SetTooltip(string text) => SetPropFluent(() => control?.SetTooltip(text));
+
+    /// <summary>
+    /// Sets the tooltip of this control to display the properties of an item/entity, as if hovering that item.
+    /// Used in python API
+    /// </summary>
+    /// <param name="serial">The serial of the item/entity whose tooltip should be shown.</param>
+    public ApiUiBaseControl SetItemTooltip(uint serial) => SetPropFluent(() => control?.SetTooltip(serial));
+
+    /// <summary>
+    /// Clears the tooltip from this control.
+    /// Used in python API
+    /// </summary>
+    public ApiUiBaseControl ClearTooltip() => SetPropFluent(() => control?.ClearTooltip());
+
+    /// <summary>
     /// Clears all child controls from this control.
     /// Used in python API
     /// </summary>

--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiBaseControl.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiBaseControl.cs
@@ -172,7 +172,7 @@ public class ApiUiBaseControl(Control control)
     /// Used in python API
     /// </summary>
     /// <param name="serial">The serial of the item/entity whose tooltip should be shown.</param>
-    public ApiUiBaseControl SetItemTooltip(uint serial) => SetPropFluent(() => control?.SetTooltip(serial));
+    public ApiUiBaseControl SetEntityTooltip(uint serial) => SetPropFluent(() => control?.SetTooltip(serial));
 
     /// <summary>
     /// Clears the tooltip from this control.

--- a/src/ClassicUO.Client/LegionScripting/docs/API.py
+++ b/src/ClassicUO.Client/LegionScripting/docs/API.py
@@ -431,7 +431,7 @@ class ApiUiBaseControl:
         """
         pass
 
-    def SetItemTooltip(self, serial: "int") -> "ApiUiBaseControl":
+    def SetEntityTooltip(self, serial: "int") -> "ApiUiBaseControl":
         """
          Sets the tooltip of this control to display the properties of an item/entity, as if hovering that item.
          Used in python API

--- a/src/ClassicUO.Client/LegionScripting/docs/API.py
+++ b/src/ClassicUO.Client/LegionScripting/docs/API.py
@@ -423,11 +423,35 @@ class ApiUiBaseControl:
         """
         pass
 
+    def SetTooltip(self, text: "str") -> "ApiUiBaseControl":
+        """
+         Sets a plain text tooltip that is shown when hovering this control.
+         Used in python API
+
+        """
+        pass
+
+    def SetItemTooltip(self, serial: "int") -> "ApiUiBaseControl":
+        """
+         Sets the tooltip of this control to display the properties of an item/entity, as if hovering that item.
+         Used in python API
+
+        """
+        pass
+
+    def ClearTooltip(self) -> "ApiUiBaseControl":
+        """
+         Clears the tooltip from this control.
+         Used in python API
+
+        """
+        pass
+
     def Clear(self) -> "ApiUiBaseControl":
         """
          Clears all child controls from this control.
          Used in python API
-        
+
         """
         pass
 

--- a/src/ClassicUO.Client/LegionScripting/docs/ApiUiBaseControl.md
+++ b/src/ClassicUO.Client/LegionScripting/docs/ApiUiBaseControl.md
@@ -239,7 +239,7 @@ description: ApiUiBaseControl class documentation
 
 ---
 
-### SetItemTooltip
+### SetEntityTooltip
 `(serial)`
  Sets the tooltip of this control to display the properties of an item/entity, as if hovering that item.
  Used in python API

--- a/src/ClassicUO.Client/LegionScripting/docs/ApiUiBaseControl.md
+++ b/src/ClassicUO.Client/LegionScripting/docs/ApiUiBaseControl.md
@@ -223,6 +223,48 @@ description: ApiUiBaseControl class documentation
 
 ---
 
+### SetTooltip
+`(text)`
+ Sets a plain text tooltip that is shown when hovering this control.
+ Used in python API
+
+
+**Parameters:**
+
+| Name | Type | Optional | Description |
+| --- | --- | --- | --- |
+| `text` | `string` | ❌ No | The tooltip text to display. Pass an empty string to clear the tooltip. |
+
+**Return Type:** `ApiUiBaseControl`
+
+---
+
+### SetItemTooltip
+`(serial)`
+ Sets the tooltip of this control to display the properties of an item/entity, as if hovering that item.
+ Used in python API
+
+
+**Parameters:**
+
+| Name | Type | Optional | Description |
+| --- | --- | --- | --- |
+| `serial` | `uint` | ❌ No | The serial of the item/entity whose tooltip should be shown. |
+
+**Return Type:** `ApiUiBaseControl`
+
+---
+
+### ClearTooltip
+
+ Clears the tooltip from this control.
+ Used in python API
+
+
+**Return Type:** `ApiUiBaseControl`
+
+---
+
 ### Clear
 
  Clears all child controls from this control.


### PR DESCRIPTION
Add SetTooltip(string), SetEntityTooltip(uint serial), and ClearTooltip() to ApiUiBaseControl so scripts can attach plain-text tooltips or item-property tooltips to any UI control. Methods follow the existing fluent pattern and marshal onto the main thread.