### PR TITLE
Scale counter bar icons to the counter slot size

### DIFF
--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.18.3</AssemblyVersion>
-    <FileVersion>5.18.3</FileVersion>
+    <AssemblyVersion>5.18.4</AssemblyVersion>
+    <FileVersion>5.18.4</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.cs
@@ -1107,19 +1107,20 @@ namespace ClassicUO.Game.UI.Gumps
 
                         Vector3 hueVector = ShaderHueTranslator.GetHueVector(_hue, _partial, 1f, _isGumpGraphic);
 
+                        // Scale the icon to fill the cell while preserving its aspect ratio, then center it.
+                        // This scales small icons up and large icons down so they always match the slot size.
                         var originalSize = new Point(Width, Height);
                         var point = new Point();
 
-                        if (rect.Width < Width)
+                        if (rect.Width > 0 && rect.Height > 0)
                         {
-                            originalSize.X = rect.Width;
-                            point.X = (Width >> 1) - (originalSize.X >> 1);
-                        }
+                            float scale = Math.Min((float)Width / rect.Width, (float)Height / rect.Height);
 
-                        if (rect.Height < Height)
-                        {
-                            originalSize.Y = rect.Height;
-                            point.Y = (Height >> 1) - (originalSize.Y >> 1);
+                            originalSize.X = Math.Max(1, (int)(rect.Width * scale));
+                            originalSize.Y = Math.Max(1, (int)(rect.Height * scale));
+
+                            point.X = (Width - originalSize.X) >> 1;
+                            point.Y = (Height - originalSize.Y) >> 1;
                         }
 
                         if (_isGumpGraphic)


### PR DESCRIPTION
Previously counter bar icons were only scaled down when larger than the cell and otherwise drawn at their native size, leaving small icons under-filling larger slots. Icons now scale up or down to fill the slot while preserving their aspect ratio, then center within the cell.