### PR TITLE
Remember password per account in login gump context menu

### DIFF
--- a/src/ClassicUO.Client/Game/Managers/SimpleAccountManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/SimpleAccountManager.cs
@@ -1,10 +1,18 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
+using ClassicUO.Configuration;
+using ClassicUO.Utility;
 
 namespace ClassicUO.Game.Managers
 {
     internal static class SimpleAccountManager
     {
+        private static readonly string appDataRoot = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "TazUO"
+        );
+
         private static string accountPath = Path.Combine(CUOEnviroment.ExecutablePath, "Data", "Profiles");
 
         public static string[] GetAccounts()
@@ -21,6 +29,82 @@ namespace ClassicUO.Game.Managers
                 }
             }
             return accounts.ToArray();
+        }
+
+        /// <summary>
+        /// Returns the stored (encrypted) password for an account, or null when
+        /// none has been saved. Optional convenience; the client still works with
+        /// a single global password when no per-account password exists.
+        /// Passwords are stored outside the game folder under
+        /// %APPDATA%/TazUO/&lt;server&gt;/&lt;account&gt;/account.password.
+        /// </summary>
+        public static string GetAccountPassword(string account)
+        {
+            if (string.IsNullOrEmpty(account))
+                return null;
+
+            foreach (string file in FindAccountPasswordFiles(account))
+            {
+                try
+                {
+                    return File.ReadAllText(file);
+                }
+                catch
+                {
+                    // Try the next server folder if this one is unreadable.
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Persists the (encrypted) password for an account outside the game folder,
+        /// keyed by the last server used: %APPDATA%/TazUO/&lt;server&gt;/&lt;account&gt;/account.password.
+        /// Passing null or empty removes any stored password for that account.
+        /// </summary>
+        public static void SetAccountPassword(string account, string encryptedPassword)
+        {
+            if (string.IsNullOrEmpty(account))
+                return;
+
+            string server = string.IsNullOrEmpty(Settings.GlobalSettings.LastServerName)
+                ? "Unknown"
+                : Settings.GlobalSettings.LastServerName;
+
+            string file = Path.Combine(appDataRoot, server, account, "account.password");
+            string dir = Path.GetDirectoryName(file);
+
+            if (string.IsNullOrWhiteSpace(encryptedPassword))
+            {
+                if (File.Exists(file))
+                {
+                    try { File.Delete(file); } catch { }
+                }
+                return;
+            }
+
+            try
+            {
+                Directory.CreateDirectory(dir);
+                File.WriteAllText(file, encryptedPassword);
+            }
+            catch
+            {
+                // Best effort: a writable profile folder is normally guaranteed.
+            }
+        }
+
+        private static IEnumerable<string> FindAccountPasswordFiles(string account)
+        {
+            if (!Directory.Exists(appDataRoot))
+                yield break;
+
+            foreach (string serverDir in Directory.GetDirectories(appDataRoot))
+            {
+                string file = Path.Combine(serverDir, account, "account.password");
+                if (File.Exists(file))
+                    yield return file;
+            }
         }
     }
 }

--- a/src/ClassicUO.Client/Game/Scenes/LoginScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/LoginScene.cs
@@ -389,6 +389,7 @@ namespace ClassicUO.Game.Scenes
             {
                 Settings.GlobalSettings.Username = account;
                 Settings.GlobalSettings.Password = Crypter.Encrypt(password);
+                SimpleAccountManager.SetAccountPassword(account, Settings.GlobalSettings.Password);
                 try
                 {
                     Settings.GlobalSettings.Save();

--- a/src/ClassicUO.Client/Game/UI/Gumps/Login/LoginGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/Login/LoginGump.cs
@@ -343,7 +343,13 @@ namespace ClassicUO.Game.UI.Gumps.Login
                 _textboxAccount.ContextMenu = new ContextMenuControl(this);
                 foreach (string acct in accts)
                 {
-                    _textboxAccount.ContextMenu.Add(new ContextMenuItemEntry(acct, () => { _textboxAccount.SetText(acct); }));
+                    _textboxAccount.ContextMenu.Add(new ContextMenuItemEntry(acct, () =>
+                    {
+                        _textboxAccount.SetText(acct);
+                        string accountPassword = SimpleAccountManager.GetAccountPassword(acct);
+                        if (accountPassword != null)
+                            _passwordFake.RealText = Crypter.Decrypt(accountPassword);
+                    }));
                 }
                 _textboxAccount.SetTooltip(TazLang.Get("accountcontextmenutooltip"));
                 _textboxAccount.MouseUp += (s, e) =>


### PR DESCRIPTION
The login gump already saves your username and password (encrypted) when "Save account" is checked — but only for one account: the last one you logged in with. The account field's right-click context menu lists all saved profiles, yet selecting another account only fills the username; the password field keeps the previous account's value, causing confusing failed logins when accounts have different passwords.
This PR extends the existing password-saving mechanism to store each account's password separately (same Crypter encryption as today), so selecting an account from the context menu restores both username and password. It's fully optional, requires no UI change, and piggybacks on the existing "Save account" checkbox. Behavior is unchanged when no per-account password is stored.