### PR TITLE
Guard remaining LegionAPI/ApiUiGump methods with OnMain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to TazUO will be recorded here.
 * Counter bar cells can now hold any spell bar action (spell, macro, weapon ability, script, or skill) in addition to item counters, with per-cell hotkeys (via the shared hotkey window), optional keybind labels, active-ability highlighting, and a hotkey-press flash - [P.R 812](https://github.com/PlayTazUO/TazUO/pull/812) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
+* Guarded the remaining LegionAPI/ApiUiGump methods that touched the game world, UI manager, or gump controls off the main thread, fixing a double-free malloc crash caused by Legion scripts racing with the main thread - [P.R 836](https://github.com/PlayTazUO/TazUO/pull/836) ([bittiez](https://github.com/bittiez))
 * Fixed NullReferenceException in Chunk.Destroy when Node is null - [P.R 835](https://github.com/PlayTazUO/TazUO/pull/835) ([bittiez](https://github.com/bittiez))
 * Fixed a client crash from oversized font sizes overflowing the font texture atlas ("Could not add rect to the newly created atlas") - [P.R 834](https://github.com/PlayTazUO/TazUO/pull/834) ([bittiez](https://github.com/bittiez))
 * Better light handling for lights under ground - [P.R 825](https://github.com/PlayTazUO/TazUO/pull/825) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.20.14</AssemblyVersion>
-    <FileVersion>5.20.14</FileVersion>
+    <AssemblyVersion>5.20.15</AssemblyVersion>
+    <FileVersion>5.20.15</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiGump.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiUiGump.cs
@@ -31,22 +31,23 @@ public class ApiUiGump(LegionAPI api)
     /// <param name="canMove">Allow the player to move this gump</param>
     /// <param name="keepOpen">If true, the gump won't be closed if the script stops. Otherwise, it will be closed when the script is stopped. Defaults to false.</param>
     /// <returns>A new, empty gump</returns>
-    public ApiUiBaseGump CreateGump(bool acceptMouseInput = true, bool canMove = true, bool keepOpen = false)
-    {
-        var g = new Gump(api.World, 0, 0)
+    public ApiUiBaseGump CreateGump(bool acceptMouseInput = true, bool canMove = true, bool keepOpen = false) =>
+        OnMain(() =>
         {
-            AcceptMouseInput = acceptMouseInput,
-            CanMove = canMove,
-            WantUpdateSize = true
-        };
+            var g = new Gump(api.World, 0, 0)
+            {
+                AcceptMouseInput = acceptMouseInput,
+                CanMove = canMove,
+                WantUpdateSize = true
+            };
 
-        ApiUiBaseGump apiUiGump = new(g);
+            ApiUiBaseGump apiUiGump = new(g);
 
-        if (!keepOpen)
-            api._gumps.Add(g);
+            if (!keepOpen)
+                api._gumps.Add(g);
 
-        return apiUiGump;
-    }
+            return apiUiGump;
+        });
 
     /// <summary>
     /// Creates a modern nine-slice gump using ModernUIConstants for consistent styling.

--- a/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionAPI.cs
@@ -1339,7 +1339,7 @@ namespace ClassicUO.LegionScripting
         /// <param name="name">The name of the organizer configuration to run</param>
         /// <param name="source">Optional serial of the source container (0 for default)</param>
         /// <param name="destination">Optional serial of the destination container (0 for default)</param>
-        public void Organizer(string name, uint source = 0, uint destination = 0)
+        public void Organizer(string name, uint source = 0, uint destination = 0) => OnMain(() =>
         {
             if (string.IsNullOrEmpty(name))
             {
@@ -1348,13 +1348,13 @@ namespace ClassicUO.LegionScripting
             }
 
             OrganizerAgent.Instance.RunOrganizer(name, source, destination);
-        }
+        });
 
         /// <summary>
         /// Executes a client command as if typed in the game console
         /// </summary>
         /// <param name="command">The command to execute (including any arguments)</param>
-        public void ClientCommand(string command)
+        public void ClientCommand(string command) => OnMain(() =>
         {
             if (string.IsNullOrEmpty(command))
             {
@@ -1365,7 +1365,7 @@ namespace ClassicUO.LegionScripting
             string[] split = command.Split(' ');
 
             World.Instance.CommandManager.Execute(split[0], split);
-        }
+        });
 
         /// <summary>
         /// Check if a buff is active.
@@ -3035,7 +3035,7 @@ namespace ClassicUO.LegionScripting
         /// </summary>
         /// <param name="ID">Gump ID, blank to use the last gump.</param>
         /// <returns></returns>
-        public string GetGumpContents(uint ID = uint.MaxValue)
+        public string GetGumpContents(uint ID = uint.MaxValue) => OnMain(() =>
         {
             if (World.Player == null)
                 return string.Empty;
@@ -3056,7 +3056,7 @@ namespace ClassicUO.LegionScripting
             }
 
             return allControlsText;
-        }
+        });
 
         /// <summary>
         /// Get a gump by ID.
@@ -3105,13 +3105,13 @@ namespace ClassicUO.LegionScripting
         /// <returns></returns>
         public bool WaitForGump(uint ID = uint.MaxValue, double delay = 5)
         {
-            if (World.Player == null)
+            if (OnMain(() => World.Player) == null)
                 return false;
 
             DateTime expire = DateTime.UtcNow.AddSeconds(delay);
 
             if (ID == uint.MaxValue)
-                ID = World.Player.LastGumpID;
+                ID = OnMain(() => World.Player.LastGumpID);
 
             while (!OnMain(() => UIManager.GetGumpServer(ID) != null) && !StopRequested)
             {
@@ -3184,7 +3184,7 @@ namespace ClassicUO.LegionScripting
         /// ```
         /// </summary>
         /// <returns>true/false</returns>
-        public bool PrimaryAbilityActive() => World.Player != null && ((byte)World.Player.PrimaryAbility & 0x80) != 0;
+        public bool PrimaryAbilityActive() => OnMain(() => World.Player != null && ((byte)World.Player.PrimaryAbility & 0x80) != 0);
 
         /// <summary>
         /// Check if your secondary ability is active.
@@ -3195,7 +3195,7 @@ namespace ClassicUO.LegionScripting
         /// ```
         /// </summary>
         /// <returns>true/false</returns>
-        public bool SecondaryAbilityActive() => World.Player != null && ((byte)World.Player.SecondaryAbility & 0x80) != 0;
+        public bool SecondaryAbilityActive() => OnMain(() => World.Player != null && ((byte)World.Player.SecondaryAbility & 0x80) != 0);
 
         /// <summary>
         /// Gets your currently available ability names.
@@ -3203,13 +3203,13 @@ namespace ClassicUO.LegionScripting
         /// The full list of known abilities can be obtained via the `KnownAbilityNames` API
         /// </summary>
         /// <returns>The returned array will be [PrimaryAbility, SecondaryAbility] or an empty array if no ability is available</returns>
-        public string[] CurrentAbilityNames()
+        public string[] CurrentAbilityNames() => OnMain<string[]>(() =>
         {
             if (World?.Player == null)
                 return [];
 
             return [World.Player.PrimaryAbility.GetName(), World.Player.SecondaryAbility.GetName()];
-        }
+        });
 
         /// <summary>
         /// Gets an array of all known ability names
@@ -4092,7 +4092,7 @@ namespace ClassicUO.LegionScripting
         /// <summary>
         /// Use API.Gumps.CreateModernGump instead.
         /// </summary>
-        public ApiUiNineSliceGump CreateModernGump(int x, int y, int width, int height, bool resizable = true, int minWidth = 50, int minHeight = 50, object onResized = null) => new ApiUiNineSliceGump(this, x, y, width, height, resizable, minWidth, minHeight, onResized);
+        public ApiUiNineSliceGump CreateModernGump(int x, int y, int width, int height, bool resizable = true, int minWidth = 50, int minHeight = 50, object onResized = null) => Gumps.CreateModernGump(x, y, width, height, resizable, minWidth, minHeight, onResized);
         /// <summary>
         /// Use API.Gumps.AddControlOnClick instead.
         /// </summary>
@@ -4395,7 +4395,7 @@ namespace ClassicUO.LegionScripting
         {
             if (string.IsNullOrEmpty(name))
             {
-                GameActions.Print(World, "Var's must have a name.", 32);
+                OnMain(() => GameActions.Print(World, "Var's must have a name.", 32));
                 return;
             }
 
@@ -4415,7 +4415,7 @@ namespace ClassicUO.LegionScripting
         {
             if (string.IsNullOrEmpty(name))
             {
-                GameActions.Print(World, "Var's must have a name.", 32);
+                OnMain(() => GameActions.Print(World, "Var's must have a name.", 32));
                 return;
             }
 
@@ -4436,7 +4436,7 @@ namespace ClassicUO.LegionScripting
         {
             if (string.IsNullOrEmpty(name))
             {
-                GameActions.Print(World, "Var's must have a name.", 32);
+                OnMain(() => GameActions.Print(World, "Var's must have a name.", 32));
                 return defaultValue;
             }
 


### PR DESCRIPTION
Legion scripts run on a background thread, so any access to the game world, UI manager, or gump controls must be marshalled to the main thread. Several methods were touching main-thread-only state directly, which could race with the main thread's rendering/disposal and corrupt native resources (observed as a double-free malloc crash).

Wrap the remaining unprotected methods in OnMain:
- ApiUiGump.CreateGump: constructed a Gump off-thread.
- Organizer / ClientCommand: ran agent/command logic off-thread.
- GetGumpContents: iterated a gump's children off-thread.
- WaitForGump: read World.Player off-thread before the wait loop.
- PrimaryAbilityActive / SecondaryAbilityActive / CurrentAbilityNames: read World.Player off-thread.
- Save/Remove/GetPersistentVar: called GameActions.Print off-thread.
- Deprecated CreateModernGump: constructed the gump off-thread; now delegates to the OnMain-guarded Gumps.CreateModernGump.