### PR TITLE
Persist Legion Script Manager window size and position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to TazUO will be recorded here.
 * Added `API.ActiveSpells()`, `API.ActiveSpellNames()` and `API.IsSpellActive(spell)` so scripts can see which toggle spells/moves are currently active (the same ones the spell bar highlights) ([bittiez](https://github.com/bittiez))
 
 ### Features
+* The Legion Script Manager window now remembers its size and position and restores them when reopened - [P.R 828](https://github.com/PlayTazUO/TazUO/pull/828) ([bittiez](https://github.com/bittiez))
 * Added an optional candle flicker effect that makes lights gently ebb and flow (enabled by default, toggle under Video > Lighting) - [P.R 824](https://github.com/PlayTazUO/TazUO/pull/824) ([bittiez](https://github.com/bittiez))
 * Added optional FSR shader to post processing effects - [P.R 821](https://github.com/PlayTazUO/TazUO/pull/821) ([bittiez](https://github.com/bittiez))
 * Counter bar cells can now hold any spell bar action (spell, macro, weapon ability, script, or skill) in addition to item counters, with per-cell hotkeys (via the shared hotkey window), optional keybind labels, active-ability highlighting, and a hotkey-press flash - [P.R 812](https://github.com/PlayTazUO/TazUO/pull/812) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.20.6</AssemblyVersion>
-    <FileVersion>5.20.6</FileVersion>
+    <AssemblyVersion>5.20.7</AssemblyVersion>
+    <FileVersion>5.20.7</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Configuration/SqlProfile.cs
+++ b/src/ClassicUO.Client/Configuration/SqlProfile.cs
@@ -401,4 +401,22 @@ public sealed partial class Profile
         [JsonIgnore]
         [SqlSetting(SettingsScope.Global, "candle_flicker_lights", true)]
         public partial bool CandleFlickerLights { get; set; }
+
+        // Persisted size/position of the Legion Script Manager window. A width/height of 0 means
+        // "not set" (auto-size to content); an X/Y of -1 means "not set" (center on open).
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, "script_manager_window_width", 0)]
+        public partial int ScriptManagerWindowWidth { get; set; }
+
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, "script_manager_window_height", 0)]
+        public partial int ScriptManagerWindowHeight { get; set; }
+
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, "script_manager_window_x", -1)]
+        public partial int ScriptManagerWindowX { get; set; }
+
+        [JsonIgnore]
+        [SqlSetting(SettingsScope.Global, "script_manager_window_y", -1)]
+        public partial int ScriptManagerWindowY { get; set; }
 }

--- a/src/ClassicUO.Client/Configuration/SqlProfile.cs
+++ b/src/ClassicUO.Client/Configuration/SqlProfile.cs
@@ -387,15 +387,15 @@ public sealed partial class Profile
         public partial string AutoSkinningKnifeGraphics { get; set; }
 
         [JsonIgnore]
-        [SqlSetting(SettingsScope.Global, "auto_skinning_human_corpses", false)]
+        [SqlSetting(SettingsScope.Char, "auto_skinning_human_corpses", false)]
         public partial bool AutoSkinningHumanCorpses { get; set; }
 
         [JsonIgnore]
-        [SqlSetting(SettingsScope.Global, "enable_auto_skinning", false)]
+        [SqlSetting(SettingsScope.Char, "enable_auto_skinning", false)]
         public partial bool EnableAutoSkinning { get; set; }
 
         [JsonIgnore]
-        [SqlSetting(SettingsScope.Global, "auto_loot_human_corpses", false)]
+        [SqlSetting(SettingsScope.Char, "auto_loot_human_corpses", false)]
         public partial bool AutoLootHumanCorpses { get; set; }
 
         // When true, in-game lights gently ebb and flow like a mild candle flame.
@@ -406,10 +406,10 @@ public sealed partial class Profile
         // Persisted size/position of the Legion Script Manager window. A null value means
         // "not set": no stored size auto-sizes to content, no stored position centers on open.
         [JsonIgnore]
-        [SqlSetting(SettingsScope.Global, "script_manager_window_size")]
+        [SqlSetting(SettingsScope.Char, "script_manager_window_size")]
         public partial Point? ScriptManagerWindowSize { get; set; }
 
         [JsonIgnore]
-        [SqlSetting(SettingsScope.Global, "script_manager_window_position")]
+        [SqlSetting(SettingsScope.Char, "script_manager_window_position")]
         public partial Point? ScriptManagerWindowPosition { get; set; }
 }

--- a/src/ClassicUO.Client/Configuration/SqlProfile.cs
+++ b/src/ClassicUO.Client/Configuration/SqlProfile.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Text.Json.Serialization;
 using ClassicUO.Game;
+using Microsoft.Xna.Framework;
 
 namespace ClassicUO.Configuration;
 
@@ -402,21 +403,13 @@ public sealed partial class Profile
         [SqlSetting(SettingsScope.Global, "candle_flicker_lights", true)]
         public partial bool CandleFlickerLights { get; set; }
 
-        // Persisted size/position of the Legion Script Manager window. A width/height of 0 means
-        // "not set" (auto-size to content); an X/Y of -1 means "not set" (center on open).
+        // Persisted size/position of the Legion Script Manager window. A null value means
+        // "not set": no stored size auto-sizes to content, no stored position centers on open.
         [JsonIgnore]
-        [SqlSetting(SettingsScope.Global, "script_manager_window_width", 0)]
-        public partial int ScriptManagerWindowWidth { get; set; }
+        [SqlSetting(SettingsScope.Global, "script_manager_window_size")]
+        public partial Point? ScriptManagerWindowSize { get; set; }
 
         [JsonIgnore]
-        [SqlSetting(SettingsScope.Global, "script_manager_window_height", 0)]
-        public partial int ScriptManagerWindowHeight { get; set; }
-
-        [JsonIgnore]
-        [SqlSetting(SettingsScope.Global, "script_manager_window_x", -1)]
-        public partial int ScriptManagerWindowX { get; set; }
-
-        [JsonIgnore]
-        [SqlSetting(SettingsScope.Global, "script_manager_window_y", -1)]
-        public partial int ScriptManagerWindowY { get; set; }
+        [SqlSetting(SettingsScope.Global, "script_manager_window_position")]
+        public partial Point? ScriptManagerWindowPosition { get; set; }
 }

--- a/src/ClassicUO.Client/Game/Managers/SQLSettingsManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/SQLSettingsManager.cs
@@ -172,18 +172,10 @@ namespace ClassicUO.Game.Managers
                     return (T)(object)double.Parse(value);
 
                 if (type == typeof(Point))
-                {
-                    // Point.ToString() produces a string in the form "{X:5 Y:10}"
-                    Match match = PointRegex.Match(value);
-                    if (match.Success)
-                    {
-                        return (T)(object)new Point(
-                            int.Parse(match.Groups["X"].Value),
-                            int.Parse(match.Groups["Y"].Value));
-                    }
+                    return TryParsePoint(value, out Point point) ? (T)(object)point : defaultValue;
 
-                    return defaultValue;
-                }
+                if (type == typeof(Point?))
+                    return TryParsePoint(value, out Point nPoint) ? (T)(object)(Point?)nPoint : defaultValue;
 
                 return defaultValue;
             }
@@ -191,6 +183,29 @@ namespace ClassicUO.Game.Managers
             {
                 return defaultValue;
             }
+        }
+
+        /// <summary>
+        /// Parses a <see cref="Point"/> from its <see cref="Point.ToString"/> representation
+        /// (e.g. "{X:5 Y:10}"). Used both by <see cref="ParseValue{T}"/> and by the generated
+        /// SQL-setting loaders for [SqlSetting] properties typed as <see cref="Point"/>/<see cref="Point"/>?.
+        /// </summary>
+        public static bool TryParsePoint(string value, out Point point)
+        {
+            if (!string.IsNullOrEmpty(value))
+            {
+                Match match = PointRegex.Match(value);
+                if (match.Success &&
+                    int.TryParse(match.Groups["X"].Value, out int x) &&
+                    int.TryParse(match.Groups["Y"].Value, out int y))
+                {
+                    point = new Point(x, y);
+                    return true;
+                }
+            }
+
+            point = default;
+            return false;
         }
 
         private string GetScopeKey(SettingsScope scope)

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/ScriptManagerWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/ScriptManagerWindow.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
-using System.Xml;
+using ClassicUO.Common;
 using ClassicUO.Common.Enums;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Managers;
@@ -50,7 +50,7 @@ public class ScriptManagerWindow : MyraControl
         Instance = this;
         CanBeSaved = true;
         Build();
-        CenterInViewPort();
+        RestoreWindowState();
         LegionScripting.LegionScripting.ScriptStarted += OnScriptChanged;
         LegionScripting.LegionScripting.ScriptStopped += OnScriptChanged;
     }
@@ -61,7 +61,9 @@ public class ScriptManagerWindow : MyraControl
         {
             if (g is ScriptManagerWindow w)
             {
-                w.CenterInViewPort();
+                // Keep the window where the user left it; SetInScreen guards against it being
+                // fully off-screen without clobbering the remembered position.
+                w.SetInScreen();
                 w.BringOnTop();
                 return;
             }
@@ -73,6 +75,7 @@ public class ScriptManagerWindow : MyraControl
     {
         LegionScripting.LegionScripting.ScriptStarted -= OnScriptChanged;
         LegionScripting.LegionScripting.ScriptStopped -= OnScriptChanged;
+        _rootWindow.LocationChanged -= OnWindowLocationChanged;
         if (Instance == this)
             Instance = null;
         base.Dispose();
@@ -94,18 +97,53 @@ public class ScriptManagerWindow : MyraControl
         }
     }
 
-    public override void Save(XmlTextWriter xml)
+    // Restores the window's size and position from the profile (persisted in SqlProfile). Falls
+    // back to auto-sizing / centering for any dimension that has not been saved yet.
+    private void RestoreWindowState()
     {
-        base.Save(xml);
-        xml.WriteAttributeString("width",  (_rootWindow.Width).ToString());
-        xml.WriteAttributeString("height", (_rootWindow.Height).ToString());
+        Profile profile = ProfileManager.CurrentProfile;
+
+        // Size is persisted through the window's InitialSizeStore accessor so it also plays nicely
+        // with the built-in resize/reset handling. The accessor reads/writes the profile below.
+        _rootWindow.Props.InitialSizeStore = new Accessor<Point?>(
+            () =>
+            {
+                Profile p = ProfileManager.CurrentProfile;
+                if (p == null || p.ScriptManagerWindowWidth < MIN_WIDTH || p.ScriptManagerWindowHeight < MIN_HEIGHT)
+                    return null;
+                return new Point(p.ScriptManagerWindowWidth, p.ScriptManagerWindowHeight);
+            },
+            value =>
+            {
+                Profile p = ProfileManager.CurrentProfile;
+                if (p == null)
+                    return;
+                p.ScriptManagerWindowWidth  = value?.X ?? 0;
+                p.ScriptManagerWindowHeight = value?.Y ?? 0;
+            });
+
+        // Restore position, or center when it has never been saved. Persist future moves.
+        if (profile != null && profile.ScriptManagerWindowX >= 0 && profile.ScriptManagerWindowY >= 0)
+        {
+            SetPosition(profile.ScriptManagerWindowX, profile.ScriptManagerWindowY);
+            SetInScreen();
+        }
+        else
+        {
+            CenterInViewPort();
+        }
+
+        _rootWindow.LocationChanged += OnWindowLocationChanged;
     }
 
-    public override void Load(XmlElement xml)
+    private void OnWindowLocationChanged(object sender, EventArgs e)
     {
-        base.Load(xml);
-        if (int.TryParse(xml.GetAttribute("width"),  out int w) && w >= MIN_WIDTH)  _rootWindow.Width  = w;
-        if (int.TryParse(xml.GetAttribute("height"), out int h) && h >= MIN_HEIGHT) _rootWindow.Height = h;
+        Profile profile = ProfileManager.CurrentProfile;
+        if (profile == null)
+            return;
+
+        profile.ScriptManagerWindowX = _rootWindow.Left;
+        profile.ScriptManagerWindowY = _rootWindow.Top;
     }
 
     private void Build()

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/ScriptManagerWindow.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/ScriptManagerWindow.cs
@@ -31,9 +31,6 @@ public class ScriptManagerWindow : MyraControl
 
     public static ScriptManagerWindow Instance { get; private set; }
 
-    private const int MIN_WIDTH  = 200;
-    private const int MIN_HEIGHT = 200;
-
     private readonly HashSet<string> _collapsedGroups = [];
     private bool _pendingReload = true;
     private string _searchFilter = "";
@@ -98,7 +95,7 @@ public class ScriptManagerWindow : MyraControl
     }
 
     // Restores the window's size and position from the profile (persisted in SqlProfile). Falls
-    // back to auto-sizing / centering for any dimension that has not been saved yet.
+    // back to auto-sizing / centering when a value has not been saved yet.
     private void RestoreWindowState()
     {
         Profile profile = ProfileManager.CurrentProfile;
@@ -106,26 +103,18 @@ public class ScriptManagerWindow : MyraControl
         // Size is persisted through the window's InitialSizeStore accessor so it also plays nicely
         // with the built-in resize/reset handling. The accessor reads/writes the profile below.
         _rootWindow.Props.InitialSizeStore = new Accessor<Point?>(
-            () =>
-            {
-                Profile p = ProfileManager.CurrentProfile;
-                if (p == null || p.ScriptManagerWindowWidth < MIN_WIDTH || p.ScriptManagerWindowHeight < MIN_HEIGHT)
-                    return null;
-                return new Point(p.ScriptManagerWindowWidth, p.ScriptManagerWindowHeight);
-            },
+            () => ProfileManager.CurrentProfile?.ScriptManagerWindowSize,
             value =>
             {
-                Profile p = ProfileManager.CurrentProfile;
-                if (p == null)
-                    return;
-                p.ScriptManagerWindowWidth  = value?.X ?? 0;
-                p.ScriptManagerWindowHeight = value?.Y ?? 0;
+                if (ProfileManager.CurrentProfile != null)
+                    ProfileManager.CurrentProfile.ScriptManagerWindowSize = value;
             });
 
         // Restore position, or center when it has never been saved. Persist future moves.
-        if (profile != null && profile.ScriptManagerWindowX >= 0 && profile.ScriptManagerWindowY >= 0)
+        Point? position = profile?.ScriptManagerWindowPosition;
+        if (position.HasValue)
         {
-            SetPosition(profile.ScriptManagerWindowX, profile.ScriptManagerWindowY);
+            SetPosition(position.Value.X, position.Value.Y);
             SetInScreen();
         }
         else
@@ -142,8 +131,7 @@ public class ScriptManagerWindow : MyraControl
         if (profile == null)
             return;
 
-        profile.ScriptManagerWindowX = _rootWindow.Left;
-        profile.ScriptManagerWindowY = _rootWindow.Top;
+        profile.ScriptManagerWindowPosition = new Point(_rootWindow.Left, _rootWindow.Top);
     }
 
     private void Build()

--- a/src/ClassicUO.Client/LegionScripting/docs/API.py
+++ b/src/ClassicUO.Client/LegionScripting/docs/API.py
@@ -599,7 +599,7 @@ class ApiUiGump:
         """
         pass
 
-    def CreateModernGump(self, x: "int", y: "int", width: "int", height: "int", resizable: "bool" = True, minWidth: "int" = 50, minHeight: "int" = 50, onResized: "Any" = None) -> "ApiUiNineSliceGump":
+    def CreateModernGump(self, x: "int", y: "int", width: "int", height: "int", resizable: "bool" = True, minWidth: "int" = 50, minHeight: "int" = 50, onResized: "Any" = None, keepOpen: "bool" = False) -> "ApiUiNineSliceGump":
         """
          Creates a modern nine-slice gump using ModernUIConstants for consistent styling.
          The gump uses the standard modern UI panel texture and border size internally.

--- a/src/ClassicUO.Client/LegionScripting/docs/ApiUiGump.md
+++ b/src/ClassicUO.Client/LegionScripting/docs/ApiUiGump.md
@@ -37,7 +37,7 @@ description: ApiUiGump class documentation
 ---
 
 ### CreateModernGump
-`(x, y, width, height, resizable, minWidth, minHeight, onResized)`
+`(x, y, width, height, resizable, minWidth, minHeight, onResized, keepOpen)`
  Creates a modern nine-slice gump using ModernUIConstants for consistent styling.
  The gump uses the standard modern UI panel texture and border size internally.
 
@@ -54,6 +54,7 @@ description: ApiUiGump class documentation
 | `minWidth` | `int` | ✅ Yes | Minimum width (default: 50) |
 | `minHeight` | `int` | ✅ Yes | Minimum height (default: 50) |
 | `onResized` | `object` | ✅ Yes | Optional callback function called when the gump is resized |
+| `keepOpen` | `bool` | ✅ Yes |  |
 
 **Return Type:** `ApiUiNineSliceGump`
 

--- a/src/ClassicUO.SourceGenerators/SqlSettingGenerator.cs
+++ b/src/ClassicUO.SourceGenerators/SqlSettingGenerator.cs
@@ -157,6 +157,8 @@ namespace ClassicUO.Configuration
                 case "float":
                 case "double":
                 case "string":
+                case "Point":
+                case "Point?":
                     return true;
                 default:
                     return false;
@@ -217,6 +219,9 @@ namespace ClassicUO.Configuration
                 case "ulong":  return $"ulong.TryParse({rawVar}, out ulong {varName})";
                 case "float":  return $"float.TryParse({rawVar}, out float {varName})";
                 case "double": return $"double.TryParse({rawVar}, out double {varName})";
+                // Point.ToString() round-trips through the SQL store; the manager exposes a parser.
+                case "Point":
+                case "Point?": return $"ClassicUO.Game.Managers.SQLSettingsManager.TryParsePoint({rawVar}, out var {varName})";
                 case "string": return null; // no TryParse needed
                 default:       return null;
             }
@@ -228,6 +233,10 @@ namespace ClassicUO.Configuration
             {
                 case "bool":   return literal == "true";
                 case "string": return literal != "null" && literal != "\"\"";
+                // Point/Point? cannot carry a compile-time default via the attribute, so they
+                // always fall back to the type's own default (null / {0,0}); never initialize.
+                case "Point":
+                case "Point?": return false;
                 default:       return literal != "0" && literal != "0f" && literal != "0d";
             }
         }
@@ -281,6 +290,7 @@ namespace ClassicUO.Configuration
             sb.AppendLine("using System.Text.Json.Serialization;");
             sb.AppendLine("using ClassicUO.Game;");
             sb.AppendLine("using ClassicUO.Game.Managers;");
+            sb.AppendLine("using Microsoft.Xna.Framework;");
             sb.AppendLine();
             sb.AppendLine("namespace ClassicUO.Configuration");
             sb.AppendLine("{");


### PR DESCRIPTION
Store the Script Manager window's size and position in the SqlProfile and restore them when the window is opened again. Size is wired through the window's InitialSizeStore accessor (so it integrates with the built-in resize/reset handling) and position is restored on construction and saved on move. Replaces the previous XML-only width/height persistence.