### PR TITLE
Separate scavenger from autoloot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to TazUO will be recorded here.
 ---
 ## In Development
 
+### Features
+* Separated Scavenger agent from Autoloot, they now each have their own loot lists and enabled/disabled toggles
+
 ### Fixes
+* Improved treasure map location calculations - [P.R 1012](https://github.com/PlayTazUO/TazUO/pull/1012) [Erumite](https://github.com/Erumite)
 * Door movement blocking no longer stops you from walking into closed doors when the "Open doors while pathfinding" (smooth doors) setting is enabled, and the option label is now "Block walking into doors"
 
 ## 5.31.2

--- a/src/ClassicUO.Client/Configuration/Profile.cs
+++ b/src/ClassicUO.Client/Configuration/Profile.cs
@@ -797,6 +797,7 @@ namespace ClassicUO.Configuration
         public bool DisableTargetingGridContainers { get; set => SetProperty(ref field, value); }
         public bool ControllerEnabled { get; set => SetProperty(ref field, value); } = true;
         public bool EnableScavenger { get; set => SetProperty(ref field, value); } = true;
+        public string ScavengerSelectedListUid { get; set => SetProperty(ref field, value); } = "";
         public bool CounterGumpLocked { get; set => SetProperty(ref field, value); }
         public bool NearbyLootConcealsContainerOnOpen { get; set => SetProperty(ref field, value); } = true;
         public bool SpellBar_ShowHotkeys { get; set => SetProperty(ref field, value); } = true;

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -1071,6 +1071,7 @@ assistant_general_tab_pathfinding=Pathfinding
 
 ; Assistant agent sub-tabs
 assistant_agent_tab_autoloot=Auto Loot
+assistant_agent_tab_scavenger=Scavenger
 assistant_agent_tab_dress=Dress Agent
 assistant_agent_tab_autobuy=Auto Buy
 assistant_agent_tab_autosell=Auto Sell

--- a/src/ClassicUO.Client/Game/Managers/AutoLootManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/AutoLootManager.cs
@@ -411,11 +411,6 @@ namespace ClassicUO.Game.Managers
         {
             if (!_loaded) return;
 
-            if (ProfileManager.CurrentProfile.EnableScavenger)
-                foreach (Item item in _world.Items.Values)
-                    if (item != null && item.OnGround && !item.IsLocked && !item.IsCorpse && item.Distance < 3)
-                        CheckAndLoot(item);
-
             if (IsEnabled)
                 foreach (Item corpse in _world.GetCorpseSnapshot())
                     CheckCorpse(corpse);
@@ -433,12 +428,7 @@ namespace ClassicUO.Game.Managers
             if (!_loaded || !IsEnabled) return;
 
             if (sender is Item i)
-            {
                 CheckCorpse(i);
-
-                // Check for ground items to auto-loot (scavenger functionality)
-                if (ProfileManager.CurrentProfile.EnableScavenger && i.OnGround && !i.IsCorpse && !i.IsLocked && i.Distance <= ProfileManager.CurrentProfile.AutoOpenCorpseRange) CheckAndLoot(i);
-            }
         }
 
         private void OnOPLReceived(object sender, OPLEventArgs e)

--- a/src/ClassicUO.Client/Game/Managers/ScavengerManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/ScavengerManager.cs
@@ -72,7 +72,7 @@ namespace ClassicUO.Game.Managers
 
         private readonly HashSet<uint> _quickContainsLookup = new();
         private readonly HashSet<uint> _recentlyLooted = new();
-        private static readonly PriorityQueue<(uint item, ScavengerEntry entry), ScavengerPriority> _lootItems = new();
+        private readonly PriorityQueue<(uint item, ScavengerEntry entry), ScavengerPriority> _lootItems = new();
         private readonly List<ScavengerEntry> _fallbackEntries = new();
         private ScavengerData _data = new();
         private ScavengerList _currentList;
@@ -149,7 +149,7 @@ namespace ClassicUO.Game.Managers
         /// <summary>
         /// Add an entry for scavenging to match against items on the ground.
         /// </summary>
-        public ScavengerEntry AddScavengerEntry(ushort graphic = 0, ushort hue = ushort.MaxValue, string name = "")
+        public ScavengerEntry AddScavengerEntry(int graphic = 0, ushort hue = ushort.MaxValue, string name = "")
         {
             if (!_loaded) return null;
 

--- a/src/ClassicUO.Client/Game/Managers/ScavengerManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/ScavengerManager.cs
@@ -1,0 +1,604 @@
+using ClassicUO.Common;
+using ClassicUO.Configuration;
+using ClassicUO.Game.GameObjects;
+using ClassicUO.Game.Managers.Structs;
+using ClassicUO.Utility;
+using ClassicUO.Utility.Logging;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using System.Text.RegularExpressions;
+
+namespace ClassicUO.Game.Managers
+{
+    [JsonSerializable(typeof(ScavengerManager.ScavengerEntry))]
+    [JsonSerializable(typeof(List<ScavengerManager.ScavengerEntry>))]
+    [JsonSerializable(typeof(ScavengerManager.ScavengerPriority))]
+    [JsonSerializable(typeof(ScavengerManager.ScavengerList))]
+    [JsonSerializable(typeof(List<ScavengerManager.ScavengerList>))]
+    [JsonSerializable(typeof(ScavengerManager.ScavengerData))]
+    [JsonSourceGenerationOptions(WriteIndented = true)]
+    public partial class ScavengerJsonContext : JsonSerializerContext
+    {
+    }
+
+    /// <summary>
+    /// Scavenger support - automatically picks up items on the ground that match the configured
+    /// scavenger lists. Independent of <see cref="AutoLootManager"/>: it has its own lists, config
+    /// file and queue, sharing only the grab bag and move infrastructure.
+    /// </summary>
+    public class ScavengerManager
+    {
+        public static ScavengerManager Instance
+        {
+            get
+            {
+                if (field == null)
+                    field = new();
+                return field;
+            }
+            private set => field = value;
+        }
+
+        /// <summary>
+        /// Entries of the currently selected scavenger list. Matching, adding and removing all
+        /// operate against this list.
+        /// </summary>
+        public List<ScavengerEntry> ScavengerEntries => _currentList?.Entries ?? _fallbackEntries;
+
+        /// <summary>
+        /// All configured scavenger lists. There is always at least one.
+        /// </summary>
+        public IReadOnlyList<ScavengerList> Lists => _data.Lists;
+
+        /// <summary>
+        /// The scavenger list currently selected/active.
+        /// </summary>
+        public ScavengerList CurrentList => _currentList;
+
+        /// <summary>
+        /// True once the config file has finished loading. Mutating operations are ignored until
+        /// this is true so the background load cannot overwrite user changes.
+        /// </summary>
+        public bool IsLoaded => _loaded;
+
+        /// <summary>
+        /// Name of the list that first-run configs are seeded into.
+        /// </summary>
+        public const string DefaultListName = "Default";
+
+        private readonly HashSet<uint> _quickContainsLookup = new();
+        private readonly HashSet<uint> _recentlyLooted = new();
+        private static readonly PriorityQueue<(uint item, ScavengerEntry entry), ScavengerPriority> _lootItems = new();
+        private readonly List<ScavengerEntry> _fallbackEntries = new();
+        private ScavengerData _data = new();
+        private ScavengerList _currentList;
+        private bool _loaded = false;
+        private long _nextLootTime = Time.Ticks;
+        private long _nextClearRecents = Time.Ticks + (ProfileManager.CurrentProfile?.AutoLootRetryDelay ?? 5000);
+        private bool IsEnabled => ProfileManager.CurrentProfile.EnableScavenger;
+
+        private readonly World _world;
+
+        /// <summary>
+        /// The UID of the currently selected scavenger list. Stored per character on the profile so
+        /// each character can have a different active list while the lists themselves are shared
+        /// across the server.
+        /// </summary>
+        private string SelectedListUid
+        {
+            get => ProfileManager.CurrentProfile?.ScavengerSelectedListUid ?? string.Empty;
+            set
+            {
+                if (ProfileManager.CurrentProfile != null)
+                    ProfileManager.CurrentProfile.ScavengerSelectedListUid = value;
+            }
+        }
+
+        private ScavengerManager()
+        {
+            _world = Client.Game.UO.World;
+        }
+
+        public void LootItem(uint serial)
+        {
+            Item item = _world.Items.Get(serial);
+            if (item != null) LootItem(item, null);
+        }
+
+        public void LootItem(Item item, ScavengerEntry entry = null, ScavengerPriority priority = ScavengerPriority.Normal)
+        {
+            if (item == null || !_recentlyLooted.Add(item.Serial) || !_quickContainsLookup.Add(item.Serial)) return;
+
+            if (entry != null)
+                priority = entry.Priority;
+            _lootItems.Enqueue((item, entry), priority);
+            _nextClearRecents = Time.Ticks + (ProfileManager.CurrentProfile?.AutoLootRetryDelay ?? 5000);
+        }
+
+        /// <summary>
+        /// Check a ground item against the scavenger list, if it needs to be picked up it will be.
+        /// </summary>
+        private void CheckAndLoot(Item i)
+        {
+            if (!_loaded || i == null || _quickContainsLookup.Contains(i.Serial)) return;
+
+            ScavengerEntry entry = IsOnLootList(i);
+            if (entry != null) LootItem(i, entry);
+        }
+
+        /// <summary>
+        /// Check if an item is on the scavenger list.
+        /// </summary>
+        /// <param name="i">The item to check the scavenger list against</param>
+        /// <returns>The matched ScavengerEntry, or null if no match found</returns>
+        private ScavengerEntry IsOnLootList(Item i)
+        {
+            if (!_loaded) return null;
+
+            foreach (ScavengerEntry entry in ScavengerEntries)
+                if (entry.Match(i))
+                    return entry;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Add an entry for scavenging to match against items on the ground.
+        /// </summary>
+        public ScavengerEntry AddScavengerEntry(ushort graphic = 0, ushort hue = ushort.MaxValue, string name = "")
+        {
+            if (!_loaded) return null;
+
+            var item = new ScavengerEntry() { Graphic = graphic, Hue = hue, Name = name };
+
+            foreach (ScavengerEntry entry in ScavengerEntries)
+                if (entry.Equals(item))
+                    return entry;
+
+            ScavengerEntries.Add(item);
+
+            return item;
+        }
+
+        public void TryRemoveScavengerEntry(string uid)
+        {
+            if (!_loaded) return;
+
+            List<ScavengerEntry> entries = ScavengerEntries;
+            int removeAt = -1;
+
+            for (int i = 0; i < entries.Count; i++)
+                if (entries[i].Uid == uid)
+                    removeAt = i;
+
+            if (removeAt > -1) entries.RemoveAt(removeAt);
+        }
+
+        /// <summary>
+        /// Ensures there is always at least one scavenger list and that a list is selected.
+        /// </summary>
+        private void EnsureAtLeastOneList()
+        {
+            _data ??= new ScavengerData();
+            _data.Lists ??= new List<ScavengerList>();
+
+            if (_data.Lists.Count == 0)
+                _data.Lists.Add(new ScavengerList { Name = DefaultListName });
+
+            if (_currentList == null || !_data.Lists.Contains(_currentList))
+            {
+                ScavengerList found = null;
+
+                if (!string.IsNullOrEmpty(SelectedListUid))
+                    found = _data.Lists.Find(l => l.Uid == SelectedListUid);
+
+                _currentList = found ?? _data.Lists[0];
+                SelectedListUid = _currentList.Uid;
+            }
+        }
+
+        /// <summary>
+        /// Selects the given scavenger list as the active one. All matching/adding will use it.
+        /// </summary>
+        public void SelectList(ScavengerList list)
+        {
+            if (!_loaded || list == null || !_data.Lists.Contains(list) || _currentList == list) return;
+
+            _currentList = list;
+            SelectedListUid = list.Uid;
+            Save();
+        }
+
+        /// <summary>
+        /// Creates a new scavenger list and selects it.
+        /// </summary>
+        public ScavengerList AddList(string name)
+        {
+            if (!_loaded) return null;
+
+            var list = new ScavengerList { Name = string.IsNullOrWhiteSpace(name) ? "New List" : name.Trim() };
+
+            _data.Lists.Add(list);
+            _currentList = list;
+            SelectedListUid = list.Uid;
+            Save();
+
+            return list;
+        }
+
+        /// <summary>
+        /// Deletes a scavenger list. Refuses to delete the last remaining list so there is always at
+        /// least one. If the deleted list was selected, the first remaining list becomes active.
+        /// </summary>
+        /// <returns>True if the list was deleted.</returns>
+        public bool DeleteList(ScavengerList list)
+        {
+            if (!_loaded || list == null || _data.Lists.Count <= 1 || !_data.Lists.Remove(list)) return false;
+
+            if (_currentList == list)
+            {
+                _currentList = _data.Lists[0];
+                SelectedListUid = _currentList.Uid;
+            }
+
+            Save();
+            return true;
+        }
+
+        /// <summary>
+        /// Renames a scavenger list.
+        /// </summary>
+        public void RenameList(ScavengerList list, string newName)
+        {
+            if (!_loaded || list == null || string.IsNullOrWhiteSpace(newName)) return;
+
+            list.Name = newName.Trim();
+            Save();
+        }
+
+        public void OnSceneLoad()
+        {
+            Load();
+            EventSink.OnItemCreatedInternal += OnItemCreatedOrUpdated;
+            EventSink.OnItemUpdatedInternal += OnItemCreatedOrUpdated;
+            EventSink.OnPositionChanged += OnPositionChanged;
+        }
+
+        public void OnSceneUnload()
+        {
+            EventSink.OnItemCreatedInternal -= OnItemCreatedOrUpdated;
+            EventSink.OnItemUpdatedInternal -= OnItemCreatedOrUpdated;
+            EventSink.OnPositionChanged -= OnPositionChanged;
+            Save();
+            Instance = null;
+        }
+
+        /// <summary>
+        /// Invoked whenever the player changes position. Scans ground items within reach so freshly
+        /// dropped items (or items stepped over) get picked up without a new item event firing.
+        /// </summary>
+        private void OnPositionChanged(object sender, PositionChangedArgs e)
+        {
+            if (!_loaded || !IsEnabled) return;
+
+            foreach (Item item in _world.Items.Values)
+                if (item != null && item.OnGround && !item.IsLocked && !item.IsCorpse && item.Distance < 3)
+                    CheckAndLoot(item);
+        }
+
+        private void OnItemCreatedOrUpdated(object sender, EventArgs e)
+        {
+            if (!_loaded || !IsEnabled) return;
+
+            if (sender is Item i && i.OnGround && !i.IsCorpse && !i.IsLocked && i.Distance <= ProfileManager.CurrentProfile.AutoOpenCorpseRange)
+                CheckAndLoot(i);
+        }
+
+        public void Update()
+        {
+            if (!_loaded || !IsEnabled || !_world.InGame) return;
+
+            if (_nextLootTime > Time.Ticks) return;
+
+            if (Client.Game.UO.GameCursor.ItemHold.Enabled)
+                return; //Prevent moving stuff while holding an item.
+
+            if (_lootItems.Count == 0)
+            {
+                if (Time.Ticks > _nextClearRecents)
+                {
+                    _recentlyLooted.Clear();
+                    _nextClearRecents = Time.Ticks + (ProfileManager.CurrentProfile?.AutoLootRetryDelay ?? 5000);
+                }
+                return;
+            }
+
+            (uint item, ScavengerEntry entry) = _lootItems.Dequeue();
+            if (item == 0) return;
+
+            _quickContainsLookup.Remove(item);
+
+            Item moveItem = _world.Items.Get(item);
+
+            if (moveItem == null)
+                return;
+
+            if (moveItem.Distance > ProfileManager.CurrentProfile.AutoOpenCorpseRange)
+            {
+                _recentlyLooted.Remove(item);
+                return;
+            }
+
+            uint destinationSerial = 0;
+
+            //If this entry has a specific container, use it
+            if (entry != null && entry.DestinationContainer != 0)
+            {
+                Item itemDestContainer = _world.Items.Get(entry.DestinationContainer);
+                if (itemDestContainer != null) destinationSerial = entry.DestinationContainer;
+            }
+
+            if (destinationSerial == 0 && ProfileManager.CurrentProfile.GrabBagSerial != 0)
+            {
+                Item grabBag = _world.Items.Get(ProfileManager.CurrentProfile.GrabBagSerial);
+                if (grabBag != null) destinationSerial = ProfileManager.CurrentProfile.GrabBagSerial;
+            }
+
+            if (destinationSerial == 0)
+            {
+                Item backpack = _world.Player.Backpack;
+                if (backpack != null) destinationSerial = backpack.Serial;
+            }
+
+            if (destinationSerial != 0)
+            {
+                ActionPriority lootPriority = entry?.Priority switch
+                {
+                    ScavengerPriority.High => ActionPriority.LootItemHigh,
+                    ScavengerPriority.Low => ActionPriority.LootItem,
+                    _ => ActionPriority.LootItemMedium,
+                };
+
+                ushort amount = GetAmountToMove(moveItem, entry, destinationSerial);
+                if (amount > 0)
+                    ObjectActionQueue.Instance.Enqueue(new MoveRequest(moveItem.Serial, destinationSerial, amount).ToObjectActionQueueItem(), lootPriority);
+            }
+            else
+                GameActions.Print("Could not find a container to loot into. Try setting a grab bag.");
+
+            _nextLootTime = Time.Ticks + ProfileManager.CurrentProfile.MoveMultiObjectDelay;
+        }
+
+        /// <summary>
+        /// Computes how much of <paramref name="item"/> to move so the destination container ends
+        /// up with at most <see cref="ScavengerEntry.MaxAmount"/> matching items. Returns the item's
+        /// full amount when no limit is configured.
+        /// </summary>
+        private ushort GetAmountToMove(Item item, ScavengerEntry entry, uint destinationSerial)
+        {
+            if (entry == null || entry.MaxAmount <= 0)
+                return item.Amount;
+
+            Item destCont = _world.Items.Get(destinationSerial);
+            if (destCont == null)
+                return item.Amount;
+
+            int existing = 0;
+            for (LinkedObject i = destCont.Items; i != null; i = i.Next)
+            {
+                if (i is Item destItem && destItem.Serial != item.Serial && entry.Match(destItem))
+                    existing += destItem.Amount;
+            }
+
+            int toMove = entry.MaxAmount - existing;
+            if (toMove <= 0)
+                return 0;
+
+            return (ushort)Math.Min(toMove, item.Amount);
+        }
+
+        private void Load()
+        {
+            if (_loaded) return;
+
+            try
+            {
+                _data = ScavengerData.Load();
+                _currentList = null;
+                EnsureAtLeastOneList();
+                _loaded = true;
+            }
+            catch
+            {
+                Log.Error("There was an error loading your scavenger config file, please check it with a json validator.");
+                _loaded = false;
+            }
+        }
+
+        public void Save()
+        {
+            if (!_loaded) return;
+
+            try
+            {
+                if (_currentList != null)
+                    SelectedListUid = _currentList.Uid;
+
+                _data.Save();
+            }
+            catch (Exception e) { Console.WriteLine(e.ToString()); }
+        }
+
+        public void ClearActiveLootQueue()
+        {
+            while (_lootItems.TryDequeue(out _, out _));
+            _quickContainsLookup.Clear();
+        }
+
+        private void ImportEntries(List<ScavengerEntry> entries, string source)
+        {
+            var newItems = new List<ScavengerEntry>();
+            int duplicateCount = 0;
+
+            List<ScavengerEntry> currentEntries = ScavengerEntries;
+
+            foreach (ScavengerEntry importedItem in entries)
+            {
+                bool isDuplicate = false;
+                foreach (ScavengerEntry existingItem in currentEntries)
+                    if (existingItem.Equals(importedItem))
+                    {
+                        isDuplicate = true;
+                        duplicateCount++;
+                        break;
+                    }
+
+                if (!isDuplicate) newItems.Add(importedItem);
+            }
+
+            if (newItems.Count > 0)
+            {
+                currentEntries.AddRange(newItems);
+                Save();
+            }
+
+            string message = $"Imported {newItems.Count} new scavenger entries from {source}";
+            if (duplicateCount > 0) message += $" ({duplicateCount} duplicates skipped)";
+            GameActions.Print(message, 0x48);
+        }
+
+        #nullable enable
+        public string? GetJsonExport()
+        {
+            try
+            {
+                return JsonSerializer.Serialize(ScavengerEntries, ScavengerJsonContext.Default.ListScavengerEntry);
+            }
+            catch (Exception e)
+            {
+                Log.Error($"Error exporting scavenger to JSON: {e}");
+            }
+
+            return null;
+        }
+        #nullable disable
+
+        public bool ImportFromJson(string json)
+        {
+            try
+            {
+                List<ScavengerEntry> importedItems = JsonSerializer.Deserialize(json, ScavengerJsonContext.Default.ListScavengerEntry);
+
+                if (importedItems != null)
+                {
+                    ImportEntries(importedItems, "clipboard");
+                    return true;
+                }
+            }
+            catch (Exception e)
+            {
+                Log.Error($"Error importing scavenger from JSON: {e}");
+            }
+
+            return false;
+        }
+
+        public enum ScavengerPriority { Low = 0, Normal = 1, High = 2 }
+
+        /// <summary>
+        /// A named collection of scavenger entries. Users can create multiple lists and quickly
+        /// swap between them.
+        /// </summary>
+        public class ScavengerList
+        {
+            public string Name { get; set; } = "";
+            public List<ScavengerEntry> Entries { get; set; } = new();
+            /// <summary>
+            /// Do not set this manually.
+            /// </summary>
+            public string Uid { get; set; } = Guid.NewGuid().ToString();
+        }
+
+        /// <summary>
+        /// Root persisted object holding every scavenger list. Saving/loading (with rotating
+        /// backups) is handled by <see cref="JsonSave{T}"/>. The selected list UID lives on the
+        /// profile (per character) rather than here.
+        /// </summary>
+        public class ScavengerData : JsonSave<ScavengerData>, INotifyPropertyChanged
+        {
+            public const string ScavengerFileName = "Scavenger.json";
+
+            public List<ScavengerList> Lists { get; set; } = new();
+
+            /// <summary>Lives in the server folder so it is shared across all characters on a server.</summary>
+            protected override SettingsScope Scope => SettingsScope.Server;
+
+            protected override string FileName => ScavengerFileName;
+
+            protected override JsonTypeInfo<ScavengerData> TypeInfo => ScavengerJsonContext.Default.ScavengerData;
+        }
+
+        public class ScavengerEntry
+        {
+            public string Name { get; set; } = "";
+            public int Graphic { get; set; } = 0;
+            public ushort Hue { get; set; } = ushort.MaxValue;
+            [JsonConverter(typeof(RawStringConverter))]
+            public string RegexSearch { get; set; } = string.Empty;
+            public uint DestinationContainer { get; set; } = 0;
+            public ScavengerPriority Priority { get; set; } = ScavengerPriority.Normal;
+            /// <summary>
+            /// Maximum number of matching items to keep in the destination container when scavenging
+            /// this entry. Counts items already in the destination. 0 = no limit (pick up all).
+            /// </summary>
+            public int MaxAmount { get; set; } = 0;
+            private bool RegexMatch => !string.IsNullOrEmpty(RegexSearch);
+            /// <summary>
+            /// Do not set this manually.
+            /// </summary>
+            public string Uid { get; set; } = Guid.NewGuid().ToString();
+
+            public bool Match(Item compareTo)
+            {
+                if (Graphic != -1 && Graphic != compareTo.Graphic) return false;
+
+                if (!HueCheck(compareTo.Hue)) return false;
+
+                if (RegexMatch && !RegexCheck(compareTo.World, compareTo)) return false;
+
+                return true;
+            }
+
+            private bool HueCheck(ushort value)
+            {
+                if (Hue == ushort.MaxValue) //Ignore hue.
+                    return true;
+                else if (Hue == value) //Hue must match, and it does
+                    return true;
+                else //Hue is not ignored, and does not match
+                    return false;
+            }
+
+            private bool RegexCheck(World world, Item compareTo)
+            {
+                string search;
+
+                if (compareTo.OPLName.NotNullNotEmpty())
+                    search = compareTo.OPLName;
+                else
+                    search = compareTo.GetNormalizedName(false);
+
+                if (compareTo.OPLData.NotNullNotEmpty())
+                    search += compareTo.OPLData;
+
+                return RegexHelper.GetRegex(RegexSearch, RegexOptions.Multiline).IsMatch(search);
+            }
+
+            public bool Equals(ScavengerEntry other) => other.Graphic == Graphic && other.Hue == Hue && RegexSearch == other.RegexSearch;
+        }
+    }
+}

--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -241,6 +241,7 @@ namespace ClassicUO.Game.Scenes
             SpellVisualRangeManager.Instance.OnSceneLoad();
             AutoLootManager.Instance.OnSceneLoad();
             AutoSkinningManager.Instance.OnSceneLoad();
+            ScavengerManager.Instance.OnSceneLoad();
             DressAgentManager.Instance.Load();
             FriendsListManager.Instance.OnSceneLoad();
 
@@ -452,6 +453,7 @@ namespace ClassicUO.Game.Scenes
             AutoLootManager.Instance.OnSceneUnload();
             GridHighlightData.Unload();
             AutoSkinningManager.Instance.OnSceneUnload();
+            ScavengerManager.Instance.OnSceneUnload();
             FriendsListManager.Instance.OnSceneUnload();
 
             NameOverHeadManager.Save();
@@ -983,6 +985,7 @@ namespace ClassicUO.Game.Scenes
 
             ObjectActionQueue.Instance.Update();
             AutoLootManager.Instance.Update();
+            ScavengerManager.Instance.Update();
             BandageManager.Instance.Update();
             GridHighlightData.ProcessQueue(_world);
             Profiler.ExitContext("Actions");

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/AgentTab.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/AgentTab.cs
@@ -9,6 +9,7 @@ public static class AgentTab
     {
         var tabs = new MyraTabControl();
         tabs.AddTab(TazLang.Get("assistant_agent_tab_autoloot", "Auto Loot"), AutoLootAgentTabContent.Build);
+        tabs.AddTab(TazLang.Get("assistant_agent_tab_scavenger", "Scavenger"), ScavengerAgentTabContent.Build);
         tabs.AddTab(TazLang.Get("assistant_agent_tab_dress", "Dress Agent"), DressAgentTabContent.Build);
         tabs.AddTab(TazLang.Get("assistant_agent_tab_autobuy", "Auto Buy"), AutoBuyAgentTabContent.Build);
         tabs.AddTab(TazLang.Get("assistant_agent_tab_autosell", "Auto Sell"), AutoSellAgentTabContent.Build);

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/ScavengerAgentTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/ScavengerAgentTabContent.cs
@@ -97,6 +97,7 @@ public static class ScavengerAgentTabContent
         listSelectRow.Widgets.Add(new MyraButton("Rename", () =>
         {
             ScavengerManager.ScavengerList current = ScavengerManager.Instance.CurrentList;
+            if (current == null) return;
             var nameBox = new MyraInputBox { Text = current.Name, HintText = "List name", Width = 220 };
             new MyraDialog("Rename Scavenger List", nameBox, ok =>
             {
@@ -115,6 +116,7 @@ public static class ScavengerAgentTabContent
             }
 
             ScavengerManager.ScavengerList current = ScavengerManager.Instance.CurrentList;
+            if (current == null) return;
             new MyraDialog("Delete Scavenger List",
                 new MyraLabel($"Delete list \"{current.Name}\" and all of its entries?", MyraLabel.TextStyle.P),
                 ok =>
@@ -162,7 +164,7 @@ public static class ScavengerAgentTabContent
                 ScavengerManager.ScavengerEntry entry = entries[i];
 
                 // Art image (col 0)
-                if (entry.Graphic is > 0 and < ushort.MaxValue)
+                if (entry.Graphic > 0)
                     grid.AddWidget(new MyraArtTexture((uint)entry.Graphic) { Tooltip = entry.Name, Margin = new Thickness(2, 0) }, dataRow, 0);
                 else
                 {
@@ -180,13 +182,13 @@ public static class ScavengerAgentTabContent
                 // Graphic
                 var graphicBox = new MyraInputBox
                 {
-                    Text = entry.Graphic == ushort.MaxValue ? "-1" : entry.Graphic.ToString(),
+                    Text = entry.Graphic == -1 ? "-1" : entry.Graphic.ToString(),
                     Tooltip = "Item graphic ID. Set to -1 to match any graphic.",
                 };
                 graphicBox.TextChangedByUser += (_, _) =>
                 {
                     if (StringHelper.TryParseInt(graphicBox.Text, out int g))
-                        entry.Graphic = g == -1 ? ushort.MaxValue : g;
+                        entry.Graphic = g;
                 };
                 grid.AddWidget(graphicBox, dataRow, 1);
 
@@ -352,17 +354,14 @@ public static class ScavengerAgentTabContent
                 if (graphic > ushort.MaxValue)
                     return;
 
-                if (graphic == -1)
-                    graphic = ushort.MaxValue;
-
                 if (!MyraInputBox.TryParseHue(newHueBox.Text, out ushort hue))
                     hue = ushort.MaxValue;
 
-                ScavengerManager.ScavengerEntry? entry = ScavengerManager.Instance.AddScavengerEntry((ushort)graphic, hue, newNameBox.Text);
+                ScavengerManager.ScavengerEntry? entry = ScavengerManager.Instance.AddScavengerEntry(graphic, hue, newNameBox.Text);
                 if (entry == null) return;
 
                 entry.RegexSearch = newRegexBox.Text;
-                if (int.TryParse(newMaxBox.Text, out int maxAmount))
+                if (int.TryParse(newMaxBox.Text, out int maxAmount) && maxAmount >= 0)
                     entry.MaxAmount = maxAmount;
 
                 newNameBox.Text = "";

--- a/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/ScavengerAgentTabContent.cs
+++ b/src/ClassicUO.Client/Game/UI/MyraWindows/Widgets/Assistant/Agents/ScavengerAgentTabContent.cs
@@ -8,12 +8,12 @@ using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.UI.MyraWindows.Widgets.ArtTexture;
 using ClassicUO.Utility;
-using Myra.Graphics2D.UI;
 using Myra.Graphics2D;
+using Myra.Graphics2D.UI;
 
 namespace ClassicUO.Game.UI.MyraWindows.Widgets.Assistant.Agents;
 
-public static class AutoLootAgentTabContent
+public static class ScavengerAgentTabContent
 {
     private static readonly string[] PriorityLabels = { "Low", "Normal", "High" };
 
@@ -23,13 +23,13 @@ public static class AutoLootAgentTabContent
 
         var root = new VerticalStackPanel { Spacing = 6 };
 
-        // Enable Auto Loot + Set Grab Bag
+        // Enable Scavenger + Set Grab Bag
         var topRow = new HorizontalStackPanel { Spacing = 8 };
         topRow.Widgets.Add(MyraCheckButton.CreateWithCallback(
-            profile.EnableAutoLoot,
-            b => profile.EnableAutoLoot = b,
-            "Enable Auto Loot",
-            "Auto Loot allows you to automatically pick up items from corpses based on configured criteria."));
+            profile.EnableScavenger,
+            b => profile.EnableScavenger = b,
+            "Enable Scavenger",
+            "Scavenger automatically picks up items on the ground based on configured criteria."));
         topRow.Widgets.Add(new MyraButton("Set Grab Bag", () =>
         {
             GameActions.Print(Client.Game.UO.World, "Target container to grab items into");
@@ -37,110 +37,12 @@ public static class AutoLootAgentTabContent
         }) { Tooltip = "Choose a container to grab items into" });
         root.Widgets.Add(topRow);
 
-        // Options
-        var optRow1 = new HorizontalStackPanel { Spacing = 8 };
-        optRow1.Widgets.Add(MyraCheckButton.CreateWithCallback(
-            profile.EnableAutoLootProgressBar,
-            b => profile.EnableAutoLootProgressBar = b,
-            "Enable Progress Bar",
-            "Shows a progress bar gump."));
-
-        var optRow2 = new HorizontalStackPanel { Spacing = 8 };
-        optRow2.Widgets.Add(MyraCheckButton.CreateWithCallback(
-            profile.AutoLootHumanCorpses,
-            b => profile.AutoLootHumanCorpses = b,
-            "Auto Loot Human Corpses",
-            "Auto loots human corpses."));
-        optRow2.Widgets.Add(MyraCheckButton.CreateWithCallback(
-            profile.HueCorpseAfterAutoloot,
-            b => profile.HueCorpseAfterAutoloot = b,
-            "Hue Corpse After Processing",
-            "Hue corpses after processing to make it easier to see if autoloot has processed them."));
-
-        var optRow3 = new HorizontalStackPanel { Spacing = 8, VerticalAlignment = Myra.Graphics2D.UI.VerticalAlignment.Center };
-        optRow3.Widgets.Add(new MyraLabel("Corpse retry delay (ms):", MyraLabel.TextStyle.P)
-        {
-            Tooltip = "Milliseconds before a failed corpse is retried. Minimum 1000ms.",
-            VerticalAlignment = Myra.Graphics2D.UI.VerticalAlignment.Center
-        });
-        var retrySpinner = new SpinButton
-        {
-            Integer = true,
-            Value = profile.AutoLootRetryDelay,
-            Minimum = 1000,
-            Maximum = 600000,
-            MinWidth = 100,
-            Tooltip = "Milliseconds before a failed corpse is retried. Minimum 1000ms."
-        };
-        retrySpinner.ValueChangedByUser += (_, _) =>
-            profile.AutoLootRetryDelay = (int)Math.Clamp(retrySpinner.Value ?? 5000f, 1000f, 600000f);
-        optRow3.Widgets.Add(retrySpinner);
-        optRow3.Widgets.Add(MyraCheckButton.CreateWithCallback(
-            profile.DisableAutolootCorpseRetry,
-            b => profile.DisableAutolootCorpseRetry = b,
-            TazLang.Get("autoloot_disableretry"),
-            TazLang.Get("autoloot_disableretry_tooltip")));
-
-        root.Widgets.Add(new VisualContainer(
-            new VisualContainerProps { LabelText = "Options:" },
-            optRow1,
-            optRow2,
-            optRow3
-        ));
-
-        // Auto skinning section
-        var skinGraphicsBox = new MyraInputBox
-        {
-            Text = profile.AutoSkinningKnifeGraphics,
-            MinWidth = 250,
-            Tooltip = TazLang.Get("autoskinning_graphics_tooltip", "Graphic IDs of knives/daggers used to skin corpses. The first one found in your backpack is used. Separate multiple with ';'. Accepts hex (0x0F52) or decimal.")
-        };
-
-        var skinRow = new HorizontalStackPanel { Spacing = 8, VerticalAlignment = Myra.Graphics2D.UI.VerticalAlignment.Center };
-        skinRow.Widgets.Add(MyraCheckButton.CreateWithCallback(
-            profile.EnableAutoSkinning,
-            b => profile.EnableAutoSkinning = b,
-            TazLang.Get("autoskinning_enable", "Enable Auto Skinning"),
-            TazLang.Get("autoskinning_enable_tooltip", "When a corpse is opened, automatically use a knife/dagger from the graphic list below on it (double clicks the knife and targets the corpse). Uses the action queue.")));
-        skinRow.Widgets.Add(MyraCheckButton.CreateWithCallback(
-            profile.AutoSkinningHumanCorpses,
-            b => profile.AutoSkinningHumanCorpses = b,
-            TazLang.Get("autoskinning_humancorpses", "Skin Human Corpses"),
-            TazLang.Get("autoskinning_humancorpses_tooltip", "Also auto skin human/humanoid corpses.")));
-        skinRow.Widgets.Add(new MyraButton(TazLang.Get("autoskinning_targetweapon", "Target Skinning Weapon"), () =>
-        {
-            World.Instance.TargetManager.SetTargeting(targeted =>
-            {
-                if (targeted is Entity entity && SerialHelper.IsItem(entity))
-                {
-                    string appended = AppendSkinningGraphic(profile.AutoSkinningKnifeGraphics, entity.Graphic);
-                    profile.AutoSkinningKnifeGraphics = appended;
-                    skinGraphicsBox.Text = appended;
-                }
-            });
-        }) { Tooltip = TazLang.Get("autoskinning_targetweapon_tooltip", "Target a weapon to add its graphic to the skinning knife list.") });
-
-        var skinGraphicsRow = new HorizontalStackPanel { Spacing = 8, VerticalAlignment = Myra.Graphics2D.UI.VerticalAlignment.Center };
-        skinGraphicsRow.Widgets.Add(new MyraLabel(TazLang.Get("autoskinning_graphics", "Knife graphic IDs:"), MyraLabel.TextStyle.P)
-        {
-            Tooltip = TazLang.Get("autoskinning_graphics_tooltip", "Graphic IDs of knives/daggers used to skin corpses. The first one found in your backpack is used. Separate multiple with ';'. Accepts hex (0x0F52) or decimal."),
-            VerticalAlignment = Myra.Graphics2D.UI.VerticalAlignment.Center
-        });
-        skinGraphicsBox.TextChangedByUser += (_, _) => profile.AutoSkinningKnifeGraphics = skinGraphicsBox.Text;
-        skinGraphicsRow.Widgets.Add(skinGraphicsBox);
-
-        root.Widgets.Add(new VisualContainer(
-            new VisualContainerProps { LabelText = TazLang.Get("autoskinning_title", "Auto Skinning") },
-            skinRow,
-            skinGraphicsRow
-        ));
-
-        // Entries panel (declared early so the loot-list selector callbacks can rebuild it).
+        // Entries panel (declared early so the list selector callbacks can rebuild it).
         var entriesPanel = new VerticalStackPanel { Spacing = 4 };
 
-        // Loot list selection
+        // Scavenger list selection
         root.Widgets.Add(new MyraSpacer(15, 5));
-        root.Widgets.Add(new MyraLabel("Loot Lists:", MyraLabel.TextStyle.H2));
+        root.Widgets.Add(new MyraLabel("Scavenger Lists:", MyraLabel.TextStyle.H2));
 
         var listSelectRow = new HorizontalStackPanel { Spacing = 6, VerticalAlignment = VerticalAlignment.Center };
 
@@ -153,12 +55,12 @@ public static class AutoLootAgentTabContent
             suppressListEvent = true;
             listCombo.ListView.Widgets.Clear();
 
-            IReadOnlyList<AutoLootManager.AutoLootList> lists = AutoLootManager.Instance.Lists;
+            IReadOnlyList<ScavengerManager.ScavengerList> lists = ScavengerManager.Instance.Lists;
             int selectedIdx = 0;
             for (int i = 0; i < lists.Count; i++)
             {
                 listCombo.ListView.Widgets.Add(new Label { Text = lists[i].Name });
-                if (lists[i] == AutoLootManager.Instance.CurrentList) selectedIdx = i;
+                if (lists[i] == ScavengerManager.Instance.CurrentList) selectedIdx = i;
             }
 
             if (lists.Count > 0) listCombo.ListView.SelectedIndex = selectedIdx;
@@ -171,10 +73,10 @@ public static class AutoLootAgentTabContent
             if (suppressListEvent) return;
 
             int? idx = listCombo.ListView.SelectedIndex;
-            IReadOnlyList<AutoLootManager.AutoLootList> lists = AutoLootManager.Instance.Lists;
+            IReadOnlyList<ScavengerManager.ScavengerList> lists = ScavengerManager.Instance.Lists;
             if (idx.HasValue && idx.Value >= 0 && idx.Value < lists.Count)
             {
-                AutoLootManager.Instance.SelectList(lists[idx.Value]);
+                ScavengerManager.Instance.SelectList(lists[idx.Value]);
                 BuildEntriesList();
             }
         };
@@ -183,45 +85,45 @@ public static class AutoLootAgentTabContent
         listSelectRow.Widgets.Add(new MyraButton("New", () =>
         {
             var nameBox = new MyraInputBox { HintText = "List name", Width = 220 };
-            new MyraDialog("New Loot List", nameBox, ok =>
+            new MyraDialog("New Scavenger List", nameBox, ok =>
             {
                 if (!ok) return;
-                AutoLootManager.Instance.AddList(nameBox.Text);
+                ScavengerManager.Instance.AddList(nameBox.Text);
                 RefreshListCombo();
                 BuildEntriesList();
             });
-        }) { Tooltip = "Create a new loot list and switch to it." });
+        }) { Tooltip = "Create a new scavenger list and switch to it." });
 
         listSelectRow.Widgets.Add(new MyraButton("Rename", () =>
         {
-            AutoLootManager.AutoLootList current = AutoLootManager.Instance.CurrentList;
+            ScavengerManager.ScavengerList current = ScavengerManager.Instance.CurrentList;
             var nameBox = new MyraInputBox { Text = current.Name, HintText = "List name", Width = 220 };
-            new MyraDialog("Rename Loot List", nameBox, ok =>
+            new MyraDialog("Rename Scavenger List", nameBox, ok =>
             {
                 if (!ok || string.IsNullOrWhiteSpace(nameBox.Text)) return;
-                AutoLootManager.Instance.RenameList(current, nameBox.Text);
+                ScavengerManager.Instance.RenameList(current, nameBox.Text);
                 RefreshListCombo();
             });
-        }) { Tooltip = "Rename the selected loot list." });
+        }) { Tooltip = "Rename the selected scavenger list." });
 
         deleteListBtn = new MyraButton("Delete List", () =>
         {
-            if (AutoLootManager.Instance.Lists.Count <= 1)
+            if (ScavengerManager.Instance.Lists.Count <= 1)
             {
-                GameActions.Print("You must have at least one loot list.", Constants.HUE_ERROR);
+                GameActions.Print("You must have at least one scavenger list.", Constants.HUE_ERROR);
                 return;
             }
 
-            AutoLootManager.AutoLootList current = AutoLootManager.Instance.CurrentList;
-            new MyraDialog("Delete Loot List",
+            ScavengerManager.ScavengerList current = ScavengerManager.Instance.CurrentList;
+            new MyraDialog("Delete Scavenger List",
                 new MyraLabel($"Delete list \"{current.Name}\" and all of its entries?", MyraLabel.TextStyle.P),
                 ok =>
                 {
-                    if (!ok || !AutoLootManager.Instance.DeleteList(current)) return;
+                    if (!ok || !ScavengerManager.Instance.DeleteList(current)) return;
                     RefreshListCombo();
                     BuildEntriesList();
                 });
-        }) { Tooltip = "Delete the selected loot list. At least one list must remain." };
+        }) { Tooltip = "Delete the selected scavenger list. At least one list must remain." };
         listSelectRow.Widgets.Add(MyraStyle.ApplyButtonDangerStyle(deleteListBtn));
 
         root.Widgets.Add(listSelectRow);
@@ -233,7 +135,7 @@ public static class AutoLootAgentTabContent
         void BuildEntriesList()
         {
             entriesPanel.Widgets.Clear();
-            List<AutoLootManager.AutoLootConfigEntry>? entries = AutoLootManager.Instance.AutoLootEntries;
+            List<ScavengerManager.ScavengerEntry>? entries = ScavengerManager.Instance.ScavengerEntries;
 
             if (entries.Count == 0)
             {
@@ -257,7 +159,7 @@ public static class AutoLootAgentTabContent
             int dataRow = 1;
             for (int i = entries.Count - 1; i >= 0; i--)
             {
-                AutoLootManager.AutoLootConfigEntry entry = entries[i];
+                ScavengerManager.ScavengerEntry entry = entries[i];
 
                 // Art image (col 0)
                 if (entry.Graphic is > 0 and < ushort.MaxValue)
@@ -320,14 +222,14 @@ public static class AutoLootAgentTabContent
                 priorityRow.Widgets.Add(new MyraButton("<", () =>
                 {
                     int p = ((int)entry.Priority - 1 + PriorityLabels.Length) % PriorityLabels.Length;
-                    entry.Priority = (AutoLootManager.AutoLootPriority)p;
+                    entry.Priority = (ScavengerManager.ScavengerPriority)p;
                     priorityLabel.Text = PriorityLabels[p];
                 }));
                 priorityRow.Widgets.Add(priorityLabel);
                 priorityRow.Widgets.Add(new MyraButton(">", () =>
                 {
                     int p = ((int)entry.Priority + 1) % PriorityLabels.Length;
-                    entry.Priority = (AutoLootManager.AutoLootPriority)p;
+                    entry.Priority = (ScavengerManager.ScavengerPriority)p;
                     priorityLabel.Text = PriorityLabels[p];
                 }));
                 grid.AddWidget(priorityRow, dataRow, 4);
@@ -377,7 +279,7 @@ public static class AutoLootAgentTabContent
                 }) { Tooltip = "Target a container to use as the destination for this entry." });
                 grid.AddWidget(destCell, dataRow, 6);
 
-                // Up / Down reorder buttons (col 6)
+                // Up / Down reorder buttons (col 7)
                 // Display is reversed: i = entries.Count-1 is top row, i=0 is bottom row.
                 // "Up" in display = swap with i+1 in list; "Down" = swap with i-1.
                 var orderRow = new HorizontalStackPanel { Spacing = 2 };
@@ -407,7 +309,7 @@ public static class AutoLootAgentTabContent
 
                 var delBtn = new MyraButton("Delete", () =>
                 {
-                    AutoLootManager.Instance.TryRemoveAutoLootEntry(entry.Uid);
+                    ScavengerManager.Instance.TryRemoveScavengerEntry(entry.Uid);
                     BuildEntriesList();
                 });
                 delBtn.VerticalAlignment = VerticalAlignment.Center;
@@ -450,13 +352,13 @@ public static class AutoLootAgentTabContent
                 if (graphic > ushort.MaxValue)
                     return;
 
-                if(graphic == -1)
+                if (graphic == -1)
                     graphic = ushort.MaxValue;
 
                 if (!MyraInputBox.TryParseHue(newHueBox.Text, out ushort hue))
                     hue = ushort.MaxValue;
 
-                AutoLootManager.AutoLootConfigEntry? entry = AutoLootManager.Instance.AddAutoLootEntry((ushort)graphic, hue, newNameBox.Text);
+                ScavengerManager.ScavengerEntry? entry = ScavengerManager.Instance.AddScavengerEntry((ushort)graphic, hue, newNameBox.Text);
                 if (entry == null) return;
 
                 entry.RegexSearch = newRegexBox.Text;
@@ -484,45 +386,14 @@ public static class AutoLootAgentTabContent
         addEntryPanel.Widgets.Add(addFieldsRow);
         addEntryPanel.Widgets.Add(addConfirmRow);
 
-        // Import from character inline panel
-        var importCharPanel = new VerticalStackPanel { Visible = false, Spacing = 4 };
-
-        void BuildImportCharPanel()
-        {
-            importCharPanel.Widgets.Clear();
-            Dictionary<string, List<AutoLootManager.AutoLootConfigEntry>>? otherConfigs = AutoLootManager.Instance.GetOtherCharacterConfigs();
-
-            if (otherConfigs.Count == 0)
-            {
-                importCharPanel.Widgets.Add(new MyraLabel("No other character configurations found.", MyraLabel.TextStyle.P));
-            }
-            else
-            {
-                importCharPanel.Widgets.Add(new MyraLabel("Select a character to import from:", MyraLabel.TextStyle.H3));
-                foreach (KeyValuePair<string, List<AutoLootManager.AutoLootConfigEntry>> kv in otherConfigs.OrderBy(c => c.Key))
-                {
-                    string charName = kv.Key;
-                    List<AutoLootManager.AutoLootConfigEntry> configs = kv.Value;
-                    importCharPanel.Widgets.Add(new MyraButton($"{charName} ({configs.Count} items)", () =>
-                    {
-                        AutoLootManager.Instance.ImportFromOtherCharacter(charName, configs);
-                        BuildEntriesList();
-                        importCharPanel.Visible = false;
-                    }));
-                }
-            }
-
-            importCharPanel.Widgets.Add(new MyraButton("Cancel", () => importCharPanel.Visible = false));
-        }
-
         // Action buttons
         var actionRow = new HorizontalStackPanel { Spacing = 6 };
         actionRow.Widgets.Add(new MyraButton("Import", () =>
         {
             string? json = Clipboard.GetClipboardText();
-            if (json.NotNullNotEmpty() && AutoLootManager.Instance.ImportFromJson(json))
+            if (json.NotNullNotEmpty() && ScavengerManager.Instance.ImportFromJson(json))
             {
-                GameActions.Print("Imported loot list!", Constants.HUE_SUCCESS);
+                GameActions.Print("Imported scavenger list!", Constants.HUE_SUCCESS);
                 BuildEntriesList();
                 return;
             }
@@ -531,15 +402,9 @@ public static class AutoLootAgentTabContent
 
         actionRow.Widgets.Add(new MyraButton("Export", () =>
         {
-            AutoLootManager.Instance.GetJsonExport()?.CopyToClipboard();
-            GameActions.Print("Exported loot list to your clipboard!", Constants.HUE_SUCCESS);
+            ScavengerManager.Instance.GetJsonExport()?.CopyToClipboard();
+            GameActions.Print("Exported scavenger list to your clipboard!", Constants.HUE_SUCCESS);
         }) { Tooltip = "Export your list to clipboard." });
-
-        actionRow.Widgets.Add(new MyraButton("Import from Character", () =>
-        {
-            BuildImportCharPanel();
-            importCharPanel.Visible = !importCharPanel.Visible;
-        }) { Tooltip = "Import autoloot configuration from another character." });
 
         var addRow = new HorizontalStackPanel { Spacing = 6 };
         addRow.Widgets.Add(new MyraButton("Add Manual Entry", () => addEntryPanel.Visible = !addEntryPanel.Visible));
@@ -549,34 +414,17 @@ public static class AutoLootAgentTabContent
             {
                 if (targeted is Entity entity && SerialHelper.IsItem(entity))
                 {
-                    AutoLootManager.Instance.AddAutoLootEntry(entity.Graphic, entity.Hue, entity.Name);
+                    ScavengerManager.Instance.AddScavengerEntry(entity.Graphic, entity.Hue, entity.Name);
                     BuildEntriesList();
                 }
             });
-        }) { Tooltip = "Target an item to add it to the loot list." });
+        }) { Tooltip = "Target an item to add it to the scavenger list." });
 
         root.Widgets.Add(actionRow);
         root.Widgets.Add(addRow);
         root.Widgets.Add(addEntryPanel);
-        root.Widgets.Add(importCharPanel);
         root.Widgets.Add(new ScrollViewer { MaxHeight = 300, Content = entriesPanel });
 
         return root;
-    }
-
-    /// <summary>
-    /// Appends <paramref name="graphic"/> (formatted as hex) to a ';'-separated skinning graphic
-    /// list, skipping it if an equal value is already present.
-    /// </summary>
-    private static string AppendSkinningGraphic(string current, ushort graphic)
-    {
-        current ??= string.Empty;
-
-        foreach (string part in current.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-            if (StringHelper.TryParseInt(part, out int existing) && existing == graphic)
-                return current;
-
-        string entry = $"0x{graphic:X4}";
-        return string.IsNullOrWhiteSpace(current) ? entry : $"{current.TrimEnd(';', ' ')};{entry}";
     }
 }

--- a/tests/ClassicUO.UnitTests/Game/Managers/ScavengerManagerTest.cs
+++ b/tests/ClassicUO.UnitTests/Game/Managers/ScavengerManagerTest.cs
@@ -1,0 +1,251 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using ClassicUO.Game.Managers;
+using FluentAssertions;
+using Xunit;
+
+namespace ClassicUO.UnitTests.Game.Managers
+{
+    public class ScavengerManagerTest
+    {
+        #region ScavengerEntry - Default Values Tests
+
+        [Fact]
+        public void ScavengerEntry_DefaultValues_ShouldBeCorrect()
+        {
+            // Arrange & Act
+            var entry = new ScavengerManager.ScavengerEntry();
+
+            // Assert
+            entry.Name.Should().BeEmpty();
+            entry.Graphic.Should().Be(0);
+            entry.Hue.Should().Be(ushort.MaxValue);
+            entry.RegexSearch.Should().BeEmpty();
+            entry.DestinationContainer.Should().Be(0u);
+            entry.MaxAmount.Should().Be(0);
+            entry.Uid.Should().NotBeEmpty();
+        }
+
+        [Fact]
+        public void ScavengerEntry_Uid_ShouldBeUniqueAndValidGuid()
+        {
+            // Arrange & Act
+            var entry1 = new ScavengerManager.ScavengerEntry();
+            var entry2 = new ScavengerManager.ScavengerEntry();
+
+            // Assert
+            entry1.Uid.Should().NotBe(entry2.Uid);
+            Guid.TryParse(entry1.Uid, out _).Should().BeTrue();
+        }
+
+        #endregion
+
+        #region ScavengerEntry - Property Setting Tests
+
+        [Fact]
+        public void ScavengerEntry_SetProperties_ShouldPersist()
+        {
+            // Arrange
+            var entry = new ScavengerManager.ScavengerEntry();
+            string testUid = Guid.NewGuid().ToString();
+
+            // Act
+            entry.Name = "Gold Coin";
+            entry.Graphic = 3821;
+            entry.Hue = 1153;
+            entry.RegexSearch = ".*gold.*";
+            entry.DestinationContainer = 12345u;
+            entry.MaxAmount = 100;
+            entry.Priority = ScavengerManager.ScavengerPriority.High;
+            entry.Uid = testUid;
+
+            // Assert
+            entry.Name.Should().Be("Gold Coin");
+            entry.Graphic.Should().Be(3821);
+            entry.Hue.Should().Be(1153);
+            entry.RegexSearch.Should().Be(".*gold.*");
+            entry.DestinationContainer.Should().Be(12345u);
+            entry.MaxAmount.Should().Be(100);
+            entry.Priority.Should().Be(ScavengerManager.ScavengerPriority.High);
+            entry.Uid.Should().Be(testUid);
+        }
+
+        #endregion
+
+        #region ScavengerEntry - Equals Tests
+
+        [Fact]
+        public void ScavengerEntry_Equals_WithSameProperties_ShouldReturnTrue()
+        {
+            // Arrange
+            var entry1 = new ScavengerManager.ScavengerEntry { Graphic = 3821, Hue = 1153, RegexSearch = ".*gold.*" };
+            var entry2 = new ScavengerManager.ScavengerEntry { Graphic = 3821, Hue = 1153, RegexSearch = ".*gold.*" };
+
+            // Act & Assert
+            entry1.Equals(entry2).Should().BeTrue();
+        }
+
+        [Fact]
+        public void ScavengerEntry_Equals_WithDifferentGraphic_ShouldReturnFalse()
+        {
+            // Arrange
+            var entry1 = new ScavengerManager.ScavengerEntry { Graphic = 3821, Hue = 1153, RegexSearch = "" };
+            var entry2 = new ScavengerManager.ScavengerEntry { Graphic = 3822, Hue = 1153, RegexSearch = "" };
+
+            // Act & Assert
+            entry1.Equals(entry2).Should().BeFalse();
+        }
+
+        [Fact]
+        public void ScavengerEntry_Equals_WithDifferentHue_ShouldReturnFalse()
+        {
+            // Arrange
+            var entry1 = new ScavengerManager.ScavengerEntry { Graphic = 3821, Hue = 1153, RegexSearch = "" };
+            var entry2 = new ScavengerManager.ScavengerEntry { Graphic = 3821, Hue = 1154, RegexSearch = "" };
+
+            // Act & Assert
+            entry1.Equals(entry2).Should().BeFalse();
+        }
+
+        [Fact]
+        public void ScavengerEntry_Equals_WithDifferentRegexSearch_ShouldReturnFalse()
+        {
+            // Arrange
+            var entry1 = new ScavengerManager.ScavengerEntry { Graphic = 3821, Hue = 1153, RegexSearch = ".*gold.*" };
+            var entry2 = new ScavengerManager.ScavengerEntry { Graphic = 3821, Hue = 1153, RegexSearch = ".*silver.*" };
+
+            // Act & Assert
+            entry1.Equals(entry2).Should().BeFalse();
+        }
+
+        [Fact]
+        public void ScavengerEntry_Equals_IgnoresNameDestinationAndPriority()
+        {
+            // Arrange
+            var entry1 = new ScavengerManager.ScavengerEntry { Graphic = 3821, Hue = 1153, RegexSearch = "", Name = "A", DestinationContainer = 100u, Priority = ScavengerManager.ScavengerPriority.Low };
+            var entry2 = new ScavengerManager.ScavengerEntry { Graphic = 3821, Hue = 1153, RegexSearch = "", Name = "B", DestinationContainer = 200u, Priority = ScavengerManager.ScavengerPriority.High };
+
+            // Act & Assert
+            entry1.Equals(entry2).Should().BeTrue();
+        }
+
+        #endregion
+
+        #region ScavengerEntry - JSON Serialization Tests
+
+        [Fact]
+        public void ScavengerEntry_Serialization_ShouldPreserveAllProperties()
+        {
+            // Arrange
+            var entry = new ScavengerManager.ScavengerEntry
+            {
+                Name = "Test Item",
+                Graphic = 1234,
+                Hue = 5678,
+                RegexSearch = ".*test.*",
+                DestinationContainer = 99999u,
+                MaxAmount = 250,
+                Priority = ScavengerManager.ScavengerPriority.High,
+                Uid = "test-uid-123"
+            };
+
+            // Act
+            string json = JsonSerializer.Serialize(entry, ScavengerJsonContext.Default.ScavengerEntry);
+            ScavengerManager.ScavengerEntry deserialized = JsonSerializer.Deserialize(json, ScavengerJsonContext.Default.ScavengerEntry);
+
+            // Assert
+            deserialized.Should().NotBeNull();
+            deserialized.Name.Should().Be(entry.Name);
+            deserialized.Graphic.Should().Be(entry.Graphic);
+            deserialized.Hue.Should().Be(entry.Hue);
+            deserialized.RegexSearch.Should().Be(entry.RegexSearch);
+            deserialized.DestinationContainer.Should().Be(entry.DestinationContainer);
+            deserialized.MaxAmount.Should().Be(entry.MaxAmount);
+            deserialized.Priority.Should().Be(entry.Priority);
+            deserialized.Uid.Should().Be(entry.Uid);
+        }
+
+        [Fact]
+        public void ScavengerEntry_ListSerialization_ShouldWork()
+        {
+            // Arrange
+            var list = new List<ScavengerManager.ScavengerEntry>
+            {
+                new() { Name = "Item 1", Graphic = 100, Hue = 200 },
+                new() { Name = "Item 2", Graphic = 300, Hue = 400 }
+            };
+
+            // Act
+            string json = JsonSerializer.Serialize(list, ScavengerJsonContext.Default.ListScavengerEntry);
+            List<ScavengerManager.ScavengerEntry> deserialized = JsonSerializer.Deserialize(json, ScavengerJsonContext.Default.ListScavengerEntry);
+
+            // Assert
+            deserialized.Should().NotBeNull();
+            deserialized.Should().HaveCount(2);
+            deserialized[0].Name.Should().Be("Item 1");
+            deserialized[1].Name.Should().Be("Item 2");
+            deserialized[1].Graphic.Should().Be(300);
+        }
+
+        #endregion
+
+        #region ScavengerList / ScavengerData Tests
+
+        [Fact]
+        public void ScavengerList_DefaultValues_ShouldBeCorrect()
+        {
+            // Arrange & Act
+            var list = new ScavengerManager.ScavengerList();
+
+            // Assert
+            list.Name.Should().BeEmpty();
+            list.Entries.Should().NotBeNull();
+            list.Entries.Should().BeEmpty();
+            list.Uid.Should().NotBeEmpty();
+            Guid.TryParse(list.Uid, out _).Should().BeTrue();
+        }
+
+        [Fact]
+        public void ScavengerData_DefaultValues_ShouldBeCorrect()
+        {
+            // Arrange & Act
+            var data = new ScavengerManager.ScavengerData();
+
+            // Assert
+            data.Lists.Should().NotBeNull();
+            data.Lists.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ScavengerData_Serialization_ShouldPreserveLists()
+        {
+            // Arrange
+            var data = new ScavengerManager.ScavengerData();
+            data.Lists.Add(new ScavengerManager.ScavengerList
+            {
+                Name = "Default",
+                Uid = "list-1",
+                Entries =
+                {
+                    new ScavengerManager.ScavengerEntry { Name = "Gold", Graphic = 3821, Hue = 0 }
+                }
+            });
+
+            // Act
+            string json = JsonSerializer.Serialize(data, ScavengerJsonContext.Default.ScavengerData);
+            ScavengerManager.ScavengerData deserialized = JsonSerializer.Deserialize(json, ScavengerJsonContext.Default.ScavengerData);
+
+            // Assert
+            deserialized.Should().NotBeNull();
+            deserialized.Lists.Should().HaveCount(1);
+            deserialized.Lists[0].Name.Should().Be("Default");
+            deserialized.Lists[0].Uid.Should().Be("list-1");
+            deserialized.Lists[0].Entries.Should().HaveCount(1);
+            deserialized.Lists[0].Entries[0].Name.Should().Be("Gold");
+            deserialized.Lists[0].Entries[0].Graphic.Should().Be(3821);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Scavenger assistant tab.
  * Configure scavenger lists with item graphics, hues, name filters, priorities, quantity limits, and destination containers.
  * Add items manually or from targeted items, reorder entries, and manage multiple lists.
  * Import and export scavenger configurations as JSON.
  * Scavenging now automatically queues matching ground items for pickup.

* **Changes**
  * Removed scavenger settings from the Auto Loot tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->