### PR TITLE
Allow disabling highlights per grid container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to TazUO will be recorded here.
 * Added a new modern compact status bar option
 * Grid container item locks now expire after 60 days of the item being absent from the container, automatically clearing the saved lock and slot
 * Separated Scavenger agent from Autoloot, they now each have their own loot lists and enabled/disabled toggles
+* Added a per-container option to disable grid highlighting without affecting other containers - [P.R 1032](https://github.com/PlayTazUO/TazUO/pull/1032) ([Aryx75](https://github.com/Aryx75))
 
 ### Legion
 * Added `API.IsKeyPressed("CTRL+SHIFT+F1")` method to see if a key(s) is currently held down

--- a/src/ClassicUO.Client/Configuration/language.ini
+++ b/src/ClassicUO.Client/Configuration/language.ini
@@ -502,6 +502,7 @@ gridcontainer_quickloot_container_tooltip=Drop an item here to send it to your b
 gridcontainer_sort_tooltip=Sort this container.<br>Left click to show sort options<br>Alt + Click to enable auto sort<br>Current sort: {0}<br>Auto sort currently {1}
 gridcontainer_editbands=Edit Grid Bands
 gridcontainer_disablebands=Disable Bands for This Container
+gridcontainer_disablehighlights=Disable Highlights for This Container
 
 ; Grid container bands
 gridbands_title=Grid Container Bands

--- a/src/ClassicUO.Client/Game/Managers/GridContainerSaveData.cs
+++ b/src/ClassicUO.Client/Game/Managers/GridContainerSaveData.cs
@@ -349,6 +349,9 @@ public class GridContainerEntry
     /// <summary>Per-container override to disable band layout even when bands are enabled globally.</summary>
     [JsonPropertyName("bd")] public bool BandsDisabled { get; set; }
 
+    /// <summary>Per-container override to suppress grid-highlight rules in this container.</summary>
+    [JsonPropertyName("hd")] public bool HighlightsDisabled { get; set; }
+
     [JsonPropertyName("vs")] public bool VisuallyStackNonStackables { get; set; }
 
     [JsonPropertyName("sm")] public int SortMode { get; set; }
@@ -413,6 +416,7 @@ public class GridContainerEntry
         UseOriginalContainer = container.UseOldContainerStyle ?? container.GridContainerEntry.UseOriginalContainer;
         AutoSort = container.AutoSortContainer;
         BandsDisabled = container.BandsDisabledForContainer;
+        HighlightsDisabled = container.HighlightsDisabledForContainer;
         VisuallyStackNonStackables = container.StackNonStackableItems;
         SortMode = (int)container.SortMode;
         IsMinimized = container.IsMinimized;

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/Controls/GridItem.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/Controls/GridItem.cs
@@ -1049,7 +1049,7 @@ public class GridItem : Control
         int itemCellHeight = _isListLayout ? GridContainer.LIST_ICON_SIZE : Height;
         Rectangle itemCellBounds = new(x, y, itemCellWidth, itemCellHeight);
 
-        if (_item.MatchesHighlightData)
+        if (_item.MatchesHighlightData && !_gridContainer.HighlightsDisabledForContainer)
         {
             Texture2D borderTexture = SolidColorTextureCache.GetTexture(_item.HighlightColor);
             var borderHueVec = new Vector3(1, 0, 1);

--- a/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/GridContainer.cs
+++ b/src/ClassicUO.Client/Game/UI/Gumps/GridContainers/GridContainer.cs
@@ -84,6 +84,7 @@ public partial class GridContainer : ResizableGump
         public bool? UseOldContainerStyle;
         private bool _autoSortContainer;
         private bool _bandsDisabledForContainer;
+        private bool _highlightsDisabledForContainer;
         private GridSortMode _sortMode = GridSortMode.GraphicAndHue;
 
         private readonly bool _skipSave;
@@ -132,6 +133,9 @@ public partial class GridContainer : ResizableGump
 
         /// <summary>Per-container override that disables band layout for this container even when bands are enabled globally.</summary>
         public bool BandsDisabledForContainer => _bandsDisabledForContainer;
+
+        /// <summary>Per-container override that suppresses grid-highlight rules in this container.</summary>
+        public bool HighlightsDisabledForContainer => _highlightsDisabledForContainer;
 
         public GridSortMode SortMode => _sortMode;
         public readonly GridSlotManager SlotManager;
@@ -256,6 +260,7 @@ public partial class GridContainer : ResizableGump
 
             _autoSortContainer = _gridContainerEntry.AutoSort;
             _bandsDisabledForContainer = _gridContainerEntry.BandsDisabled;
+            _highlightsDisabledForContainer = _gridContainerEntry.HighlightsDisabled;
             StackNonStackableItems = _gridContainerEntry.VisuallyStackNonStackables;
             _sortMode = (GridSortMode)_gridContainerEntry.SortMode;
 
@@ -683,6 +688,14 @@ public partial class GridContainer : ResizableGump
                 _openRegularGump.ContextMenu = GenContextMenu();
                 RequestUpdateContents();
             }, true, _bandsDisabledForContainer));
+
+            control.Add(new ContextMenuItemEntry(TazLang.Get("gridcontainer_disablehighlights", "Disable Highlights for This Container"), () =>
+            {
+                _highlightsDisabledForContainer = !_highlightsDisabledForContainer;
+                _gridContainerEntry.HighlightsDisabled = _highlightsDisabledForContainer;
+                _gridContainerEntry.UpdateSaveDataEntry(this);
+                _openRegularGump.ContextMenu = GenContextMenu();
+            }, true, _highlightsDisabledForContainer));
 
             if (Container != World.Player?.Backpack)
             {

--- a/tests/ClassicUO.UnitTests/Game/Managers/GridContainerSaveDataTests.cs
+++ b/tests/ClassicUO.UnitTests/Game/Managers/GridContainerSaveDataTests.cs
@@ -1,0 +1,51 @@
+using System.Text.Json;
+using ClassicUO.Game.Managers;
+using FluentAssertions;
+using Xunit;
+
+namespace ClassicUO.UnitTests.Game.Managers;
+
+public class GridContainerSaveDataTests
+{
+    [Fact]
+    public void HighlightsDisabledSurvivesSerializationRoundTrip()
+    {
+        var entry = new GridContainerEntry
+        {
+            Serial = 0x40000001,
+            HighlightsDisabled = true
+        };
+
+        string json = JsonSerializer.Serialize(entry, GridContainerSerializerContext.Default.GridContainerEntry);
+        GridContainerEntry restored = JsonSerializer.Deserialize(json, GridContainerSerializerContext.Default.GridContainerEntry);
+
+        restored.HighlightsDisabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void HighlightsDisabledIsScopedToOneContainer()
+    {
+        GridContainerEntry[] entries =
+        [
+            new GridContainerEntry { Serial = 0x40000001, HighlightsDisabled = true },
+            new GridContainerEntry { Serial = 0x40000002 }
+        ];
+
+        string json = JsonSerializer.Serialize(entries, GridContainerSerializerContext.Default.GridContainerEntryArray);
+        GridContainerEntry[] restored = JsonSerializer.Deserialize(json, GridContainerSerializerContext.Default.GridContainerEntryArray);
+
+        restored.Should().ContainSingle(entry => entry.Serial == 0x40000001 && entry.HighlightsDisabled);
+        restored.Should().ContainSingle(entry => entry.Serial == 0x40000002 && !entry.HighlightsDisabled);
+    }
+
+    [Fact]
+    public void ExistingSaveWithoutHighlightOverrideKeepsHighlightsEnabled()
+    {
+        GridContainerEntry restored = JsonSerializer.Deserialize(
+            "{\"s\":1073741825}",
+            GridContainerSerializerContext.Default.GridContainerEntry
+        );
+
+        restored.HighlightsDisabled.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Description
Adds a per-container opt-out for grid highlighting, next to the existing band override.

The new `Disable Highlights for This Container` context-menu option is stored with the displayed container's grid settings. It only suppresses drawing highlight borders in that grid, so global rules and highlights in other containers remain untouched. This also means nested bags are handled by the bag whose grid is currently open rather than by its root container.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing
- `dotnet build tests/ClassicUO.UnitTests/ClassicUO.UnitTests.csproj -c Release --no-restore`
- Added persistence, per-container isolation, and legacy-save coverage (`3/3` passing)
- Full Release suite: `1160/1161` passing. The remaining failure is the existing `ControlsTest.Dispose.CleanUpDisposedChildren` UI cleanup test; it reproduces on repeated runs and is unrelated to the grid-container changes.

## Screenshots (if applicable)
Not included. The change adds one checkbox-style entry to the existing grid-container context menu.

## Additional Notes
The override uses the same `grid_containers.json` storage path as `Disable Bands for This Container`. Existing saves default to highlights enabled.
