### PR TITLE
Fix pants rendering above boots with female armor layering

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Controls/PaperDollInteractable.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/PaperDollInteractable.cs
@@ -466,8 +466,8 @@ namespace ClassicUO.Game.UI.Controls
 
                 if (pantsLayerIdx >= 0 && torsoLayerIdx >= 0 && pantsLayerIdx < torsoLayerIdx)
                 {
-                    Array.Copy(copy, pantsLayerIdx + 1, copy, pantsLayerIdx, torsoLayerIdx - pantsLayerIdx);
-                    copy[torsoLayerIdx] = Layer.Pants;
+                    Array.Copy(copy, pantsLayerIdx, copy, pantsLayerIdx + 1, torsoLayerIdx - pantsLayerIdx);
+                    copy[pantsLayerIdx] = Layer.Torso;
                 }
             }
 


### PR DESCRIPTION
## Description

Follow-up to #493. Fixes a regression introduced by that PR: when a mobile wears one of the female torso armors (Female Leather/Studded/Plate Armor) **together with boots**, pants are now rendered above the boots instead of beneath them.

Root cause: the original fix moved `Layer.Pants` to the position of `Layer.Torso` via `Array.Copy`, which shifts the *entire* block between Pants and Torso (including `Layer.Shoes`, `Layer.Legs`, `Layer.Arms`) left by one. This unintentionally pulls Shoes in front of Pants in the draw order, causing pants to render on top of boots.

The fix instead moves only `Layer.Torso` forward to the Pants position, leaving the relative order of Shoes/Legs/Arms untouched.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing

Tested in-game using affected combinations.

Verified that:
- Pants still render above Female Leather/Studded/Plate Armor (behavior from #493 preserved).
- Boots now render above pants again, matching Classic Client/Orion behavior.
- Leather/Studded Sleeves and Ringmail Arms still render correctly above torso armor.

## Screenshots

Before:

<img width="119" height="188" alt="grafik" src="https://github.com/user-attachments/assets/f47b5c71-7e69-457f-a2a5-1f26f2e95b76" />

After:

<img width="106" height="183" alt="grafik" src="https://github.com/user-attachments/assets/55a3a65e-c70e-4327-9e12-8b486be74ab1" />


## Additional Notes

No changes to the arms/sleeves reordering logic or the Eventine-specific legs ordering — only the Pants/Torso block in `GetOrderedLayersCopy` was touched.