### PR TITLE
fix: make scale-down dead space usable for gumps and UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to TazUO will be recorded here.
 * The classic journal gump (JournalGump) now respects the "Hide journal timestamps" setting, which was moved from per-profile to machine-wide (global) settings
 
 ### Fixes
+* The right/bottom dead space that appeared when using a global scale below 100% is now usable: gumps, windows, containers, and the world viewport can be dragged into and interacted with there, and gumps/dropdowns/tooltips now center and clamp against the full visible window instead of the shrunken world view
 * Properly restore corpse container position after new game session
 * Attempt to catch plugin crashes before the kill the client
 * Fix a rare crash fix on periphial input before profiles have been loaded

--- a/src/ClassicUO.Client/ClassicUO.Client.csproj
+++ b/src/ClassicUO.Client/ClassicUO.Client.csproj
@@ -5,8 +5,8 @@
     <ApplicationIcon>cuoicon.ico</ApplicationIcon>
     <AssemblyName>TazUO</AssemblyName>
     <RootNamespace>ClassicUO</RootNamespace>
-    <AssemblyVersion>5.31.1</AssemblyVersion>
-    <FileVersion>5.31.1</FileVersion>
+    <AssemblyVersion>5.31.2</AssemblyVersion>
+    <FileVersion>5.31.2</FileVersion>
     <PackageProjectUrl>https://github.com/PlayTazUO/TazUO</PackageProjectUrl>
     <PublishAot>false</PublishAot>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/ClassicUO.Client/Game/Managers/ContainerManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/ContainerManager.cs
@@ -8,6 +8,7 @@ using System.IO;
 using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
 using ClassicUO.Game.GameObjects;
+using ClassicUO.Game.UI;
 using ClassicUO.Game.UI.Gumps;
 using ClassicUO.Utility;
 using ClassicUO.Utility.Logging;
@@ -93,7 +94,7 @@ namespace ClassicUO.Game.Managers
                                 break;
 
                             case 1:
-                                X = Client.Game.Window.ClientBounds.Width - width;
+                                X = ScaleHelper.LogicalWindowWidth - width;
                                 Y = 0;
 
                                 break;
@@ -114,12 +115,12 @@ namespace ClassicUO.Game.Managers
                                 break;
                         }
 
-                        if (X + width > Client.Game.Window.ClientBounds.Width)
+                        if (X + width > ScaleHelper.LogicalWindowWidth)
                         {
                             X -= width;
                         }
 
-                        if (Y + height > Client.Game.Window.ClientBounds.Height)
+                        if (Y + height > ScaleHelper.LogicalWindowHeight)
                         {
                             Y -= height;
                         }
@@ -132,14 +133,14 @@ namespace ClassicUO.Game.Managers
                         {
                             if (
                                 X + width + Constants.CONTAINER_RECT_STEP
-                                > Client.Game.Window.ClientBounds.Width
+                                > ScaleHelper.LogicalWindowWidth
                             )
                             {
                                 X = Constants.CONTAINER_RECT_DEFAULT_POSITION;
 
                                 if (
                                     Y + height + Constants.CONTAINER_RECT_LINESTEP
-                                    > Client.Game.Window.ClientBounds.Height
+                                    > ScaleHelper.LogicalWindowHeight
                                 )
                                 {
                                     Y = Constants.CONTAINER_RECT_DEFAULT_POSITION;
@@ -151,12 +152,12 @@ namespace ClassicUO.Game.Managers
                             }
                             else if (
                                 Y + height + Constants.CONTAINER_RECT_STEP
-                                > Client.Game.Window.ClientBounds.Height
+                                > ScaleHelper.LogicalWindowHeight
                             )
                             {
                                 if (
                                     X + width + Constants.CONTAINER_RECT_LINESTEP
-                                    > Client.Game.Window.ClientBounds.Width
+                                    > ScaleHelper.LogicalWindowWidth
                                 )
                                 {
                                     X = Constants.CONTAINER_RECT_DEFAULT_POSITION;

--- a/src/ClassicUO.Client/Game/Managers/MacroManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/MacroManager.cs
@@ -895,8 +895,8 @@ namespace ClassicUO.Game.Managers
 
                                     if (party == null)
                                     {
-                                        int x = Client.Game.Window.ClientBounds.Width / 2 - 272;
-                                        int y = Client.Game.Window.ClientBounds.Height / 2 - 240;
+                                        int x = ScaleHelper.LogicalWindowWidth / 2 - 272;
+                                        int y = ScaleHelper.LogicalWindowHeight / 2 - 240;
                                         UIManager.Add(new PartyGump(_world, x, y, _world.Party.CanLoot));
                                     }
                                     else
@@ -1280,8 +1280,8 @@ namespace ClassicUO.Game.Managers
 
                                     if (party == null)
                                     {
-                                        int x = Client.Game.Window.ClientBounds.Width / 2 - 272;
-                                        int y = Client.Game.Window.ClientBounds.Height / 2 - 240;
+                                        int x = ScaleHelper.LogicalWindowWidth / 2 - 272;
+                                        int y = ScaleHelper.LogicalWindowHeight / 2 - 240;
                                         UIManager.Add(new PartyGump(_world, x, y, _world.Party.CanLoot));
                                     }
                                     else

--- a/src/ClassicUO.Client/Game/UI/Controls/Combobox.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/Combobox.cs
@@ -120,7 +120,7 @@ namespace ClassicUO.Game.UI.Controls
             }
             else if (comboY + _maxHeight > ScaleHelper.LogicalWindowHeight)
             {
-                comboY = ScaleHelper.LogicalWindowHeight - _maxHeight;
+                comboY = Math.Max(0, ScaleHelper.LogicalWindowHeight - _maxHeight);
             }
 
             UIManager.Add

--- a/src/ClassicUO.Client/Game/UI/Controls/Combobox.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/Combobox.cs
@@ -118,9 +118,9 @@ namespace ClassicUO.Game.UI.Controls
             {
                 comboY = 0;
             }
-            else if (comboY + _maxHeight > Client.Game.Window.ClientBounds.Height)
+            else if (comboY + _maxHeight > ScaleHelper.LogicalWindowHeight)
             {
-                comboY = Client.Game.Window.ClientBounds.Height - _maxHeight;
+                comboY = ScaleHelper.LogicalWindowHeight - _maxHeight;
             }
 
             UIManager.Add

--- a/src/ClassicUO.Client/Game/UI/Controls/MacroControl.cs
+++ b/src/ClassicUO.Client/Game/UI/Controls/MacroControl.cs
@@ -445,8 +445,8 @@ namespace ClassicUO.Game.UI.Controls
 
             if (btnEditorGump == null)
             {
-                int posX = (Client.Game.Window.ClientBounds.Width >> 1) - 300;
-                int posY = (Client.Game.Window.ClientBounds.Height >> 1) - 250;
+                int posX = (ScaleHelper.LogicalWindowWidth >> 1) - 300;
+                int posY = (ScaleHelper.LogicalWindowHeight >> 1) - 250;
                 if (position.HasValue)
                 {
                     posX = (int)position.Value.X;

--- a/src/ClassicUO.Client/Game/UI/Gumps/BaseOptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/BaseOptionsGump.cs
@@ -2257,9 +2257,9 @@ public class BaseOptionsGump : Gump
                 {
                     comboY = 0;
                 }
-                else if (comboY + _maxHeight > Client.Game.Window.ClientBounds.Height)
+                else if (comboY + _maxHeight > ScaleHelper.LogicalWindowHeight)
                 {
-                    comboY = Client.Game.Window.ClientBounds.Height - _maxHeight;
+                    comboY = ScaleHelper.LogicalWindowHeight - _maxHeight;
                 }
 
                 UIManager.Add(new ComboboxGump(world, ScreenCoordinateX, comboY, Width, _maxHeight, _sortedItems, _originalIndices, this));

--- a/src/ClassicUO.Client/Game/UI/Gumps/BaseOptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/BaseOptionsGump.cs
@@ -2259,7 +2259,7 @@ public class BaseOptionsGump : Gump
                 }
                 else if (comboY + _maxHeight > ScaleHelper.LogicalWindowHeight)
                 {
-                    comboY = ScaleHelper.LogicalWindowHeight - _maxHeight;
+                    comboY = Math.Max(0, ScaleHelper.LogicalWindowHeight - _maxHeight);
                 }
 
                 UIManager.Add(new ComboboxGump(world, ScreenCoordinateX, comboY, Width, _maxHeight, _sortedItems, _originalIndices, this));

--- a/src/ClassicUO.Client/Game/UI/Gumps/Gump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/Gump.cs
@@ -176,13 +176,18 @@ namespace ClassicUO.Game.UI.Gumps
 
         public void SetInScreen()
         {
-            Rectangle windowBounds = Client.Game.Window.ClientBounds;
+            // Gump coordinates live in logical UI space; clamp against the logical window bounds so
+            // the dead space revealed by a scale-down (scale < 1) stays usable for gump placement.
+            // The physical window bounds are RenderScale smaller than the logical ones in that case,
+            // so clamping to them would trap gumps inside the shrunken world view.
+            int windowWidth = ScaleHelper.LogicalWindowWidth;
+            int windowHeight = ScaleHelper.LogicalWindowHeight;
 
             int halfWidth = Width / 2;
             int halfHeight = Height / 2;
 
-            int newX = (int)MathHelper.Clamp(X, -halfWidth, windowBounds.Width - halfWidth);
-            int newY = (int)MathHelper.Clamp(Y, -halfHeight, windowBounds.Height - halfHeight);
+            int newX = (int)MathHelper.Clamp(X, -halfWidth, windowWidth - halfWidth);
+            int newY = (int)MathHelper.Clamp(Y, -halfHeight, windowHeight - halfHeight);
 
             X = newX;
             Y = newY;
@@ -223,14 +228,14 @@ namespace ClassicUO.Game.UI.Gumps
                 position.Y = -halfHeight;
             }
 
-            if (X > Client.Game.Window.ClientBounds.Width - (Width - halfWidth))
+            if (X > ScaleHelper.LogicalWindowWidth - (Width - halfWidth))
             {
-                position.X = Client.Game.Window.ClientBounds.Width - (Width - halfWidth);
+                position.X = ScaleHelper.LogicalWindowWidth - (Width - halfWidth);
             }
 
-            if (Y > Client.Game.Window.ClientBounds.Height - (Height - halfHeight))
+            if (Y > ScaleHelper.LogicalWindowHeight - (Height - halfHeight))
             {
-                position.Y = Client.Game.Window.ClientBounds.Height - (Height - halfHeight);
+                position.Y = ScaleHelper.LogicalWindowHeight - (Height - halfHeight);
             }
 
             Location = position;

--- a/src/ClassicUO.Client/Game/UI/Gumps/MessageBoxGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/MessageBoxGump.cs
@@ -72,8 +72,8 @@ namespace ClassicUO.Game.UI.Gumps
                 }
             );
 
-            X = (Client.Game.Window.ClientBounds.Width - Width) >> 1;
-            Y = (Client.Game.Window.ClientBounds.Height - Height) >> 1;
+            X = (ScaleHelper.LogicalWindowWidth - Width) >> 1;
+            Y = (ScaleHelper.LogicalWindowHeight - Height) >> 1;
 
             // OK
             Button b;
@@ -222,8 +222,8 @@ namespace ClassicUO.Game.UI.Gumps
 
             Add(_textBox);
 
-            X = (Client.Game.Window.ClientBounds.Width - Width) >> 1;
-            Y = (Client.Game.Window.ClientBounds.Height - Height) >> 1;
+            X = (ScaleHelper.LogicalWindowWidth - Width) >> 1;
+            Y = (ScaleHelper.LogicalWindowHeight - Height) >> 1;
 
 
             // OK

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernOptionsGump.cs
@@ -992,8 +992,8 @@ namespace ClassicUO.Game.UI.Gumps
                         {
                             if (b)
                             {
-                                viewport.ResizeGameWindow(new Point(Client.Game.Window.ClientBounds.Width,
-                                    Client.Game.Window.ClientBounds.Height));
+                                viewport.ResizeGameWindow(new Point(ScaleHelper.LogicalWindowWidth,
+                                    ScaleHelper.LogicalWindowHeight));
                                 viewport.SetGameWindowPosition(new Point(0, 0));
                                 profile.GameWindowPosition = new Point(0, 0);
                             }
@@ -1052,7 +1052,7 @@ namespace ClassicUO.Game.UI.Gumps
             (
                 new SliderWithLabel
                 (
-                    TazLang.Get("mog_video_viewportx"), 0, ThemeSettings.SLIDER_WIDTH, 0, Client.Game.Window.ClientBounds.Width,
+                    TazLang.Get("mog_video_viewportx"), 0, ThemeSettings.SLIDER_WIDTH, 0, ScaleHelper.LogicalWindowWidth,
                     profile.GameWindowPosition.X, (r) =>
                     {
                         profile.GameWindowPosition = new Point(r, profile.GameWindowPosition.Y);
@@ -1065,7 +1065,7 @@ namespace ClassicUO.Game.UI.Gumps
             (
                 new SliderWithLabel
                 (
-                    TazLang.Get("mog_video_viewporty"), 0, ThemeSettings.SLIDER_WIDTH, 0, Client.Game.Window.ClientBounds.Height,
+                    TazLang.Get("mog_video_viewporty"), 0, ThemeSettings.SLIDER_WIDTH, 0, ScaleHelper.LogicalWindowHeight,
                     profile.GameWindowPosition.Y, (r) =>
                     {
                         profile.GameWindowPosition = new Point(profile.GameWindowPosition.X, r);
@@ -1080,7 +1080,7 @@ namespace ClassicUO.Game.UI.Gumps
             (
                 new SliderWithLabel
                 (
-                    TazLang.Get("mog_video_viewportw"), 0, ThemeSettings.SLIDER_WIDTH, 0, Client.Game.Window.ClientBounds.Width,
+                    TazLang.Get("mog_video_viewportw"), 0, ThemeSettings.SLIDER_WIDTH, 0, ScaleHelper.LogicalWindowWidth,
                     profile.GameWindowSize.X, (r) =>
                     {
                         profile.GameWindowSize = new Point(r, profile.GameWindowSize.Y);
@@ -1093,7 +1093,7 @@ namespace ClassicUO.Game.UI.Gumps
             (
                 new SliderWithLabel
                 (
-                    TazLang.Get("mog_video_viewporth"), 0, ThemeSettings.SLIDER_WIDTH, 0, Client.Game.Window.ClientBounds.Height,
+                    TazLang.Get("mog_video_viewporth"), 0, ThemeSettings.SLIDER_WIDTH, 0, ScaleHelper.LogicalWindowHeight,
                     profile.GameWindowSize.Y, (r) =>
                     {
                         profile.GameWindowSize = new Point(profile.GameWindowSize.X, r);
@@ -5730,8 +5730,8 @@ namespace ClassicUO.Game.UI.Gumps
 
                 if (btnEditorGump == null)
                 {
-                    int posX = (Client.Game.Window.ClientBounds.Width >> 1) - 300;
-                    int posY = (Client.Game.Window.ClientBounds.Height >> 1) - 250;
+                    int posX = (ScaleHelper.LogicalWindowWidth >> 1) - 300;
+                    int posY = (ScaleHelper.LogicalWindowHeight >> 1) - 250;
                     Gump opt = UIManager.GetGump<ModernOptionsGump>();
 
                     if (opt != null)

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernPaperdoll.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernPaperdoll.cs
@@ -812,8 +812,8 @@ namespace ClassicUO.Game.UI.Gumps
 
                     if (party == null)
                     {
-                        int x = Client.Game.Window.ClientBounds.Width / 2 - 272;
-                        int y = Client.Game.Window.ClientBounds.Height / 2 - 240;
+                        int x = ScaleHelper.LogicalWindowWidth / 2 - 272;
+                        int y = ScaleHelper.LogicalWindowHeight / 2 - 240;
                         UIManager.Add(new PartyGump(world, x, y, World.Party.CanLoot));
                     }
                     else

--- a/src/ClassicUO.Client/Game/UI/Gumps/ModernPaperdoll.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/ModernPaperdoll.cs
@@ -812,8 +812,8 @@ namespace ClassicUO.Game.UI.Gumps
 
                     if (party == null)
                     {
-                        int x = ScaleHelper.LogicalWindowWidth / 2 - 272;
-                        int y = ScaleHelper.LogicalWindowHeight / 2 - 240;
+                        int x = Math.Max(0, ScaleHelper.LogicalWindowWidth / 2 - 272);
+                        int y = Math.Max(0, ScaleHelper.LogicalWindowHeight / 2 - 240);
                         UIManager.Add(new PartyGump(world, x, y, World.Party.CanLoot));
                     }
                     else

--- a/src/ClassicUO.Client/Game/UI/Gumps/MultiItemMoveGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/MultiItemMoveGump.cs
@@ -25,7 +25,7 @@ namespace ClassicUO.Game.UI.Gumps
         public static void ShowNextTo(Control anchor, int padding = -2)
         {
             int w = PreferredWidth;
-            int screenH = Client.Game.Window.ClientBounds.Height;
+            int screenH = ScaleHelper.LogicalWindowHeight;
 
             int x = anchor.X >= w + padding
                 ? anchor.X - (w + padding)           // left of anchor

--- a/src/ClassicUO.Client/Game/UI/Gumps/MultipleToolTipGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/MultipleToolTipGump.cs
@@ -79,18 +79,18 @@ namespace ClassicUO.Game.UI.Gumps
             {
                 x = 0;
             }
-            else if (x > Client.Game.Window.ClientBounds.Width - z_width)
+            else if (x > ScaleHelper.LogicalWindowWidth - z_width)
             {
-                x = Client.Game.Window.ClientBounds.Width - z_width;
+                x = ScaleHelper.LogicalWindowWidth - z_width;
             }
 
             if (y < 0)
             {
                 y = 0;
             }
-            else if (y > Client.Game.Window.ClientBounds.Height - z_height)
+            else if (y > ScaleHelper.LogicalWindowHeight - z_height)
             {
-                y = Client.Game.Window.ClientBounds.Height - z_height;
+                y = ScaleHelper.LogicalWindowHeight - z_height;
             }
 
             SSX = x - 4;

--- a/src/ClassicUO.Client/Game/UI/Gumps/MultipleToolTipGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/MultipleToolTipGump.cs
@@ -1,4 +1,5 @@
-﻿using ClassicUO.Game.UI.Controls;
+﻿using System;
+using ClassicUO.Game.UI.Controls;
 using ClassicUO.Renderer;
 
 namespace ClassicUO.Game.UI.Gumps
@@ -81,7 +82,7 @@ namespace ClassicUO.Game.UI.Gumps
             }
             else if (x > ScaleHelper.LogicalWindowWidth - z_width)
             {
-                x = ScaleHelper.LogicalWindowWidth - z_width;
+                x = Math.Max(0, ScaleHelper.LogicalWindowWidth - z_width);
             }
 
             if (y < 0)
@@ -90,7 +91,7 @@ namespace ClassicUO.Game.UI.Gumps
             }
             else if (y > ScaleHelper.LogicalWindowHeight - z_height)
             {
-                y = ScaleHelper.LogicalWindowHeight - z_height;
+                y = Math.Max(0, ScaleHelper.LogicalWindowHeight - z_height);
             }
 
             SSX = x - 4;

--- a/src/ClassicUO.Client/Game/UI/Gumps/PaperdollGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/PaperdollGump.cs
@@ -445,8 +445,8 @@ namespace ClassicUO.Game.UI.Gumps
 
                 if (party == null)
                 {
-                    int x = Client.Game.Window.ClientBounds.Width / 2 - 272;
-                    int y = Client.Game.Window.ClientBounds.Height / 2 - 240;
+                    int x = ScaleHelper.LogicalWindowWidth / 2 - 272;
+                    int y = ScaleHelper.LogicalWindowHeight / 2 - 240;
                     UIManager.Add(new PartyGump(World, x, y, World.Party.CanLoot));
                 }
                 else

--- a/src/ClassicUO.Client/Game/UI/Gumps/QuestionGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/QuestionGump.cs
@@ -15,7 +15,7 @@ namespace ClassicUO.Game.UI.Gumps
         public QuestionGump(World world, string message, Action<bool> result) : base(world, 0, 0)
         {
             CanCloseWithRightClick = true;
-            var ab = new AlphaBlendControl(0.15f) { Width = Client.Game.Window.ClientBounds.Width, Height = Client.Game.Window.ClientBounds.Height };
+            var ab = new AlphaBlendControl(0.15f) { Width = ScaleHelper.LogicalWindowWidth, Height = ScaleHelper.LogicalWindowHeight };
             Add(ab);
 
             Add(new GumpPic(0, 0, 0x0816, 0));

--- a/src/ClassicUO.Client/Game/UI/Gumps/Supporters.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/Supporters.cs
@@ -37,8 +37,8 @@ namespace ClassicUO.Game.UI.Gumps
         {
             Width = WIDTH;
             Height = HEIGHT;
-            X = (Client.Game.Window.ClientBounds.Width - Width) >> 1;
-            Y = (Client.Game.Window.ClientBounds.Height - Height) >> 1;
+            X = (ScaleHelper.LogicalWindowWidth - Width) >> 1;
+            Y = (ScaleHelper.LogicalWindowHeight - Height) >> 1;
 
             CanCloseWithEsc = true;
             CanCloseWithRightClick = true;

--- a/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/WorldMapGump.cs
@@ -753,8 +753,8 @@ public class WorldMapGump : ResizableGump
         if (_isFullscreen)
         {
             // Keep the map filling the client window if it gets resized while fullscreen.
-            int targetW = Client.Game.Window.ClientBounds.Width;
-            int targetH = Client.Game.Window.ClientBounds.Height;
+            int targetW = ScaleHelper.LogicalWindowWidth;
+            int targetH = ScaleHelper.LogicalWindowHeight;
 
             if (Width != targetW || Height != targetH || X != 0 || Y != 0)
             {
@@ -4109,7 +4109,7 @@ public class WorldMapGump : ResizableGump
 
             X = 0;
             Y = 0;
-            ApplySize(Client.Game.Window.ClientBounds.Width, Client.Game.Window.ClientBounds.Height);
+            ApplySize(ScaleHelper.LogicalWindowWidth, ScaleHelper.LogicalWindowHeight);
         }
         else
         {

--- a/src/ClassicUO.Client/Game/UI/Gumps/WorldViewportGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/WorldViewportGump.cs
@@ -225,8 +225,8 @@ namespace ClassicUO.Game.UI.Gumps
                     }
 
                     // Enforce maximum size based on current position
-                    int maxW = Client.Game.Window.ClientBounds.Width - _scene.Camera.Bounds.X - BORDER_WIDTH;
-                    int maxH = Client.Game.Window.ClientBounds.Height - _scene.Camera.Bounds.Y - BORDER_WIDTH;
+                    int maxW = ScaleHelper.LogicalWindowWidth - _scene.Camera.Bounds.X - BORDER_WIDTH;
+                    int maxH = ScaleHelper.LogicalWindowHeight - _scene.Camera.Bounds.Y - BORDER_WIDTH;
 
                     if (w > maxW)
                     {
@@ -294,8 +294,8 @@ namespace ClassicUO.Game.UI.Gumps
 
         private void ClampViewportToWindowBounds()
         {
-            int windowWidth = Client.Game.Window.ClientBounds.Width;
-            int windowHeight = Client.Game.Window.ClientBounds.Height;
+            int windowWidth = ScaleHelper.LogicalWindowWidth;
+            int windowHeight = ScaleHelper.LogicalWindowHeight;
 
             // Check if we're in full-size mode
             bool isFullSize = ProfileManager.CurrentProfile != null && ProfileManager.CurrentProfile.GameWindowFullSize;
@@ -392,8 +392,8 @@ namespace ClassicUO.Game.UI.Gumps
 
         public Point ResizeGameWindow(Point newSize)
         {
-            int windowWidth = Client.Game.Window.ClientBounds.Width;
-            int windowHeight = Client.Game.Window.ClientBounds.Height;
+            int windowWidth = ScaleHelper.LogicalWindowWidth;
+            int windowHeight = ScaleHelper.LogicalWindowHeight;
 
             // Enforce minimum size
             if (newSize.X < 640)

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/SpellsTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/SpellsTab.cs
@@ -84,7 +84,7 @@ public static class SpellsTab
                 TazLang.Get("uicommons_cancel"),
                 null,
                 "https://github.com/PlayTazUO/TazUO/raw/refs/heads/dev/src/ClassicUO.Client/Game/Managers/DefaultSpellIndicatorConfig.json"
-            ) { X = (Client.Game.Window.ClientBounds.Width >> 1) - 50, Y = (Client.Game.Window.ClientBounds.Height >> 1) - 50 }
+            ) { X = (ScaleHelper.LogicalWindowWidth >> 1) - 50, Y = (ScaleHelper.LogicalWindowHeight >> 1) - 50 }
         );
     }
 

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/VideoTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Options/Tabs/VideoTab.cs
@@ -115,7 +115,7 @@ public static class VideoTab
                     if (b)
                     {
                         viewport.ResizeGameWindow(
-                            new Point(Client.Game.Window.ClientBounds.Width, Client.Game.Window.ClientBounds.Height)
+                            new Point(ScaleHelper.LogicalWindowWidth, ScaleHelper.LogicalWindowHeight)
                         );
                         viewport.SetGameWindowPosition(new Point(0, 0));
                         profile.GameWindowPosition = new Point(0, 0);
@@ -159,7 +159,7 @@ public static class VideoTab
             Option.Slider(
                 TazLang.Get("mog_videotab_gamewindow_viewportx"),
                 0,
-                Client.Game.Window.ClientBounds.Width,
+                ScaleHelper.LogicalWindowWidth,
                 new Accessor<float>(() => profile.GameWindowPosition.X, f =>
                 {
                     profile.GameWindowPosition = new Point((int)f, profile.GameWindowPosition.Y);
@@ -170,7 +170,7 @@ public static class VideoTab
             Option.Slider(
                 TazLang.Get("mog_videotab_gamewindow_viewporty"),
                 0,
-                Client.Game.Window.ClientBounds.Height,
+                ScaleHelper.LogicalWindowHeight,
                 new Accessor<float>(() => profile.GameWindowPosition.Y, f =>
                 {
                     profile.GameWindowPosition = new Point(profile.GameWindowPosition.X, (int)f);
@@ -181,7 +181,7 @@ public static class VideoTab
             Option.Slider(
                 TazLang.Get("mog_videotab_gamewindow_viewportw"),
                 0,
-                Client.Game.Window.ClientBounds.Width,
+                ScaleHelper.LogicalWindowWidth,
                 new Accessor<float>(() => profile.GameWindowSize.X, f =>
                 {
                     profile.GameWindowSize = new Point((int)f, profile.GameWindowSize.Y);
@@ -192,7 +192,7 @@ public static class VideoTab
             Option.Slider(
                 TazLang.Get("mog_videotab_gamewindow_viewporth"),
                 0,
-                Client.Game.Window.ClientBounds.Height,
+                ScaleHelper.LogicalWindowHeight,
                 new Accessor<float>(() => profile.GameWindowSize.Y, f =>
                 {
                     profile.GameWindowSize = new Point(profile.GameWindowSize.X, (int)f);

--- a/src/ClassicUO.Client/GameController.cs
+++ b/src/ClassicUO.Client/GameController.cs
@@ -635,21 +635,31 @@ namespace ClassicUO
         /// <summary>
         /// Draws the tiled window background (behind the world and all gumps) using the configured
         /// <see cref="Profile.MainWindowBackgroundHue"/>. Sets a full-window viewport so it fills the
-        /// whole target regardless of any camera viewport the caller had active. Must be called while
-        /// the intended render target is bound.
+        /// whole target regardless of any camera viewport the caller had active. When the screen
+        /// target is larger than the back buffer (scale-down dead space) the background covers it
+        /// all, so the extended area isn't left as garbage/black. Must be called while the intended
+        /// render target is bound.
         /// </summary>
         public void DrawWindowBackground(UltimaBatcher2D batcher)
         {
-            GraphicsDevice.Viewport = new Viewport(bufferRect);
+            Rectangle bounds = _useScreenRenderTarget && _screenRenderTarget != null && !_screenRenderTarget.IsDisposed
+                ? _screenRenderTarget.Bounds
+                : bufferRect;
+
+            GraphicsDevice.Viewport = new Viewport(bounds);
             batcher.Begin();
-            batcher.DrawTiled(_background, bufferRect, _background.Bounds, bgHueShader);
+            batcher.DrawTiled(_background, bounds, _background.Bounds, bgHueShader);
             batcher.End();
         }
 
         private void EnsureScreenRenderTarget()
         {
-            int width = GraphicManager.PreferredBackBufferWidth;
-            int height = GraphicManager.PreferredBackBufferHeight;
+            // When scaled down, the reachable logical area (window / RenderScale) is larger than
+            // the back buffer. Size the target to cover it so gumps/UI can be placed in what would
+            // otherwise be dead space on the right/bottom. At scale >= 1 the logical area fits
+            // inside the back buffer, so the target stays back-buffer sized (upscaling crops).
+            int width = Math.Max(GraphicManager.PreferredBackBufferWidth, (int)(Client.Game.Window.ClientBounds.Width / RenderScale));
+            int height = Math.Max(GraphicManager.PreferredBackBufferHeight, (int)(Client.Game.Window.ClientBounds.Height / RenderScale));
 
             // Sanity check dimensions
             if (width <= 0 || height <= 0)

--- a/src/ClassicUO.Client/GameController.cs
+++ b/src/ClassicUO.Client/GameController.cs
@@ -464,7 +464,7 @@ namespace ClassicUO
 
             if (viewport != null && ProfileManager.CurrentProfile.GameWindowFullSize)
             {
-                viewport.ResizeGameWindow(new Point(width, height));
+                viewport.ResizeGameWindow(new Point(ScaleHelper.LogicalWindowWidth, ScaleHelper.LogicalWindowHeight));
                 viewport.X = -5;
                 viewport.Y = -5;
             }
@@ -658,8 +658,8 @@ namespace ClassicUO
             // the back buffer. Size the target to cover it so gumps/UI can be placed in what would
             // otherwise be dead space on the right/bottom. At scale >= 1 the logical area fits
             // inside the back buffer, so the target stays back-buffer sized (upscaling crops).
-            int width = Math.Max(GraphicManager.PreferredBackBufferWidth, (int)(Client.Game.Window.ClientBounds.Width / RenderScale));
-            int height = Math.Max(GraphicManager.PreferredBackBufferHeight, (int)(Client.Game.Window.ClientBounds.Height / RenderScale));
+            int width = Math.Max(GraphicManager.PreferredBackBufferWidth, ScaleHelper.LogicalWindowWidth);
+            int height = Math.Max(GraphicManager.PreferredBackBufferHeight, ScaleHelper.LogicalWindowHeight);
 
             // Sanity check dimensions
             if (width <= 0 || height <= 0)
@@ -850,7 +850,7 @@ namespace ClassicUO
             {
                 if (ProfileManager.CurrentProfile.GameWindowFullSize)
                 {
-                    viewport.ResizeGameWindow(new Point(width, height));
+                    viewport.ResizeGameWindow(new Point(ScaleHelper.LogicalWindowWidth, ScaleHelper.LogicalWindowHeight));
                     viewport.X = 0;
                     viewport.Y = 0;
                 }

--- a/src/ClassicUO.Client/Network/PacketHandlers/BulletinBoardData.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers/BulletinBoardData.cs
@@ -2,6 +2,7 @@ using System;
 using ClassicUO.Game;
 using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.Managers;
+using ClassicUO.Game.UI;
 using ClassicUO.Game.UI.Gumps;
 using ClassicUO.IO;
 using ClassicUO.Utility;
@@ -30,8 +31,8 @@ internal static class BulletinBoardData
                     );
                     bulletinBoard?.Dispose();
 
-                    int x = (Client.Game.Window.ClientBounds.Width >> 1) - 245;
-                    int y = (Client.Game.Window.ClientBounds.Height >> 1) - 205;
+                    int x = (ScaleHelper.LogicalWindowWidth >> 1) - 245;
+                    int y = (ScaleHelper.LogicalWindowHeight >> 1) - 205;
 
                     bulletinBoard = new BulletinBoardGump(world, item, x, y, p.ReadUTF8(22, true)); //p.ReadASCII(22));
                     UIManager.Add(bulletinBoard);

--- a/src/ClassicUO.Client/Network/PacketHandlers/DyeData.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers/DyeData.cs
@@ -1,6 +1,7 @@
 using ClassicUO.Configuration;
 using ClassicUO.Game;
 using ClassicUO.Game.Managers;
+using ClassicUO.Game.UI;
 using ClassicUO.Game.UI.Gumps;
 using ClassicUO.IO;
 using ClassicUO.Network;
@@ -18,8 +19,8 @@ internal static class DyeData
 
         ref readonly SpriteInfo gumpInfo = ref Client.Game.UO.Gumps.GetGump(0x0906);
 
-        int x = (Client.Game.Window.ClientBounds.Width >> 1) - (gumpInfo.UV.Width >> 1);
-        int y = (Client.Game.Window.ClientBounds.Height >> 1) - (gumpInfo.UV.Height >> 1);
+        int x = (ScaleHelper.LogicalWindowWidth >> 1) - (gumpInfo.UV.Width >> 1);
+        int y = (ScaleHelper.LogicalWindowHeight >> 1) - (gumpInfo.UV.Height >> 1);
 
         if (ProfileManager.GlobalSettings.UseModernColorPicker)
         {

--- a/src/ClassicUO.Client/Network/PacketHandlers/OpenMenu.cs
+++ b/src/ClassicUO.Client/Network/PacketHandlers/OpenMenu.cs
@@ -1,5 +1,6 @@
 using ClassicUO.Game;
 using ClassicUO.Game.Managers;
+using ClassicUO.Game.UI;
 using ClassicUO.Game.UI.Controls;
 using ClassicUO.Game.UI.Gumps;
 using ClassicUO.IO;
@@ -57,8 +58,8 @@ internal static class OpenMenu
         {
             var gump = new GrayMenuGump(world, serial, id, name)
             {
-                X = (Client.Game.Window.ClientBounds.Width >> 1) - 200,
-                Y = (Client.Game.Window.ClientBounds.Height >> 1) - ((121 + count * 21) >> 1)
+                X = (ScaleHelper.LogicalWindowWidth >> 1) - 200,
+                Y = (ScaleHelper.LogicalWindowHeight >> 1) - ((121 + count * 21) >> 1)
             };
 
             int offsetY = 35 + gump.Height;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UI positioning and boundary handling across different display scales and resolutions.
  * Gumps, menus, dialogs, tooltips, dropdowns, and party interfaces now remain centered and within the visible game area.
  * Improved viewport and fullscreen map sizing.
  * Corrected background rendering and screen coverage when display scaling is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->