### PR TITLE
Smooth overhead text vertical anchor to stop jitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to TazUO will be recorded here.
 * Counter bar cells can now hold any spell bar action (spell, macro, weapon ability, script, or skill) in addition to item counters, with per-cell hotkeys (via the shared hotkey window), optional keybind labels, active-ability highlighting, and a hotkey-press flash - [P.R 812](https://github.com/PlayTazUO/TazUO/pull/812) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
+* Fixed text draw position bouncing with always show names enabled - [P.R 840](https://github.com/PlayTazUO/TazUO/pull/840) ([bittiez](https://github.com/bittiez))
 * Fixed spell cast bar not drawing based on actual player position - [P.R 839](https://github.com/PlayTazUO/TazUO/pull/839) ([bittiez](https://github.com/bittiez))
 * Fixed unexpected behaviour when clicking outside of an input field - [P.R 837](https://github.com/PlayTazUO/TazUO/pull/837) ([bittiez](https://github.com/bittiez))
 * Fixed mobile names not being drawn at the edge of the screen for off-screen mobiles - [P.R 838](https://github.com/PlayTazUO/TazUO/pull/838) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.20.20</AssemblyVersion>
-    <FileVersion>5.20.20</FileVersion>
+    <AssemblyVersion>5.20.21</AssemblyVersion>
+    <FileVersion>5.20.21</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
@@ -47,9 +47,7 @@ namespace ClassicUO.Game.GameObjects
         private ushort _animationRepeateMode = 1;
         private ushort _animationRepeatModeCount = 1;
 
-        // The per-frame animation height/center used to anchor overhead text jitters as the
-        // sprite animates. These fields smooth that value over real time so the text follows
-        // the mobile without jumping frame-to-frame. -1 means "uninitialized" (snap on first use).
+        // Smooths the per-frame animation offset that anchors overhead text so it doesn't jitter (-1 = uninitialized).
         private float _smoothedTextAnimOffset = -1f;
         private uint _lastTextCoordUpdate;
 
@@ -1003,11 +1001,7 @@ namespace ClassicUO.Game.GameObjects
                 out int height
             );
 
-            // height/centerY come from the current animation frame and change every frame as the
-            // sprite plays, which makes overhead text bounce up and down (very noticeable once the
-            // name overhead reserves extra space above it). Smooth the anchor toward the target so
-            // the text glides instead of jumping. Offset.X/Y (walking) are already interpolated and
-            // stay outside the smoothing so text tracking the mobile stays tight.
+            // height/centerY change every animation frame and bounce the text; smooth the anchor so it glides instead of jumping.
             int targetAnimOffset = height + centerY + 8;
             int smoothedAnimOffset = SmoothTextAnimOffset(targetAnimOffset);
 
@@ -1050,13 +1044,10 @@ namespace ClassicUO.Game.GameObjects
             FixTextCoordinatesInScreen();
         }
 
-        // Frame-rate independent exponential smoothing of the animation-driven text anchor offset.
-        // Advances at most once per game tick (repeated calls in the same tick are no-ops), so it
-        // stays stable no matter how many times UpdateTextCoordsV runs in a frame.
+        // Frame-rate independent exponential smoothing of the text anchor offset; advances at most once per game tick.
         private int SmoothTextAnimOffset(int target)
         {
-            // First use, or a large jump (mount/dismount, morph, graphic swap): snap so the text
-            // doesn't slowly slide across a big gap.
+            // First use or a large jump (mount/dismount, morph, graphic swap): snap instead of sliding across the gap.
             if (_smoothedTextAnimOffset < 0f || Math.Abs(target - _smoothedTextAnimOffset) > 40f)
             {
                 _smoothedTextAnimOffset = target;

--- a/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Mobile.cs
@@ -47,6 +47,12 @@ namespace ClassicUO.Game.GameObjects
         private ushort _animationRepeateMode = 1;
         private ushort _animationRepeatModeCount = 1;
 
+        // The per-frame animation height/center used to anchor overhead text jitters as the
+        // sprite animates. These fields smooth that value over real time so the text follows
+        // the mobile without jumping frame-to-frame. -1 means "uninitialized" (snap on first use).
+        private float _smoothedTextAnimOffset = -1f;
+        private uint _lastTextCoordUpdate;
+
         public Mobile(World world, uint serial) : base(world, serial)
         {
             LastAnimationChangeTime = Time.Ticks;
@@ -997,8 +1003,16 @@ namespace ClassicUO.Game.GameObjects
                 out int height
             );
 
+            // height/centerY come from the current animation frame and change every frame as the
+            // sprite plays, which makes overhead text bounce up and down (very noticeable once the
+            // name overhead reserves extra space above it). Smooth the anchor toward the target so
+            // the text glides instead of jumping. Offset.X/Y (walking) are already interpolated and
+            // stay outside the smoothing so text tracking the mobile stays tight.
+            int targetAnimOffset = height + centerY + 8;
+            int smoothedAnimOffset = SmoothTextAnimOffset(targetAnimOffset);
+
             p.X += (int)Offset.X + 22;
-            p.Y += (int)(Offset.Y - Offset.Z - (height + centerY + 8));
+            p.Y += (int)(Offset.Y - Offset.Z - smoothedAnimOffset);
             // Removed Camera.WorldToScreen() - text is now transformed by worldRTMatrix during rendering
 
             if (ObjectHandlesStatus == ObjectHandlesStatus.DISPLAYING)
@@ -1034,6 +1048,35 @@ namespace ClassicUO.Game.GameObjects
             }
 
             FixTextCoordinatesInScreen();
+        }
+
+        // Frame-rate independent exponential smoothing of the animation-driven text anchor offset.
+        // Advances at most once per game tick (repeated calls in the same tick are no-ops), so it
+        // stays stable no matter how many times UpdateTextCoordsV runs in a frame.
+        private int SmoothTextAnimOffset(int target)
+        {
+            // First use, or a large jump (mount/dismount, morph, graphic swap): snap so the text
+            // doesn't slowly slide across a big gap.
+            if (_smoothedTextAnimOffset < 0f || Math.Abs(target - _smoothedTextAnimOffset) > 40f)
+            {
+                _smoothedTextAnimOffset = target;
+                _lastTextCoordUpdate = Time.Ticks;
+                return target;
+            }
+
+            uint now = Time.Ticks;
+            float dt = (now - _lastTextCoordUpdate) / 1000f;
+
+            if (dt > 0f)
+            {
+                // ~200ms to converge; higher speed = snappier, lower = smoother.
+                const float SPEED = 12f;
+                float t = 1f - MathF.Exp(-SPEED * dt);
+                _smoothedTextAnimOffset += (target - _smoothedTextAnimOffset) * t;
+                _lastTextCoordUpdate = now;
+            }
+
+            return (int)MathF.Round(_smoothedTextAnimOffset);
         }
 
         public override void CheckGraphicChange(byte animIndex = 0)


### PR DESCRIPTION
Overhead speech text was anchored to the mobile using the current animation frame's height/center from GetAnimationDimensions. Those values change every frame as the sprite plays (breathing, walking), so the text bounced up and down - especially noticeable once the name overhead reserves extra space above it.

Smooth that animation-driven offset toward its target with frame-rate independent exponential smoothing so the text glides instead of jumping. Walking interpolation (Offset.X/Y) stays outside the smoothing so text still tracks the mobile tightly, and large jumps (mount/dismount, graphic swaps) snap instead of sliding.