### PR TITLE
Remove the Camera Smoothing option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to TazUO will be recorded here.
 * Counter bar cells can now hold any spell bar action (spell, macro, weapon ability, script, or skill) in addition to item counters, with per-cell hotkeys (via the shared hotkey window), optional keybind labels, active-ability highlighting, and a hotkey-press flash - [P.R 812](https://github.com/PlayTazUO/TazUO/pull/812) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
+* Removed the Camera Smoothing option; the camera now always stays locked on the player (the smoothing effect caused the camera to lag behind the player) ([bittiez](https://github.com/bittiez))
 * Hotkey input window doesn't loose keys when releasing them ([bittiez](https://github.com/bittiez))
 * Fixed a journal crash (`InvalidOperation_EnumFailedVersion`) caused by a race while checking the top-most gump for inactive transparency - [P.R 822](https://github.com/PlayTazUO/TazUO/pull/822) ([bittiez](https://github.com/bittiez))
 * Fixed several bandage agent bugs: a client crash from the retry timer touching game state off the main thread, a duplicate bandage in "check for buff" mode, a stuck bandaging buff that could disable healing, and the retry timer spinning indefinitely for un-healable targets - [P.R 826](https://github.com/PlayTazUO/TazUO/pull/826) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.20.8</AssemblyVersion>
-    <FileVersion>5.20.8</FileVersion>
+    <AssemblyVersion>5.20.9</AssemblyVersion>
+    <FileVersion>5.20.9</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -882,10 +882,6 @@ namespace ClassicUO.Configuration
         public Point PlayerOffset { get; set => SetProperty(ref field, value); } = new Point(0, 0);
 
         [Obsolete]
-        [JsonPropertyName("camera_smoothing_factor")]
-        public float OldCameraSmoothingFactor { get; set => SetProperty(ref field, value); } = 0f;
-
-        [Obsolete]
         [JsonPropertyName("paperdoll_scale")]
         public double OldPaperdollScale { get; set => SetProperty(ref field, value); } = 1f;
 
@@ -1187,7 +1183,6 @@ namespace ClassicUO.Configuration
                 DisableTargetingGridContainers = OldDisableTargetingGridContainers;
                 BuyAgentSubContainers = OldBuyAgentSubContainers;
                 PaperdollScale = OldPaperdollScale;
-                CameraSmoothingFactor = OldCameraSmoothingFactor;
                 HideLayersForSelf = OldHideLayersForSelf;
                 HiddenLayersEnabled = OldHiddenLayersEnabled;
                 DisableMouseInteractionOverheadText = OldDisableMouseInteractionOverheadText;

--- a/src/ClassicUO.Client/Configuration/SqlProfile.cs
+++ b/src/ClassicUO.Client/Configuration/SqlProfile.cs
@@ -331,10 +331,6 @@ public sealed partial class Profile
         public partial double PaperdollScale { get; set; }
 
         [JsonIgnore]
-        [SqlSetting(SettingsScope.Global, "camera_smoothing_factor", 0f)]
-        public partial float CameraSmoothingFactor { get; set; }
-
-        [JsonIgnore]
         [SqlSetting(SettingsScope.Global, "hide_layers_for_self", true)]
         public partial bool HideLayersForSelf { get; set; }
 

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -727,8 +727,6 @@ profileeditor_cannotdeletebuiltinprofile=This profile is a built-in one and cann
 ; Assistant - general tab
 assistant_visualconfig=Visual Config
 assistant_delayconfig=Delay Config
-assistant_camerasmoothing=Camera smoothing
-assistant_camerasmoothing_tooltip=Smooth camera following when moving. 0 = instant (classic), 1 = very smooth/floaty.
 assistant_highlightgameobjects=Highlight game objects
 assistant_shownameplates=Show nameplates
 assistant_petscaling=Pet scaling

--- a/src/ClassicUO.Client/Game/Scenes/GameSceneDrawingSorting.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameSceneDrawingSorting.cs
@@ -47,12 +47,6 @@ namespace ClassicUO.Game.Scenes
             _oldPlayerZ;
         private int _foliageCount;
 
-        // Smooth camera following
-        private Vector2 _currentSmoothedOffset = Vector2.Zero;
-        private int _smoothLastPlayerX = int.MinValue,
-            _smoothLastPlayerY = int.MinValue;
-
-
         private readonly List<GameObject> _renderListStatics = new List<GameObject>();
         private readonly List<GameObject> _renderListTransparentObjects = new List<GameObject>();
         private readonly List<GameObject> _renderListAnimations = new List<GameObject>();
@@ -1190,49 +1184,8 @@ namespace ClassicUO.Game.Scenes
             _maxPixel.X = maxPixelsX;
             _maxPixel.Y = maxPixelsY;
 
-            // Apply smooth camera interpolation
-            var targetOffset = new Vector2(winDrawOffsetX, winDrawOffsetY);
-            float smoothingFactor = ProfileManager.CurrentProfile.CameraSmoothingFactor;
-
-            // Detect a teleport (e.g. dungeon entrance/exit, recall, gate). A normal walk step
-            // never moves the player by more than one tile between updates, so anything larger
-            // must be an instant relocation. Snap the camera instead of panning across the map.
-            bool teleported =
-                _smoothLastPlayerX != int.MinValue
-                && (Math.Abs(_world.Player.X - _smoothLastPlayerX) > 1
-                    || Math.Abs(_world.Player.Y - _smoothLastPlayerY) > 1);
-
-            _smoothLastPlayerX = _world.Player.X;
-            _smoothLastPlayerY = _world.Player.Y;
-
-            if (smoothingFactor > 0f && !teleported)
-            {
-                // Calculate distance to target
-                float distance = Vector2.Distance(_currentSmoothedOffset, targetOffset);
-
-                if (distance > 0.5f)
-                {
-                    // Smooth interpolation with easing - similar to Camera.CalculatePeek()
-                    // Higher smoothing factor = slower camera movement (more smoothing)
-                    float lerpAmount = Math.Min(Time.Delta * (10f / smoothingFactor), 1f);
-                    _currentSmoothedOffset = Vector2.Lerp(_currentSmoothedOffset, targetOffset, lerpAmount);
-                }
-                else
-                {
-                    // Snap to target when very close to avoid jitter
-                    _currentSmoothedOffset = targetOffset;
-                }
-
-                _offset.X = (int)_currentSmoothedOffset.X;
-                _offset.Y = (int)_currentSmoothedOffset.Y;
-            }
-            else
-            {
-                // No smoothing - instant camera follow (classic behavior)
-                _currentSmoothedOffset = targetOffset;
-                _offset.X = winDrawOffsetX;
-                _offset.Y = winDrawOffsetY;
-            }
+            _offset.X = winDrawOffsetX;
+            _offset.Y = winDrawOffsetY;
 
             _last_scaled_offset.X = winGameScaledOffsetX;
             _last_scaled_offset.Y = winGameScaledOffsetY;

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/GeneralTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/GeneralTabContent.cs
@@ -28,10 +28,6 @@ public static class GeneralTabContent
         leftSide.Widgets.Add(new MyraLabel(TazLang.Get("assistant_visualconfig"), MyraLabel.TextStyle.H2));
         rightSide.Widgets.Add(new MyraLabel(TazLang.Get("assistant_delayconfig"), MyraLabel.TextStyle.H2));
 
-        leftSide.Widgets.Add(LabeledHorizontalSlider.SliderWithLabel(TazLang.Get("assistant_camerasmoothing"), out LabeledHorizontalSlider _cSmoothSlider, v => profile.CameraSmoothingFactor = v, 0, 1, profile.CameraSmoothingFactor));
-        _cSmoothSlider.RoundValues = false;
-        _cSmoothSlider.WheelStep = 0.1f;
-
         leftSide.Widgets.Add(MyraCheckButton.CreateWithCallback(profile.HighlightGameObjects, (b) => profile.HighlightGameObjects = b, TazLang.Get("assistant_highlightgameobjects")));
 
         leftSide.Widgets.Add(MyraCheckButton.CreateWithCallback(profile.NameOverheadToggled, (b) => profile.NameOverheadToggled = b, TazLang.Get("assistant_shownameplates")));


### PR DESCRIPTION
The Camera Smoothing effect interpolated the world draw offset behind the player, which made the camera visibly lag/trail the player. The camera effect was jarring and not really ideal, so remove the feature entirely:

- Drop the smoothing interpolation in GameSceneDrawingSorting.GetViewPort; the world offset now follows the player instantly (classic behavior).
- Remove the CameraSmoothingFactor SQL-backed setting and the obsolete OldCameraSmoothingFactor JSON property (and its migration assignment).
- Remove the Camera smoothing slider from the assistant General tab and the associated language strings.