### PR TITLE
Fix NRE when nameplate gump art is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to TazUO will be recorded here.
 * Spell names, reagent names, and magic circle names now use server cliloc strings when available, falling back to the built-in English strings otherwise - [P.R 885](https://github.com/PlayTazUO/TazUO/pull/885) ([bittiez](https://github.com/bittiez))
 
 ### Fixes
+* Fixed a NullReferenceException when toggling "Stay active" in the nameplate manager gump on shards whose gumpart is missing the radio button art; failed button construction is now handled gracefully instead of leaving a broken control behind ([bittiez](https://github.com/bittiez))
 * Fixed empty chat input entries being saved to the message history - [P.R 900](https://github.com/PlayTazUO/TazUO/pull/900) ([bittiez](https://github.com/bittiez))
 * Fixed a rare "The deque is empty" crash when processing mobile movement steps, caused by the steps deque being cleared concurrently while the main thread removed a step ([bittiez](https://github.com/bittiez))
 * Minor UI bug fixes in modern paperdoll and myra windows ([bittiez](https://github.com/bittiez))

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.22.17</AssemblyVersion>
-    <FileVersion>5.22.17</FileVersion>
+    <AssemblyVersion>5.22.18</AssemblyVersion>
+    <FileVersion>5.22.18</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/UI/Controls/Checkbox.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/Checkbox.cs
@@ -74,7 +74,7 @@ namespace ClassicUO.Game.UI.Controls
 
         public override ClickPriority Priority => ClickPriority.High;
 
-        public string Text => _text.Text;
+        public string Text => _text?.Text ?? string.Empty;
 
         public event EventHandler ValueChanged;
 

--- a/src/ClassicUO.Client/Game/UI/Gumps/NameOverHeadHandlerGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/NameOverHeadHandlerGump.cs
@@ -178,6 +178,9 @@ namespace ClassicUO.Game.UI.Gumps
         {
             foreach (RadioButton button in _overheadButtons)
             {
+                if (button.IsDisposed)
+                    continue;
+
                 button.IsChecked = NameOverHeadManager.LastActiveNameOverheadOption.Replace("\\u0026", "&") == button.Text;
             }
         }
@@ -186,6 +189,8 @@ namespace ClassicUO.Game.UI.Gumps
         {
             foreach (RadioButton button in _overheadButtons)
                 Remove(button);
+
+            _overheadButtons.Clear();
 
             DrawChoiceButtons();
         }
@@ -197,7 +202,10 @@ namespace ClassicUO.Game.UI.Gumps
 
             for (int i = 0; i < options.Count; i++)
             {
-                biggestWidth = Math.Max(biggestWidth, AddOverheadOptionButton(options[i], i).Width);
+                RadioButton button = AddOverheadOptionButton(options[i], i);
+
+                if (button != null)
+                    biggestWidth = Math.Max(biggestWidth, button.Width);
             }
 
             _alpha.Width = biggestWidth;
@@ -223,6 +231,13 @@ namespace ClassicUO.Game.UI.Gumps
                     IsChecked = NameOverHeadManager.LastActiveNameOverheadOption.Replace("\\u0026", "&") == option.Name,
                 }
             );
+
+            if (button.IsDisposed)
+            {
+                Remove(button);
+
+                return null;
+            }
 
             if (button.IsChecked)
             {


### PR DESCRIPTION
Fix a NullReferenceException when toggling 'Stay active' in the nameplate manager gump on shards whose gumpart is missing the radio button art. The Checkbox constructor leaves _text null when it early-returns on missing textures, so Text is now null-safe and failed buttons are skipped instead of being left as broken controls in the gump.

Bump version to 5.22.18.
