### PR TITLE
Prefer known mount mappings over tile data animation IDs

### DIFF
--- a/src/ClassicUO.Client/Game/Data/Mounts.cs
+++ b/src/ClassicUO.Client/Game/Data/Mounts.cs
@@ -112,6 +112,22 @@ internal static class Mounts
     }
 
     public static bool TryGet(ushort animId, out MountInfo mountInfo) => _mounts.TryGetValue(animId, out mountInfo);
+
+    /// <summary>
+    /// Resolves a mount item's animation graphic, preferring known mount mappings over tile data.
+    /// </summary>
+    /// <param name="itemGraphic">The mount item's graphic.</param>
+    /// <param name="tileDataAnimationId">The fallback animation ID from tile data.</param>
+    /// <returns>The animation graphic to draw for the mounted creature.</returns>
+    public static ushort ResolveAnimationGraphic(ushort itemGraphic, ushort tileDataAnimationId)
+    {
+        if (TryGet(itemGraphic, out MountInfo mountInfo))
+        {
+            return mountInfo.Graphic;
+        }
+
+        return tileDataAnimationId != 0 ? tileDataAnimationId : itemGraphic;
+    }
 }
 
 internal readonly struct MountInfo

--- a/src/ClassicUO.Client/Game/Data/Mounts.cs
+++ b/src/ClassicUO.Client/Game/Data/Mounts.cs
@@ -91,6 +91,7 @@ internal static class Mounts
             LoadMountsDef();
     }
 
+    /// <summary>Loads custom mount animation mappings from the active client data directory.</summary>
     public static void LoadMountsDef()
     {
         string file = Client.Game.UO.FileManager.GetUOFilePath("Mounts.def");
@@ -111,6 +112,10 @@ internal static class Mounts
         }
     }
 
+    /// <summary>Gets the known mount mapping for an item graphic.</summary>
+    /// <param name="animId">The mount item graphic to look up.</param>
+    /// <param name="mountInfo">The mapped mount information when found.</param>
+    /// <returns><see langword="true"/> when a mapping exists.</returns>
     public static bool TryGet(ushort animId, out MountInfo mountInfo) => _mounts.TryGetValue(animId, out mountInfo);
 
     /// <summary>
@@ -137,6 +142,11 @@ internal readonly struct MountInfo
     public readonly sbyte OffsetY;
     public readonly bool DrawAsSingleLayer;
 
+    /// <summary>Creates a mount animation mapping.</summary>
+    /// <param name="graphic">The creature graphic to draw while mounted.</param>
+    /// <param name="animId">The mount item graphic represented by this mapping.</param>
+    /// <param name="offsetY">The vertical drawing offset for the mounted creature.</param>
+    /// <param name="drawAsSingleLayer">Whether the mount is drawn as a single animation layer.</param>
     public MountInfo(ushort graphic, ushort animId, sbyte offsetY, bool drawAsSingleLayer = false)
     {
         Graphic = graphic;

--- a/src/ClassicUO.Client/Game/GameObjects/Item.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Item.cs
@@ -471,6 +471,9 @@ namespace ClassicUO.Game.GameObjects
 
             ProcessAnimation();
         }
+
+        /// <summary>Gets the animation graphic, preferring known mount mappings over tile data fallbacks.</summary>
+        /// <returns>The graphic used to render this item's animation.</returns>
         public override ushort GetGraphicForAnimation()
         {
             ushort graphic = Graphic;

--- a/src/ClassicUO.Client/Game/GameObjects/Item.cs
+++ b/src/ClassicUO.Client/Game/GameObjects/Item.cs
@@ -489,15 +489,7 @@ namespace ClassicUO.Game.GameObjects
                     return 0x00BF;
                 }
 
-                if (Mounts.TryGet(graphic, out MountInfo mountInfo))
-                {
-                    graphic = mountInfo.Graphic;
-                }
-
-                if (ItemData.AnimID != 0)
-                {
-                    graphic = ItemData.AnimID;
-                }
+                graphic = Mounts.ResolveAnimationGraphic(graphic, ItemData.AnimID);
             }
             else if (IsCorpse)
             {

--- a/tests/ClassicUO.UnitTests/Game/Data/MountsTests.cs
+++ b/tests/ClassicUO.UnitTests/Game/Data/MountsTests.cs
@@ -4,6 +4,7 @@ namespace ClassicUO.UnitTests.Game.Data;
 
 public class MountsTests
 {
+    /// <summary>Verifies that stale tile data cannot override a known mount mapping.</summary>
     [Fact]
     public void ResolveAnimationGraphic_KnownMount_PrefersMountMapping()
     {
@@ -12,6 +13,7 @@ public class MountsTests
         Assert.Equal((ushort)0x007A, result);
     }
 
+    /// <summary>Verifies that unknown custom mounts retain the tile data fallback.</summary>
     [Fact]
     public void ResolveAnimationGraphic_UnknownMount_UsesTileDataAnimation()
     {
@@ -20,6 +22,7 @@ public class MountsTests
         Assert.Equal((ushort)0x0123, result);
     }
 
+    /// <summary>Verifies that an unknown mount without a fallback retains its item graphic.</summary>
     [Fact]
     public void ResolveAnimationGraphic_UnknownMountWithoutTileDataAnimation_KeepsItemGraphic()
     {

--- a/tests/ClassicUO.UnitTests/Game/Data/MountsTests.cs
+++ b/tests/ClassicUO.UnitTests/Game/Data/MountsTests.cs
@@ -1,0 +1,30 @@
+using Xunit;
+
+namespace ClassicUO.UnitTests.Game.Data;
+
+public class MountsTests
+{
+    [Fact]
+    public void ResolveAnimationGraphic_KnownMount_PrefersMountMapping()
+    {
+        ushort result = Mounts.ResolveAnimationGraphic(0x3EB4, 0x0037);
+
+        Assert.Equal((ushort)0x007A, result);
+    }
+
+    [Fact]
+    public void ResolveAnimationGraphic_UnknownMount_UsesTileDataAnimation()
+    {
+        ushort result = Mounts.ResolveAnimationGraphic(0x4000, 0x0123);
+
+        Assert.Equal((ushort)0x0123, result);
+    }
+
+    [Fact]
+    public void ResolveAnimationGraphic_UnknownMountWithoutTileDataAnimation_KeepsItemGraphic()
+    {
+        ushort result = Mounts.ResolveAnimationGraphic(0x4000, 0);
+
+        Assert.Equal((ushort)0x4000, result);
+    }
+}


### PR DESCRIPTION
## Description

Known mount item graphics are now resolved through TazUO's mount table before considering the animation ID from tile data.

Older or heavily customized client data can contain stale `AnimID` values for mount items. Previously, those values unconditionally replaced an already resolved known mount mapping. The mount table now takes precedence, while the tile data animation ID remains the fallback for unknown custom mounts.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing

Added regression tests covering:

- A known unicorn mount (`0x3EB4`) with a conflicting tile data animation ID.
- An unknown mount using its tile data animation ID as a fallback.
- An unknown mount without a tile data animation ID retaining its item graphic.

Result: 3 tests passed.

## Additional Notes

This is a general compatibility fix for known mounts when using older or customized UO client data. Normal items, corpses, and unknown custom mounts retain their existing behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mount animation graphic selection.
  * Known mounts now use their mapped animation graphics.
  * Unknown mounts fall back to available tile animation data, or retain the item graphic when no animation data exists.

* **Tests**
  * Added coverage for known-mount mappings and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->