### PR TITLE
Add Legion API methods to query active toggled spells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to TazUO will be recorded here.
 ---
 ## In Development
 
+### Legion
+* Added `API.ActiveSpells()`, `API.ActiveSpellNames()` and `API.IsSpellActive(spell)` so scripts can see which toggle spells/moves are currently active (the same ones the spell bar highlights) ([bittiez](https://github.com/bittiez))
+
 ### Features
 * Counter bar cells can now hold any spell bar action (spell, macro, weapon ability, script, or skill) in addition to item counters, with per-cell hotkeys (via the shared hotkey window), optional keybind labels, active-ability highlighting, and a hotkey-press flash - [P.R 812](https://github.com/PlayTazUO/TazUO/pull/812) ([bittiez](https://github.com/bittiez))
 

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.18.0</AssemblyVersion>
-    <FileVersion>5.18.0</FileVersion>
+    <AssemblyVersion>5.18.1</AssemblyVersion>
+    <FileVersion>5.18.1</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/Managers/ActiveIconsManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/ActiveIconsManager.cs
@@ -26,6 +26,14 @@ namespace ClassicUO.Game.Managers
 
         public bool IsActive(ushort id) => _activeIcons.Count != 0 && _activeIcons.Contains(id);
 
+        /// <summary>The spell ids currently toggled on (a snapshot copy).</summary>
+        public ushort[] GetActive()
+        {
+            ushort[] result = new ushort[_activeIcons.Count];
+            _activeIcons.CopyTo(result);
+            return result;
+        }
+
         public void Clear() => _activeIcons.Clear();
     }
 }

--- a/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
@@ -1410,6 +1410,99 @@ namespace ClassicUO.LegionScripting
         });
 
         /// <summary>
+        /// Get a list of spell ids for spells that are currently toggled on/active.
+        /// These are toggle spells/moves (for example Ninjitsu or Bushido moves) that the server
+        /// reports as active, the same ones the spell bar highlights.
+        /// Example:
+        /// ```py
+        /// for spellId in API.ActiveSpells():
+        ///     API.SysMsg("Active spell id: " + str(spellId))
+        /// ```
+        /// </summary>
+        /// <returns>An array of active spell ids.</returns>
+        public int[] ActiveSpells() => OnMain(() =>
+        {
+            if (World == null)
+                return new int[] { };
+
+            ushort[] active = World.ActiveSpellIcons.GetActive();
+            int[] result = new int[active.Length];
+
+            for (int i = 0; i < active.Length; i++)
+                result[i] = active[i];
+
+            return result;
+        });
+
+        /// <summary>
+        /// Get a list of names for spells that are currently toggled on/active.
+        /// These are toggle spells/moves (for example Ninjitsu or Bushido moves) that the server
+        /// reports as active, the same ones the spell bar highlights.
+        /// Example:
+        /// ```py
+        /// for name in API.ActiveSpellNames():
+        ///     API.SysMsg("Active spell: " + name)
+        /// ```
+        /// </summary>
+        /// <returns>An array of active spell names.</returns>
+        public string[] ActiveSpellNames() => OnMain(() =>
+        {
+            if (World == null)
+                return new string[] { };
+
+            ushort[] active = World.ActiveSpellIcons.GetActive();
+            List<string> result = new();
+
+            foreach (ushort id in active)
+            {
+                SpellDefinition spell = SpellDefinition.FullIndexGetSpell(id);
+
+                if (spell != null && !string.IsNullOrEmpty(spell.Name) && spell != SpellDefinition.EmptySpell)
+                    result.Add(spell.Name);
+            }
+
+            return result.ToArray();
+        });
+
+        /// <summary>
+        /// Check if a toggle spell/move is currently active.
+        /// You can pass a spell name (for example "Confidence") or a spell id.
+        /// These are toggle spells/moves that the server reports as active, the same ones the spell bar highlights.
+        /// Example:
+        /// ```py
+        /// if API.IsSpellActive("Confidence"):
+        ///     API.SysMsg("Confidence is active!")
+        /// ```
+        /// </summary>
+        /// <param name="spell">The spell name or spell id to check.</param>
+        /// <returns>True if the spell is currently toggled on.</returns>
+        public bool IsSpellActive(object spell) => OnMain(() =>
+        {
+            if (World == null || spell == null)
+                return false;
+
+            if (spell is string spellName)
+            {
+                if (string.IsNullOrEmpty(spellName))
+                    return false;
+
+                if (!SpellDefinition.TryGetSpellFromName(spellName, out SpellDefinition def))
+                    return false;
+
+                return World.ActiveSpellIcons.IsActive((ushort)def.ID);
+            }
+
+            try
+            {
+                return World.ActiveSpellIcons.IsActive(Convert.ToUInt16(spell));
+            }
+            catch
+            {
+                return false;
+            }
+        });
+
+        /// <summary>
         /// Show a system message(Left side of screen).
         /// Example:
         /// ```py

--- a/src/ClassicUO.Client/LegionScripting/docs/API.py
+++ b/src/ClassicUO.Client/LegionScripting/docs/API.py
@@ -426,16 +426,27 @@ class ApiUiBaseControl:
     def SetTooltip(self, text: "str") -> "ApiUiBaseControl":
         """
          Sets a plain text tooltip that is shown when hovering this control.
+         Automatically enables mouse input so the tooltip can be triggered by hovering.
          Used in python API
-
+        
         """
         pass
 
     def SetEntityTooltip(self, serial: "int") -> "ApiUiBaseControl":
         """
          Sets the tooltip of this control to display the properties of an item/entity, as if hovering that item.
+         Automatically enables mouse input so the tooltip can be triggered by hovering.
          Used in python API
+        
+        """
+        pass
 
+    def SetAcceptMouseInput(self, enabled: "bool") -> "ApiUiBaseControl":
+        """
+         Sets whether this control accepts mouse input. Mouse input must be enabled for
+         hover-based features such as tooltips to work.
+         Used in python API
+        
         """
         pass
 
@@ -443,7 +454,7 @@ class ApiUiBaseControl:
         """
          Clears the tooltip from this control.
          Used in python API
-
+        
         """
         pass
 
@@ -451,7 +462,7 @@ class ApiUiBaseControl:
         """
          Clears all child controls from this control.
          Used in python API
-
+        
         """
         pass
 
@@ -1668,6 +1679,48 @@ def ActiveBuffs() -> "list[ApiBuff]":
      buffs = API.ActiveBuffs()
      for buff in buffs:
          API.SysMsg(buff.Title)
+     ```
+    
+    """
+    pass
+
+def ActiveSpells() -> "list[int]":
+    """
+     Get a list of spell ids for spells that are currently toggled on/active.
+     These are toggle spells/moves (for example Ninjitsu or Bushido moves) that the server
+     reports as active, the same ones the spell bar highlights.
+     Example:
+     ```py
+     for spellId in API.ActiveSpells():
+         API.SysMsg("Active spell id: " + str(spellId))
+     ```
+    
+    """
+    pass
+
+def ActiveSpellNames() -> "list[str]":
+    """
+     Get a list of names for spells that are currently toggled on/active.
+     These are toggle spells/moves (for example Ninjitsu or Bushido moves) that the server
+     reports as active, the same ones the spell bar highlights.
+     Example:
+     ```py
+     for name in API.ActiveSpellNames():
+         API.SysMsg("Active spell: " + name)
+     ```
+    
+    """
+    pass
+
+def IsSpellActive(spell: "Any") -> "bool":
+    """
+     Check if a toggle spell/move is currently active.
+     You can pass a spell name (for example "Confidence") or a spell id.
+     These are toggle spells/moves that the server reports as active, the same ones the spell bar highlights.
+     Example:
+     ```py
+     if API.IsSpellActive("Confidence"):
+         API.SysMsg("Confidence is active!")
      ```
     
     """

--- a/src/ClassicUO.Client/LegionScripting/docs/ApiUiBaseControl.md
+++ b/src/ClassicUO.Client/LegionScripting/docs/ApiUiBaseControl.md
@@ -226,6 +226,7 @@ description: ApiUiBaseControl class documentation
 ### SetTooltip
 `(text)`
  Sets a plain text tooltip that is shown when hovering this control.
+ Automatically enables mouse input so the tooltip can be triggered by hovering.
  Used in python API
 
 
@@ -242,6 +243,7 @@ description: ApiUiBaseControl class documentation
 ### SetEntityTooltip
 `(serial)`
  Sets the tooltip of this control to display the properties of an item/entity, as if hovering that item.
+ Automatically enables mouse input so the tooltip can be triggered by hovering.
  Used in python API
 
 
@@ -250,6 +252,23 @@ description: ApiUiBaseControl class documentation
 | Name | Type | Optional | Description |
 | --- | --- | --- | --- |
 | `serial` | `uint` | ❌ No | The serial of the item/entity whose tooltip should be shown. |
+
+**Return Type:** `ApiUiBaseControl`
+
+---
+
+### SetAcceptMouseInput
+`(enabled)`
+ Sets whether this control accepts mouse input. Mouse input must be enabled for
+ hover-based features such as tooltips to work.
+ Used in python API
+
+
+**Parameters:**
+
+| Name | Type | Optional | Description |
+| --- | --- | --- | --- |
+| `enabled` | `bool` | ❌ No | True to accept mouse input, false to ignore it. |
 
 **Return Type:** `ApiUiBaseControl`
 

--- a/src/ClassicUO.Client/LegionScripting/docs/LegionAPI.md
+++ b/src/ClassicUO.Client/LegionScripting/docs/LegionAPI.md
@@ -1001,6 +1001,60 @@ You can now type `-updateapi` in game to download the latest API.py file.
 
 ---
 
+### ActiveSpells
+
+ Get a list of spell ids for spells that are currently toggled on/active.
+ These are toggle spells/moves (for example Ninjitsu or Bushido moves) that the server
+ reports as active, the same ones the spell bar highlights.
+ Example:
+ ```py
+ for spellId in API.ActiveSpells():
+     API.SysMsg("Active spell id: " + str(spellId))
+ ```
+
+
+**Return Type:** `int[]`
+
+---
+
+### ActiveSpellNames
+
+ Get a list of names for spells that are currently toggled on/active.
+ These are toggle spells/moves (for example Ninjitsu or Bushido moves) that the server
+ reports as active, the same ones the spell bar highlights.
+ Example:
+ ```py
+ for name in API.ActiveSpellNames():
+     API.SysMsg("Active spell: " + name)
+ ```
+
+
+**Return Type:** `string[]`
+
+---
+
+### IsSpellActive
+`(spell)`
+ Check if a toggle spell/move is currently active.
+ You can pass a spell name (for example "Confidence") or a spell id.
+ These are toggle spells/moves that the server reports as active, the same ones the spell bar highlights.
+ Example:
+ ```py
+ if API.IsSpellActive("Confidence"):
+     API.SysMsg("Confidence is active!")
+ ```
+
+
+**Parameters:**
+
+| Name | Type | Optional | Description |
+| --- | --- | --- | --- |
+| `spell` | `object` | ❌ No | The spell name or spell id to check. |
+
+**Return Type:** `bool`
+
+---
+
 ### SysMsg
 `(message, hue)`
  Show a system message(Left side of screen).


### PR DESCRIPTION
Expose the toggle spells/moves the server reports as active (the same ones the spell bar highlights) to the Python scripting API:
- API.ActiveSpells() returns active spell ids
- API.ActiveSpellNames() returns active spell names
- API.IsSpellActive(spell) checks a spell by name or id

Adds ActiveSpellIconsManager.GetActive() to enumerate the active ids.