### PR TITLE
Fix ResizableJournal scroll drifting when trimming old entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to TazUO will be recorded here.
 * Added a screenshot on death option(enabled by default) - [P.R 857](https://github.com/PlayTazUO/TazUO/pull/857) ([bittiez](https://github.com/bittiez))
 * Added a Randomize button to the character creation screen that picks random hair/facial hair styles and random colors (skin, shirt, pants, hair, beard) while keeping the selected race and gender ([bittiez](https://github.com/bittiez))
 
+### Fixes
+* Fix journal partially scrolled sometimes still scrolling up - [P.R 858](https://github.com/PlayTazUO/TazUO/pull/858) ([bittiez](https://github.com/bittiez))
+
 ## 5.20.26
 
 ### Legion

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.22.0</AssemblyVersion>
-    <FileVersion>5.22.0</FileVersion>
+    <AssemblyVersion>5.22.1</AssemblyVersion>
+    <FileVersion>5.22.1</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Gumps/ResizableJournal.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ResizableJournal.cs
@@ -678,6 +678,12 @@ namespace ClassicUO.Game.UI.Gumps
                         ClearSelection();
                     }
 
+                    //Trimming from the top shifts content up, so drop the scroll value by the removed height to keep the view anchored on the same lines.
+                    if (!maxScroll && removed != null && CanBeDrawn(removed.TextType, removed.MessageType))
+                    {
+                        _scrollBar.Value = Math.Max(_scrollBar.MinValue, _scrollBar.Value - removed.EntryText.Height);
+                    }
+
                     removed?.Destroy();
                 }
 


### PR DESCRIPTION
When the journal reached its max entry cap, each new message trimmed an entry from the top via RemoveFromFront(), shifting all content upward. The scroll Value (pixel offset from content-top) was never adjusted, so a view that was scrolled up would drift downward and appear to keep scrolling. Now, when scrolled up, subtract the removed entry's height from the scroll value to keep the view anchored on the same lines.