### PR TITLE
Fix tooltip background double-scaling with global scaling

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Tooltip.cs
+++ b/src/ClassicUO.Client/Game/UI/Tooltip.cs
@@ -142,8 +142,12 @@ namespace ClassicUO.Game.UI
                 return false;
             }
 
-            int z_width = (int)((_textBox.Width + 8) * Client.Game.RenderScale);
-            int z_height = (int)((_textBox.Height + 8) * Client.Game.RenderScale);
+            // Tooltip dimensions stay in logical UI space: the whole UI is drawn to a render
+            // target that the global RenderScale maps onto the screen at blit time, so multiplying
+            // here would double-count the scale (background scales with RenderScale^2 while the
+            // text scales with RenderScale once). See ScaleHelper's "never multiply by RenderScale".
+            int z_width = _textBox.Width + 8;
+            int z_height = _textBox.Height + 8;
 
             if (x < 0)
             {


### PR DESCRIPTION
The tooltip background dimensions were multiplied by Client.Game.RenderScale while the tooltip text and the rest of the UI stay in logical space. Because the entire UI is rendered to a target that RenderScale maps onto the screen at blit time, this double-counted the scale: the background scaled with RenderScale^2 while the text scaled with RenderScale once. Above 100% global scaling the background was too large; below 100% the text overflowed it.

Keep the dimensions in logical space, consistent with ScaleHelper's contract and every other UI element. This also fixes the on-screen position clamping, which compared the inflated dimensions against logical window bounds.
