### PR TITLE
Prevent client crash when nameoverhead.xml save fails

### DIFF
--- a/src/ClassicUO.Client/Game/Managers/NameOverHeadManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/NameOverHeadManager.cs
@@ -398,6 +398,7 @@ namespace ClassicUO.Game.Managers
             }
             catch (Exception ex)
             {
+                // Non-fatal: a failed save (e.g. read-only install dir) must not crash the client
                 Log.Error($"Failed to save nameoverhead.xml: {ex}");
 
                 // Clean up temp file if it exists
@@ -412,7 +413,6 @@ namespace ClassicUO.Game.Managers
                         // Ignore cleanup errors
                     }
                 }
-                throw;
             }
         }
 


### PR DESCRIPTION
A read-only or protected install directory (e.g. C:\Program Files) caused Save() to rethrow UnauthorizedAccessException, which propagated through Load() and GameScene.Load() and crashed the client on login. Saving the name-overhead config is non-fatal, so log the failure instead of rethrowing.