### PR TITLE
Keep overhead names anchored above the mobile at screen edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to TazUO will be recorded here.
 * Counter bar cells can now hold any spell bar action (spell, macro, weapon ability, script, or skill) in addition to item counters, with per-cell hotkeys (via the shared hotkey window), optional keybind labels, active-ability highlighting, and a hotkey-press flash - [P.R 812](https://github.com/PlayTazUO/TazUO/pull/812) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
+* Fixed mobile names not being drawn at the edge of the screen for off-screen mobiles - [P.R 838](https://github.com/PlayTazUO/TazUO/pull/838) ([bittiez](https://github.com/bittiez))
 * Added a suggested crash fix for "Bad uop file" errors, explaining that a `.uop` data file is corrupt, truncated, or mid-patch and how to resolve it - [P.R 841](https://github.com/PlayTazUO/TazUO/pull/841) ([bittiez](https://github.com/bittiez))
 * Guarded the remaining LegionAPI/ApiUiGump methods that touched the game world, UI manager, or gump controls off the main thread, fixing a double-free malloc crash caused by Legion scripts racing with the main thread - [P.R 836](https://github.com/PlayTazUO/TazUO/pull/836) ([bittiez](https://github.com/bittiez))
 * Fixed NullReferenceException in Chunk.Destroy when Node is null - [P.R 835](https://github.com/PlayTazUO/TazUO/pull/835) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.20.17</AssemblyVersion>
-    <FileVersion>5.20.17</FileVersion>
+    <AssemblyVersion>5.20.18</AssemblyVersion>
+    <FileVersion>5.20.18</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/GameObjects/GameObject.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/GameObject.cs
@@ -300,10 +300,6 @@ namespace ClassicUO.Game.GameObjects
                     continue;
                 }
 
-                // The overhead box is a fixed, wide, centre-aligned box, so the visible text sits
-                // in the middle of it. Clamp the visible text's real edges (not the whole box) to
-                // the screen so the name stays fully on screen while being drawn at the edge
-                // closest to the object, instead of drifting toward the middle of the screen.
                 int textWidth = item.TextBox.MeasuredSize.X;
                 int startX = item.RealScreenPosition.X + ((item.TextBox.Width - textWidth) >> 1);
                 int endX = startX + textWidth;

--- a/src/ClassicUO.Client/Game/GameObjects/GameObject.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/GameObject.cs
@@ -285,7 +285,7 @@ namespace ClassicUO.Game.GameObjects
             int offsetY = 0;
 
             int minX = 6;
-            int maxX = minX + Client.Game.Scene.Camera.Bounds.Width - 6;
+            int maxX = Client.Game.Scene.Camera.Bounds.Width - 6;
             int minY = 0;
             //int maxY = minY + ProfileManager.CurrentProfile.GameWindowSize.Y - 6;
 
@@ -300,15 +300,19 @@ namespace ClassicUO.Game.GameObjects
                     continue;
                 }
 
-                int startX = item.RealScreenPosition.X;
-                int endX = startX + item.TextBox.Width;
+                // The overhead box is a fixed, wide, centre-aligned box, so the visible text sits
+                // in the middle of it. Clamp the visible text's real edges (not the whole box) to
+                // the screen so the name stays fully on screen while being drawn at the edge
+                // closest to the object, instead of drifting toward the middle of the screen.
+                int textWidth = item.TextBox.MeasuredSize.X;
+                int startX = item.RealScreenPosition.X + ((item.TextBox.Width - textWidth) >> 1);
+                int endX = startX + textWidth;
 
                 if (startX < minX)
                 {
                     item.RealScreenPosition.X += minX - startX;
                 }
-
-                if (endX > maxX)
+                else if (endX > maxX)
                 {
                     item.RealScreenPosition.X -= endX - maxX;
                 }


### PR DESCRIPTION
Overhead name labels (used by the "incoming names" feature) were being dragged inward by FixTextCoordinatesInScreen to stay fully on screen. When a mobile was loaded at or just off the screen edge, its name appeared pulled toward the center of the screen and only snapped above the mobile once it scrolled fully into view.

Skip the on-screen clamping for MessageType.Label text so names stay centered above their object regardless of the object's screen position, while regular overhead speech still remains clamped on screen.