### PR TITLE
Add Highlight(hue) to ApiGameObject and OriginalHue to GameObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to TazUO will be recorded here.
 ---
 ## In Development
 
+### Legion
+* Added `Highlight(hue)` to game objects, setting the hue and remembering the original so it can be restored with `Highlight(None)`; on mobiles it also recolors all equipped items - [P.R 881](https://github.com/PlayTazUO/TazUO/pull/881) ([bittiez](https://github.com/bittiez))
+
 ### Features
 * Added a screenshot on death option(enabled by default) - [P.R 857](https://github.com/PlayTazUO/TazUO/pull/857) ([bittiez](https://github.com/bittiez))
 * Added a Randomize button to the character creation screen that picks random hair/facial hair styles and random colors (skin, shirt, pants, hair, beard) while keeping the selected race and gender ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.22.8</AssemblyVersion>
-    <FileVersion>5.22.8</FileVersion>
+    <AssemblyVersion>5.22.9</AssemblyVersion>
+    <FileVersion>5.22.9</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/GameObjects/GameObject.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/GameObject.cs
@@ -121,6 +121,13 @@ namespace ClassicUO.Game.GameObjects
                 hue = value;
             }
         }
+
+        /// <summary>
+        /// The hue captured before a highlight was applied. Null when no highlight is active,
+        /// allowing the original hue to be restored later.
+        /// </summary>
+        public ushort? OriginalHue { get; set; }
+
         public Vector3 Offset;
 
         /// <summary>

--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiGameObject.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiGameObject.cs
@@ -117,6 +117,44 @@ public class ApiGameObject
     }
 
     /// <summary>
+    /// Highlight this object by setting its hue. The original hue is remembered so it can be restored.
+    /// Call with <c>None</c> to restore the original hue.
+    /// Example:
+    /// ```py
+    /// obj.Highlight(0x0021)
+    /// obj.Highlight(None)
+    /// ```
+    /// </summary>
+    /// <param name="hue">The hue to apply, or <c>null</c> to restore the original hue.</param>
+    public virtual void Highlight(ushort? hue = null)
+    {
+        if (_gameObject == null || _gameObject.IsDestroyed)
+            return;
+
+        MainThreadQueue.EnqueueAction(() => ApplyHighlight(_gameObject, hue));
+    }
+
+    /// <summary>
+    /// Applies or clears a highlight hue on a single game object. Must run on the main thread.
+    /// </summary>
+    private protected static void ApplyHighlight(GameObject obj, ushort? hue)
+    {
+        if (obj == null || obj.IsDestroyed)
+            return;
+
+        if (hue.HasValue)
+        {
+            obj.OriginalHue ??= obj.Hue; //Remember the original hue only on the first highlight.
+            obj.Hue = hue.Value;
+        }
+        else if (obj.OriginalHue.HasValue)
+        {
+            obj.Hue = obj.OriginalHue.Value;
+            obj.OriginalHue = null;
+        }
+    }
+
+    /// <summary>
     /// Determines if there is line of sight from the specified observer to this object.
     /// If no observer is specified, it defaults to the player.
     /// </summary>

--- a/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiMobile.cs
+++ b/src/ClassicUO.Client/LegionScripting/ApiClasses/ApiMobile.cs
@@ -1,3 +1,4 @@
+using ClassicUO.Game;
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.Managers;
 using static ClassicUO.LegionScripting.LegionAPI;
@@ -91,6 +92,36 @@ public class ApiMobile : ApiEntity
 
             return m != null ? selector(m) : fallback;
         });
+
+    /// <summary>
+    /// Highlight this mobile and all of its equipped items with the given hue.
+    /// The original hues are remembered so they can be restored.
+    /// Call with <c>None</c> to restore the mobile and its equipped items to their original hues.
+    /// Example:
+    /// ```py
+    /// mob.Highlight(0x0021)
+    /// mob.Highlight(None)
+    /// ```
+    /// </summary>
+    /// <param name="hue">The hue to apply, or <c>null</c> to restore the original hues.</param>
+    public override void Highlight(ushort? hue = null)
+    {
+        MainThreadQueue.EnqueueAction(() =>
+        {
+            Mobile m = GetMobileUnsafe();
+
+            if (m == null || m.IsDestroyed)
+                return;
+
+            ApplyHighlight(m, hue);
+
+            for (LinkedObject i = m.Items; i != null; i = i.Next)
+            {
+                if (i is Item it)
+                    ApplyHighlight(it, hue);
+            }
+        });
+    }
 
     /// <summary>
     /// Gets the mobile name and properties (tooltip text).

--- a/src/ClassicUO.Client/LegionScripting/docs/API.py
+++ b/src/ClassicUO.Client/LegionScripting/docs/API.py
@@ -59,6 +59,19 @@ class ApiGameObject:
         """
         pass
 
+    def Highlight(self, hue: "int | None" = None) -> None:
+        """
+         Highlight this object by setting its hue. The original hue is remembered so it can be restored.
+         Call with `None` to restore the original hue.
+         Example:
+         ```py
+         obj.Highlight(0x0021)
+         obj.Highlight(None)
+         ```
+        
+        """
+        pass
+
     def HasLineOfSightFrom(self, observer: "ApiGameObject" = None) -> "bool":
         """
          Determines if there is line of sight from the specified observer to this object.
@@ -199,6 +212,20 @@ class ApiMobile(ApiEntity):
     Backpack: ApiItem = None
     Mount: ApiItem = None
     __class__: str = None
+
+    def Highlight(self, hue: "int | None" = None) -> None:
+        """
+         Highlight this mobile and all of its equipped items with the given hue.
+         The original hues are remembered so they can be restored.
+         Call with `None` to restore the mobile and its equipped items to their original hues.
+         Example:
+         ```py
+         mob.Highlight(0x0021)
+         mob.Highlight(None)
+         ```
+        
+        """
+        pass
 
     def NameAndProps(self, wait: "bool" = False, timeout: "int" = 10) -> "str":
         """

--- a/src/ClassicUO.Client/LegionScripting/docs/ApiGameObject.md
+++ b/src/ClassicUO.Client/LegionScripting/docs/ApiGameObject.md
@@ -108,6 +108,27 @@ description:  Base class for all Python-accessible game world objects.  Encapsul
 
 ---
 
+### Highlight
+`(hue)`
+ Highlight this object by setting its hue. The original hue is remembered so it can be restored.
+ Call with `None` to restore the original hue.
+ Example:
+ ```py
+ obj.Highlight(0x0021)
+ obj.Highlight(None)
+ ```
+
+
+**Parameters:**
+
+| Name | Type | Optional | Description |
+| --- | --- | --- | --- |
+| `hue` | `ushort?` | ✅ Yes | The hue to apply, or `null` to restore the original hue. |
+
+**Return Type:** `void` *(Does not return anything)*
+
+---
+
 ### HasLineOfSightFrom
 `(observer)`
  Determines if there is line of sight from the specified observer to this object.

--- a/src/ClassicUO.Client/LegionScripting/docs/ApiMobile.md
+++ b/src/ClassicUO.Client/LegionScripting/docs/ApiMobile.md
@@ -140,6 +140,28 @@ description:  Represents a Python-accessible mobile (NPC, creature, or player ch
 *No enums found.*
 
 ## Methods
+### Highlight
+`(hue)`
+ Highlight this mobile and all of its equipped items with the given hue.
+ The original hues are remembered so they can be restored.
+ Call with `None` to restore the mobile and its equipped items to their original hues.
+ Example:
+ ```py
+ mob.Highlight(0x0021)
+ mob.Highlight(None)
+ ```
+
+
+**Parameters:**
+
+| Name | Type | Optional | Description |
+| --- | --- | --- | --- |
+| `hue` | `ushort?` | ✅ Yes | The hue to apply, or `null` to restore the original hues. |
+
+**Return Type:** `void` *(Does not return anything)*
+
+---
+
 ### NameAndProps
 `(wait, timeout)`
  Gets the mobile name and properties (tooltip text).


### PR DESCRIPTION
Highlight sets the object's hue while remembering the original so it can be restored by calling Highlight(None). ApiMobile overrides it to also recolor all equipped items. GameObject gains a nullable OriginalHue property to track the pre-highlight hue.