### PR TITLE
Add layer name tooltips to empty paperdoll equipment slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to TazUO will be recorded here.
 * Added `Highlight(hue)` to game objects, setting the hue and remembering the original so it can be restored with `Highlight(None)`; on mobiles it also recolors all equipped items - [P.R 881](https://github.com/PlayTazUO/TazUO/pull/881) ([bittiez](https://github.com/bittiez))
 
 ### Features
+* Added tooltips to empty slots on paperdoll for what layer they are ([bittiez](https://github.com/bittiez))
 * Added a screenshot on death option(enabled by default) - [P.R 857](https://github.com/PlayTazUO/TazUO/pull/857) ([bittiez](https://github.com/bittiez))
 * Added a Randomize button to the character creation screen that picks random hair/facial hair styles and random colors (skin, shirt, pants, hair, beard) while keeping the selected race and gender ([bittiez](https://github.com/bittiez))
 

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.22.9</AssemblyVersion>
-    <FileVersion>5.22.9</FileVersion>
+    <AssemblyVersion>5.22.10</AssemblyVersion>
+    <FileVersion>5.22.10</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Gumps/PaperdollGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/PaperdollGump.cs
@@ -842,6 +842,9 @@ namespace ClassicUO.Game.UI.Gumps
 
                 AcceptMouseInput = true;
 
+                // Show the layer name when the slot is empty (item gumps show their own tooltip on top)
+                SetTooltip(layer.ToString());
+
                 WantUpdateSize = false;
             }
 


### PR DESCRIPTION
Empty equipment slots on the original paperdoll now show a tooltip with the slot's layer name on hover. When a slot holds an item, the item gump renders on top and continues to show its own tooltip.