### PR TITLE
Crash fix for concurrent uimanager access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to TazUO will be recorded here.
 * Counter bar cells can now hold any spell bar action (spell, macro, weapon ability, script, or skill) in addition to item counters, with per-cell hotkeys (via the shared hotkey window), optional keybind labels, active-ability highlighting, and a hotkey-press flash - [P.R 812](https://github.com/PlayTazUO/TazUO/pull/812) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
+* Address a concurrency issue causing a rare crash - [P.R 851](https://github.com/PlayTazUO/TazUO/pull/851) ([yuval-po](https://github.com/yuval-po))
 * Fixed ScriptManagerWindow not restoring to the correct size - [P.R 847](https://github.com/PlayTazUO/TazUO/pull/847) ([yuval-po](https://github.com/yuval-po))
 * Fixed the bandage agent monopolizing the shared action queue: heals still run through the queue, but the queued heal is now re-validated when it runs and only resets the global action cooldown on rounds where a bandage is actually applied - so no-op heal rounds (mobile recovered, still on the bandage timer, no bandage, etc.) no longer stall the player's own queued loot/move/equip actions - [P.R 846](https://github.com/PlayTazUO/TazUO/pull/846) ([bittiez](https://github.com/bittiez))
 * Fixed text draw position bouncing with always show names enabled - [P.R 840](https://github.com/PlayTazUO/TazUO/pull/840) ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.20.24</AssemblyVersion>
-    <FileVersion>5.20.24</FileVersion>
+    <AssemblyVersion>5.20.25</AssemblyVersion>
+    <FileVersion>5.20.25</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/Managers/UIManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/UIManager.cs
@@ -19,14 +19,6 @@ namespace ClassicUO.Game.Managers
     internal static class UIManager
     {
         private static readonly Dictionary<Type, List<IGui>> _gumpTypeList = new();
-
-        // Guards every access to _gumpTypeList and the List<IGui> buckets it holds.
-        // Gumps can be added, removed and looked up from more than one thread (e.g. the
-        // network thread while the game thread is tearing gumps down on scene unload), and
-        // a plain Dictionary corrupts its bucket chains under concurrent access, surfacing as
-        // InvalidOperation_ConcurrentOperationsNotSupported. Monitor is reentrant so nested
-        // calls on the same thread are safe.
-        private static readonly object _gumpTypeListLock = new();
         private static readonly ConcurrentDictionary<uint, Point> _gumpPositionCache = new();
         private static readonly IGui[] _mouseDownControls = new IGui[0xFF];
 
@@ -505,24 +497,21 @@ namespace ClassicUO.Game.Managers
 
         public static T GetGump<T>(uint? serial = null) where T : class, IGui
         {
-            lock (_gumpTypeListLock)
-            {
-                if (!_gumpTypeList.TryGetValue(typeof(T), out List<IGui> list))
-                    return null;
-
-                list.RemoveAll(i => i.IsDisposed);
-
-                if (list.Count <= 0) return null;
-
-                if (!serial.HasValue)
-                    return list[0] as T;
-
-                foreach (IGui gump in list)
-                    if (gump.LocalSerial == serial.Value)
-                        return gump as T;
-
+            if (!_gumpTypeList.TryGetValue(typeof(T), out List<IGui> list))
                 return null;
-            }
+
+            list.RemoveAll(i => i.IsDisposed);
+
+            if (list.Count <= 0) return null;
+
+            if(!serial.HasValue)
+                return list[0] as T;
+
+            foreach(IGui gump in list)
+                if (gump.LocalSerial == serial.Value)
+                    return gump as T;
+
+            return null;
         }
 
         public static Gump GetGump(uint serial)
@@ -691,21 +680,18 @@ namespace ClassicUO.Game.Managers
 
             Type t = gump.GetType();
 
+            if (!_gumpTypeList.TryGetValue(t, out List<IGui> list))
+                return;
+
             // The type list bucket also contains subclass instances (RegisterGump registers
             // each gump under every type in its inheritance chain). Count only instances whose
             // exact runtime type matches so the warning reflects the real number of this gump.
             int count = 0;
 
-            lock (_gumpTypeListLock)
+            foreach (IGui g in list)
             {
-                if (!_gumpTypeList.TryGetValue(t, out List<IGui> list))
-                    return;
-
-                foreach (IGui g in list)
-                {
-                    if (g.GetType() == t)
-                        count++;
-                }
+                if (g.GetType() == t)
+                    count++;
             }
 
             if (count > SAME_TYPE_GUMP_WARN_THRESHOLD)
@@ -722,10 +708,7 @@ namespace ClassicUO.Game.Managers
             }
             Gumps.Clear();
 
-            lock (_gumpTypeListLock)
-            {
-                _gumpTypeList.Clear();
-            }
+            _gumpTypeList.Clear();
         }
 
         /// <summary>
@@ -736,21 +719,18 @@ namespace ClassicUO.Game.Managers
         {
             Type t = item.GetType();
 
-            lock (_gumpTypeListLock)
+            while (t != null)
             {
-                while (t != null)
+                if (t == typeof(Control)) break; //break early at control ( XX <- Gump <- Control -< Object )
+
+                if (!_gumpTypeList.TryGetValue(t, out List<IGui> list))
                 {
-                    if (t == typeof(Control)) break; //break early at control ( XX <- Gump <- Control -< Object )
-
-                    if (!_gumpTypeList.TryGetValue(t, out List<IGui> list))
-                    {
-                        list = new List<IGui>();
-                        _gumpTypeList[t] = list;
-                    }
-                    list.Add(item);
-
-                    t = t.BaseType;
+                    list = new List<IGui>();
+                    _gumpTypeList[t] = list;
                 }
+                list.Add(item);
+
+                t = t.BaseType;
             }
         }
 
@@ -762,17 +742,14 @@ namespace ClassicUO.Game.Managers
         {
             Type t = item.GetType();
 
-            lock (_gumpTypeListLock)
+            while (t != null)
             {
-                while (t != null)
-                {
-                    if (t == typeof(Control)) break;
+                if (t == typeof(Control)) break;
 
-                    if (_gumpTypeList.TryGetValue(t, out List<IGui> list))
-                        list.Remove(item);
+                if (_gumpTypeList.TryGetValue(t, out List<IGui> list))
+                    list.Remove(item);
 
-                    t = t.BaseType;
-                }
+                t = t.BaseType;
             }
         }
 
@@ -786,20 +763,15 @@ namespace ClassicUO.Game.Managers
             IGui[] snapshot;
             int count;
 
-            // Build the snapshot under the lock, then release it before invoking the action so
-            // callbacks that re-enter UIManager (adding/removing gumps) don't run while we hold it.
-            lock (_gumpTypeListLock)
-            {
-                if (!_gumpTypeList.TryGetValue(typeof(T), out List<IGui> list))
-                    return false;
+            if (!_gumpTypeList.TryGetValue(typeof(T), out List<IGui> list))
+                return false;
 
-                list.RemoveAll(i => i.IsDisposed);
-                count = list.Count;
-                if (count == 0) return false;
+            list.RemoveAll(i => i.IsDisposed);
+            count = list.Count;
+            if (count == 0) return false;
 
-                snapshot = ArrayPool<IGui>.Shared.Rent(count);
-                list.CopyTo(snapshot, 0);
-            }
+            snapshot = ArrayPool<IGui>.Shared.Rent(count);
+            list.CopyTo(snapshot, 0);
 
             int c = 0;
 

--- a/src/ClassicUO.Client/Game/Managers/UIManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/UIManager.cs
@@ -19,6 +19,14 @@ namespace ClassicUO.Game.Managers
     internal static class UIManager
     {
         private static readonly Dictionary<Type, List<IGui>> _gumpTypeList = new();
+
+        // Guards every access to _gumpTypeList and the List<IGui> buckets it holds.
+        // Gumps can be added, removed and looked up from more than one thread (e.g. the
+        // network thread while the game thread is tearing gumps down on scene unload), and
+        // a plain Dictionary corrupts its bucket chains under concurrent access, surfacing as
+        // InvalidOperation_ConcurrentOperationsNotSupported. Monitor is reentrant so nested
+        // calls on the same thread are safe.
+        private static readonly object _gumpTypeListLock = new();
         private static readonly ConcurrentDictionary<uint, Point> _gumpPositionCache = new();
         private static readonly IGui[] _mouseDownControls = new IGui[0xFF];
 
@@ -497,21 +505,24 @@ namespace ClassicUO.Game.Managers
 
         public static T GetGump<T>(uint? serial = null) where T : class, IGui
         {
-            if (!_gumpTypeList.TryGetValue(typeof(T), out List<IGui> list))
+            lock (_gumpTypeListLock)
+            {
+                if (!_gumpTypeList.TryGetValue(typeof(T), out List<IGui> list))
+                    return null;
+
+                list.RemoveAll(i => i.IsDisposed);
+
+                if (list.Count <= 0) return null;
+
+                if (!serial.HasValue)
+                    return list[0] as T;
+
+                foreach (IGui gump in list)
+                    if (gump.LocalSerial == serial.Value)
+                        return gump as T;
+
                 return null;
-
-            list.RemoveAll(i => i.IsDisposed);
-
-            if (list.Count <= 0) return null;
-
-            if(!serial.HasValue)
-                return list[0] as T;
-
-            foreach(IGui gump in list)
-                if (gump.LocalSerial == serial.Value)
-                    return gump as T;
-
-            return null;
+            }
         }
 
         public static Gump GetGump(uint serial)
@@ -680,18 +691,21 @@ namespace ClassicUO.Game.Managers
 
             Type t = gump.GetType();
 
-            if (!_gumpTypeList.TryGetValue(t, out List<IGui> list))
-                return;
-
             // The type list bucket also contains subclass instances (RegisterGump registers
             // each gump under every type in its inheritance chain). Count only instances whose
             // exact runtime type matches so the warning reflects the real number of this gump.
             int count = 0;
 
-            foreach (IGui g in list)
+            lock (_gumpTypeListLock)
             {
-                if (g.GetType() == t)
-                    count++;
+                if (!_gumpTypeList.TryGetValue(t, out List<IGui> list))
+                    return;
+
+                foreach (IGui g in list)
+                {
+                    if (g.GetType() == t)
+                        count++;
+                }
             }
 
             if (count > SAME_TYPE_GUMP_WARN_THRESHOLD)
@@ -708,7 +722,10 @@ namespace ClassicUO.Game.Managers
             }
             Gumps.Clear();
 
-            _gumpTypeList.Clear();
+            lock (_gumpTypeListLock)
+            {
+                _gumpTypeList.Clear();
+            }
         }
 
         /// <summary>
@@ -719,18 +736,21 @@ namespace ClassicUO.Game.Managers
         {
             Type t = item.GetType();
 
-            while (t != null)
+            lock (_gumpTypeListLock)
             {
-                if (t == typeof(Control)) break; //break early at control ( XX <- Gump <- Control -< Object )
-
-                if (!_gumpTypeList.TryGetValue(t, out List<IGui> list))
+                while (t != null)
                 {
-                    list = new List<IGui>();
-                    _gumpTypeList[t] = list;
-                }
-                list.Add(item);
+                    if (t == typeof(Control)) break; //break early at control ( XX <- Gump <- Control -< Object )
 
-                t = t.BaseType;
+                    if (!_gumpTypeList.TryGetValue(t, out List<IGui> list))
+                    {
+                        list = new List<IGui>();
+                        _gumpTypeList[t] = list;
+                    }
+                    list.Add(item);
+
+                    t = t.BaseType;
+                }
             }
         }
 
@@ -742,14 +762,17 @@ namespace ClassicUO.Game.Managers
         {
             Type t = item.GetType();
 
-            while (t != null)
+            lock (_gumpTypeListLock)
             {
-                if (t == typeof(Control)) break;
+                while (t != null)
+                {
+                    if (t == typeof(Control)) break;
 
-                if (_gumpTypeList.TryGetValue(t, out List<IGui> list))
-                    list.Remove(item);
+                    if (_gumpTypeList.TryGetValue(t, out List<IGui> list))
+                        list.Remove(item);
 
-                t = t.BaseType;
+                    t = t.BaseType;
+                }
             }
         }
 
@@ -763,15 +786,20 @@ namespace ClassicUO.Game.Managers
             IGui[] snapshot;
             int count;
 
-            if (!_gumpTypeList.TryGetValue(typeof(T), out List<IGui> list))
-                return false;
+            // Build the snapshot under the lock, then release it before invoking the action so
+            // callbacks that re-enter UIManager (adding/removing gumps) don't run while we hold it.
+            lock (_gumpTypeListLock)
+            {
+                if (!_gumpTypeList.TryGetValue(typeof(T), out List<IGui> list))
+                    return false;
 
-            list.RemoveAll(i => i.IsDisposed);
-            count = list.Count;
-            if (count == 0) return false;
+                list.RemoveAll(i => i.IsDisposed);
+                count = list.Count;
+                if (count == 0) return false;
 
-            snapshot = ArrayPool<IGui>.Shared.Rent(count);
-            list.CopyTo(snapshot, 0);
+                snapshot = ArrayPool<IGui>.Shared.Rent(count);
+                list.CopyTo(snapshot, 0);
+            }
 
             int c = 0;
 

--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -494,6 +494,11 @@ namespace ClassicUO.Game.Scenes
             // work runs there; InvokeOnMainThread runs inline when already on the main thread.
             MainThreadQueue.InvokeOnMainThread(() =>
             {
+                // The callback can be drained a frame later, by which point this scene may already
+                // have been unloaded/replaced; skip the stale teardown then.
+                if (IsDestroyed || Instance != this)
+                    return;
+
                 if (DisconnectionRequested)
                 {
                     Client.Game.SetScene(new LoginScene(_world));

--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -487,38 +487,46 @@ namespace ClassicUO.Game.Scenes
 
         private void SocketOnDisconnected(object sender, SocketError e)
         {
-            if (DisconnectionRequested)
+            // Disconnected is raised from the background network/receive tasks (see AsyncNetClient),
+            // but this handler tears down the scene and adds gumps, which mutates UIManager state
+            // (_gumpTypeList, the Gumps list, etc.). Touching that off the main thread races the
+            // game loop and corrupts those collections. Marshal onto the main thread so all the UI
+            // work runs there; InvokeOnMainThread runs inline when already on the main thread.
+            MainThreadQueue.InvokeOnMainThread(() =>
             {
-                Client.Game.SetScene(new LoginScene(_world));
+                if (DisconnectionRequested)
+                {
+                    Client.Game.SetScene(new LoginScene(_world));
 
-                return;
-            }
-            if (Settings.GlobalSettings.Reconnect)
-            {
-                LoginHandshake.Reconnect = true;
-                _forceStopScene = true;
-            }
-            else
-            {
-                UIManager.Add(
-                    new MessageBoxGump(
-                        _world,
-                        200,
-                        200,
-                        string.Format(
-                            ResGeneral.ConnectionLost0,
-                            StringHelper.AddSpaceBeforeCapital(e.ToString())
-                        ),
-                        s =>
-                        {
-                            if (s)
+                    return;
+                }
+                if (Settings.GlobalSettings.Reconnect)
+                {
+                    LoginHandshake.Reconnect = true;
+                    _forceStopScene = true;
+                }
+                else
+                {
+                    UIManager.Add(
+                        new MessageBoxGump(
+                            _world,
+                            200,
+                            200,
+                            string.Format(
+                                ResGeneral.ConnectionLost0,
+                                StringHelper.AddSpaceBeforeCapital(e.ToString())
+                            ),
+                            s =>
                             {
-                                Client.Game.SetScene(new LoginScene(_world));
+                                if (s)
+                                {
+                                    Client.Game.SetScene(new LoginScene(_world));
+                                }
                             }
-                        }
-                    )
-                );
-            }
+                        )
+                    );
+                }
+            });
         }
 
         public void RequestQuitGame() => UIManager.Add(


### PR DESCRIPTION
This is a most likely fix scenario, it's not easily reproducable so it's a best guess

Original crash:

```
Exception:
System.InvalidOperationException: InvalidOperation_ConcurrentOperationsNotSupported

   at ClassicUO.Game.Managers.UIManager.GetGump[T](Nullable`1 serial) in D:\a\TazUO\TazUO\src\ClassicUO.Client\Game\Managers\UIManager.cs:line 444

   at ClassicUO.Game.UI.Gumps.ContainerGump.Dispose() in D:\a\TazUO\TazUO\src\ClassicUO.Client\Game\UI\Gumps\ContainerGump.cs:line 781

   at ClassicUO.Game.Managers.UIManager.Clear() in D:\a\TazUO\TazUO\src\ClassicUO.Client\Game\Managers\UIManager.cs:line 649

   at ClassicUO.Game.Scenes.GameScene.Unload() in D:\a\TazUO\TazUO\src\ClassicUO.Client\Game\Scenes\GameScene.cs:line 456

   at ClassicUO.Game.Scenes.Scene.Dispose() in D:\a\TazUO\TazUO\src\ClassicUO.Client\Game\Scenes\Scene.cs:line 28

   at ClassicUO.GameController.SetScene(Scene scene) in D:\a\TazUO\TazUO\src\ClassicUO.Client\GameController.cs:line 308

   at ClassicUO.Game.Scenes.GameScene.<SocketOnDisconnected>b__56_0(Boolean s) in D:\a\TazUO\TazUO\src\ClassicUO.Client\Game\Scenes\GameScene.cs:line 503

   at ClassicUO.Game.UI.Gumps.MessageBoxGump.OnButtonClick(Int32 buttonID) in D:\a\TazUO\TazUO\src\ClassicUO.Client\Game\UI\Gumps\MessageBoxGump.cs:line 133

   at ClassicUO.Game.UI.Controls.Control.OnButtonClick(Int32 buttonID) in D:\a\TazUO\TazUO\src\ClassicUO.Client\Game\UI\Controls\Control.cs:line 949

   at ClassicUO.Game.UI.Controls.Button.OnMouseUp(Int32 x, Int32 y, MouseButtonType button) in D:\a\TazUO\TazUO\src\ClassicUO.Client\Game\UI\Controls\Button.cs:line 287

   at ClassicUO.Game.UI.Controls.Control.InvokeMouseUp(Point position, MouseButtonType button) in D:\a\TazUO\TazUO\src\ClassicUO.Client\Game\UI\Controls\Control.cs:line 708

   at ClassicUO.Game.Managers.UIManager.OnMouseButtonUp(MouseButtonType button) in D:\a\TazUO\TazUO\src\ClassicUO.Client\Game\Managers\UIManager.cs:line 250

   at ClassicUO.GameController.HandleSdlEvent(IntPtr userdata, SDL_Event* sdlEvent) in D:\a\TazUO\TazUO\src\ClassicUO.Client\GameController.cs:line 1076

   at SDL3.SDL.SDL_PollEvent(SDL_Event& event)

   at Microsoft.Xna.Framework.SDL3_FNAPlatform.PollEvents(Game game, GraphicsAdapter& currentAdapter, Boolean[] textInputControlDown, Boolean& textInputSuppress) in D:\a\TazUO\TazUO\external\FNA\src\FNAPlatform\SDL3_FNAPlatform.cs:line 893

   at Microsoft.Xna.Framework.Game.Tick() in D:\a\TazUO\TazUO\external\FNA\src\Game.cs:line 460

   at Microsoft.Xna.Framework.Game.RunLoop() in D:\a\TazUO\TazUO\external\FNA\src\Game.cs:line 876

   at Microsoft.Xna.Framework.Game.Run() in D:\a\TazUO\TazUO\external\FNA\src\Game.cs:line 417

   at ClassicUO.Client.Run(IPluginHost pluginHost) in D:\a\TazUO\TazUO\src\ClassicUO.Client\Client.cs:line 251

   at ClassicUO.Bootstrap.Boot(UnmanagedAssistantHost pluginHost, String[] args) in D:\a\TazUO\TazUO\src\ClassicUO.Client\Main.cs:line 228

   at ClassicUO.Bootstrap.Main(String[] args) in D:\a\TazUO\TazUO\src\ClassicUO.Client\Main.cs:line 39

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection-loss handling to ensure reconnect actions, scene changes, and connection-lost messages occur reliably.
  * Preserved existing disconnection behavior while improving consistency during network interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->