### PR TITLE
Fix hotkey capture combo being overwritten on modifier release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ All notable changes to TazUO will be recorded here.
 ### Features
 * Counter bar cells can now hold any spell bar action (spell, macro, weapon ability, script, or skill) in addition to item counters, with per-cell hotkeys (via the shared hotkey window), optional keybind labels, active-ability highlighting, and a hotkey-press flash - [P.R 812](https://github.com/PlayTazUO/TazUO/pull/812) ([bittiez](https://github.com/bittiez))
 
----
+### Fixes
+* Hotkey input window doesn't loose keys when releasing them ([bittiez](https://github.com/bittiez))
+
 ## V5.17.7
 
 ### Legion

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.18.2</AssemblyVersion>
-    <FileVersion>5.18.2</FileVersion>
+    <AssemblyVersion>5.18.3</AssemblyVersion>
+    <FileVersion>5.18.3</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/Managers/Hotkeys/HotkeyCapture.cs
+++ b/src/ClassicUO.Client/Game/Managers/Hotkeys/HotkeyCapture.cs
@@ -159,6 +159,12 @@ namespace ClassicUO.Game.Managers.Hotkeys
 
         private void Capture(HotkeyBinding binding)
         {
+            // A concrete input (key, mouse button, wheel or controller) has been captured, so the
+            // held modifiers are already baked into this binding. Clear the modifier accumulator so a
+            // later modifier release does not commit a bare-modifier binding that overwrites this one
+            // (e.g. pressing Ctrl+1 then releasing Ctrl must keep Ctrl+1, not fall back to just Ctrl).
+            _modAccum = SDL.SDL_Keymod.SDL_KMOD_NONE;
+
             if (!AutoStop)
             {
                 // Continuous mode: report the binding but keep listening so the user can keep


### PR DESCRIPTION
In the universal hotkey capture window, pressing a chord like Ctrl+1 and then releasing the key (1) while still holding the modifier caused the binding to fall back to just the bare modifier. When the modifier was finally released, OnBareModifier committed a bare-modifier binding because the modifier accumulator still held the held modifiers, overwriting the Ctrl+1 that had already been captured.

Clear the modifier accumulator whenever a concrete input (key, mouse button, wheel or controller) is captured, since the held modifiers are already baked into that binding. A later modifier release then no longer commits a bare-modifier binding on top of it, so a captured combo stays until it is replaced by another input or explicitly cleared.