### PR TITLE
Add mild candle-flicker effect to lighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to TazUO will be recorded here.
 * Added `API.ActiveSpells()`, `API.ActiveSpellNames()` and `API.IsSpellActive(spell)` so scripts can see which toggle spells/moves are currently active (the same ones the spell bar highlights) ([bittiez](https://github.com/bittiez))
 
 ### Features
+* Added an optional candle flicker effect that makes lights gently ebb and flow (enabled by default, toggle under Video > Lighting) - [P.R 824](https://github.com/PlayTazUO/TazUO/pull/824) ([bittiez](https://github.com/bittiez))
 * Added optional FSR shader to post processing effects - [P.R 821](https://github.com/PlayTazUO/TazUO/pull/821) ([bittiez](https://github.com/bittiez))
 * Counter bar cells can now hold any spell bar action (spell, macro, weapon ability, script, or skill) in addition to item counters, with per-cell hotkeys (via the shared hotkey window), optional keybind labels, active-ability highlighting, and a hotkey-press flash - [P.R 812](https://github.com/PlayTazUO/TazUO/pull/812) ([bittiez](https://github.com/bittiez))
 

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.19.0</AssemblyVersion>
-    <FileVersion>5.19.0</FileVersion>
+    <AssemblyVersion>5.20.0</AssemblyVersion>
+    <FileVersion>5.20.0</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -286,7 +286,6 @@ namespace ClassicUO.Configuration
         public int LightLevelType { get; set => SetProperty(ref field, value); } // 0 = absolute, 1 = minimum
         public bool UseColoredLights { get; set => SetProperty(ref field, value); } = true;
         public bool UseDarkNights { get; set => SetProperty(ref field, value); }
-        public bool CandleFlickerLights { get; set => SetProperty(ref field, value); } = true;
         public int CloseHealthBarType { get; set => SetProperty(ref field, value); } = 2; // 0 = none, 1 == not exists, 2 == is dead
         public bool ActivateChatAfterEnter { get; set => SetProperty(ref field, value); }
         public bool ActivateChatAdditionalButtons { get; set => SetProperty(ref field, value); } = true;

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -286,6 +286,7 @@ namespace ClassicUO.Configuration
         public int LightLevelType { get; set => SetProperty(ref field, value); } // 0 = absolute, 1 = minimum
         public bool UseColoredLights { get; set => SetProperty(ref field, value); } = true;
         public bool UseDarkNights { get; set => SetProperty(ref field, value); }
+        public bool CandleFlickerLights { get; set => SetProperty(ref field, value); } = true;
         public int CloseHealthBarType { get; set => SetProperty(ref field, value); } = 2; // 0 = none, 1 == not exists, 2 == is dead
         public bool ActivateChatAfterEnter { get; set => SetProperty(ref field, value); }
         public bool ActivateChatAdditionalButtons { get; set => SetProperty(ref field, value); } = true;

--- a/src/ClassicUO.Client/Configuration/SqlProfile.cs
+++ b/src/ClassicUO.Client/Configuration/SqlProfile.cs
@@ -396,4 +396,9 @@ public sealed partial class Profile
         [JsonIgnore]
         [SqlSetting(SettingsScope.Global, "auto_loot_human_corpses", false)]
         public partial bool AutoLootHumanCorpses { get; set; }
+
+        // When true, in-game lights gently ebb and flow like a mild candle flame.
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, "candle_flicker_lights", true)]
+        public partial bool CandleFlickerLights { get; set; }
 }

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -2067,6 +2067,7 @@ mog_videotab_gamewindow_viewportx=Viewport X
 mog_videotab_gamewindow_viewporty=Viewport Y
 mog_videotab_label=Video
 mog_videotab_lighting_altlights=Alternative lights
+mog_videotab_lighting_candleflicker=Candle flicker
 mog_videotab_lighting_coloredlight=Colored lights
 mog_videotab_lighting_customllevel=Custom light level
 mog_videotab_lighting_darknight=Dark nights

--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -1415,6 +1415,10 @@ namespace ClassicUO.Game.Scenes
 
             hue.Z = 1f;
 
+            bool candleFlicker = ProfileManager.CurrentProfile.CandleFlickerLights;
+            // Time in seconds, used as the phase base for the flicker oscillation.
+            float flickerTime = Time.Ticks / 1000f;
+
             for (int i = 0; i < _lightCount; i++)
             {
                 ref LightData l = ref _lights[i];
@@ -1423,6 +1427,23 @@ namespace ClassicUO.Game.Scenes
                 if (lightInfo.Texture == null)
                 {
                     continue;
+                }
+
+                // Gently modulate each light's intensity so it ebbs and flows like a
+                // candle. A per-light phase seed derived from its position keeps nearby
+                // lights out of sync, and blending two frequencies avoids an obvious
+                // pulse. The amplitude is intentionally small for a subtle effect.
+                if (candleFlicker)
+                {
+                    float seed = l.DrawX * 0.73f + l.DrawY * 1.31f;
+
+                    hue.Z = 1f
+                        + 0.06f * (float)Math.Sin(flickerTime * 3.1f + seed)
+                        + 0.03f * (float)Math.Sin(flickerTime * 7.7f + seed * 1.7f);
+                }
+                else
+                {
+                    hue.Z = 1f;
                 }
 
                 hue.X = l.Color;

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/VideoTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/VideoTab.cs
@@ -398,6 +398,11 @@ public static class VideoTab
                 TazLang.Get("mog_videotab_lighting_coloredlight"),
                 new Accessor<bool>(() => profile.UseColoredLights),
                 search: new SearchMetadata(TazLang.Get("mog_videotab_lighting_coloredlight"), Keywords: [TazLang.Get("mog_kw_color"), TazLang.Get("mog_kw_light")])
+            ),
+            Option.Checkbox(
+                TazLang.Get("mog_videotab_lighting_candleflicker"),
+                new Accessor<bool>(() => profile.CandleFlickerLights),
+                search: new SearchMetadata(TazLang.Get("mog_videotab_lighting_candleflicker"), Keywords: [TazLang.Get("mog_kw_light")])
             )
         ).WithSearch(new SearchMetadata(TazLang.Get("mog_videotab_lighting_label"), Tags: [TazLang.Get("mog_kw_light")]));
 


### PR DESCRIPTION
Lights now gently ebb and flow like a candle. Each light's intensity is modulated by a low-amplitude blend of two sine waves, with a per-light phase seed derived from its screen position so nearby lights flicker independently rather than pulsing in unison.

Added a 'Candle flicker' toggle (enabled by default) under the Lighting video options.
