### PR TITLE
Convert Legion script settings JSON save to base JsonSave class

### DIFF
--- a/src/ClassicUO.Client/LegionScripting/LScriptSettings.cs
+++ b/src/ClassicUO.Client/LegionScripting/LScriptSettings.cs
@@ -1,12 +1,33 @@
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using ClassicUO.Configuration;
 
 namespace ClassicUO.LegionScripting
 {
-    public class LScriptSettings
+    /// <summary>
+    /// JSON-backed store for Legion script settings. Persisted to <c>lscript.json</c> in the shared
+    /// <c>Data</c> folder. Saving/loading (with rotating backups) is handled by <see cref="JsonSave{T}"/>.
+    /// </summary>
+    public class LScriptSettings : JsonSave<LScriptSettings>
     {
+        private const string LScriptSettingsFileName = "lscript.json";
+
         public List<string> GlobalAutoStartScripts { get; set; } = new List<string>();
         public Dictionary<string, List<string>> CharAutoStartScripts { get; set; } = new Dictionary<string, List<string>>();
         public Dictionary<string, bool> GroupCollapsed { get; set; } = new Dictionary<string, bool>();
         public bool DisableModuleCache { get; set; }
+
+        /// <summary>Lives in the shared <c>Data</c> folder, matching the legacy save location.</summary>
+        protected override SettingsScope Scope => SettingsScope.Global;
+
+        protected override string FileName => LScriptSettingsFileName;
+
+        protected override JsonTypeInfo<LScriptSettings> TypeInfo => LScriptJsonContext.Default.LScriptSettings;
+    }
+
+    [JsonSerializable(typeof(LScriptSettings))]
+    public partial class LScriptJsonContext : JsonSerializerContext
+    {
     }
 }

--- a/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using ClassicUO.Configuration;
@@ -13,7 +12,6 @@ using ClassicUO.Game.Managers;
 using ClassicUO.Utility.Logging;
 using IronPython.Hosting;
 using Microsoft.Scripting.Hosting;
-using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using ClassicUO.Game.UI.MyraWindows;
 using ClassicUO.LegionScripting.ApiClasses;
@@ -24,11 +22,6 @@ using SourceCodeKind = Microsoft.Scripting.SourceCodeKind;
 
 namespace ClassicUO.LegionScripting
 {
-    [JsonSerializable(typeof(LScriptSettings))]
-    public partial class LScriptJsonContext : JsonSerializerContext
-    {
-    }
-
     internal static class LegionScripting
     {
         public static string ScriptPath;
@@ -385,47 +378,20 @@ namespace ClassicUO.LegionScripting
 
         private static void LoadLScriptSettings()
         {
-            string path = Path.Combine(CUOEnviroment.ExecutablePath, "Data", "lscript.json");
+            LScriptSettings = JsonSave<LScriptSettings>.Load();
 
-            try
+            for (int i = 0; i < LScriptSettings.CharAutoStartScripts.Count; i++)
             {
-                if (File.Exists(path))
-                {
-                    LScriptSettings = JsonSerializer.Deserialize(File.ReadAllText(path), LScriptJsonContext.Default.LScriptSettings);
-
-                    for (int i = 0; i < LScriptSettings.CharAutoStartScripts.Count; i++)
-                    {
-                        KeyValuePair<string, List<string>> val = LScriptSettings.CharAutoStartScripts.ElementAt(i);
-                        val.Value.RemoveAll(script => LoadedScripts.All(s => s.FileName != script));
-                    }
-
-                    LScriptSettings.GlobalAutoStartScripts.RemoveAll(script => LoadedScripts.All(s => s.FileName != script));
-
-                    return;
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error($"Unexpected error: {ex}");
+                KeyValuePair<string, List<string>> val = LScriptSettings.CharAutoStartScripts.ElementAt(i);
+                val.Value.RemoveAll(script => LoadedScripts.All(s => s.FileName != script));
             }
 
-            LScriptSettings = new LScriptSettings();
+            LScriptSettings.GlobalAutoStartScripts.RemoveAll(script => LoadedScripts.All(s => s.FileName != script));
         }
 
         private static void SaveScriptSettings()
         {
-            string path = Path.Combine(CUOEnviroment.ExecutablePath, "Data", "lscript.json");
-
-            string json = JsonSerializer.Serialize(LScriptSettings, LScriptJsonContext.Default.LScriptSettings);
-
-            try
-            {
-                File.WriteAllText(path, json);
-            }
-            catch (Exception e)
-            {
-                Log.Error($"Error saving lscript settings: {e}");
-            }
+            LScriptSettings?.Save();
         }
 
         public static void Unload()


### PR DESCRIPTION
Make LScriptSettings derive from JsonSave<T> so it uses the shared atomic save, rotating backups, and cross-process locking instead of a bespoke read/write. The file continues to live at Data/lscript.json (SettingsScope.Global) with the same property names for backward compatibility.