### PR TITLE
feat: add full low contrast highlight style

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/Controls/GridItem.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/Controls/GridItem.cs
@@ -914,6 +914,9 @@ public class GridItem : Control
         DrawSpotlightRectangle(batcher, InflateRectangle(destination, 2), cellBounds, _lowContrastSpotlightInnerHue);
     }
 
+    private void DrawLowContrastFull(UltimaBatcher2D batcher, Rectangle cellBounds) =>
+        batcher.Draw(_whiteTexture, cellBounds, _lowContrastSpotlightInnerHue);
+
     private void DrawSpotlightRectangle(UltimaBatcher2D batcher, Rectangle rectangle, Rectangle cellBounds, Vector3 hueVector)
     {
         int left = Math.Max(rectangle.Left, cellBounds.Left);
@@ -1103,10 +1106,18 @@ public class GridItem : Control
 
         if (_profile.GridHighlightLowContrastItems && IsLowContrastItem())
         {
-            if ((LowContrastHighlightStyle)_profile.GridHighlightLowContrastItemsStyle == LowContrastHighlightStyle.Spotlight)
-                DrawLowContrastSpotlight(batcher, destination, itemCellBounds);
-            else
-                DrawLowContrastSpriteBorder(batcher, destination, source);
+            switch ((LowContrastHighlightStyle)_profile.GridHighlightLowContrastItemsStyle)
+            {
+                case LowContrastHighlightStyle.Spotlight:
+                    DrawLowContrastSpotlight(batcher, destination, itemCellBounds);
+                    break;
+                case LowContrastHighlightStyle.Full:
+                    DrawLowContrastFull(batcher, itemCellBounds);
+                    break;
+                default:
+                    DrawLowContrastSpriteBorder(batcher, destination, source);
+                    break;
+            }
         }
 
         batcher.Draw(_texture, destination, source, hueVector);

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/Enums/LowContrastHighlightStyle.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/Enums/LowContrastHighlightStyle.cs
@@ -3,5 +3,6 @@ namespace ClassicUO.Game.UI.Gumps;
 public enum LowContrastHighlightStyle
 {
     Border,
-    Spotlight
+    Spotlight,
+    Full
 }


### PR DESCRIPTION
## Description
Adds a third `Full` option to the low-contrast item highlight styles.

The new style fills the entire grid item square with a translucent white highlight behind the
item. Existing `Border` and `Spotlight` settings remain unchanged.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing

- Smoke tests

## Screenshots (if applicable)

<img width="217" height="167" alt="image" src="https://github.com/user-attachments/assets/b8b9d9ff-693c-4f58-82d5-a49c090d2c81" />
