### PR TITLE
Fix treasure map location estimation calculation in MapGump

### DIFF
--- a/src/ClassicUO.Client/Game/UI/Gumps/MapGump.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/MapGump.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-License-Identifier: BSD-2-Clause
+// SPDX-License-Identifier: BSD-2-Clause
 
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.UI.Controls;
@@ -182,16 +182,14 @@ namespace ClassicUO.Game.UI.Gumps
                 //    finalX = int(mapinfo.MapOrigin.X + multiX)
                 //    finalY = int(mapinfo.MapOrigin.Y + multiY)
 
-                float multiplier = (float)Width / 300f;
-                //if (Width == 200)
-                //    multiplier = 0.666666666f;
-                //if (Width == 600)
-                //    multiplier = 2f;
-                if (CUOEnviroment.Debug)
-                    GameActions.Print(World, $"Width: {Width}, Multiplier: {multiplier}, Facet: {mapFacet}, MapData: {mapX}, {mapY}, {mapEndX}, {mapEndY}");
+                float scaleX = mapEndX > mapX ? (float)(mapEndX - mapX) / 300f : 1f;
+                float scaleY = mapEndY > mapY ? (float)(mapEndY - mapY) / 300f : 1f;
 
-                mapX = (int)(mapX + (x * multiplier));
-                mapY = (int)(mapY + (y * multiplier));
+                if (CUOEnviroment.Debug)
+                    GameActions.Print(World, $"Width: {Width}, Height: {Height}, ScaleX: {scaleX}, ScaleY: {scaleY}, Facet: {mapFacet}, MapData: {mapX}, {mapY}, {mapEndX}, {mapEndY}");
+
+                mapX = (int)(mapX + (x * scaleX));
+                mapY = (int)(mapY + (y * scaleY));
 
                 //mapX = mapX + x;
                 //mapY = mapY + y;


### PR DESCRIPTION
## Description
Fixes an issue in `MapGump.cs` where the estimated world coordinates for deciphered treasure map pins were calculated incorrectly.

Previously, the client attempted to estimate tile coordinates by multiplying server pin offsets by `Width / 300f`. This resulted in large inaccuracies (off by ~130+ tiles) because:
1. In Ultima Online network protocol (packet `0x56 MapMessage`), server map pins `(x, y)` are sent on a standard **300 × 300 grid** (the classic 2D client map resolution), regardless of the client window/texture display size.
2. The scaling factor must scale the 300-grid pin units to the world map region's tile span (`mapEndX - mapStartX` and `mapEndY - mapStartY`).

The calculation was updated to:
- `scaleX = (mapEndX - mapX) / 300f`
- `scaleY = (mapEndY - mapY) / 300f`
- `mapX = mapX + (int)(x * scaleX)`
- `mapY = mapY + (int)(y * scaleY)`

This accurately projects the pin coordinates to the estimated world tile coordinates (within the standard UO chest digging radius).

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing
- Tested in-game with server-sent map data:
  - **Map Region Bounds**: `(1889, 1781)` to `(2489, 2381)` ($\Delta X = 600$, $\Delta Y = 600$)
  - **Server Pin Input**: `x ≈ 148.5`, `y ≈ 104.7`
  - **Original Calculation Output**: `(2059, 1901)` (Off by ~129 tiles)
  - **Updated Calculation Output**: `(2187, 1991)` vs Actual Location `(2180, 1991)` (Matches within standard 7-tile digging radius)
- Verified clean compilation in both `Debug` and `Release` configurations.

## Screenshots (if applicable)
N/A

## Additional Notes
Fixes coordinate estimation printed when deciphering/opening server-sent treasure map gumps ("I can't be certain but I believe this is somewhere near...").


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Smooth door movement now allows approaching closed doors when automatic door opening is enabled.
  * Updated the movement setting label to “Block walking into doors.”

* **Bug Fixes**
  * Improved map pin positioning for maps with different horizontal and vertical scales.
  * Preserved traditional door blocking when smooth door movement is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->