### PR TITLE
Keep launcher profile login when client is launched via -settings

### DIFF
--- a/src/ClassicUO.Client/Game/Scenes/LoginScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/LoginScene.cs
@@ -384,12 +384,16 @@ namespace ClassicUO.Game.Scenes
             Password = password;
             LoginHandshake.Instance.Connect(account, password, Settings.GlobalSettings.IP, Settings.GlobalSettings.Port);
 
-            // Save credentials to config file
+            // Save credentials to config file. When launched by the launcher, keep the profile's login.
             if (Settings.GlobalSettings.SaveAccount)
             {
-                Settings.GlobalSettings.Username = account;
-                Settings.GlobalSettings.Password = Crypter.Encrypt(password);
-                SimpleAccountManager.SetAccountPassword(account, Settings.GlobalSettings.Password);
+                if (Settings.CustomSettingsFilepath == null)
+                {
+                    Settings.GlobalSettings.Username = account;
+                    Settings.GlobalSettings.Password = Crypter.Encrypt(password);
+                }
+
+                SimpleAccountManager.SetAccountPassword(account, Crypter.Encrypt(password));
                 try
                 {
                     Settings.GlobalSettings.Save();


### PR DESCRIPTION
When the client is launched via the launcher (custom settings file), it
overwrote the username/password in that shared file, changing the
launcher profile's login. Now the client only saves Username/Password
when launched standalone, the launcher profile keeps its own login.