### PR TITLE
Auto-enable mouse input when setting tooltips in API base control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to TazUO will be recorded here.
 ## In Development
 
 ### Legion
+* `SetTooltip(text)` and `SetEntityTooltip(serial)` now enable mouse input automatically so hover tooltips work without extra setup, and added a dedicated `SetAcceptMouseInput(enabled)` method to the base UI control - [P.R 811](https://github.com/PlayTazUO/TazUO/pull/811) ([bittiez](https://github.com/bittiez))
 * Added `SetTooltip(text)`, `SetEntityTooltip(serial)` and `ClearTooltip()` to the base UI control so scripts can attach plain-text or entity-property tooltips to any control - [P.R 810](https://github.com/PlayTazUO/TazUO/pull/810) ([bittiez](https://github.com/bittiez))
 * Added `API.ListRunningScripts()` and `API.IsScriptRunning(path)`, and switched `API.PlayScript`, `API.StopScript` and `API.ToggleScript` to match scripts by their path relative to the LegionScripts folder so scripts sharing a file name are no longer ambiguous - [P.R 809](https://github.com/PlayTazUO/TazUO/pull/809) ([bittiez](https://github.com/bittiez))
 * Added a string-based `API.ContextMenu(serial, entry)` overload that selects a context menu entry by its text - [P.R 808](https://github.com/PlayTazUO/TazUO/pull/808) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.17.6</AssemblyVersion>
-    <FileVersion>5.17.6</FileVersion>
+    <AssemblyVersion>5.17.7</AssemblyVersion>
+    <FileVersion>5.17.7</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiBaseControl.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiBaseControl.cs
@@ -162,17 +162,41 @@ public class ApiUiBaseControl(Control control)
 
     /// <summary>
     /// Sets a plain text tooltip that is shown when hovering this control.
+    /// Automatically enables mouse input so the tooltip can be triggered by hovering.
     /// Used in python API
     /// </summary>
     /// <param name="text">The tooltip text to display. Pass an empty string to clear the tooltip.</param>
-    public ApiUiBaseControl SetTooltip(string text) => SetPropFluent(() => control?.SetTooltip(text));
+    public ApiUiBaseControl SetTooltip(string text) => SetPropFluent(() =>
+    {
+        if (control == null) return;
+        control.AcceptMouseInput = true;
+        control.SetTooltip(text);
+    });
 
     /// <summary>
     /// Sets the tooltip of this control to display the properties of an item/entity, as if hovering that item.
+    /// Automatically enables mouse input so the tooltip can be triggered by hovering.
     /// Used in python API
     /// </summary>
     /// <param name="serial">The serial of the item/entity whose tooltip should be shown.</param>
-    public ApiUiBaseControl SetEntityTooltip(uint serial) => SetPropFluent(() => control?.SetTooltip(serial));
+    public ApiUiBaseControl SetEntityTooltip(uint serial) => SetPropFluent(() =>
+    {
+        if (control == null) return;
+        control.AcceptMouseInput = true;
+        control.SetTooltip(serial);
+    });
+
+    /// <summary>
+    /// Sets whether this control accepts mouse input. Mouse input must be enabled for
+    /// hover-based features such as tooltips to work.
+    /// Used in python API
+    /// </summary>
+    /// <param name="enabled">True to accept mouse input, false to ignore it.</param>
+    public ApiUiBaseControl SetAcceptMouseInput(bool enabled) => SetPropFluent(() =>
+    {
+        if (control != null)
+            control.AcceptMouseInput = enabled;
+    });
 
     /// <summary>
     /// Clears the tooltip from this control.


### PR DESCRIPTION
Tooltips only display for the control resolved as MouseOverControl, and hit-testing skips controls with AcceptMouseInput = false. Make SetTooltip and SetEntityTooltip enable mouse input automatically so scripted tooltips work without extra setup, and add a dedicated SetAcceptMouseInput method for explicit control.