### PR TITLE
Add counter bar item/icon scaling toggles

### DIFF
--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.18.4</AssemblyVersion>
-    <FileVersion>5.18.4</FileVersion>
+    <AssemblyVersion>5.18.5</AssemblyVersion>
+    <FileVersion>5.18.5</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Configuration/SqlProfile.cs
+++ b/src/ClassicUO.Client/Configuration/SqlProfile.cs
@@ -155,6 +155,14 @@ public sealed partial class Profile
         public partial bool CounterBarShowHotkeys { get; set; }
 
         [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, "counter_bar__disable_item_scaling", false)]
+        public partial bool CounterBarDisableItemScaling { get; set; }
+
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, "counter_bar__disable_icon_scaling", false)]
+        public partial bool CounterBarDisableIconScaling { get; set; }
+
+        [JsonIgnore]
         [SqlSetting(SettingsScope.Global, "nearby_loot_conceals_container_on_open", true)]
         public partial bool NearbyLootConcealsContainerOnOpen { get; set; }
 

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -1240,6 +1240,8 @@ mog_counters_highlightredwhenamountislow=Highlight red when amount is low
 mog_counters_rows=Rows
 mog_counters_sectionhighlightinglabel=Counter Highlighting
 mog_counters_showhotkeys=Display hotkeys on counters
+mog_counters_disableitemscaling=Disable item scaling
+mog_counters_disableiconscaling=Disable spell/ability icon scaling
 
 ; --- experimental ---
 mog_experimental_disablearrowsnumlockarrowsplayermovement=Disable arrows & numlock arrows(player movement)

--- a/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.cs
@@ -1112,12 +1112,27 @@ namespace ClassicUO.Game.UI.Gumps
                         var originalSize = new Point(Width, Height);
                         var point = new Point();
 
+                        // Scaling can be disabled per graphic kind: spell/ability icons resolve to gump
+                        // graphics, plain item counters to art. When disabled we draw the graphic at its
+                        // native size (still centered) instead of stretching it to the cell.
+                        bool disableScaling = _isGumpGraphic
+                            ? ProfileManager.CurrentProfile.CounterBarDisableIconScaling
+                            : ProfileManager.CurrentProfile.CounterBarDisableItemScaling;
+
                         if (rect.Width > 0 && rect.Height > 0)
                         {
-                            float scale = Math.Min((float)Width / rect.Width, (float)Height / rect.Height);
+                            if (disableScaling)
+                            {
+                                originalSize.X = rect.Width;
+                                originalSize.Y = rect.Height;
+                            }
+                            else
+                            {
+                                float scale = Math.Min((float)Width / rect.Width, (float)Height / rect.Height);
 
-                            originalSize.X = Math.Max(1, (int)(rect.Width * scale));
-                            originalSize.Y = Math.Max(1, (int)(rect.Height * scale));
+                                originalSize.X = Math.Max(1, (int)(rect.Width * scale));
+                                originalSize.Y = Math.Max(1, (int)(rect.Height * scale));
+                            }
 
                             point.X = (Width - originalSize.X) >> 1;
                             point.Y = (Height - originalSize.Y) >> 1;

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/CountersTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/CountersTab.cs
@@ -54,6 +54,16 @@ public static class CountersTab
                 }),
                 search: new SearchMetadata(TazLang.Get("mog_counters_showhotkeys"), Keywords: [TazLang.Get("mog_kw_counter"), TazLang.Get("mog_kw_hotkey")])
             ),
+            Option.Checkbox(
+                TazLang.Get("mog_counters_disableitemscaling"),
+                new Accessor<bool>(() => profile.CounterBarDisableItemScaling, b => profile.CounterBarDisableItemScaling = b),
+                search: new SearchMetadata(TazLang.Get("mog_counters_disableitemscaling"), Keywords: [TazLang.Get("mog_kw_counter"), TazLang.Get("mog_kw_item"), TazLang.Get("mog_kw_scaling")])
+            ),
+            Option.Checkbox(
+                TazLang.Get("mog_counters_disableiconscaling"),
+                new Accessor<bool>(() => profile.CounterBarDisableIconScaling, b => profile.CounterBarDisableIconScaling = b),
+                search: new SearchMetadata(TazLang.Get("mog_counters_disableiconscaling"), Keywords: [TazLang.Get("mog_kw_counter"), TazLang.Get("mog_kw_icon"), TazLang.Get("mog_kw_spell"), TazLang.Get("mog_kw_scaling")])
+            ),
             GetAbbreviationGroup(),
             GetHighlightGroup(),
             GetLayoutGroup()


### PR DESCRIPTION
Counter bar cells scale their graphics to fill the cell size. Add two profile options to disable that scaling and draw graphics at native size: "Disable item scaling" (art graphics for item counters) and "Disable spell/ability icon scaling" (gump graphics for action slots). Both are stored in SqlProfile.cs and exposed on the Counters options tab.