### PR TITLE
Use JsonSave base class for profile persistence

### DIFF
--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.22.12</AssemblyVersion>
-    <FileVersion>5.22.12</FileVersion>
+    <AssemblyVersion>5.22.13</AssemblyVersion>
+    <FileVersion>5.22.13</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Configuration/JsonSave.cs
+++ b/src/ClassicUO.Client/Configuration/JsonSave.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 using System.Threading;
 using ClassicUO.Game;
@@ -42,40 +43,49 @@ namespace ClassicUO.Configuration
         protected abstract JsonTypeInfo<T> TypeInfo { get; }
 
         /// <summary>The directory this file is saved in, resolved from <see cref="Scope"/>.</summary>
-        public string SaveDirectory => JsonSaveLocationHelper.GetScopeDirectory(Scope);
+        [JsonIgnore] public string SaveDirectory => JsonSaveLocationHelper.GetScopeDirectory(Scope);
 
         /// <summary>The full path to the save file.</summary>
-        public string FilePath => Path.Combine(SaveDirectory, FileName);
+        [JsonIgnore] public string FilePath => Path.Combine(SaveDirectory, FileName);
 
         /// <summary>The directory that holds the rotating backups for this file.</summary>
-        public string BackupDirectory => Path.Combine(SaveDirectory, Constants.BACKUP_FOLDER);
+        [JsonIgnore] public string BackupDirectory => Path.Combine(SaveDirectory, Constants.BACKUP_FOLDER);
 
         /// <summary>
-        /// Loads the save for type <typeparamref name="T"/>. If the main file is missing or unreadable the
-        /// backups are tried in order; if they all fail a fresh instance is created and written to disk so a
-        /// valid file always exists afterwards.
+        /// Loads the save for type <typeparamref name="T"/> from <see cref="FilePath"/>. If the main file is
+        /// missing or unreadable the backups are tried in order; if they all fail a fresh instance is created
+        /// and written to disk so a valid file always exists afterwards.
         /// </summary>
-        public static T Load()
+        public static T Load() => LoadFrom(new T().FilePath);
+
+        /// <summary>
+        /// Like <see cref="Load"/>, but reads from an explicit path rather than <see cref="FilePath"/>.
+        /// </summary>
+        protected static T LoadFrom(string filePath)
         {
             T instance = new T();
 
-            using (instance.AcquireLock())
-                return instance.LoadCore();
+            using (instance.AcquireLock(filePath))
+                return instance.LoadCore(filePath);
         }
 
         /// <summary>
-        /// Saves this instance to disk atomically, rotating the previous version into the backups folder.
+        /// Saves this instance to <see cref="FilePath"/> atomically, rotating the previous version into the
+        /// backups folder.
         /// </summary>
-        public void Save()
+        public void Save() => SaveTo(FilePath);
+
+        /// <summary>
+        /// Like <see cref="Save"/>, but writes to an explicit path rather than <see cref="FilePath"/>.
+        /// </summary>
+        protected void SaveTo(string filePath)
         {
-            using (AcquireLock())
-                SaveCore();
+            using (AcquireLock(filePath))
+                SaveCore(filePath);
         }
 
-        private T LoadCore()
+        private T LoadCore(string filePath)
         {
-            string filePath = FilePath;
-
             // Try the main file first.
             if (TryDeserialize(filePath, out T loaded))
                 return loaded;
@@ -87,7 +97,7 @@ namespace ClassicUO.Configuration
             // Fall back through the rotating backups, newest first.
             for (int i = 1; i <= MAX_BACKUPS; i++)
             {
-                if (TryDeserialize(GetBackupPath(i), out loaded))
+                if (TryDeserialize(GetBackupPath(filePath, i), out loaded))
                 {
                     Log.Warn($"Recovered JSON save '{filePath}' from backup {i}.");
                     return loaded;
@@ -99,23 +109,24 @@ namespace ClassicUO.Configuration
                 Log.Error($"Failed to load JSON save '{filePath}' and all backups; creating a fresh copy.");
 
             T fresh = new T();
-            fresh.SaveCore();
+            fresh.SaveCore(filePath);
             return fresh;
         }
 
-        private void SaveCore()
+        private void SaveCore(string filePath)
         {
-            string filePath = FilePath;
-            string tempPath = Path.Combine(SaveDirectory, FileName + ".tmp");
+            string tempPath = filePath + ".tmp";
+            string directory = Path.GetDirectoryName(filePath);
 
             try
             {
-                Directory.CreateDirectory(SaveDirectory);
+                if (!string.IsNullOrEmpty(directory))
+                    Directory.CreateDirectory(directory);
 
                 string json = JsonSerializer.Serialize((T)this, TypeInfo);
                 File.WriteAllText(tempPath, json);
 
-                RotateBackups();
+                RotateBackups(filePath);
 
                 // RotateBackups moved the old main file into backup 1, so the destination is free.
                 File.Move(tempPath, filePath);
@@ -157,15 +168,15 @@ namespace ClassicUO.Configuration
             }
         }
 
-        private void RotateBackups()
+        private void RotateBackups(string filePath)
         {
-            string backupDir = BackupDirectory;
+            string backupDir = GetBackupDirectory(filePath);
             Directory.CreateDirectory(backupDir);
 
             // Rotate existing backups: oldest deleted, each other shifted up one (2 -> 3, 1 -> 2).
             for (int i = MAX_BACKUPS; i > 0; i--)
             {
-                string current = GetBackupPath(i);
+                string current = GetBackupPath(filePath, i);
 
                 if (i == MAX_BACKUPS)
                 {
@@ -174,7 +185,7 @@ namespace ClassicUO.Configuration
                 }
                 else
                 {
-                    string next = GetBackupPath(i + 1);
+                    string next = GetBackupPath(filePath, i + 1);
 
                     if (File.Exists(current))
                     {
@@ -187,8 +198,7 @@ namespace ClassicUO.Configuration
             }
 
             // Move the current main file into backup slot 1.
-            string firstBackup = GetBackupPath(1);
-            string filePath = FilePath;
+            string firstBackup = GetBackupPath(filePath, 1);
 
             if (File.Exists(filePath))
             {
@@ -218,7 +228,9 @@ namespace ClassicUO.Configuration
             }
         }
 
-        private string GetBackupPath(int index) => Path.Combine(BackupDirectory, $"{FileName}.{index}");
+        private static string GetBackupDirectory(string filePath) => Path.Combine(Path.GetDirectoryName(filePath) ?? string.Empty, Constants.BACKUP_FOLDER);
+
+        private static string GetBackupPath(string filePath, int index) => Path.Combine(GetBackupDirectory(filePath), $"{Path.GetFileName(filePath)}.{index}");
 
         /// <summary>
         /// Acquires a cross-process lock guarding this file. A save can be touched by multiple client
@@ -226,7 +238,7 @@ namespace ClassicUO.Configuration
         /// Account/Char files can also collide when the same server/account/character is logged in from more
         /// than one client - so every scope is protected with a named mutex keyed on the file path.
         /// </summary>
-        private IDisposable AcquireLock() => new CrossProcessLock(FilePath);
+        private IDisposable AcquireLock(string filePath = null) => new CrossProcessLock(filePath ?? FilePath);
 
         private sealed class CrossProcessLock : IDisposable
         {

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -1006,6 +1006,13 @@ namespace ClassicUO.Configuration
                         File.Delete(f);
                 }
 
+                dir = JsonSaveLocationHelper.GetScopeDirectory(SettingsScope.Char);
+                foreach (string f in Directory.EnumerateFiles(dir, "*.bak*"))
+                {
+                    if (!f.Contains("grid_container"))
+                        File.Delete(f);
+                }
+
                 dir = JsonSaveLocationHelper.GetScopeDirectory(SettingsScope.Server);
                 foreach (string f in Directory.EnumerateFiles(dir, "*.backup*"))
                 {

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -15,6 +15,7 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 using System.Threading.Tasks;
 using System.Xml;
 using System.ComponentModel;
@@ -84,11 +85,18 @@ namespace ClassicUO.Configuration
 
 
 
-    public sealed partial class Profile : INotifyPropertyChanged
+    public sealed partial class Profile : JsonSave<Profile>, INotifyPropertyChanged
     {
         public event PropertyChangedEventHandler PropertyChanged;
 
         private static Profile _defaultPreview;
+
+        /// <summary>Lives in the profile folder as <c>profile.json</c>.</summary>
+        protected override SettingsScope Scope => SettingsScope.Char;
+
+        protected override string FileName => "profile.json";
+
+        protected override JsonTypeInfo<Profile> TypeInfo => ProfileJsonContext.DefaultToUse.Profile;
 
         /// <summary>
         /// A cached default profile with safe default settings, used as a fallback when no profile
@@ -1060,13 +1068,9 @@ namespace ClassicUO.Configuration
                 return;
 
             Log.Trace($"Saving path:\t\t{path}");
-            string filePath = Path.Combine(path, "profile.json");
 
-            // Create backup rotation before saving
-            CreateBackupRotation(filePath);
-
-            // Save profile settings
-            ConfigurationResolver.Save(this, filePath, ProfileJsonContext.DefaultToUse.Profile);
+            // Atomic write with rotating backups, handled by JsonSave.
+            SaveTo(Path.Combine(path, "profile.json"));
 
             // Grid highlights live in a separate grid_highlights.json (see GridHighlightsConfig); persist
             // them alongside the profile so in-place rule edits are saved on the same cadence as before.
@@ -1081,47 +1085,9 @@ namespace ClassicUO.Configuration
             lastSave = Time.Ticks;
         }
 
-        public void SaveAsFile(string path, string filename) => ConfigurationResolver.Save(this, Path.Combine(path, filename), ProfileJsonContext.DefaultToUse.Profile);
+        public void SaveAsFile(string path, string filename) => SaveTo(Path.Combine(path, filename));
 
-        private void CreateBackupRotation(string filePath)
-        {
-            if (!File.Exists(filePath))
-                return;
-
-            string backup3 = filePath + ".bak3";
-            string backup2 = filePath + ".bak2";
-            string backup1 = filePath + ".bak1";
-
-            try
-            {
-                // Remove oldest backup if it exists
-                if (File.Exists(backup3))
-                {
-                    File.Delete(backup3);
-                }
-
-                // Rotate backups: .bak2 -> .bak3, .bak1 -> .bak2
-                if (File.Exists(backup2))
-                {
-                    File.Move(backup2, backup3);
-                }
-
-                if (File.Exists(backup1))
-                {
-                    File.Move(backup1, backup2);
-                }
-
-                // Copy current file to .bak1
-                File.Copy(filePath, backup1);
-            }
-            catch (IOException e)
-            {
-                // Log backup rotation failure but don't prevent the save
-                Log.Error($"Failed to create backup rotation: {e}");
-            }
-        }
-
-        public void SaveAs(string path, string filename = "default.json") => ConfigurationResolver.Save(this, Path.Combine(path, filename), ProfileJsonContext.DefaultToUse.Profile);
+        public void SaveAs(string path, string filename = "default.json") => SaveTo(Path.Combine(path, filename));
 
         private void SaveGumps(World world, string path)
         {

--- a/src/ClassicUO.Client/Configuration/ProfileManager.cs
+++ b/src/ClassicUO.Client/Configuration/ProfileManager.cs
@@ -73,7 +73,10 @@ namespace ClassicUO.Configuration
             string fileToLoad = Path.Combine(path, "profile.json");
 
             ProfilePath = path;
-            CurrentProfile = ConfigurationResolver.Load<Profile>(fileToLoad, ProfileJsonContext.DefaultToUse.Profile) ?? NewFromDefault();
+
+            // Load through JsonSave (which recovers from the rotating backups), falling back to the
+            // default.json template when the character has no saved profile yet.
+            CurrentProfile = File.Exists(fileToLoad) ? Profile.Load() : NewFromDefault();
 
             CurrentProfile.Username = username;
             CurrentProfile.ServerName = servername;
@@ -83,13 +86,13 @@ namespace ClassicUO.Configuration
             // Load (or migrate from the in-profile GridHighlightSetup / legacy per-list storage) the grid highlights.
             if (GridHighlightsConfig.LoadForProfile(ProfilePath, CurrentProfile))
             {
-                ConfigurationResolver.Save(CurrentProfile, Path.Combine(ProfilePath, "profile.json"), ProfileJsonContext.DefaultToUse.Profile);
+                CurrentProfile.Save();
             }
 
             // Load (or migrate from the legacy per-list profile storage) the cooldown-bar rules.
             if (CooldownBarsConfig.LoadForProfile(ProfilePath, CurrentProfile))
             {
-                ConfigurationResolver.Save(CurrentProfile, Path.Combine(ProfilePath, "profile.json"), ProfileJsonContext.DefaultToUse.Profile);
+                CurrentProfile.Save();
             }
 
             // Load the grid-container band layout rules for this profile.

--- a/src/ClassicUO.Client/LegionScripting/docs/LegionAPI.md
+++ b/src/ClassicUO.Client/LegionScripting/docs/LegionAPI.md
@@ -21,7 +21,7 @@ You can now type `-updateapi` in game to download the latest API.py file.
 
 [Additional notes](../notes/)  
 
-*This was generated on `8/3/26`.*
+*This was generated on `8/4/26`.*
 
 ## Properties
 ### `Events`


### PR DESCRIPTION
Refactor Profile to inherit from JsonSave<Profile> so profile.json gets the shared atomic write, rotating backups, and cross-process locking.

- Add path-parameterized SaveTo/LoadFrom to JsonSave for arbitrary targets
- Remove Profile's legacy .bak rotation in favor of the backups folder
- Mark JsonSave path helpers [JsonIgnore] so they aren't serialized
- Load through Profile.Load() with default.json template fallback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile loading and saving reliability, including backup recovery and rotating backups.
  * Added support for saving profiles to specific file paths.
  * Ensured profile migrations persist changes consistently.

* **Documentation**
  * Updated the Legion API documentation timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->