### PR TITLE
Fix bandage agent bugs: crash, double-heal, and retry spin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to TazUO will be recorded here.
 ### Fixes
 * Hotkey input window doesn't loose keys when releasing them ([bittiez](https://github.com/bittiez))
 * Fixed a journal crash (`InvalidOperation_EnumFailedVersion`) caused by a race while checking the top-most gump for inactive transparency - [P.R 822](https://github.com/PlayTazUO/TazUO/pull/822) ([bittiez](https://github.com/bittiez))
+* Fixed several bandage agent bugs: a client crash from the retry timer touching game state off the main thread, a duplicate bandage in "check for buff" mode, a stuck bandaging buff that could disable healing, and the retry timer spinning indefinitely for un-healable targets - [P.R 826](https://github.com/PlayTazUO/TazUO/pull/826) ([bittiez](https://github.com/bittiez))
 
 ## V5.17.7
 

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.20.1</AssemblyVersion>
-    <FileVersion>5.20.1</FileVersion>
+    <AssemblyVersion>5.20.2</AssemblyVersion>
+    <FileVersion>5.20.2</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/Managers/BandageManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/BandageManager.cs
@@ -220,7 +220,7 @@ namespace ClassicUO.Game.Managers
                 // can eventually stop spinning (e.g. no bandages, or a stuck target).
                 PruneExpiredRetries();
 
-                if (player.FindBandage(BandageGraphic) == null)
+                if (FindBandage() == null)
                     return; // Return early if we don't have bandages..
 
                 uint serial;

--- a/src/ClassicUO.Client/Game/Managers/BandageManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/BandageManager.cs
@@ -24,11 +24,22 @@ namespace ClassicUO.Game.Managers
         }
 
         private long _nextBandageTime = 0;
+        private long _bandagingBuffSetTime = 0;
         private readonly LinkedList<uint> _pendingHeals = new();
         private readonly HashSet<uint> _enqueuedInGlobalQueue = new();
+        private readonly Dictionary<uint, long> _retryDeadlines = new();
         private readonly Lock _queueLock = new();
         private Timer _retryTimer;
         private const int RETRY_INTERVAL_MS = 100;
+
+        // Upper bound on how long a single mobile is kept in the retry queue while it
+        // can't actually be healed (e.g. permanently out of range and HP not changing),
+        // so we don't spin the retry timer forever. Reset whenever a heal is attempted.
+        private const long MAX_RETRY_DURATION_MS = 30_000;
+
+        // Safety net in case a buff-removed event is ever missed: treat the bandaging
+        // buff as expired after this long so the agent can't get stuck never healing.
+        private const long MAX_BANDAGE_BUFF_AGE_MS = 15_000;
 
         public int PendingHealCount => _pendingHeals.Count;
         public int PendingInGlobalQueueCount => _enqueuedInGlobalQueue.Count;
@@ -69,9 +80,20 @@ namespace ClassicUO.Game.Managers
 
         private void OnBuffAdded(object sender, BuffEventArgs e)
         {
-            if (e.Buff.Type == BuffIconType.Healing) HasBandagingBuff = true;
-            if (e.Buff.Type == BuffIconType.Veterinary) HasBandagingBuff = true;
+            if (!IsEnabled) return;
+
+            if (e.Buff.Type == BuffIconType.Healing || e.Buff.Type == BuffIconType.Veterinary)
+            {
+                HasBandagingBuff = true;
+                _bandagingBuffSetTime = Time.Ticks;
+            }
         }
+
+        /// <summary>
+        /// Whether the bandaging buff is currently considered active. Includes a maximum
+        /// age so a missed buff-removed event can't permanently disable healing.
+        /// </summary>
+        private bool IsBandagingBuffActive => HasBandagingBuff && (Time.Ticks - _bandagingBuffSetTime) < MAX_BANDAGE_BUFF_AGE_MS;
 
         private void OnJournalEntryAdded(object sender, JournalEntry e)
         {
@@ -125,18 +147,25 @@ namespace ClassicUO.Game.Managers
         /// <summary>
         /// Schedules a retry
         /// </summary>
-        private void ScheduleRetry(uint mobileSerial = 0)
+        private void ScheduleRetry(uint mobileSerial)
         {
-            if (!IsEnabled) return;
+            if (!IsEnabled || mobileSerial == 0) return;
+
+            uint playerSerial = World.Instance?.Player?.Serial ?? 0;
 
             lock (_queueLock)
-                if(!_pendingHeals.Contains(mobileSerial))
+            {
+                if (!_pendingHeals.Contains(mobileSerial))
                 {
-                    if (mobileSerial == World.Instance.Player)
+                    if (mobileSerial == playerSerial)
                         _pendingHeals.AddFirst(mobileSerial);
                     else
                         _pendingHeals.AddLast(mobileSerial);
                 }
+
+                if (!_retryDeadlines.ContainsKey(mobileSerial))
+                    _retryDeadlines[mobileSerial] = Time.Ticks + MAX_RETRY_DURATION_MS;
+            }
 
             VerifyTimer();
         }
@@ -161,40 +190,109 @@ namespace ClassicUO.Game.Managers
         }
 
         /// <summary>
-        /// Timer callback to process the retry queue
+        /// Timer callback to process the retry queue. The timer fires on a threadpool
+        /// thread, but healing reads and mutates game state, so the actual work is
+        /// marshaled onto the main thread.
         /// </summary>
         private void ProcessRetryQueue(object state)
         {
-            uint serial;
+            MainThreadQueue.EnqueueAction(ProcessRetryQueueMainThread);
+        }
 
-            if (World.Instance.Player.FindBandage(BandageGraphic) == null) {
-                VerifyTimer();
-                return; //Return early if we don't have bandages..
+        /// <summary>
+        /// Processes a single pending heal on the main thread.
+        /// </summary>
+        private void ProcessRetryQueueMainThread()
+        {
+            try
+            {
+                if (!IsEnabled)
+                {
+                    ClearAllPendingHeals();
+                    return;
+                }
+
+                PlayerMobile player = World.Instance?.Player;
+                if (player == null)
+                    return; // Not in game yet (login/logout/world load); keep the queue and retry later.
+
+                // Drop anything that has been un-healable for too long so the timer
+                // can eventually stop spinning (e.g. no bandages, or a stuck target).
+                PruneExpiredRetries();
+
+                if (player.FindBandage(BandageGraphic) == null)
+                    return; // Return early if we don't have bandages..
+
+                uint serial;
+
+                // Safely get and remove the first item from the queue
+                lock (_queueLock)
+                {
+                    if (_pendingHeals.Count == 0) return;
+
+                    serial = _pendingHeals.First.Value;
+                    _pendingHeals.RemoveFirst();
+                }
+
+                Mobile mobile = World.Instance?.Mobiles?.Get(serial);
+                if (ShouldAttemptHeal(mobile))
+                {
+                    AttemptHealMobile(mobile);
+                }
+                else if (IsHealCandidate(mobile) && !IsRetryExpired(serial))
+                {
+                    // Conditions temporarily not met (e.g., distance, hidden, invul) but
+                    // mobile still needs healing - keep retrying so we don't lose track
+                    ScheduleRetry(serial);
+                }
+                else
+                {
+                    // Recovered, no longer a valid target, or retry window elapsed - stop tracking.
+                    lock (_queueLock) _retryDeadlines.Remove(serial);
+                }
             }
+            catch (Exception e)
+            {
+                Log.Error($"BandageManager failed while processing the heal retry queue: {e}");
+            }
+            finally
+            {
+                VerifyTimer();
+            }
+        }
 
-            // Safely get and remove the first item from the queue
+        /// <summary>
+        /// Whether the retry window for a mobile has elapsed without a successful heal attempt.
+        /// </summary>
+        private bool IsRetryExpired(uint serial)
+        {
+            lock (_queueLock)
+                return _retryDeadlines.TryGetValue(serial, out long deadline) && Time.Ticks >= deadline;
+        }
+
+        /// <summary>
+        /// Removes queued heals whose retry window has elapsed so the retry timer
+        /// doesn't spin indefinitely for targets that can never be healed.
+        /// </summary>
+        private void PruneExpiredRetries()
+        {
             lock (_queueLock)
             {
                 if (_pendingHeals.Count == 0) return;
 
-                serial = _pendingHeals.First.Value;
-                _pendingHeals.RemoveFirst();
+                long now = Time.Ticks;
+                LinkedListNode<uint> node = _pendingHeals.First;
+                while (node != null)
+                {
+                    LinkedListNode<uint> next = node.Next;
+                    if (_retryDeadlines.TryGetValue(node.Value, out long deadline) && now >= deadline)
+                    {
+                        _pendingHeals.Remove(node);
+                        _retryDeadlines.Remove(node.Value);
+                    }
+                    node = next;
+                }
             }
-
-            // Process outside the lock to avoid holding it during game logic
-            Mobile mobile = World.Instance?.Mobiles?.Get(serial);
-            if (ShouldAttemptHeal(mobile))
-            {
-                AttemptHealMobile(mobile);
-            }
-            else if (IsHealCandidate(mobile))
-            {
-                // Conditions temporarily not met (e.g., distance, hidden, invul) but
-                // mobile still needs healing - keep retrying so we don't lose track
-                ScheduleRetry(serial);
-            }
-
-            VerifyTimer();
         }
 
         /// <summary>
@@ -277,19 +375,26 @@ namespace ClassicUO.Game.Managers
 
         private void AttemptHealMobile(Mobile mobile)
         {
-            // If using buff checking, only prevent healing if buff is present
-            if (CheckForBuff && HasBandagingBuff)
+            if (mobile == null) return;
+
+            // If using buff checking, only prevent healing while the bandaging buff is present
+            if (CheckForBuff && IsBandagingBuffActive)
             {
                 ScheduleRetry(mobile.Serial);
                 return;
             }
 
-            // If using delay checking (not buff checking), check time delay
-            if (!CheckForBuff && Time.Ticks < _nextBandageTime)
+            // Always honor the minimum time before the next bandage. In buff mode this
+            // covers the short window between sending a heal and the buff packet arriving,
+            // preventing a duplicate bandage from being applied.
+            if (Time.Ticks < _nextBandageTime)
             {
                 ScheduleRetry(mobile.Serial);
                 return;
             }
+
+            // A heal is being attempted, so refresh the retry deadline for this mobile.
+            lock (_queueLock) _retryDeadlines[mobile.Serial] = Time.Ticks + MAX_RETRY_DURATION_MS;
 
             // Only enqueue if not already in the global priority queue
             bool shouldEnqueue;
@@ -367,6 +472,7 @@ namespace ClassicUO.Game.Managers
             {
                 _pendingHeals.Clear();
                 _enqueuedInGlobalQueue.Clear();
+                _retryDeadlines.Clear();
             }
             DestroyTimer();
         }


### PR DESCRIPTION
Several issues in BandageManager that could crash the client, waste bandages, or spin the retry timer indefinitely:

- Crash / NRE: the retry timer fires on a threadpool thread and read World.Instance.Player.FindBandage(...) plus other game state directly, with no null guard and no exception handling. During login/logout/world load Player is null, and an unhandled exception in a Timer callback terminates the process. The callback now marshals all work onto the main thread via MainThreadQueue, null-guards Player, and is wrapped in try/catch so healing state is only ever touched on the main thread.

- Double-bandage in "check for buff" mode: ExecuteHealMobile set a short _nextBandageTime guard window intended to prevent a second bandage before the Healing buff packet arrives, but AttemptHealMobile only honored _nextBandageTime when NOT in buff mode, making the guard dead code. The minimum-delay check is now applied in both modes.

- Stuck bandaging buff: if a buff-removed event is ever missed, HasBandagingBuff could remain true forever and silently disable healing. Buff state now expires after a maximum age.

- Unbounded retry spin: candidates that can never be healed (permanently out of range with unchanging HP, or no bandages) kept the 100ms timer running forever. Queued heals now carry a retry deadline and are pruned once it elapses; the deadline is refreshed on each heal attempt.

- Minor hardening: guard OnBuffAdded behind IsEnabled, remove the unsafe default serial (0) parameter on ScheduleRetry and ignore serial 0, and clear the new retry-deadline tracking in ClearAllPendingHeals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bandage healing retries for more reliable recovery attempts.
  * Prevented healing from becoming blocked indefinitely when buff updates are missed.
  * Added safeguards to stop retries when healing is unavailable or targets are no longer eligible.
  * Improved cleanup of expired and canceled healing attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->