### PR TITLE
feat: add dress agent bar actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to TazUO will be recorded here.
 * Added `API.ActiveSpells()`, `API.ActiveSpellNames()` and `API.IsSpellActive(spell)` so scripts can see which toggle spells/moves are currently active (the same ones the spell bar highlights) ([bittiez](https://github.com/bittiez))
 
 ### Features
+* Counter bar slots can now trigger Dress or Undress for any dress-agent configuration belonging to the current character - [P.R 844](https://github.com/PlayTazUO/TazUO/pull/844) ([Nesci28](https://github.com/Nesci28))
 * The Legion Script Manager window now remembers its size and position and restores them when reopened - [P.R 828](https://github.com/PlayTazUO/TazUO/pull/828) ([bittiez](https://github.com/bittiez))
 * Added an optional candle flicker effect that makes lights gently ebb and flow (enabled by default, toggle under Video > Lighting) - [P.R 824](https://github.com/PlayTazUO/TazUO/pull/824) ([bittiez](https://github.com/bittiez))
 * Added optional FSR shader to post processing effects - [P.R 821](https://github.com/PlayTazUO/TazUO/pull/821) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -95,6 +95,7 @@ spellbar_setability=Set ability
 spellbar_ability_primary=Primary ability
 spellbar_ability_secondary=Secondary ability
 spellbar_clear=Clear
+counterbar_setdressagent=Set dress agent
 counterbar_sethotkey=Set hotkey
 counterbar_slot=Counter Slot {0}
 spellbar_search=Search..

--- a/src/ClassicUO.Client/Game/Managers/CounterBarSlot.cs
+++ b/src/ClassicUO.Client/Game/Managers/CounterBarSlot.cs
@@ -2,22 +2,23 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Serialization;
 using ClassicUO.Assets;
+using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.LegionScripting;
 
 namespace ClassicUO.Game.Managers;
 
 /// <summary>The kind of action stored in a single counter bar slot.</summary>
-public enum CounterBarSlotType { Empty = 0, Spell = 1, Macro = 2, Ability = 3, Script = 4, Skill = 5 }
+public enum CounterBarSlotType { Empty = 0, Spell = 1, Macro = 2, Ability = 3, Script = 4, Skill = 5, DressAgent = 6 }
 
 /// <summary>
 /// A single counter bar slot. Holds one of: nothing, a spell, a macro, a weapon
-/// (primary/secondary) ability, a script, or a skill, and centralizes activation,
-/// icon, and tooltip resolution.
+/// (primary/secondary) ability, a script, a skill, or a dress-agent action, and
+/// centralizes activation, icon, and tooltip resolution.
 /// </summary>
 public class CounterBarSlot
 {
-    /// <summary>What this slot holds (spell, macro, ability, script, skill, or empty).</summary>
+    /// <summary>What this slot holds (spell, macro, ability, script, skill, dress agent, or empty).</summary>
     public CounterBarSlotType Type { get; set; } = CounterBarSlotType.Empty;
 
     /// <summary>Full spell index when <see cref="Type"/> is <see cref="CounterBarSlotType.Spell"/>.</summary>
@@ -34,6 +35,12 @@ public class CounterBarSlot
 
     /// <summary>True for the primary ability, false for the secondary, when <see cref="Type"/> is <see cref="CounterBarSlotType.Ability"/>.</summary>
     public bool AbilityPrimary { get; set; }        // Type == Ability (true = primary, false = secondary)
+
+    /// <summary>Dress configuration name when <see cref="Type"/> is <see cref="CounterBarSlotType.DressAgent"/>.</summary>
+    public string DressConfigName { get; set; }     // Type == DressAgent
+
+    /// <summary>True to undress, false to dress, when <see cref="Type"/> is <see cref="CounterBarSlotType.DressAgent"/>.</summary>
+    public bool DressAgentUndress { get; set; }     // Type == DressAgent
 
     /// <summary>True when the slot holds nothing.</summary>
     [JsonIgnore]
@@ -80,13 +87,27 @@ public class CounterBarSlot
         }
     }
 
-    /// <summary>The short in-slot label text for icon-less slots (macro/script/skill), or null for other types.</summary>
+    /// <summary>Friendly action name for a dress-agent slot.</summary>
+    [JsonIgnore]
+    public string DressAgentDisplayName
+    {
+        get
+        {
+            string action = DressAgentUndress
+                ? TazLang.Get("dressagent_undress", "Undress")
+                : TazLang.Get("dressagent_dress", "Dress");
+            return string.IsNullOrEmpty(DressConfigName) ? action : $"{action}: {DressConfigName}";
+        }
+    }
+
+    /// <summary>The short in-slot label text for icon-less slots, or null for other types.</summary>
     [JsonIgnore]
     public string SlotLabel => Type switch
     {
         CounterBarSlotType.Macro => MacroName,
         CounterBarSlotType.Script => ScriptDisplayName,
         CounterBarSlotType.Skill => SkillDisplayName,
+        CounterBarSlotType.DressAgent => DressAgentDisplayName,
         _ => null
     };
 
@@ -159,7 +180,21 @@ public class CounterBarSlot
         return new CounterBarSlot { Type = CounterBarSlotType.Skill, SkillIndex = skillIndex };
     }
 
-    /// <summary>Performs the slot's action: casts the spell, runs the macro, or triggers the ability.</summary>
+    /// <summary>Creates a dress-agent slot, or an empty slot when <paramref name="config"/> is null.</summary>
+    public static CounterBarSlot FromDressAgent(DressConfig config, bool undress)
+    {
+        if (config == null)
+            return Empty();
+
+        return new CounterBarSlot
+        {
+            Type = CounterBarSlotType.DressAgent,
+            DressConfigName = config.Name,
+            DressAgentUndress = undress
+        };
+    }
+
+    /// <summary>Performs the action represented by this slot.</summary>
     public void Activate(World world)
     {
         switch (Type)
@@ -200,6 +235,18 @@ public class CounterBarSlot
             case CounterBarSlotType.Skill:
                 if (SkillIndex >= 0)
                     GameActions.UseSkill(SkillIndex);
+                break;
+
+            case CounterBarSlotType.DressAgent:
+                DressConfig config = DressAgentManager.Instance.CurrentPlayerConfigs.FirstOrDefault(
+                    c => c?.Name?.Equals(DressConfigName, System.StringComparison.OrdinalIgnoreCase) == true);
+                if (config != null)
+                {
+                    if (DressAgentUndress)
+                        DressAgentManager.Instance.UndressFromConfig(config);
+                    else
+                        DressAgentManager.Instance.DressFromConfig(config);
+                }
                 break;
         }
     }
@@ -265,6 +312,10 @@ public class CounterBarSlot
 
             case CounterBarSlotType.Skill:
                 text = SkillDisplayName;
+                return !string.IsNullOrEmpty(text);
+
+            case CounterBarSlotType.DressAgent:
+                text = DressAgentDisplayName;
                 return !string.IsNullOrEmpty(text);
         }
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/CounterBarGump.cs
@@ -340,6 +340,10 @@ namespace ClassicUO.Game.UI.Gumps
                         case CounterBarSlotType.Ability:
                             writer.WriteAttributeString("abilityprimary", slot.AbilityPrimary.ToString());
                             break;
+                        case CounterBarSlotType.DressAgent:
+                            writer.WriteAttributeString("dressconfigname", slot.DressConfigName ?? string.Empty);
+                            writer.WriteAttributeString("dressagentundress", slot.DressAgentUndress.ToString());
+                            break;
                     }
                 }
 
@@ -393,7 +397,7 @@ namespace ClassicUO.Game.UI.Gumps
 
                         if (slot != null && !slot.IsEmpty)
                         {
-                            // Spell/macro/ability/script/skill action; resolves its own icon/label.
+                            // Spell/macro/ability/script/skill/dress-agent action; resolves its own icon/label.
                             items[index]?.SetSlot(slot);
                         }
                         else
@@ -448,6 +452,13 @@ namespace ClassicUO.Game.UI.Gumps
                             return CounterBarSlot.FromSkill(int.Parse(controlXml.GetAttribute("skillindex")));
                         case CounterBarSlotType.Ability:
                             return CounterBarSlot.FromAbility(bool.Parse(controlXml.GetAttribute("abilityprimary")));
+                        case CounterBarSlotType.DressAgent:
+                            return new CounterBarSlot
+                            {
+                                Type = CounterBarSlotType.DressAgent,
+                                DressConfigName = controlXml.GetAttribute("dressconfigname"),
+                                DressAgentUndress = bool.Parse(controlXml.GetAttribute("dressagentundress"))
+                            };
                     }
                 }
 
@@ -533,6 +544,7 @@ namespace ClassicUO.Game.UI.Gumps
             private CounterBarSlot _slot = CounterBarSlot.Empty();
             private ContextMenuItemEntry _macroMenu;
             private ContextMenuItemEntry _scriptMenu;
+            private ContextMenuItemEntry _dressAgentMenu;
 
             public CounterItem(CounterBarGump gump, int x, int y, int w, int h)
             {
@@ -582,6 +594,10 @@ namespace ClassicUO.Game.UI.Gumps
                 GenSkillList(skillMenu);
                 ContextMenu.Add(skillMenu);
 
+                _dressAgentMenu = new ContextMenuItemEntry(TazLang.Get("counterbar_setdressagent", "Set dress agent"));
+                GenDressAgentList(_dressAgentMenu);
+                ContextMenu.Add(_dressAgentMenu);
+
                 ContextMenu.Add(new ContextMenuItemEntry(TazLang.Get("counterbar_sethotkey"), SetHotkey));
             }
 
@@ -589,7 +605,7 @@ namespace ClassicUO.Game.UI.Gumps
 
             public ushort Hue { get; private set; }
 
-            /// <summary>The spell/macro/ability/script/skill action assigned to this cell, or an empty slot for a plain item counter.</summary>
+            /// <summary>The action assigned to this cell, or an empty slot for a plain item counter.</summary>
             public CounterBarSlot Slot => _slot;
 
             /// <summary>True when this cell holds a spell bar action instead of an item to count.</summary>
@@ -640,7 +656,7 @@ namespace ClassicUO.Game.UI.Gumps
                 }
                 else
                 {
-                    // Scripts and skills (and graphic-less macros) fall back to a short text label.
+                    // Icon-less actions (and graphic-less macros) fall back to a short text label.
                     _image.ChangeGraphic(0, 0, true);
                     _image.SetAmount(StringHelper.AbbreviateToInitials(_slot.SlotLabel));
                 }
@@ -832,13 +848,38 @@ namespace ClassicUO.Game.UI.Gumps
                 }
             }
 
+            private void GenDressAgentList(ContextMenuItemEntry parent)
+            {
+                if (parent == null)
+                    return;
+
+                parent.Items.Clear();
+
+                foreach (DressConfig config in DressAgentManager.Instance.CurrentPlayerConfigs)
+                {
+                    if (config == null)
+                        continue;
+
+                    DressConfig selectedConfig = config;
+                    var configMenu = new ContextMenuItemEntry(selectedConfig.Name ?? string.Empty);
+                    configMenu.Add(new ContextMenuItemEntry(
+                        TazLang.Get("dressagent_dress", "Dress"),
+                        () => SetSlot(CounterBarSlot.FromDressAgent(selectedConfig, false))));
+                    configMenu.Add(new ContextMenuItemEntry(
+                        TazLang.Get("dressagent_undress", "Undress"),
+                        () => SetSlot(CounterBarSlot.FromDressAgent(selectedConfig, true))));
+                    parent.Add(configMenu);
+                }
+            }
+
             public override void OnMouseUp(int x, int y, MouseButtonType button)
             {
                 if (button == MouseButtonType.Right)
                 {
-                    // Refresh the dynamic lists so newly added macros/scripts appear.
+                    // Refresh the dynamic lists so newly added macros, scripts, and dress configs appear.
                     GenMacroList(_macroMenu);
                     GenScriptList(_scriptMenu);
+                    GenDressAgentList(_dressAgentMenu);
                 }
 
                 if (button == MouseButtonType.Left)

--- a/tests/ClassicUO.UnitTests/Game/Managers/CounterBarSlotTest.cs
+++ b/tests/ClassicUO.UnitTests/Game/Managers/CounterBarSlotTest.cs
@@ -37,6 +37,12 @@ namespace ClassicUO.UnitTests.Game.Managers
         }
 
         [Fact]
+        public void DressAgentSlotType_HasValue6()
+        {
+            ((int)CounterBarSlotType.DressAgent).Should().Be(6);
+        }
+
+        [Fact]
         public void FromSkill_Negative_ReturnsEmpty()
         {
             CounterBarSlot.FromSkill(-1).IsEmpty.Should().BeTrue();
@@ -50,6 +56,29 @@ namespace ClassicUO.UnitTests.Game.Managers
             slot.IsEmpty.Should().BeFalse();
             slot.Type.Should().Be(CounterBarSlotType.Skill);
             slot.SkillIndex.Should().Be(21);
+        }
+
+        [Fact]
+        public void FromDressAgent_Null_ReturnsEmpty()
+        {
+            CounterBarSlot.FromDressAgent(null, false).IsEmpty.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData(false, "Dress: PvP")]
+        [InlineData(true, "Undress: PvP")]
+        public void FromDressAgent_ValidConfig_CreatesActionSlot(bool undress, string expectedLabel)
+        {
+            CounterBarSlot slot = CounterBarSlot.FromDressAgent(
+                new DressConfig { Name = "PvP", CharacterName = "Character Name" }, undress);
+
+            slot.IsEmpty.Should().BeFalse();
+            slot.Type.Should().Be(CounterBarSlotType.DressAgent);
+            slot.DressConfigName.Should().Be("PvP");
+            slot.DressAgentUndress.Should().Be(undress);
+            slot.SlotLabel.Should().Be(expectedLabel);
+            slot.TryGetTooltip(null, out string tooltip).Should().BeTrue();
+            tooltip.Should().Be(expectedLabel);
         }
 
         [Fact]


### PR DESCRIPTION
## Description

Adds Dress Agent actions to Spell Bar and Counter Bar slots.

The new Set dress agent menu lists every Dress Agent configuration belonging to the current character:

Set dress agent → Configuration → Dress / Undress

Dress Agent slots support activation by click or hotkey, labels and tooltips, Spell Bar JSON persistence, and Counter
Bar XML persistence.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing

- Smoke tests

## Screenshots (if applicable)

<img width="424" height="247" alt="image" src="https://github.com/user-attachments/assets/ef246757-792e-404d-849e-23fa69457d4b" />
<img width="562" height="273" alt="image" src="https://github.com/user-attachments/assets/3936b924-8051-4530-81cc-a75f93fbe30b" />
