### PR TITLE
Fully terminate process on exit so no background process lingers

### DIFF
--- a/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
@@ -453,9 +453,9 @@ namespace ClassicUO.LegionScripting
 
                 // Route to correct executor based on script type
                 if (script.Type == ScriptFile.ScriptType.CSharp)
-                    script.ScriptThread = new Thread(() => ExecuteCSharpScript(script)) { Name = $"Legion: {script.FileName}" };
+                    script.ScriptThread = new Thread(() => ExecuteCSharpScript(script)) { Name = $"Legion: {script.FileName}", IsBackground = true };
                 else
-                    script.ScriptThread = new Thread(() => ExecutePythonScript(script)) { Name = $"Legion: {script.FileName}" };
+                    script.ScriptThread = new Thread(() => ExecutePythonScript(script)) { Name = $"Legion: {script.FileName}", IsBackground = true };
 
                 if(!PyThreads.TryAdd(script.ScriptThread.ManagedThreadId, script))
                     PyThreads[script.ScriptThread.ManagedThreadId] = script;

--- a/src/ClassicUO.Client/Main.cs
+++ b/src/ClassicUO.Client/Main.cs
@@ -229,6 +229,12 @@ namespace ClassicUO
             }
 
             Log.Trace("Closing...");
+
+            // Force full process termination. The game loop has returned and all cleanup has run,
+            // but lingering foreground threads (script threads, native plugin host, HttpListener,
+            // IronPython, etc.) can keep the process alive after the window closes. Environment.Exit
+            // guarantees the process ends so no background process is left running.
+            Environment.Exit(0);
         }
 
         private static void ReadSettingsFromArgs(string[] args)


### PR DESCRIPTION
Clicking Quit on the login scene closed the window but left the process running. After the FNA game loop returns, any lingering foreground thread keeps the .NET process alive. Force-exit at the single application exit point so closing always fully terminates TazUO, and mark Legion script threads as background so a running script can't hold the process open.