### PR TITLE
Refocus system chat when the game viewport is clicked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to TazUO will be recorded here.
 * Counter bar cells can now hold any spell bar action (spell, macro, weapon ability, script, or skill) in addition to item counters, with per-cell hotkeys (via the shared hotkey window), optional keybind labels, active-ability highlighting, and a hotkey-press flash - [P.R 812](https://github.com/PlayTazUO/TazUO/pull/812) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
+* Fixed unexpected behaviour when clicking outside of an input field - [P.R 837](https://github.com/PlayTazUO/TazUO/pull/837) ([bittiez](https://github.com/bittiez))
 * Fixed mobile names not being drawn at the edge of the screen for off-screen mobiles - [P.R 838](https://github.com/PlayTazUO/TazUO/pull/838) ([bittiez](https://github.com/bittiez))
 * Added a suggested crash fix for "Bad uop file" errors, explaining that a `.uop` data file is corrupt, truncated, or mid-patch and how to resolve it - [P.R 841](https://github.com/PlayTazUO/TazUO/pull/841) ([bittiez](https://github.com/bittiez))
 * Guarded the remaining LegionAPI/ApiUiGump methods that touched the game world, UI manager, or gump controls off the main thread, fixing a double-free malloc crash caused by Legion scripts racing with the main thread - [P.R 836](https://github.com/PlayTazUO/TazUO/pull/836) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.20.18</AssemblyVersion>
-    <FileVersion>5.20.18</FileVersion>
+    <AssemblyVersion>5.20.19</AssemblyVersion>
+    <FileVersion>5.20.19</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/Managers/UIManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/UIManager.cs
@@ -209,8 +209,21 @@ namespace ClassicUO.Game.Managers
                 return;
             }
 
+            IGui previousFocus = KeyboardFocusControl;
+
             KeyboardFocusControl = null;
             chat.SetFocus();
+
+            // Setting KeyboardFocusControl above fired OnFocusLost on the field we just left, clearing its
+            // IsFocused flag. The mouse-focus tracker (_lastFocus) is separate and, on a world/background
+            // click, still points at that field. Left as-is, the "_lastFocus != control" guard in
+            // OnMouseButtonDown skips OnFocusEnter the next time the field is clicked, so it becomes
+            // keyboard-focused but stays visually unfocused (e.g. a search box keeps showing its
+            // placeholder text). Clear the tracker so re-clicking the field re-runs OnFocusEnter.
+            if (_lastFocus == previousFocus)
+            {
+                _lastFocus = null;
+            }
         }
 
         /// <summary>

--- a/src/ClassicUO.Client/Game/Managers/UIManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/UIManager.cs
@@ -193,10 +193,11 @@ namespace ClassicUO.Game.Managers
         }
 
         /// <summary>
-        /// Moves keyboard focus off any non-chat input field (search boxes, Myra windows, etc.) and
-        /// hands it back to the system chat when the game world or empty background is clicked. When
-        /// chat input is inactive/disabled, focus is simply cleared so nothing keeps capturing
-        /// keystrokes. Lets the player click away from a text field instead of pressing Esc or clicking chat.
+        /// Moves keyboard focus off any non-chat input field (search boxes, rename fields, etc.) and
+        /// hands it back to the system chat when the player clicks away from it - the game world, the
+        /// empty background, or a different gump. When chat input is inactive/disabled, focus is simply
+        /// cleared so nothing keeps capturing keystrokes. Lets the player click away from a text field
+        /// instead of pressing Esc or clicking chat.
         /// </summary>
         public static void RestoreSystemChatFocus()
         {
@@ -211,6 +212,12 @@ namespace ClassicUO.Game.Managers
             KeyboardFocusControl = null;
             chat.SetFocus();
         }
+
+        /// <summary>
+        /// Returns the top-level gump that owns a control (the control itself when it is already
+        /// top-level). Used to tell whether a click landed in the same window as the focused input.
+        /// </summary>
+        private static IGui GetOwningGump(IGui control) => control?.RootParent ?? control;
 
         public static void OnMouseButtonDown(MouseButtonType button)
         {
@@ -234,6 +241,14 @@ namespace ClassicUO.Game.Managers
                 if (MouseOverControl.AcceptKeyboardInput)
                 {
                     _keyboardFocusControl = MouseOverControl;
+                }
+                else if (button == MouseButtonType.Left && !IsModalOpen && _keyboardFocusControl != null
+                         && GetOwningGump(_keyboardFocusControl) != GetOwningGump(MouseOverControl))
+                {
+                    // Clicked a different gump than the one that owns the focused input field (search
+                    // boxes, rename fields, etc.), so release it back to the system chat - same as a
+                    // world/background click. Clicks inside the field's own gump keep it focused.
+                    RestoreSystemChatFocus();
                 }
 
                 _mouseDownControls[(int)button] = MouseOverControl;

--- a/src/ClassicUO.Client/Game/Managers/UIManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/UIManager.cs
@@ -192,6 +192,26 @@ namespace ClassicUO.Game.Managers
             }
         }
 
+        /// <summary>
+        /// Moves keyboard focus off any non-chat input field (search boxes, Myra windows, etc.) and
+        /// hands it back to the system chat when the game world or empty background is clicked. When
+        /// chat input is inactive/disabled, focus is simply cleared so nothing keeps capturing
+        /// keystrokes. Lets the player click away from a text field instead of pressing Esc or clicking chat.
+        /// </summary>
+        public static void RestoreSystemChatFocus()
+        {
+            SystemChatControl chat = SystemChat;
+
+            // Already resting on the chat input (or chat doesn't exist) - nothing to steal focus from.
+            if (chat == null || KeyboardFocusControl == chat.TextBoxControl)
+            {
+                return;
+            }
+
+            KeyboardFocusControl = null;
+            chat.SetFocus();
+        }
+
         public static void OnMouseButtonDown(MouseButtonType button)
         {
             HandleMouseInput();
@@ -220,6 +240,14 @@ namespace ClassicUO.Game.Managers
             }
             else
             {
+                // Clicking empty background (no control, and not the game world - that path never
+                // reaches here) should drop keyboard focus from other inputs, same as a world click.
+                // Skip while a modal is open so we don't steal focus from a modal that captures input.
+                if (button == MouseButtonType.Left && !IsModalOpen)
+                {
+                    RestoreSystemChatFocus();
+                }
+
                 foreach (IGui s in Gumps)
                 {
                     if (s.IsModal && s.ModalClickOutsideAreaClosesThisControl)

--- a/src/ClassicUO.Client/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameSceneInputHandler.cs
@@ -423,26 +423,6 @@ namespace ClassicUO.Game.Scenes
             return false;
         }
 
-        /// <summary>
-        /// Pulls keyboard focus away from any other input field (search boxes, Myra windows, etc.)
-        /// when the game world is clicked and hands it back to the system chat. When chat input is
-        /// inactive/disabled, focus is simply cleared so nothing keeps capturing keystrokes. This lets
-        /// the player click the game to escape a text field instead of having to press Esc or click chat.
-        /// </summary>
-        private static void RestoreFocusFromWorldClick()
-        {
-            SystemChatControl chat = UIManager.SystemChat;
-
-            // Already resting on the chat input (or chat doesn't exist) - nothing to steal focus from.
-            if (chat == null || UIManager.KeyboardFocusControl == chat.TextBoxControl)
-            {
-                return;
-            }
-
-            UIManager.KeyboardFocusControl = null;
-            chat.SetFocus();
-        }
-
         private bool OnLeftMouseDown()
         {
             if (
@@ -460,7 +440,7 @@ namespace ClassicUO.Game.Scenes
 
             // Drop focus from other inputs the instant the world is pressed, not just on release,
             // so a press-and-hold (e.g. hold-to-walk) also releases the previously focused field.
-            RestoreFocusFromWorldClick();
+            UIManager.RestoreSystemChatFocus();
 
             if (_world.CustomHouseManager != null)
             {
@@ -564,7 +544,7 @@ namespace ClassicUO.Game.Scenes
                 return false;
             }
 
-            RestoreFocusFromWorldClick();
+            UIManager.RestoreSystemChatFocus();
 
             if (!ProfileManager.CurrentProfile.DisableAutoMove && _rightMousePressed)
             {

--- a/src/ClassicUO.Client/Game/Scenes/GameSceneInputHandler.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameSceneInputHandler.cs
@@ -423,6 +423,26 @@ namespace ClassicUO.Game.Scenes
             return false;
         }
 
+        /// <summary>
+        /// Pulls keyboard focus away from any other input field (search boxes, Myra windows, etc.)
+        /// when the game world is clicked and hands it back to the system chat. When chat input is
+        /// inactive/disabled, focus is simply cleared so nothing keeps capturing keystrokes. This lets
+        /// the player click the game to escape a text field instead of having to press Esc or click chat.
+        /// </summary>
+        private static void RestoreFocusFromWorldClick()
+        {
+            SystemChatControl chat = UIManager.SystemChat;
+
+            // Already resting on the chat input (or chat doesn't exist) - nothing to steal focus from.
+            if (chat == null || UIManager.KeyboardFocusControl == chat.TextBoxControl)
+            {
+                return;
+            }
+
+            UIManager.KeyboardFocusControl = null;
+            chat.SetFocus();
+        }
+
         private bool OnLeftMouseDown()
         {
             if (
@@ -437,6 +457,10 @@ namespace ClassicUO.Game.Scenes
             {
                 return false;
             }
+
+            // Drop focus from other inputs the instant the world is pressed, not just on release,
+            // so a press-and-hold (e.g. hold-to-walk) also releases the previously focused field.
+            RestoreFocusFromWorldClick();
 
             if (_world.CustomHouseManager != null)
             {
@@ -540,11 +564,7 @@ namespace ClassicUO.Game.Scenes
                 return false;
             }
 
-            if (UIManager.SystemChat != null && !UIManager.SystemChat.IsFocused)
-            {
-                UIManager.KeyboardFocusControl = null;
-                UIManager.SystemChat.SetFocus();
-            }
+            RestoreFocusFromWorldClick();
 
             if (!ProfileManager.CurrentProfile.DisableAutoMove && _rightMousePressed)
             {


### PR DESCRIPTION
Clicking the game world now pulls keyboard focus away from any other input field (search boxes, Myra windows, etc.) and hands it back to the system chat, or clears focus entirely when chat input is inactive/disabled. Previously the only ways to leave a non-chat field were pressing Esc or clicking the chat box.

Focus is now dropped on mouse-down (not just release) so a press-and-hold on the world - e.g. hold-to-walk - also releases the previously focused field. The restore logic is extracted into a shared helper and the no-op SystemChat.IsFocused guard (the container's IsFocused is never set) is replaced with a correct check against the chat text box.