### PR TITLE
Add scoped JsonSave base class with backup/recovery support

### DIFF
--- a/src/ClassicUO.Client/Configuration/JsonSave.cs
+++ b/src/ClassicUO.Client/Configuration/JsonSave.cs
@@ -221,23 +221,12 @@ namespace ClassicUO.Configuration
         private string GetBackupPath(int index) => Path.Combine(BackupDirectory, $"{FileName}.{index}");
 
         /// <summary>
-        /// Acquires a lock guarding this file. Global-scope files live in the shared <c>Data</c> folder and can
-        /// be accessed by multiple client instances at once, so they are protected with a cross-process named
-        /// mutex. Other scopes are effectively per-instance and use a no-op lock.
+        /// Acquires a cross-process lock guarding this file. A save can be touched by multiple client
+        /// instances at once regardless of scope - Global files share the <c>Data</c> folder, but Server/
+        /// Account/Char files can also collide when the same server/account/character is logged in from more
+        /// than one client - so every scope is protected with a named mutex keyed on the file path.
         /// </summary>
-        private IDisposable AcquireLock()
-        {
-            if (Scope != SettingsScope.Global)
-                return NullLock.Instance;
-
-            return new CrossProcessLock(FilePath);
-        }
-
-        private sealed class NullLock : IDisposable
-        {
-            public static readonly NullLock Instance = new NullLock();
-            public void Dispose() { }
-        }
+        private IDisposable AcquireLock() => new CrossProcessLock(FilePath);
 
         private sealed class CrossProcessLock : IDisposable
         {

--- a/src/ClassicUO.Client/Configuration/JsonSave.cs
+++ b/src/ClassicUO.Client/Configuration/JsonSave.cs
@@ -1,0 +1,290 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using System.Threading;
+using ClassicUO.Game;
+using ClassicUO.Utility.Logging;
+
+namespace ClassicUO.Configuration
+{
+    /// <summary>
+    /// Base class for JSON save files that live in a scoped location on disk (see
+    /// <see cref="SettingsScope"/> and <see cref="JsonSaveLocationHelper"/>).
+    ///
+    /// Provides:
+    /// <list type="bullet">
+    /// <item><description><see cref="Save"/> - writes the file atomically and keeps up to
+    /// <see cref="MAX_BACKUPS"/> rotating backups in a <c>backups</c> sub-folder.</description></item>
+    /// <item><description><see cref="Load"/> - loads the file, falling back through the backups on failure and
+    /// finally creating (and persisting) a fresh copy if nothing can be read. An unreadable main file is
+    /// preserved once as <c>&lt;file&gt;.corrupt</c> for later inspection.</description></item>
+    /// </list>
+    ///
+    /// Uses the curiously-recurring-template pattern so <see cref="Load"/> can return the concrete type.
+    /// Derived types are their own serializable data container and must supply a source-generated
+    /// <see cref="System.Text.Json.Serialization.Metadata.JsonTypeInfo{T}"/> via <see cref="TypeInfo"/>.
+    /// </summary>
+    /// <typeparam name="T">The concrete derived save type.</typeparam>
+    public abstract class JsonSave<T> where T : JsonSave<T>, new()
+    {
+        private const int MAX_BACKUPS = 3;
+
+        /// <summary>The scope that determines which folder this file is saved in.</summary>
+        protected abstract SettingsScope Scope { get; }
+
+        /// <summary>The file name including extension, e.g. <c>"friends.json"</c>.</summary>
+        protected abstract string FileName { get; }
+
+        /// <summary>Source-generated JSON metadata used to (de)serialize this save.</summary>
+        protected abstract JsonTypeInfo<T> TypeInfo { get; }
+
+        /// <summary>The directory this file is saved in, resolved from <see cref="Scope"/>.</summary>
+        public string SaveDirectory => JsonSaveLocationHelper.GetScopeDirectory(Scope);
+
+        /// <summary>The full path to the save file.</summary>
+        public string FilePath => Path.Combine(SaveDirectory, FileName);
+
+        /// <summary>The directory that holds the rotating backups for this file.</summary>
+        public string BackupDirectory => Path.Combine(SaveDirectory, Constants.BACKUP_FOLDER);
+
+        /// <summary>
+        /// Loads the save for type <typeparamref name="T"/>. If the main file is missing or unreadable the
+        /// backups are tried in order; if they all fail a fresh instance is created and written to disk so a
+        /// valid file always exists afterwards.
+        /// </summary>
+        public static T Load()
+        {
+            T instance = new T();
+
+            using (instance.AcquireLock())
+                return instance.LoadCore();
+        }
+
+        /// <summary>
+        /// Saves this instance to disk atomically, rotating the previous version into the backups folder.
+        /// </summary>
+        public void Save()
+        {
+            using (AcquireLock())
+                SaveCore();
+        }
+
+        private T LoadCore()
+        {
+            string filePath = FilePath;
+
+            // Try the main file first.
+            if (TryDeserialize(filePath, out T loaded))
+                return loaded;
+
+            // The main file exists but couldn't be parsed - preserve a single copy for inspection.
+            if (File.Exists(filePath))
+                BackupCorruptFile(filePath);
+
+            // Fall back through the rotating backups, newest first.
+            for (int i = 1; i <= MAX_BACKUPS; i++)
+            {
+                if (TryDeserialize(GetBackupPath(i), out loaded))
+                {
+                    Log.Warn($"Recovered JSON save '{filePath}' from backup {i}.");
+                    return loaded;
+                }
+            }
+
+            // Nothing valid on disk - start fresh and persist it (already holding the lock).
+            if (File.Exists(filePath))
+                Log.Error($"Failed to load JSON save '{filePath}' and all backups; creating a fresh copy.");
+
+            T fresh = new T();
+            fresh.SaveCore();
+            return fresh;
+        }
+
+        private void SaveCore()
+        {
+            string filePath = FilePath;
+            string tempPath = Path.Combine(SaveDirectory, FileName + ".tmp");
+
+            try
+            {
+                Directory.CreateDirectory(SaveDirectory);
+
+                string json = JsonSerializer.Serialize((T)this, TypeInfo);
+                File.WriteAllText(tempPath, json);
+
+                RotateBackups();
+
+                // RotateBackups moved the old main file into backup 1, so the destination is free.
+                File.Move(tempPath, filePath);
+                tempPath = null;
+            }
+            catch (Exception e)
+            {
+                // Mirrors the existing resolver behaviour: never let a save failure crash the client,
+                // e.g. when multiple instances point at the same file.
+                Log.Error($"Failed to save JSON '{filePath}': {e}");
+            }
+            finally
+            {
+                if (tempPath != null && File.Exists(tempPath))
+                {
+                    try { File.Delete(tempPath); }
+                    catch { /* best effort */ }
+                }
+            }
+        }
+
+        private bool TryDeserialize(string path, out T result)
+        {
+            result = null;
+
+            if (!File.Exists(path))
+                return false;
+
+            try
+            {
+                string json = File.ReadAllText(path);
+                result = JsonSerializer.Deserialize(json, TypeInfo);
+                return result != null;
+            }
+            catch (Exception e)
+            {
+                Log.Warn($"Failed to load JSON save '{path}': {e.Message}");
+                return false;
+            }
+        }
+
+        private void RotateBackups()
+        {
+            string backupDir = BackupDirectory;
+            Directory.CreateDirectory(backupDir);
+
+            // Rotate existing backups: oldest deleted, each other shifted up one (2 -> 3, 1 -> 2).
+            for (int i = MAX_BACKUPS; i > 0; i--)
+            {
+                string current = GetBackupPath(i);
+
+                if (i == MAX_BACKUPS)
+                {
+                    if (File.Exists(current))
+                        File.Delete(current);
+                }
+                else
+                {
+                    string next = GetBackupPath(i + 1);
+
+                    if (File.Exists(current))
+                    {
+                        if (File.Exists(next))
+                            File.Delete(next);
+
+                        File.Move(current, next);
+                    }
+                }
+            }
+
+            // Move the current main file into backup slot 1.
+            string firstBackup = GetBackupPath(1);
+            string filePath = FilePath;
+
+            if (File.Exists(filePath))
+            {
+                if (File.Exists(firstBackup))
+                    File.Delete(firstBackup);
+
+                File.Move(filePath, firstBackup);
+            }
+        }
+
+        private void BackupCorruptFile(string filePath)
+        {
+            try
+            {
+                string corruptPath = filePath + ".corrupt";
+
+                // Keep at most one corrupt copy - don't overwrite an earlier failure.
+                if (File.Exists(corruptPath))
+                    return;
+
+                File.Copy(filePath, corruptPath);
+                Log.Warn($"Backed up corrupt JSON save '{filePath}' to '{corruptPath}'.");
+            }
+            catch (Exception e)
+            {
+                Log.Error($"Failed to back up corrupt JSON save '{filePath}': {e}");
+            }
+        }
+
+        private string GetBackupPath(int index) => Path.Combine(BackupDirectory, $"{FileName}.{index}");
+
+        /// <summary>
+        /// Acquires a lock guarding this file. Global-scope files live in the shared <c>Data</c> folder and can
+        /// be accessed by multiple client instances at once, so they are protected with a cross-process named
+        /// mutex. Other scopes are effectively per-instance and use a no-op lock.
+        /// </summary>
+        private IDisposable AcquireLock()
+        {
+            if (Scope != SettingsScope.Global)
+                return NullLock.Instance;
+
+            return new CrossProcessLock(FilePath);
+        }
+
+        private sealed class NullLock : IDisposable
+        {
+            public static readonly NullLock Instance = new NullLock();
+            public void Dispose() { }
+        }
+
+        private sealed class CrossProcessLock : IDisposable
+        {
+            private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
+
+            private readonly Mutex _mutex;
+            private readonly bool _acquired;
+
+            public CrossProcessLock(string key)
+            {
+                _mutex = new Mutex(false, BuildMutexName(key));
+
+                try
+                {
+                    _acquired = _mutex.WaitOne(Timeout);
+
+                    if (!_acquired)
+                        Log.Warn($"Timed out acquiring cross-process lock for '{key}'; proceeding anyway.");
+                }
+                catch (AbandonedMutexException)
+                {
+                    // A previous owner crashed without releasing; we now own the mutex.
+                    _acquired = true;
+                }
+            }
+
+            public void Dispose()
+            {
+                if (_acquired)
+                {
+                    try { _mutex.ReleaseMutex(); }
+                    catch { /* best effort */ }
+                }
+
+                _mutex.Dispose();
+            }
+
+            private static string BuildMutexName(string key)
+            {
+                // Named mutexes can't contain path separators, so hash the path into a stable, valid name.
+                string hash = Convert.ToHexString(SHA1.HashData(Encoding.UTF8.GetBytes(key)));
+
+                // The Global\ prefix makes the mutex machine-wide on Windows; it isn't used on Unix.
+                string prefix = CUOEnviroment.IsUnix ? string.Empty : "Global\\";
+
+                return $"{prefix}TazUO_JsonSave_{hash}";
+            }
+        }
+    }
+}

--- a/src/ClassicUO.Client/Configuration/JsonSaveLocationHelper.cs
+++ b/src/ClassicUO.Client/Configuration/JsonSaveLocationHelper.cs
@@ -1,0 +1,100 @@
+using System;
+using System.IO;
+using ClassicUO.Game;
+using ClassicUO.Utility;
+
+namespace ClassicUO.Configuration
+{
+    /// <summary>
+    /// Resolves the on-disk directory used for a given <see cref="SettingsScope"/>.
+    ///
+    /// The scopes intentionally mirror the ones used by the SQL settings system
+    /// (<see cref="SettingsScope"/>) so both storage backends refer to the same conceptual
+    /// buckets, but here each scope maps to a folder rather than a database scope key:
+    ///
+    /// <list type="bullet">
+    /// <item><description><see cref="SettingsScope.Global"/> - the shared <c>Data</c> folder. Files here can be
+    /// touched by multiple client instances at once, so callers must guard access (see
+    /// <c>JsonSave</c>, which takes a cross-process lock for this scope).</description></item>
+    /// <item><description><see cref="SettingsScope.Server"/> - <c>Data/&lt;ServerName&gt;</c>. Matches the existing
+    /// per-server convention already used for friends lists, map markers, etc.</description></item>
+    /// <item><description><see cref="SettingsScope.Account"/> - <c>Data/&lt;ServerName&gt;/&lt;Account&gt;</c>, nested under
+    /// the server folder.</description></item>
+    /// <item><description><see cref="SettingsScope.Char"/> - the current profile's save folder
+    /// (<see cref="ProfileManager.ProfilePath"/>, i.e. <c>Data/Profiles/&lt;Account&gt;/&lt;Server&gt;/&lt;Char&gt;</c>).</description></item>
+    /// </list>
+    ///
+    /// This is factored out into a helper because these locations are needed in multiple places.
+    /// </summary>
+    public static class JsonSaveLocationHelper
+    {
+        /// <summary>The root <c>Data</c> folder (also the <see cref="SettingsScope.Global"/> location).</summary>
+        public static string DataDirectory => Path.Combine(CUOEnviroment.ExecutablePath, "Data");
+
+        /// <summary>
+        /// Returns the directory that files for the given <paramref name="scope"/> should be saved in.
+        /// The directory is not guaranteed to exist yet; callers should create it as needed.
+        /// </summary>
+        public static string GetScopeDirectory(SettingsScope scope)
+        {
+            switch (scope)
+            {
+                case SettingsScope.Global:
+                    return DataDirectory;
+
+                case SettingsScope.Server:
+                    return Path.Combine(DataDirectory, GetServerFolderName());
+
+                case SettingsScope.Account:
+                    return Path.Combine(DataDirectory, GetServerFolderName(), GetAccountFolderName());
+
+                case SettingsScope.Char:
+                    return GetCharDirectory();
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(scope), scope, null);
+            }
+        }
+
+        /// <summary>
+        /// The folder name used for the current server, sanitized for use as a path segment.
+        /// Falls back to the world's server name, then to a literal <c>"Server"</c> when nothing is loaded.
+        /// </summary>
+        public static string GetServerFolderName()
+        {
+            string server = ProfileManager.CurrentProfile?.ServerName;
+
+            if (string.IsNullOrEmpty(server))
+                server = World.Instance?.ServerName;
+
+            if (string.IsNullOrEmpty(server))
+                server = "Server";
+
+            return FileSystemHelper.RemoveInvalidChars(server);
+        }
+
+        /// <summary>
+        /// The folder name used for the current account, sanitized for use as a path segment.
+        /// Falls back to a literal <c>"Account"</c> when no profile is loaded.
+        /// </summary>
+        public static string GetAccountFolderName()
+        {
+            string account = ProfileManager.CurrentProfile?.Username;
+
+            if (string.IsNullOrEmpty(account))
+                account = "Account";
+
+            return FileSystemHelper.RemoveInvalidChars(account);
+        }
+
+        private static string GetCharDirectory()
+        {
+            // The profile save location is the natural Char scope; it already encodes account/server/char.
+            if (!string.IsNullOrEmpty(ProfileManager.ProfilePath))
+                return ProfileManager.ProfilePath;
+
+            // No profile is loaded yet - fall back to the account folder so we never write to a bogus path.
+            return GetScopeDirectory(SettingsScope.Account);
+        }
+    }
+}

--- a/src/ClassicUO.Client/Game/Constants.cs
+++ b/src/ClassicUO.Client/Game/Constants.cs
@@ -9,6 +9,12 @@ namespace ClassicUO.Game
         public const int MIN_FPS = 12;
         public const int MAX_FPS = 1000;
 
+        /// <summary>
+        /// Name of the sub-folder (relative to a scoped save location) that holds rotating
+        /// backups of JSON save files. Shared by the various JSON save systems.
+        /// </summary>
+        public const string BACKUP_FOLDER = "backups";
+
         public const int CHARACTER_ANIMATION_DELAY = 80;
         public const int ITEM_EFFECT_ANIMATION_DELAY = 50;
 


### PR DESCRIPTION
Introduce a reusable base class for JSON-serialized save files whose storage location is determined by the same scopes used by the SQL settings system (Char, Account, Server, Global).

- JsonSaveLocationHelper resolves the on-disk directory for each scope: Global -> Data/, Server -> Data/<ServerName>, Account -> Data/<ServerName>/<Account>, Char -> the profile save folder. Factored into a helper since these locations are used in multiple places.
- JsonSave<T> (CRTP) provides Save/Load. Save writes atomically and keeps up to 3 rotating backups in a "backups" sub-folder inside the scope directory. Load falls back through the backups on failure and finally creates a fresh copy if all fail, preserving an unreadable main file once as <file>.corrupt.
- Global-scope files take a cross-process named-mutex lock so multiple client instances can share the Data folder safely.
- Add Constants.BACKUP_FOLDER for the backups sub-folder name.

No existing saves are converted yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable JSON save management with atomic writes, rotating backups, corruption recovery, and fresh defaults when saved data cannot be restored.
  * Added organized storage locations for global, server, account, and character settings.
  * Added automatic sanitization for server and account folder names.
  * Added logging for save and load errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->