### PR TITLE
Fix NullReferenceException in PartyInviteGump when inviter name is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to TazUO will be recorded here.
 * Counter bar cells can now hold any spell bar action (spell, macro, weapon ability, script, or skill) in addition to item counters, with per-cell hotkeys (via the shared hotkey window), optional keybind labels, active-ability highlighting, and a hotkey-press flash - [P.R 812](https://github.com/PlayTazUO/TazUO/pull/812) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
+* Fixed NullReferenceException in PartyInviteGump when inviter name is null - [P.R 832](https://github.com/PlayTazUO/TazUO/pull/832) ([bittiez](https://github.com/bittiez))
 * Fixed InvalidCastException in DelayedObjectClickManager.Update - [P.R 831](https://github.com/PlayTazUO/TazUO/pull/831) ([bittiez](https://github.com/bittiez))
 * Removed the Camera Smoothing option; the camera now always stays locked on the player (the smoothing effect caused the camera to lag behind the player) - ([bittiez](https://github.com/bittiez))
 * Hotkey input window doesn't loose keys when releasing them ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.20.10</AssemblyVersion>
-    <FileVersion>5.20.10</FileVersion>
+    <AssemblyVersion>5.20.11</AssemblyVersion>
+    <FileVersion>5.20.11</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Gumps/PartyInviteGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/PartyInviteGump.cs
@@ -16,7 +16,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             Mobile mobile = World.Mobiles.Get(inviter);
 
-            int nameWidthAdjustment = mobile == null || mobile.Name.Length < 10 ? 0 : mobile.Name.Length * 5;
+            int nameWidthAdjustment = mobile == null || string.IsNullOrEmpty(mobile.Name) || mobile.Name.Length < 10 ? 0 : mobile.Name.Length * 5;
 
             var partyGumpBackground = new AlphaBlendControl
             {


### PR DESCRIPTION
The constructor computed nameWidthAdjustment using mobile.Name.Length without guarding against a null Name. When a party invite arrives before the inviter mobile's name has been received from the server, mobile is non-null but mobile.Name is null, causing a NullReferenceException.

Guard the Length access with string.IsNullOrEmpty, matching the null-safe handling already used for the invite label below it.