### PR TITLE
MacroManager: skip friends when selecting Hostile targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to TazUO will be recorded here.
 * Added a Randomize button to the character creation screen that picks random hair/facial hair styles and random colors (skin, shirt, pants, hair, beard) while keeping the selected race and gender ([bittiez](https://github.com/bittiez))
 
 ### Fixes
+* MacroManager select next/previous/nearest with the Hostile scan type now skips anyone on the friends list - [P.R 880](https://github.com/PlayTazUO/TazUO/pull/880) ([bittiez](https://github.com/bittiez))
 * Fixed in-game screenshots showing the world viewport as partially transparent by forcing the saved image to be fully opaque - [P.R 870](https://github.com/PlayTazUO/TazUO/pull/870) ([bittiez](https://github.com/bittiez))
 * Fix journal partially scrolled sometimes still scrolling up - [P.R 858](https://github.com/PlayTazUO/TazUO/pull/858) ([bittiez](https://github.com/bittiez))
 

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.22.7</AssemblyVersion>
-    <FileVersion>5.22.7</FileVersion>
+    <AssemblyVersion>5.22.8</AssemblyVersion>
+    <FileVersion>5.22.8</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.22.6</AssemblyVersion>
-    <FileVersion>5.22.6</FileVersion>
+    <AssemblyVersion>5.22.7</AssemblyVersion>
+    <FileVersion>5.22.7</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/World.cs
+++ b/src/ClassicUO.Client/Game/World.cs
@@ -867,6 +867,10 @@ namespace ClassicUO.Game
                             {
                                 continue;
                             }
+                            if (FriendsListManager.Instance.IsFriend(mobile.Serial))
+                            {
+                                continue;
+                            }
                             break;
                         case ScanTypeObject.Objects:
                             /* This was handled separately above */
@@ -938,6 +942,10 @@ namespace ClassicUO.Game
                             break;
                         case ScanTypeObject.Hostile:
                             if (mobile.NotorietyFlag == NotorietyFlag.Ally || mobile.NotorietyFlag == NotorietyFlag.Innocent || mobile.NotorietyFlag == NotorietyFlag.Invulnerable)
+                            {
+                                continue;
+                            }
+                            if (FriendsListManager.Instance.IsFriend(mobile.Serial))
                             {
                                 continue;
                             }


### PR DESCRIPTION
When using SelectNext/SelectPrevious/SelectNearest with the Hostile scan type, mobiles on the user's friend list are now skipped so friends are never selected as hostile targets.