### PR TITLE
Convert journal filter save system to JsonSave base class

### DIFF
--- a/src/ClassicUO.Client/Game/Managers/JournalFilterManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/JournalFilterManager.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 using ClassicUO.Configuration;
 using ClassicUO.Utility;
 
@@ -9,10 +11,9 @@ namespace ClassicUO.Game.Managers;
 
 public class JournalFilterManager
 {
-    private string _savePath;
+    private JournalFilterSave _save = new();
 
-    private HashSet<string> _filters = new();
-    public HashSet<string> Filters => _filters;
+    public HashSet<string> Filters => _save.Filters;
 
     private static JournalFilterManager _instance;
     public static JournalFilterManager Instance { get
@@ -25,17 +26,16 @@ public class JournalFilterManager
 
     private JournalFilterManager()
     {
-        _savePath = Path.Combine(ProfileManager.ProfilePath, "journal_filters.json");
         Load();
     }
 
-    public void AddFilter(string filter) => _filters.Add(filter);
+    public void AddFilter(string filter) => _save.Filters.Add(filter);
 
-    public void RemoveFilter(string filter) => _filters.Remove(filter);
+    public void RemoveFilter(string filter) => _save.Filters.Remove(filter);
 
     public bool IgnoreMessage(string message)
     {
-        foreach (string filter in _filters)
+        foreach (string filter in _save.Filters)
         {
             if (message.Contains(filter, StringComparison.OrdinalIgnoreCase))
                 return true;
@@ -45,22 +45,20 @@ public class JournalFilterManager
 
     public void Save(bool resetInstance = true)
     {
-        JsonHelper.SaveAndBackup(_filters, _savePath, HashSetContext.Default.HashSetString);
-        _instance = null;
+        _save.Save();
+
+        if (resetInstance)
+            _instance = null;
     }
 
-    public void Load()
-    {
-        if(JsonHelper.Load(_savePath, HashSetContext.Default.HashSetString, out HashSet<string> obj))
-            _filters = obj;
-    }
+    public void Load() => _save = JournalFilterSave.LoadForCurrentProfile();
 
     #nullable enable
     public string? GetJsonExport()
     {
         try
         {
-            return System.Text.Json.JsonSerializer.Serialize(_filters, HashSetContext.Default.HashSetString);
+            return JsonSerializer.Serialize(_save.Filters, HashSetContext.Default.HashSetString);
         }
         catch (Exception e)
         {
@@ -75,7 +73,7 @@ public class JournalFilterManager
     {
         try
         {
-            HashSet<string> importedFilters = System.Text.Json.JsonSerializer.Deserialize(json, HashSetContext.Default.HashSetString);
+            HashSet<string> importedFilters = JsonSerializer.Deserialize(json, HashSetContext.Default.HashSetString);
 
             if (importedFilters != null)
             {
@@ -84,7 +82,7 @@ public class JournalFilterManager
 
                 foreach (string filter in importedFilters)
                 {
-                    if (_filters.Add(filter))
+                    if (_save.Filters.Add(filter))
                     {
                         addedCount++;
                     }
@@ -112,6 +110,58 @@ public class JournalFilterManager
     }
 }
 
+/// <summary>
+/// JSON-backed store for a character's journal filters. Persisted to <c>journal_filters.json</c> in the
+/// current profile folder. Saving/loading (with rotating backups) is handled by <see cref="JsonSave{T}"/>.
+/// </summary>
+public sealed class JournalFilterSave : JsonSave<JournalFilterSave>
+{
+    public const string JournalFiltersFileName = "journal_filters.json";
+
+    public HashSet<string> Filters { get; set; } = new();
+
+    protected override SettingsScope Scope => SettingsScope.Char;
+
+    protected override string FileName => JournalFiltersFileName;
+
+    protected override JsonTypeInfo<JournalFilterSave> TypeInfo => JournalFilterJsonContext.Default.JournalFilterSave;
+
+    /// <summary>Migrates any legacy bare-array file to the wrapped format, then loads the current profile's save.</summary>
+    public static JournalFilterSave LoadForCurrentProfile()
+    {
+        MigrateLegacyFormatIfNeeded();
+        return Load();
+    }
+
+    // Older versions stored a bare JSON array; rewrite it once into the wrapped format JsonSave expects.
+    private static void MigrateLegacyFormatIfNeeded()
+    {
+        string path = Path.Combine(JsonSaveLocationHelper.GetScopeDirectory(SettingsScope.Char), JournalFiltersFileName);
+
+        if (!File.Exists(path))
+            return;
+
+        try
+        {
+            string json = File.ReadAllText(path);
+
+            if (!json.TrimStart().StartsWith('['))
+                return;
+
+            HashSet<string> legacy = JsonSerializer.Deserialize(json, HashSetContext.Default.HashSetString) ?? new HashSet<string>();
+            new JournalFilterSave { Filters = legacy }.Save();
+        }
+        catch (Exception ex)
+        {
+            Utility.Logging.Log.Error($"Error migrating legacy journal filters: {ex.Message}");
+        }
+    }
+}
+
+[JsonSerializable(typeof(JournalFilterSave), GenerationMode = JsonSourceGenerationMode.Metadata)]
+internal partial class JournalFilterJsonContext : JsonSerializerContext
+{
+}
 
 [JsonSerializable(typeof(HashSet<string>))]
 [JsonSourceGenerationOptions(


### PR DESCRIPTION
Replace the ad-hoc JsonHelper save/load in JournalFilterManager with a JournalFilterSave : JsonSave<JournalFilterSave> container, matching the DressAgentManager pattern. Adds rotating backups, atomic writes and cross-process locking for free, and migrates the legacy bare-array file format to the wrapped format on first load.