### PR TITLE
fix: Corrupt InfoBar crashes app during bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to TazUO will be recorded here.
 * The classic journal gump (JournalGump) now respects the "Hide journal timestamps" setting, which was moved from per-profile to machine-wide (global) settings
 
 ### Fixes
+* Fixed an issue where corrupt Info-Bars could prevent client from loading - [P.R 980](https://github.com/PlayTazUO/TazUO/pull/980) ([yuval-po](https://github.com/yuval-po))
 * Fixed a double max height in persistent vars window
 
 ## 5.28.1

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.29.6</AssemblyVersion>
-    <FileVersion>5.29.6</FileVersion>
+    <AssemblyVersion>5.29.7</AssemblyVersion>
+    <FileVersion>5.29.7</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/Managers/InfoBarManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/InfoBarManager.cs
@@ -76,7 +76,6 @@ namespace ClassicUO.Game.Managers
             catch (Exception ex)
             {
                 Log.Error(ex.ToString());
-
                 return;
             }
 
@@ -84,12 +83,19 @@ namespace ClassicUO.Game.Managers
 
             XmlElement root = doc["infos"];
 
-            if (root != null)
+            if (root == null)
+                return;
+
+            foreach (XmlElement xml in root.GetElementsByTagName("info"))
             {
-                foreach (XmlElement xml in root.GetElementsByTagName("info"))
+                try
                 {
                     var item = new InfoBarItem(xml);
                     infoBarItems.Add(item);
+                }
+                catch (Exception ex)
+                {
+                    Log.Error($"Failed to construct an Info-Bar item - {ex}");
                 }
             }
         }


### PR DESCRIPTION
## Description
Adds a guard around `InfoBarItem` de-serialization during `Load`

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
