### PR TITLE
Fix NullReferenceException in Chunk.Destroy when Node is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to TazUO will be recorded here.
 * Counter bar cells can now hold any spell bar action (spell, macro, weapon ability, script, or skill) in addition to item counters, with per-cell hotkeys (via the shared hotkey window), optional keybind labels, active-ability highlighting, and a hotkey-press flash - [P.R 812](https://github.com/PlayTazUO/TazUO/pull/812) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
+* Fixed NullReferenceException in Chunk.Destroy when Node is null - [P.R 835](https://github.com/PlayTazUO/TazUO/pull/835) ([bittiez](https://github.com/bittiez))
 * Fixed a client crash from oversized font sizes overflowing the font texture atlas ("Could not add rect to the newly created atlas") - [P.R 834](https://github.com/PlayTazUO/TazUO/pull/834) ([bittiez](https://github.com/bittiez))
 * Better light handling for lights under ground - [P.R 825](https://github.com/PlayTazUO/TazUO/pull/825) ([bittiez](https://github.com/bittiez))
 * Fixed NullReferenceException in PartyInviteGump when inviter name is null - [P.R 832](https://github.com/PlayTazUO/TazUO/pull/832) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.20.13</AssemblyVersion>
-    <FileVersion>5.20.13</FileVersion>
+    <AssemblyVersion>5.20.14</AssemblyVersion>
+    <FileVersion>5.20.14</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/Map/Chunk.cs
+++ b/src/ClassicUO.Client/Game/Map/Chunk.cs
@@ -492,7 +492,7 @@ namespace ClassicUO.Game.Map
                 }
             }
 
-            if (Node.Next != null || Node.Previous != null)
+            if (Node != null && (Node.Next != null || Node.Previous != null))
             {
                 Node.List?.Remove(Node);
             }
@@ -534,7 +534,7 @@ namespace ClassicUO.Game.Map
                 }
             }
 
-            if (Node.Next != null || Node.Previous != null)
+            if (Node != null && (Node.Next != null || Node.Previous != null))
             {
                 Node.List?.Remove(Node);
             }


### PR DESCRIPTION
Chunk.Destroy() and Chunk.Clear() dereferenced the Node field (Node.Next / Node.Previous) without a null check. A Chunk created via the async load path (Chunk.Create in Map.AsyncGetChunk) only gets its Node assigned once ProcessLoadedChunks places it into _terrainChunks. A chunk that is discarded before being placed still has a null Node, so destroying it threw a NullReferenceException from ProcessLoadedChunks -> PreloadChunk2 during FillGameObjectList/DrawWorld.

Guard both accesses with a Node != null check, matching the existing null-safe handling in Map.GetChunk2.