### PR TITLE
Fix font atlas overflow crash from oversized font sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to TazUO will be recorded here.
 * Counter bar cells can now hold any spell bar action (spell, macro, weapon ability, script, or skill) in addition to item counters, with per-cell hotkeys (via the shared hotkey window), optional keybind labels, active-ability highlighting, and a hotkey-press flash - [P.R 812](https://github.com/PlayTazUO/TazUO/pull/812) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
+* Fixed a client crash from oversized font sizes overflowing the font texture atlas ("Could not add rect to the newly created atlas") - [P.R 834](https://github.com/PlayTazUO/TazUO/pull/834) ([bittiez](https://github.com/bittiez))
 * Fixed NullReferenceException in PartyInviteGump when inviter name is null - [P.R 832](https://github.com/PlayTazUO/TazUO/pull/832) ([bittiez](https://github.com/bittiez))
 * Fixed InvalidCastException in DelayedObjectClickManager.Update - [P.R 831](https://github.com/PlayTazUO/TazUO/pull/831) ([bittiez](https://github.com/bittiez))
 * Removed the Camera Smoothing option; the camera now always stays locked on the player (the smoothing effect caused the camera to lag behind the player) - ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Assets/TrueTypeLoader.cs
+++ b/src/ClassicUO.Assets/TrueTypeLoader.cs
@@ -88,6 +88,33 @@ public class TrueTypeLoader
 
     private const uint MAX_NUMBER_OF_SYS_FONT_FAMILIES = 1000;
 
+    /// <summary>
+    ///     The smallest font face size that can be requested.
+    /// </summary>
+    private const float MIN_FONT_SIZE = 1f;
+
+    /// <summary>
+    ///     The largest font face size that can be requested.
+    ///     FontStashSharp rasterizes each glyph onto a fixed-size texture atlas (1024x1024 by default). A font size that
+    ///     is too large produces a glyph that cannot fit onto a freshly created atlas, which makes FontStashSharp throw
+    ///     ("Could not add rect to the newly created atlas.") from inside its draw routine and crash the client.
+    ///     Real UI text never approaches this value, so clamping here is a safe guard against oversized sizes reaching
+    ///     the rasterizer (whether from code or from a rich-text '/f[font, size]' command).
+    /// </summary>
+    private const float MAX_FONT_SIZE = 200f;
+
+    /// <summary>
+    ///     Clamps a requested font size to a range the texture atlas can safely rasterize.
+    ///     Also normalizes NaN/Infinity values that would otherwise reach the rasterizer.
+    /// </summary>
+    private static float ClampFontSize(float size)
+    {
+        if (float.IsNaN(size))
+            return MIN_FONT_SIZE;
+
+        return Math.Clamp(size, MIN_FONT_SIZE, MAX_FONT_SIZE);
+    }
+
     private readonly Dictionary<string, FontSystem> _fonts = new();
 
     private (string[], int)? _orderedFontNames;
@@ -467,6 +494,11 @@ public class TrueTypeLoader
     /// </returns>
     public SpriteFontBase GetFont(string name, float size)
     {
+        // Keep the size within a range the atlas can rasterize. This is the single choke point for every font
+        // request (direct calls and rich-text '/f[font, size]' commands), so an oversized value can never reach
+        // FontStashSharp and crash the client when it fails to fit the glyph onto a new atlas.
+        size = ClampFontSize(size);
+
         // A null or empty name can't be looked up (Dictionary.TryGetValue throws on a null key),
         // so skip straight to the fallback font below.
         if (!string.IsNullOrEmpty(name))

--- a/src/ClassicUO.Assets/TrueTypeLoader.cs
+++ b/src/ClassicUO.Assets/TrueTypeLoader.cs
@@ -88,25 +88,12 @@ public class TrueTypeLoader
 
     private const uint MAX_NUMBER_OF_SYS_FONT_FAMILIES = 1000;
 
-    /// <summary>
-    ///     The smallest font face size that can be requested.
-    /// </summary>
     private const float MIN_FONT_SIZE = 1f;
 
-    /// <summary>
-    ///     The largest font face size that can be requested.
-    ///     FontStashSharp rasterizes each glyph onto a fixed-size texture atlas (1024x1024 by default). A font size that
-    ///     is too large produces a glyph that cannot fit onto a freshly created atlas, which makes FontStashSharp throw
-    ///     ("Could not add rect to the newly created atlas.") from inside its draw routine and crash the client.
-    ///     Real UI text never approaches this value, so clamping here is a safe guard against oversized sizes reaching
-    ///     the rasterizer (whether from code or from a rich-text '/f[font, size]' command).
-    /// </summary>
+    // Oversized sizes produce glyphs too big for FontStashSharp's fixed 1024x1024 atlas, which crashes the client; real UI text never approaches this.
     private const float MAX_FONT_SIZE = 200f;
 
-    /// <summary>
-    ///     Clamps a requested font size to a range the texture atlas can safely rasterize.
-    ///     Also normalizes NaN/Infinity values that would otherwise reach the rasterizer.
-    /// </summary>
+    // Clamps a requested font size to a range the atlas can rasterize, normalizing NaN.
     private static float ClampFontSize(float size)
     {
         if (float.IsNaN(size))
@@ -494,9 +481,7 @@ public class TrueTypeLoader
     /// </returns>
     public SpriteFontBase GetFont(string name, float size)
     {
-        // Keep the size within a range the atlas can rasterize. This is the single choke point for every font
-        // request (direct calls and rich-text '/f[font, size]' commands), so an oversized value can never reach
-        // FontStashSharp and crash the client when it fails to fit the glyph onto a new atlas.
+        // Single choke point for all font requests (incl. rich-text '/f[font, size]'); clamp so an oversized value can't crash the atlas.
         size = ClampFontSize(size);
 
         // A null or empty name can't be looked up (Dictionary.TryGetValue throws on a null key),

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.20.12</AssemblyVersion>
-    <FileVersion>5.20.12</FileVersion>
+    <AssemblyVersion>5.20.13</AssemblyVersion>
+    <FileVersion>5.20.13</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Controls/TextBox.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/TextBox.cs
@@ -446,9 +446,7 @@ namespace ClassicUO.Game.UI.Controls
             }
             catch (System.Exception e)
             {
-                // Glyphs are rasterized onto the font atlas lazily during Draw, so a glyph that cannot fit
-                // (e.g. an oversized font) throws here rather than while the layout was created. Swallow it so a
-                // single bad TextBox can't crash the whole client, and stop retrying to avoid per-frame exceptions.
+                // Glyphs rasterize lazily here, so an unfittable glyph throws at draw time; skip it instead of crashing and stop retrying.
                 _drawFailed = true;
                 Log.Error($"Failed to draw TextBox text, it will be skipped. [{_font}:{_size}] - {e.Message}");
                 return false;

--- a/src/ClassicUO.Client/Game/UI/Controls/TextBox.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/TextBox.cs
@@ -52,6 +52,7 @@ namespace ClassicUO.Game.UI.Controls
         private float _size;
         private Color _color;
         private bool _dirty = false;
+        private bool _drawFailed = false;
 
         private int getStrokeSize
         {
@@ -127,6 +128,7 @@ namespace ClassicUO.Game.UI.Controls
                 text = StringHelper.RemoveUnpairedSurrogates(text); //Lone surrogates crash FontStashSharp's text measuring
                 _dirty = false;         //Reset these because we're creating a new text object
                 WantUpdateSize = false; //Not resetting them causes this to happen twice from the constructor setting _font and what not.
+                _drawFailed = false;    //New layout gets a fresh chance to draw
 
                 if (Options == null)
                 {
@@ -327,6 +329,7 @@ namespace ClassicUO.Game.UI.Controls
             Options = null;
             Alpha = 1f;
             _dirty = false;
+            _drawFailed = false;
             WantUpdateSize = false;
         }
 
@@ -423,7 +426,7 @@ namespace ClassicUO.Game.UI.Controls
 
         public bool Draw(UltimaBatcher2D batcher, int x, int y, Color color, float depth = 0f)
         {
-            if (IsDisposed)
+            if (IsDisposed || _drawFailed)
             {
                 return false;
             }
@@ -437,7 +440,19 @@ namespace ClassicUO.Game.UI.Controls
                 x += Width;
             }
 
-            _rtl.Draw(batcher, new Vector2(x, y), color * Alpha, horizontalAlignment: Options.Align, layerDepth: depth);
+            try
+            {
+                _rtl.Draw(batcher, new Vector2(x, y), color * Alpha, horizontalAlignment: Options.Align, layerDepth: depth);
+            }
+            catch (System.Exception e)
+            {
+                // Glyphs are rasterized onto the font atlas lazily during Draw, so a glyph that cannot fit
+                // (e.g. an oversized font) throws here rather than while the layout was created. Swallow it so a
+                // single bad TextBox can't crash the whole client, and stop retrying to avoid per-frame exceptions.
+                _drawFailed = true;
+                Log.Error($"Failed to draw TextBox text, it will be skipped. [{_font}:{_size}] - {e.Message}");
+                return false;
+            }
 
             return true;
         }


### PR DESCRIPTION
An oversized font size produced a glyph too large to fit onto FontStashSharp's fixed 1024x1024 texture atlas, causing it to throw 'Could not add rect to the newly created atlas' from inside its draw routine and crash the entire client.

Clamp requested font sizes to a safe range in TrueTypeLoader.GetFont, the single choke point every font request passes through (including rich-text '/f[font, size]' commands). As defense-in-depth, guard TextBox.Draw so a glyph that still fails to rasterize is skipped and logged instead of crashing the client, since glyphs are rasterized lazily at draw time after the layout is created.
