### PR TITLE
Fix spell cast bar drawing at tile position instead of player position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to TazUO will be recorded here.
 * Counter bar cells can now hold any spell bar action (spell, macro, weapon ability, script, or skill) in addition to item counters, with per-cell hotkeys (via the shared hotkey window), optional keybind labels, active-ability highlighting, and a hotkey-press flash - [P.R 812](https://github.com/PlayTazUO/TazUO/pull/812) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
+* Fixed spell cast bar not drawing based on actual player position - [P.R 839](https://github.com/PlayTazUO/TazUO/pull/839) ([bittiez](https://github.com/bittiez))
 * Fixed unexpected behaviour when clicking outside of an input field - [P.R 837](https://github.com/PlayTazUO/TazUO/pull/837) ([bittiez](https://github.com/bittiez))
 * Fixed mobile names not being drawn at the edge of the screen for off-screen mobiles - [P.R 838](https://github.com/PlayTazUO/TazUO/pull/838) ([bittiez](https://github.com/bittiez))
 * Added a suggested crash fix for "Bad uop file" errors, explaining that a `.uop` data file is corrupt, truncated, or mid-patch and how to resolve it - [P.R 841](https://github.com/PlayTazUO/TazUO/pull/841) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.20.19</AssemblyVersion>
-    <FileVersion>5.20.19</FileVersion>
+    <AssemblyVersion>5.20.20</AssemblyVersion>
+    <FileVersion>5.20.20</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/Managers/SpellVisualRange/CastTimerProgressBar.cs
+++ b/src/ClassicUO.Client/Game/Managers/SpellVisualRange/CastTimerProgressBar.cs
@@ -60,8 +60,11 @@ public class CastTimerProgressBar : Gump
 
                 if (vp == null) return false;
 
-                x = vp.Location.X + (int)(m.RealScreenPosition.X - (m.Offset.X + 22 + 5));
-                y = vp.Location.Y + (int)(m.RealScreenPosition.Y - ((m.Offset.Y - m.Offset.Z) - (height + centerY + 15) + (m.IsGargoyle && m.IsFlyingAnimationEnabled ? -22 : !m.IsMounted ? 22 : 0)));
+                // Follow the player's exact interpolated screen position (RealScreenPosition + Offset),
+                // matching how the mobile itself is drawn. Adding Offset keeps the bar glued to the
+                // smooth walk animation; using only the tile-based RealScreenPosition made it jump.
+                x = vp.Location.X + (int)(m.RealScreenPosition.X + m.Offset.X - (22 + 5));
+                y = vp.Location.Y + (int)(m.RealScreenPosition.Y + (m.Offset.Y - m.Offset.Z) + (height + centerY + 15) - (m.IsGargoyle && m.IsFlyingAnimationEnabled ? -22 : !m.IsMounted ? 22 : 0));
 
                 batcher.Draw(_background, new Rectangle(x, y, _barBounds.Width, _barBounds.Height), _barBounds, _hue);
 


### PR DESCRIPTION
The cast timer progress bar over the player subtracted the mobile's interpolation Offset instead of adding it, so it tracked the tile-based RealScreenPosition and jumped a full tile at a time while moving instead of following the smooth walk animation.

Add Offset (matching GetScreenPosition and how the mobile itself is drawn) on both axes so the bar stays glued to the player's exact interpolated screen position. Static positioning is unchanged.