### PR TITLE
Fix InvalidCastException in DelayedObjectClickManager.Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ All notable changes to TazUO will be recorded here.
 * Counter bar cells can now hold any spell bar action (spell, macro, weapon ability, script, or skill) in addition to item counters, with per-cell hotkeys (via the shared hotkey window), optional keybind labels, active-ability highlighting, and a hotkey-press flash - [P.R 812](https://github.com/PlayTazUO/TazUO/pull/812) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
-* Removed the Camera Smoothing option; the camera now always stays locked on the player (the smoothing effect caused the camera to lag behind the player) ([bittiez](https://github.com/bittiez))
+* Fixed InvalidCastException in DelayedObjectClickManager.Update - [P.R 831](https://github.com/PlayTazUO/TazUO/pull/831) ([bittiez](https://github.com/bittiez))
+* Removed the Camera Smoothing option; the camera now always stays locked on the player (the smoothing effect caused the camera to lag behind the player) - ([bittiez](https://github.com/bittiez))
 * Hotkey input window doesn't loose keys when releasing them ([bittiez](https://github.com/bittiez))
 * Fixed a journal crash (`InvalidOperation_EnumFailedVersion`) caused by a race while checking the top-most gump for inactive transparency - [P.R 822](https://github.com/PlayTazUO/TazUO/pull/822) ([bittiez](https://github.com/bittiez))
 * Fixed several bandage agent bugs: a client crash from the retry timer touching game state off the main thread, a duplicate bandage in "check for buff" mode, a stuck bandaging buff that could disable healing, and the retry timer spinning indefinitely for un-healable targets - [P.R 826](https://github.com/PlayTazUO/TazUO/pull/826) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.20.9</AssemblyVersion>
-    <FileVersion>5.20.9</FileVersion>
+    <AssemblyVersion>5.20.10</AssemblyVersion>
+    <FileVersion>5.20.10</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/Managers/DelayedObjectClickManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/DelayedObjectClickManager.cs
@@ -31,7 +31,7 @@ namespace ClassicUO.Game.Managers
 
             if (entity != null)
             {
-                if (!_world.ClientFeatures.TooltipsEnabled || SerialHelper.IsItem(Serial) && ((Item) entity).IsLocked && ((Item) entity).ItemData.Weight == 255 && !((Item) entity).ItemData.IsContainer)
+                if (!_world.ClientFeatures.TooltipsEnabled || (entity is Item item && item.IsLocked && item.ItemData.Weight == 255 && !item.ItemData.IsContainer))
                 {
                     GameActions.SingleClick(_world, Serial);
                 }


### PR DESCRIPTION
The click handler checked SerialHelper.IsItem(Serial), which only inspects the serial's numeric range, and then cast the resolved entity to Item. However World.Get() falls back to Mobiles.Get() when no item exists for a serial, so an item-range serial can resolve to a Mobile (e.g. a PlayerMobile), causing the cast to throw.

Replace the serial-range check with a runtime type check on the actual entity (entity is Item item) before accessing item-specific data.