### PR TITLE
Fix in-game screenshots showing viewport as partially transparent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to TazUO will be recorded here.
 * Added a Randomize button to the character creation screen that picks random hair/facial hair styles and random colors (skin, shirt, pants, hair, beard) while keeping the selected race and gender ([bittiez](https://github.com/bittiez))
 
 ### Fixes
-* Fixed in-game screenshots showing the world viewport as partially transparent by forcing the saved image to be fully opaque ([bittiez](https://github.com/bittiez))
+* Fixed in-game screenshots showing the world viewport as partially transparent by forcing the saved image to be fully opaque - [P.R 870](https://github.com/PlayTazUO/TazUO/pull/870) ([bittiez](https://github.com/bittiez))
 * Fix journal partially scrolled sometimes still scrolling up - [P.R 858](https://github.com/PlayTazUO/TazUO/pull/858) ([bittiez](https://github.com/bittiez))
 
 ## 5.20.26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to TazUO will be recorded here.
 * Added a Randomize button to the character creation screen that picks random hair/facial hair styles and random colors (skin, shirt, pants, hair, beard) while keeping the selected race and gender ([bittiez](https://github.com/bittiez))
 
 ### Fixes
+* Fixed in-game screenshots showing the world viewport as partially transparent by forcing the saved image to be fully opaque ([bittiez](https://github.com/bittiez))
 * Fix journal partially scrolled sometimes still scrolling up - [P.R 858](https://github.com/PlayTazUO/TazUO/pull/858) ([bittiez](https://github.com/bittiez))
 
 ## 5.20.26

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.22.1</AssemblyVersion>
-    <FileVersion>5.22.1</FileVersion>
+    <AssemblyVersion>5.22.2</AssemblyVersion>
+    <FileVersion>5.22.2</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/GameController.cs
+++ b/src/ClassicUO.Client/GameController.cs
@@ -1218,6 +1218,11 @@ namespace ClassicUO
                 GraphicsDevice.GetBackBufferData(colors);
             }
 
+            // The render target's alpha channel is not fully opaque in the world viewport (lighting
+            // and world compositing leave varying alpha). Screenshots are always opaque, so force it.
+            for (int i = 0; i < colors.Length; i++)
+                colors[i].A = 255;
+
             using (
                 var texture = new Texture2D(
                     GraphicsDevice,
@@ -1260,6 +1265,11 @@ namespace ClassicUO
             {
                 graphicDevice.GetBackBufferData(position, colors, 0, colors.Length);
             }
+
+            // The render target's alpha channel is not fully opaque in the world viewport (lighting
+            // and world compositing leave varying alpha). Screenshots are always opaque, so force it.
+            for (int i = 0; i < colors.Length; i++)
+                colors[i].A = 255;
 
             using (
                 var texture = new Texture2D(


### PR DESCRIPTION
Screenshots capture RGBA pixel data from the screen render target. In the world viewport the render target's alpha channel is left non-opaque by the lighting composite and world compositing; this is invisible on screen (the back buffer presents RGB only) but a saved PNG preserves the alpha, making the viewport appear partially transparent.

Force full alpha on the captured pixels before saving in both TakeScreenshot and ClipboardScreenshot, since a game screenshot is inherently opaque.