### PR TITLE
Change TileMarkers.json to use Data/<Server> directory instead of Data/Client

### DIFF
--- a/src/ClassicUO.Client/Game/Managers/TileMarkerManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/TileMarkerManager.cs
@@ -40,13 +40,44 @@ namespace ClassicUO.Game.Managers
 
     internal class TileMarkerManager
     {
-        public static TileMarkerManager Instance { get; private set; } = new TileMarkerManager();
+        public static TileMarkerManager Instance
+        {
+            get
+            {
+                if (field == null)
+                    field = new TileMarkerManager();
+                return field;
+            }
+        }
 
         private Dictionary<TileLocation, ushort> markedTiles = new Dictionary<TileLocation, ushort>();
+        private bool _loaded;
 
-        private TileMarkerManager() { Load(); }
+        private TileMarkerManager()
+        {
+            if (!string.IsNullOrEmpty(ProfileManager.CurrentProfile?.ServerName))
+            {
+                _loaded = true;
+                Load();
+            }
+            else
+            {
+                ProfileManager.CurrentProfileChanged += OnProfileChanged;
+            }
+        }
 
-        private string SavePath => Path.Combine(ProfileManager.ProfilePath ?? CUOEnviroment.ExecutablePath, "TileMarkers.json");
+        private void OnProfileChanged(object sender, EventArgs e)
+        {
+            if (!_loaded && !string.IsNullOrEmpty(ProfileManager.CurrentProfile?.ServerName))
+            {
+                _loaded = true;
+                Load();
+            }
+
+            ProfileManager.CurrentProfileChanged -= OnProfileChanged;
+        }
+
+        private string SavePath => Path.Combine(JsonSaveLocationHelper.GetScopeDirectory(SettingsScope.Server), "TileMarkers.json");
 
         public void AddTile(int x, int y, int map, ushort hue)
         {


### PR DESCRIPTION
## Description
TileMarkers.json was being saved to the client executable directory (or per-character
profile path when available) instead of the per-server `Data/<Server>/` directory where
other server-scoped data (MapMarkers, MapIcons) lives. This PR moves the save location
to `Data/<Server>/TileMarkers.json` and fixes the load timing so the file is properly
read when entering the world.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Documentation update

## Testing
- Placed an existing TileMarkers.json in `Data/<Server>/` and verified tiles load on login
- Added tiles via `-marktile` command in game, confirmed visual tile color change
- Exited and verified TileMarkers.json was written with correct entries in `Data/<Server>/`
- Tested across character switches on the same server

## Additional Notes
- Uses `JsonSaveLocationHelper.GetScopeDirectory(SettingsScope.Server)` for consistency
  with existing per-server data conventions
- Instance creation is now lazy to avoid constructing before a profile is available
- Handles the case where a profile is already loaded when `Instance` is first accessed