### PR TITLE
Requeue bandage heals until IsHealCandidate is false

### DIFF
--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.20.2</AssemblyVersion>
-    <FileVersion>5.20.2</FileVersion>
+    <AssemblyVersion>5.20.3</AssemblyVersion>
+    <FileVersion>5.20.3</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/Managers/BandageManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/BandageManager.cs
@@ -401,6 +401,9 @@ namespace ClassicUO.Game.Managers
             lock (_queueLock) shouldEnqueue = _enqueuedInGlobalQueue.Add(mobile.Serial);
 
             if (shouldEnqueue) ObjectActionQueue.Instance.Enqueue(new ObjectActionQueueItem(() => ExecuteHealMobile(mobile)), ActionPriority.Immediate);
+
+            // Keep the mobile queued so we re-check until IsHealCandidate is false, even if no HP-change packet arrives.
+            ScheduleRetry(mobile.Serial);
         }
 
         private void ExecuteHealMobile(Mobile mobile)


### PR DESCRIPTION
After a heal was enqueued, AttemptHealMobile did not re-add the mobile to the retry queue - the retry processor had already popped it, so the mobile only got back in via ExecuteHealMobile running later. For the player, frequent HP/status packets kept re-triggering healing and masked this, but for pets/friends HP updates are sparse, so healing stalled after one bandage until the next natural HP change.

Schedule a retry when a heal is enqueued so the mobile stays queued and is re-evaluated until IsHealCandidate returns false, independent of HP-change packets. The existing enqueue dedup and cooldown/buff guards prevent this from causing a second bandage.