### PR TITLE
Audio crash fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to TazUO will be recorded here.
 * Add some missing weapon abilities
 
 ### Fixes
+* Fixed a `NoAudioHardwareException` crash on machines without an audio device: the audio availability probe no longer creates a `DynamicSoundEffectInstance` (which left a partially-built object for the GC finalizer to crash on) and instead reads `SoundEffect.MasterVolume` ([bittiez](https://github.com/bittiez))
 * Remove presets for auto skinnig knife id's to prevent trying to use the incorrect item on servers ([bittiez](https://github.com/bittiez))
 * Fixed a rare crash that could occur when a grid container is moved - [P.R 958](https://github.com/PlayTazUO/TazUO/pull/958) ([yuval-po](https://github.com/yuval-po))
 * Fixed the candle flicker effect speeding up while moving: the flicker phase is now seeded from each light's world position instead of its screen position, so it oscillates at a constant speed

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.28.0</AssemblyVersion>
-    <FileVersion>5.28.0</FileVersion>
+    <AssemblyVersion>5.28.1</AssemblyVersion>
+    <FileVersion>5.28.1</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/Managers/AudioManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/AudioManager.cs
@@ -39,15 +39,7 @@ namespace ClassicUO.Game.Managers
 
         public void Initialize()
         {
-            try
-            {
-                new DynamicSoundEffectInstance(1000, AudioChannels.Mono).Dispose();
-            }
-            catch (NoAudioHardwareException ex)
-            {
-                Log.Warn(ex.ToString());
-                _canReproduceAudio = false;
-            }
+            _canReproduceAudio = TryCreateAudioInstance();
 
             LoginMusicIndex = Client.Game.UO.Version switch
             {
@@ -683,8 +675,7 @@ namespace ClassicUO.Game.Managers
                 {
                     try
                     {
-                        var testInstance = new DynamicSoundEffectInstance(22050, AudioChannels.Mono);
-                        testInstance.Dispose();
+                        _ = SoundEffect.MasterVolume;
 
                         Log.Info($"Audio device test successful on attempt {attempt + 1}");
                         return true;


### PR DESCRIPTION
```
Exception:
Microsoft.Xna.Framework.Audio.NoAudioHardwareException (0x80004005): Arg_ExternalException

   at Microsoft.Xna.Framework.Audio.SoundEffect.Device() in D:\a\TazUO\TazUO\external\FNA\src\Audio\SoundEffect.cs:line 894

   at Microsoft.Xna.Framework.Audio.DynamicSoundEffectInstance.Dispose(Boolean disposing) in D:\a\TazUO\TazUO\external\FNA\src\Audio\DynamicSoundEffectInstance.cs:line 295

   at Microsoft.Xna.Framework.Audio.SoundEffectInstance.Dispose() in D:\a\TazUO\TazUO\external\FNA\src\Audio\SoundEffectInstance.cs:line 238

   at Microsoft.Xna.Framework.Audio.SoundEffectInstance.Finalize() in D:\a\TazUO\TazUO\external\FNA\src\Audio\SoundEffectInstance.cs:line 229

   at System.GC.RunFinalizers()
```