### PR TITLE
Add generic CRUD and constructor schema-ensuring to SqliteDatabase base

### DIFF
--- a/src/ClassicUO.Client/Game/Managers/SqliteDatabase.cs
+++ b/src/ClassicUO.Client/Game/Managers/SqliteDatabase.cs
@@ -43,6 +43,11 @@ namespace ClassicUO.Game.Managers
         private readonly SemaphoreSlim _dbLock = new(1, 1);
         private bool _disposed;
 
+        // The primary table this database manages, when constructed with a schema. Null when the
+        // schema-less constructor is used (subclasses that still hand-roll their own SQL). The generic
+        // row helpers (AddOrUpdateAsync/DeleteAsync/GetAsync) require this to be set.
+        private readonly SqliteTableSchema? _schema;
+
         /// <summary>The directory that contains the database file.</summary>
         protected string DataDirectory { get; }
 
@@ -77,6 +82,31 @@ namespace ClassicUO.Game.Managers
                 Mode = SqliteOpenMode.ReadWriteCreate,
                 Cache = SqliteCacheMode.Shared
             }.ToString();
+        }
+
+        /// <summary>
+        /// Creates the base database and immediately ensures its primary table matches
+        /// <paramref name="schema"/> - creating it if absent and reconciling columns (adding missing,
+        /// dropping removed) otherwise. This is the recommended constructor: a subclass declares its
+        /// columns once, passes them here, and then works entirely through the generic row helpers
+        /// (<see cref="AddOrUpdateAsync"/>, <see cref="DeleteAsync"/>, <see cref="GetAsync"/>) without
+        /// writing any SQL of its own.
+        /// </summary>
+        /// <param name="schema">The table name and columns to ensure. See <see cref="EnsureTableAsync"/>.</param>
+        /// <param name="dbFileName">The database file name, e.g. <c>"mything.db"</c>.</param>
+        /// <param name="dataDirectory">
+        /// The directory to place the database in. Defaults to the shared <c>{ExecutablePath}/Data</c>
+        /// directory. Provide an explicit directory (e.g. a temp path) to make a subclass unit-testable.
+        /// </param>
+        protected SqliteDatabase(SqliteTableSchema schema, string dbFileName, string dataDirectory = null)
+            : this(dbFileName, dataDirectory)
+        {
+            _schema = schema;
+
+            // Ensure the schema up-front so the row helpers can be used immediately after construction.
+            // Blocking here mirrors the established pattern for these managers (the table must exist
+            // before any query runs) and is safe because nothing else can hold the lock yet.
+            EnsureTableAsync(schema).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -214,6 +244,219 @@ namespace ClassicUO.Game.Managers
                 ).ConfigureAwait(false);
             }
         });
+
+        /// <summary>
+        /// Inserts a row, or updates the existing row when it collides with the table's PRIMARY KEY
+        /// (an <c>INSERT ... ON CONFLICT(pk) DO UPDATE</c> upsert). Only the columns present in
+        /// <paramref name="row"/> are written; non-key columns are updated to the incoming values while
+        /// the key columns identify the row. All SQL is built here from the schema passed to the
+        /// constructor - the caller only supplies the data.
+        /// </summary>
+        /// <param name="row">The row data. Must include every PRIMARY KEY column.</param>
+        /// <returns>The number of rows affected.</returns>
+        protected Task<int> AddOrUpdateAsync(SqliteRow row)
+        {
+            SqliteTableSchema schema = RequireSchema();
+
+            // Keep only columns that are both declared in the schema and supplied on the row, in schema
+            // order so the generated SQL is stable and predictable.
+            List<SqliteColumn> columns = new();
+            foreach (SqliteColumn column in schema.Columns)
+            {
+                if (row.Contains(column.Name))
+                    columns.Add(column);
+            }
+
+            if (columns.Count == 0)
+                throw new ArgumentException("The row has no columns matching the table schema.", nameof(row));
+
+            List<string> primaryKeys = PrimaryKeyColumns(schema);
+
+            DynamicParameters parameters = new();
+            StringBuilder sql = new();
+            sql.Append("INSERT INTO ").Append(QuoteIdentifier(schema.Name)).Append(" (");
+
+            for (int i = 0; i < columns.Count; i++)
+            {
+                if (i > 0)
+                    sql.Append(", ");
+
+                sql.Append(QuoteIdentifier(columns[i].Name));
+            }
+
+            sql.Append(") VALUES (");
+
+            for (int i = 0; i < columns.Count; i++)
+            {
+                if (i > 0)
+                    sql.Append(", ");
+
+                string name = "p" + i;
+                sql.Append('@').Append(name);
+                parameters.Add(name, row[columns[i].Name]);
+            }
+
+            sql.Append(')');
+
+            if (primaryKeys.Count > 0)
+            {
+                sql.Append(" ON CONFLICT(");
+                for (int i = 0; i < primaryKeys.Count; i++)
+                {
+                    if (i > 0)
+                        sql.Append(", ");
+
+                    sql.Append(QuoteIdentifier(primaryKeys[i]));
+                }
+                sql.Append(") DO ");
+
+                // Update every supplied non-key column; if the only supplied columns are the key itself
+                // there is nothing to change, so the conflict is a no-op.
+                List<SqliteColumn> updatable = new();
+                foreach (SqliteColumn column in columns)
+                {
+                    if (!primaryKeys.Contains(column.Name, StringComparer.OrdinalIgnoreCase))
+                        updatable.Add(column);
+                }
+
+                if (updatable.Count == 0)
+                {
+                    sql.Append("NOTHING");
+                }
+                else
+                {
+                    sql.Append("UPDATE SET ");
+                    for (int i = 0; i < updatable.Count; i++)
+                    {
+                        if (i > 0)
+                            sql.Append(", ");
+
+                        string quoted = QuoteIdentifier(updatable[i].Name);
+                        sql.Append(quoted).Append(" = excluded.").Append(quoted);
+                    }
+                }
+            }
+
+            return WithConnectionAsync(connection => connection.ExecuteAsync(sql.ToString(), parameters));
+        }
+
+        /// <summary>
+        /// Deletes every row that matches the equality filter in <paramref name="filter"/> (all supplied
+        /// columns must match, combined with AND). Typically the filter is the row's PRIMARY KEY.
+        /// </summary>
+        /// <param name="filter">The columns to match. Must contain at least one column.</param>
+        /// <returns>The number of rows deleted.</returns>
+        protected Task<int> DeleteAsync(SqliteRow filter)
+        {
+            SqliteTableSchema schema = RequireSchema();
+
+            if (filter.Count == 0)
+                throw new ArgumentException(
+                    "A delete requires at least one filter column; pass the row's key to identify what to delete.",
+                    nameof(filter));
+
+            (string where, DynamicParameters parameters) = BuildWhere(filter);
+            string sql = $"DELETE FROM {QuoteIdentifier(schema.Name)} WHERE {where}";
+
+            return WithConnectionAsync(connection => connection.ExecuteAsync(sql, parameters));
+        }
+
+        /// <summary>
+        /// Reads rows from the table. With no filter it returns every row; otherwise it returns the rows
+        /// whose columns all equal the supplied values (combined with AND). Each result is a
+        /// <see cref="SqliteRow"/> the subclass maps back to its domain type.
+        /// </summary>
+        /// <param name="filter">Optional equality filter. Omit (or pass <c>default</c>) to select all rows.</param>
+        protected async Task<IReadOnlyList<SqliteRow>> GetAsync(SqliteRow filter = default)
+        {
+            SqliteTableSchema schema = RequireSchema();
+
+            StringBuilder sql = new();
+            sql.Append("SELECT * FROM ").Append(QuoteIdentifier(schema.Name));
+
+            DynamicParameters parameters = null;
+            if (filter.Count > 0)
+            {
+                (string where, DynamicParameters whereParams) = BuildWhere(filter);
+                sql.Append(" WHERE ").Append(where);
+                parameters = whereParams;
+            }
+
+            IEnumerable<dynamic> rows = await WithConnectionAsync(connection =>
+                connection.QueryAsync(sql.ToString(), parameters)).ConfigureAwait(false);
+
+            List<SqliteRow> results = new();
+            foreach (IDictionary<string, object> row in rows)
+                results.Add(SqliteRow.FromValues(row));
+
+            return results;
+        }
+
+        /// <summary>
+        /// Reads the first row matching the filter, or <c>null</c> if none match. A convenience over
+        /// <see cref="GetAsync"/> for lookups by a unique key.
+        /// </summary>
+        protected async Task<SqliteRow?> GetFirstAsync(SqliteRow filter = default)
+        {
+            IReadOnlyList<SqliteRow> rows = await GetAsync(filter).ConfigureAwait(false);
+            return rows.Count > 0 ? rows[0] : null;
+        }
+
+        /// <summary>Returns the schema set by the constructor, or throws if the schema-less constructor was used.</summary>
+        private SqliteTableSchema RequireSchema()
+        {
+            if (_schema == null)
+                throw new InvalidOperationException(
+                    "The generic row helpers require a schema. Use the SqliteDatabase(SqliteTableSchema, ...) constructor.");
+
+            return _schema.Value;
+        }
+
+        /// <summary>Returns the PRIMARY KEY column names of a schema, in declaration order.</summary>
+        private static List<string> PrimaryKeyColumns(SqliteTableSchema schema)
+        {
+            List<string> keys = new();
+            foreach (SqliteColumn column in schema.Columns)
+            {
+                if (column.PrimaryKey)
+                    keys.Add(column.Name);
+            }
+
+            return keys;
+        }
+
+        /// <summary>
+        /// Builds a parameterized WHERE fragment matching each column in <paramref name="filter"/> for
+        /// equality (a NULL value becomes <c>IS NULL</c>), combined with AND.
+        /// </summary>
+        private static (string sql, DynamicParameters parameters) BuildWhere(SqliteRow filter)
+        {
+            StringBuilder sql = new();
+            DynamicParameters parameters = new();
+
+            int i = 0;
+            foreach (string column in filter.Columns)
+            {
+                if (i > 0)
+                    sql.Append(" AND ");
+
+                object value = filter[column];
+                if (value is null)
+                {
+                    sql.Append(QuoteIdentifier(column)).Append(" IS NULL");
+                }
+                else
+                {
+                    string name = "w" + i;
+                    sql.Append(QuoteIdentifier(column)).Append(" = @").Append(name);
+                    parameters.Add(name, value);
+                }
+
+                i++;
+            }
+
+            return (sql.ToString(), parameters);
+        }
 
         /// <summary>
         /// Quotes a SQLite identifier (table/column name) so it cannot break out of the surrounding

--- a/src/ClassicUO.Client/Game/Managers/SqliteDatabase.cs
+++ b/src/ClassicUO.Client/Game/Managers/SqliteDatabase.cs
@@ -80,7 +80,12 @@ namespace ClassicUO.Game.Managers
             {
                 DataSource = DatabasePath,
                 Mode = SqliteOpenMode.ReadWriteCreate,
-                Cache = SqliteCacheMode.Shared
+                // Private cache (the default). Shared cache is an in-process cache-sharing feature: it
+                // provides no benefit across separate clients/processes and changes locking semantics so
+                // that table-level contention surfaces as SQLITE_LOCKED, which the busy handler does not
+                // retry. WAL journal mode (enabled per connection below) is what actually makes
+                // concurrent multi-client access safe and non-blocking for readers.
+                Cache = SqliteCacheMode.Private
             }.ToString();
         }
 
@@ -121,15 +126,31 @@ namespace ClassicUO.Game.Managers
             await _dbLock.WaitAsync().ConfigureAwait(false);
             try
             {
-                try
+                // Retry loop for cross-process lock contention. busy_timeout (set per connection) already
+                // makes SQLite wait inside the driver for a lock another client holds; this outer loop is
+                // a bounded backstop for the rare case a lock outlives that timeout under heavy multi-client
+                // write load, so an occasional SQLITE_BUSY is retried rather than thrown at the caller.
+                for (int attempt = 0; ; attempt++)
                 {
-                    return await OpenAndRunAsync(operation).ConfigureAwait(false);
-                }
-                catch (SqliteException ex) when (IsCorruptionError(ex) && QuarantineCorruptDatabase(ex))
-                {
-                    // The file was corrupt and has been quarantined; a fresh database will be created
-                    // on this retry. Only one retry is attempted - if it fails again the error propagates.
-                    return await OpenAndRunAsync(operation).ConfigureAwait(false);
+                    try
+                    {
+                        try
+                        {
+                            return await OpenAndRunAsync(operation).ConfigureAwait(false);
+                        }
+                        catch (SqliteException ex) when (IsCorruptionError(ex) && QuarantineCorruptDatabase(ex))
+                        {
+                            // The file was corrupt and has been quarantined; a fresh database will be created
+                            // on this retry. Only one retry is attempted - if it fails again the error propagates.
+                            return await OpenAndRunAsync(operation).ConfigureAwait(false);
+                        }
+                    }
+                    catch (SqliteException ex) when (IsBusyError(ex) && attempt < MAX_BUSY_RETRIES)
+                    {
+                        // Another client held the database longer than busy_timeout. Back off briefly (the
+                        // delay grows with each attempt) and try again; after MAX_BUSY_RETRIES it propagates.
+                        await Task.Delay(BUSY_RETRY_BASE_DELAY_MS * (attempt + 1)).ConfigureAwait(false);
+                    }
                 }
             }
             finally
@@ -150,13 +171,31 @@ namespace ClassicUO.Game.Managers
                 return true;
             });
 
-        /// <summary>Opens a fresh connection, runs the operation, and disposes the connection.</summary>
+        /// <summary>Opens a fresh connection, configures it for multi-client use, runs the operation, and disposes it.</summary>
         private async Task<T> OpenAndRunAsync<T>(Func<SqliteConnection, Task<T>> operation)
         {
             await using SqliteConnection connection = new(ConnectionString);
             await connection.OpenAsync().ConfigureAwait(false);
+            await ConfigureConnectionAsync(connection).ConfigureAwait(false);
             return await operation(connection).ConfigureAwait(false);
         }
+
+        /// <summary>
+        /// Applies the per-connection pragmas that make the database safe and non-blocking under
+        /// concurrent multi-client access:
+        /// <list type="bullet">
+        /// <item><c>busy_timeout</c> - wait this long for a lock another client holds instead of failing
+        /// immediately with SQLITE_BUSY. Per connection, so it is set on every open.</item>
+        /// <item><c>journal_mode=WAL</c> - lets multiple clients read while one writes (the default
+        /// rollback journal takes an exclusive database lock for the whole of every write). WAL is
+        /// persisted in the database header, so re-asserting it here is cheap once it is set.</item>
+        /// <item><c>synchronous=NORMAL</c> - the standard companion to WAL: durable against application
+        /// crashes, trading only the last committed transaction on an OS/power loss for much less fsync
+        /// overhead.</item>
+        /// </list>
+        /// </summary>
+        private static Task ConfigureConnectionAsync(SqliteConnection connection) => connection.ExecuteAsync(
+            $"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}; PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;");
 
         /// <summary>
         /// Ensures a table matches the given <see cref="SqliteTableSchema"/>: creates it
@@ -228,10 +267,19 @@ namespace ClassicUO.Game.Managers
                 if (existingSet.Contains(column.Name))
                     continue;
 
-                // A primary key cannot be added via ALTER TABLE, so never inline it here.
-                await connection.ExecuteAsync(
-                    $"ALTER TABLE {QuoteIdentifier(schema.Name)} ADD COLUMN {column.ToDefinition(includePrimaryKey: false)}"
-                ).ConfigureAwait(false);
+                try
+                {
+                    // A primary key cannot be added via ALTER TABLE, so never inline it here.
+                    await connection.ExecuteAsync(
+                        $"ALTER TABLE {QuoteIdentifier(schema.Name)} ADD COLUMN {column.ToDefinition(includePrimaryKey: false)}"
+                    ).ConfigureAwait(false);
+                }
+                catch (SqliteException ex) when (IsDuplicateColumnError(ex))
+                {
+                    // Another client added this column between our read of the existing columns and this
+                    // ALTER (simultaneous first launch / upgrade). The end state is what we wanted, so the
+                    // race is benign - carry on.
+                }
             }
 
             foreach (string existingColumn in existingColumns)
@@ -239,9 +287,17 @@ namespace ClassicUO.Game.Managers
                 if (desiredSet.Contains(existingColumn))
                     continue;
 
-                await connection.ExecuteAsync(
-                    $"ALTER TABLE {QuoteIdentifier(schema.Name)} DROP COLUMN {QuoteIdentifier(existingColumn)}"
-                ).ConfigureAwait(false);
+                try
+                {
+                    await connection.ExecuteAsync(
+                        $"ALTER TABLE {QuoteIdentifier(schema.Name)} DROP COLUMN {QuoteIdentifier(existingColumn)}"
+                    ).ConfigureAwait(false);
+                }
+                catch (SqliteException ex) when (IsMissingColumnError(ex))
+                {
+                    // Another client already dropped this column concurrently. Benign - the column is gone,
+                    // which is the desired outcome.
+                }
             }
         });
 
@@ -485,11 +541,47 @@ namespace ClassicUO.Game.Managers
         private static bool IsCorruptionError(SqliteException ex) =>
             ex.SqliteErrorCode == SQLITE_CORRUPT || ex.SqliteErrorCode == SQLITE_NOTADB;
 
+        /// <summary>
+        /// Returns true if the exception is transient lock contention from another client holding the
+        /// database - the kind of failure a short backoff-and-retry can clear.
+        /// </summary>
+        private static bool IsBusyError(SqliteException ex) =>
+            ex.SqliteErrorCode == SQLITE_BUSY || ex.SqliteErrorCode == SQLITE_LOCKED;
+
+        /// <summary>
+        /// Returns true if an <c>ALTER TABLE ... ADD COLUMN</c> failed because the column already exists -
+        /// i.e. another client added it concurrently. Matched on message text because SQLite reports it
+        /// with the generic SQLITE_ERROR code and no distinct extended code.
+        /// </summary>
+        private static bool IsDuplicateColumnError(SqliteException ex) =>
+            ex.SqliteErrorCode == SQLITE_ERROR &&
+            ex.Message.Contains("duplicate column", StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Returns true if an <c>ALTER TABLE ... DROP COLUMN</c> failed because the column is already gone -
+        /// i.e. another client dropped it concurrently. Matched on message text for the same reason as
+        /// <see cref="IsDuplicateColumnError"/>.
+        /// </summary>
+        private static bool IsMissingColumnError(SqliteException ex) =>
+            ex.SqliteErrorCode == SQLITE_ERROR &&
+            ex.Message.Contains("no such column", StringComparison.OrdinalIgnoreCase);
+
         // SQLite primary result codes (see https://www.sqlite.org/rescode.html). A malformed database
         // schema, "database disk image is malformed" all report SQLITE_CORRUPT (11); a file whose header
-        // is not recognizable as a SQLite database reports SQLITE_NOTADB (26).
+        // is not recognizable as a SQLite database reports SQLITE_NOTADB (26). SQLITE_BUSY (5) and
+        // SQLITE_LOCKED (6) are lock contention; a duplicate/missing column on ALTER reports the generic
+        // SQLITE_ERROR (1).
+        private const int SQLITE_ERROR = 1;
+        private const int SQLITE_BUSY = 5;
+        private const int SQLITE_LOCKED = 6;
         private const int SQLITE_CORRUPT = 11;
         private const int SQLITE_NOTADB = 26;
+
+        // How long a connection waits for a lock another client holds before giving up (SQLITE_BUSY), and
+        // the bounded application-level retry that backs it up if a lock outlives that wait.
+        private const int BUSY_TIMEOUT_MS = 30_000;
+        private const int MAX_BUSY_RETRIES = 3;
+        private const int BUSY_RETRY_BASE_DELAY_MS = 50;
 
         /// <summary>
         /// Moves a corrupt database file (and its WAL/SHM/journal sidecars) aside so a fresh, empty

--- a/src/ClassicUO.Client/Game/Managers/SqliteRow.cs
+++ b/src/ClassicUO.Client/Game/Managers/SqliteRow.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace ClassicUO.Game.Managers
+{
+    /// <summary>
+    /// A lightweight, schema-agnostic representation of a single database row: an ordered set of
+    /// column name / value pairs. It is the exchange type used by the generic CRUD helpers on
+    /// <see cref="SqliteDatabase"/> (<see cref="SqliteDatabase.AddOrUpdateAsync"/>,
+    /// <see cref="SqliteDatabase.DeleteAsync"/>, <see cref="SqliteDatabase.GetAsync"/>), so a subclass
+    /// only maps its domain object to and from a <see cref="SqliteRow"/> and never writes SQL itself.
+    /// <para>
+    /// Build one with a collection or dictionary initializer, or with the fluent <see cref="Set"/>:
+    /// </para>
+    /// <example>
+    /// <code>
+    /// var row = new SqliteRow { ["id"] = item.Serial, ["name"] = item.Name };
+    /// // or
+    /// var row = new SqliteRow().Set("id", item.Serial).Set("name", item.Name);
+    /// </code>
+    /// </example>
+    /// Column names are compared case-insensitively to match SQLite's default identifier handling.
+    /// </summary>
+    public readonly struct SqliteRow : IEnumerable<KeyValuePair<string, object>>
+    {
+        private readonly Dictionary<string, object> _values;
+
+        /// <summary>Creates an empty row ready to have columns added to it.</summary>
+        public SqliteRow()
+        {
+            _values = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        private SqliteRow(Dictionary<string, object> values)
+        {
+            _values = values;
+        }
+
+        /// <summary>The number of columns held by this row.</summary>
+        public int Count => _values?.Count ?? 0;
+
+        /// <summary>The column names present in this row, in insertion order.</summary>
+        public IEnumerable<string> Columns => _values?.Keys ?? Enumerable.Empty<string>();
+
+        /// <summary>
+        /// Gets or sets the raw value for a column. Reading an absent column returns <c>null</c>.
+        /// The setter supports the dictionary initializer syntax <c>new SqliteRow { ["c"] = v }</c>.
+        /// </summary>
+        public object this[string column]
+        {
+            get => _values != null && _values.TryGetValue(column, out object value) ? value : null;
+            set => Values()[column] = value;
+        }
+
+        /// <summary>Returns true if the given column is present in this row.</summary>
+        public bool Contains(string column) => _values != null && _values.ContainsKey(column);
+
+        /// <summary>
+        /// Adds a column/value pair. Supports the collection initializer syntax
+        /// <c>new SqliteRow { { "c", v } }</c>. Throws if the column already exists.
+        /// </summary>
+        public void Add(string column, object value) => Values().Add(column, value);
+
+        /// <summary>Sets a column to a value (adding it if absent) and returns this row for chaining.</summary>
+        public SqliteRow Set(string column, object value)
+        {
+            Values()[column] = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Gets the value for a column converted to <typeparamref name="T"/>. Handles the widening SQLite
+        /// performs (INTEGER -&gt; <see cref="long"/>, REAL -&gt; <see cref="double"/>, ...) as well as
+        /// enums, <see cref="Guid"/>, and <see cref="Nullable{T}"/> targets. An absent or NULL value
+        /// yields <c>default(T)</c>.
+        /// </summary>
+        public T Get<T>(string column) => (T)ConvertValue(this[column], typeof(T));
+
+        /// <summary>
+        /// Tries to get the value for a column converted to <typeparamref name="T"/>. Returns false if the
+        /// column is absent or holds NULL.
+        /// </summary>
+        public bool TryGet<T>(string column, out T value)
+        {
+            object raw = this[column];
+            if (raw is null or DBNull)
+            {
+                value = default;
+                return false;
+            }
+
+            value = (T)ConvertValue(raw, typeof(T));
+            return true;
+        }
+
+        /// <summary>Builds a <see cref="SqliteRow"/> from an existing dictionary (e.g. a Dapper result row).</summary>
+        internal static SqliteRow FromValues(IDictionary<string, object> values)
+        {
+            Dictionary<string, object> copy = new(values.Count, StringComparer.OrdinalIgnoreCase);
+            foreach (KeyValuePair<string, object> pair in values)
+                copy[pair.Key] = pair.Value is DBNull ? null : pair.Value;
+
+            return new SqliteRow(copy);
+        }
+
+        // Lazily materializes the backing store so a default(SqliteRow) can still be mutated. A default
+        // instance is used as the "no filter" sentinel for reads, where the store stays null.
+        private Dictionary<string, object> Values()
+        {
+            // The field is readonly, so a genuine default(SqliteRow) cannot be written to. Callers that
+            // need to build a row must start from `new SqliteRow()`; this makes that requirement explicit.
+            if (_values == null)
+                throw new InvalidOperationException(
+                    "This SqliteRow was default-initialized and is read-only. Create rows with 'new SqliteRow()'.");
+
+            return _values;
+        }
+
+        private static object ConvertValue(object value, Type targetType)
+        {
+            Type underlying = Nullable.GetUnderlyingType(targetType) ?? targetType;
+
+            if (value is null or DBNull)
+            {
+                // A non-nullable value type must return its default (0, false, ...) rather than null.
+                return targetType.IsValueType && Nullable.GetUnderlyingType(targetType) == null
+                    ? Activator.CreateInstance(targetType)
+                    : null;
+            }
+
+            if (underlying.IsInstanceOfType(value))
+                return value;
+
+            if (underlying.IsEnum)
+                return Enum.ToObject(underlying,
+                    Convert.ChangeType(value, Enum.GetUnderlyingType(underlying), CultureInfo.InvariantCulture));
+
+            if (underlying == typeof(Guid))
+                return value is byte[] bytes ? new Guid(bytes) : Guid.Parse(value.ToString());
+
+            return Convert.ChangeType(value, underlying, CultureInfo.InvariantCulture);
+        }
+
+        public IEnumerator<KeyValuePair<string, object>> GetEnumerator() =>
+            (_values ?? (IEnumerable<KeyValuePair<string, object>>)Array.Empty<KeyValuePair<string, object>>())
+            .GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/tests/ClassicUO.UnitTests/Game/Managers/SqliteDatabaseTest.cs
+++ b/tests/ClassicUO.UnitTests/Game/Managers/SqliteDatabaseTest.cs
@@ -53,6 +53,9 @@ namespace ClassicUO.UnitTests.Game.Managers
 
             public Task<List<string>> ColumnsAsync() => WithConnectionAsync(async c =>
                 (await c.QueryAsync<string>("SELECT name FROM pragma_table_info('things')")).ToList());
+
+            public Task<T> PragmaAsync<T>(string pragma) =>
+                WithConnectionAsync(c => c.ExecuteScalarAsync<T>($"PRAGMA {pragma}"));
         }
 
         private readonly string _tempDir;
@@ -273,6 +276,20 @@ namespace ClassicUO.UnitTests.Game.Managers
 
             IReadOnlyList<SqliteRow> all = await db.AllAsync();
             all.Should().HaveCount(3);
+        }
+
+        [Fact]
+        public async Task Connection_UsesWalJournalMode_AndBusyTimeout()
+        {
+            using var db = new ThingsDatabase(_tempDir);
+
+            // WAL lets multiple clients read while one writes; busy_timeout makes a client wait for a lock
+            // another holds rather than failing immediately. Both are required for safe multi-client use.
+            string journalMode = await db.PragmaAsync<string>("journal_mode");
+            journalMode.Should().Be("wal");
+
+            long busyTimeout = await db.PragmaAsync<long>("busy_timeout");
+            busyTimeout.Should().BeGreaterThan(0);
         }
 
         [Fact]

--- a/tests/ClassicUO.UnitTests/Game/Managers/SqliteDatabaseTest.cs
+++ b/tests/ClassicUO.UnitTests/Game/Managers/SqliteDatabaseTest.cs
@@ -28,6 +28,33 @@ namespace ClassicUO.UnitTests.Game.Managers
                 (await c.QueryAsync<string>($"SELECT name FROM pragma_table_info('{table}')")).ToList());
         }
 
+        // Concrete subclass built on the schema-aware constructor + generic row helpers, so tests can
+        // exercise AddOrUpdate/Delete/Get without any hand-written SQL.
+        private sealed class ThingsDatabase : SqliteDatabase
+        {
+            public static readonly SqliteTableSchema Schema = new("things",
+                SqliteColumn.Int("id", primaryKey: true),
+                SqliteColumn.Str("name", notNull: true, def: "''"),
+                SqliteColumn.Int("count", def: "0"));
+
+            public ThingsDatabase(string directory) : base(Schema, "things.db", directory) { }
+
+            public Task<int> SaveAsync(long id, string name, long count) =>
+                AddOrUpdateAsync(new SqliteRow { ["id"] = id, ["name"] = name, ["count"] = count });
+
+            public Task<int> RemoveAsync(long id) => DeleteAsync(new SqliteRow { ["id"] = id });
+
+            public Task<IReadOnlyList<SqliteRow>> AllAsync() => GetAsync();
+
+            public Task<IReadOnlyList<SqliteRow>> ByNameAsync(string name) =>
+                GetAsync(new SqliteRow { ["name"] = name });
+
+            public Task<SqliteRow?> ByIdAsync(long id) => GetFirstAsync(new SqliteRow { ["id"] = id });
+
+            public Task<List<string>> ColumnsAsync() => WithConnectionAsync(async c =>
+                (await c.QueryAsync<string>("SELECT name FROM pragma_table_info('things')")).ToList());
+        }
+
         private readonly string _tempDir;
         private readonly TestDatabase _db;
 
@@ -198,6 +225,72 @@ namespace ClassicUO.UnitTests.Game.Managers
 
             Func<Task> act = () => db.RunAsync(c => c.ExecuteAsync("SELECT 1"));
             await act.Should().ThrowAsync<ObjectDisposedException>();
+        }
+
+        [Fact]
+        public async Task SchemaConstructor_EnsuresTable_OnConstruction()
+        {
+            using var db = new ThingsDatabase(_tempDir);
+
+            File.Exists(Path.Combine(_tempDir, "things.db")).Should().BeTrue();
+            List<string> columns = await db.ColumnsAsync();
+            columns.Should().BeEquivalentTo(new[] { "id", "name", "count" });
+        }
+
+        [Fact]
+        public async Task AddOrUpdateAsync_InsertsThenUpdates_ByPrimaryKey()
+        {
+            using var db = new ThingsDatabase(_tempDir);
+
+            await db.SaveAsync(1, "original", 5);
+
+            SqliteRow? row = await db.ByIdAsync(1);
+            row.Should().NotBeNull();
+            row.Value.Get<string>("name").Should().Be("original");
+            row.Value.Get<int>("count").Should().Be(5);
+
+            // Same primary key -> update, not a duplicate row.
+            await db.SaveAsync(1, "updated", 9);
+
+            IReadOnlyList<SqliteRow> all = await db.AllAsync();
+            all.Should().HaveCount(1);
+            all[0].Get<string>("name").Should().Be("updated");
+            all[0].Get<int>("count").Should().Be(9);
+        }
+
+        [Fact]
+        public async Task GetAsync_WithFilter_ReturnsMatchingRows()
+        {
+            using var db = new ThingsDatabase(_tempDir);
+
+            await db.SaveAsync(1, "apple", 1);
+            await db.SaveAsync(2, "banana", 2);
+            await db.SaveAsync(3, "apple", 3);
+
+            IReadOnlyList<SqliteRow> apples = await db.ByNameAsync("apple");
+            apples.Should().HaveCount(2);
+            apples.Select(r => r.Get<long>("id")).Should().BeEquivalentTo(new long[] { 1, 3 });
+
+            IReadOnlyList<SqliteRow> all = await db.AllAsync();
+            all.Should().HaveCount(3);
+        }
+
+        [Fact]
+        public async Task DeleteAsync_RemovesMatchingRow()
+        {
+            using var db = new ThingsDatabase(_tempDir);
+
+            await db.SaveAsync(1, "keep", 1);
+            await db.SaveAsync(2, "remove", 2);
+
+            int deleted = await db.RemoveAsync(2);
+            deleted.Should().Be(1);
+
+            IReadOnlyList<SqliteRow> all = await db.AllAsync();
+            all.Should().HaveCount(1);
+            all[0].Get<long>("id").Should().Be(1);
+
+            (await db.ByIdAsync(2)).Should().BeNull();
         }
 
         [Fact]


### PR DESCRIPTION
Extend the shared SqliteDatabase base class so subclasses can manage a table without hand-writing any SQL:

- New schema-aware constructor takes a SqliteTableSchema and ensures the table (create + add/remove columns) during construction, so an inheriting class only declares its columns once and passes them to the base.
- Generic async row helpers built entirely in the base class from that schema: AddOrUpdateAsync (upsert on the primary key), DeleteAsync (by equality filter), GetAsync / GetFirstAsync (all rows or by filter).
- New SqliteRow struct as the schema-agnostic row exchange type, with collection/dictionary initializers, fluent Set, and typed Get<T> that handles SQLite's widening plus enums, Guid and Nullable<T>.

The existing connection/lock/corruption-recovery helpers and the older schema-less constructor are unchanged, so current managers keep working as-is; this only adds the base infrastructure for future migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved database reliability when multiple operations occur simultaneously.
  - Reduced failures caused by temporary database locks or busy states through automatic retries.
  - Improved handling of database schema updates during concurrent activity.
  - Added safeguards to better tolerate duplicate or missing database columns.
  - Improved recovery behavior for corrupted database files while preserving data access where possible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->