### PR TITLE
Fix flaky CleanUpDisposedChildren test after cross-threading change

### DIFF
--- a/tests/ClassicUO.UnitTests/Game/UI/ControlsTest.cs
+++ b/tests/ClassicUO.UnitTests/Game/UI/ControlsTest.cs
@@ -1,24 +1,32 @@
+using ClassicUO.Game.Managers;
 using ClassicUO.Game.UI.Controls;
+using ClassicUO.UnitTests.Game.LegionScript;
 using Xunit;
 
 namespace ClassicUO.UnitTests.Game.UI;
 
 public class ControlsTest
 {
+    [Collection(MainThreadCollection.Name)]
     public class Dispose
     {
         [Fact]
         public void CleanUpDisposedChildren()
         {
-            Control main = new Area();
+            Control main = MainThreadQueue.BubblingInvokeOnMainThread(() =>
+            {
+                Control m = new Area();
 
-            for (int i = 0; i < 10; i++)
-                main.Add(new Area());
+                for (int i = 0; i < 10; i++)
+                    m.Add(new Area());
 
-            foreach(Control child in main.Children)
-                child.Dispose();
+                foreach (Control child in m.Children)
+                    child.Dispose();
 
-            main.CleanUpDisposedChildren();
+                m.CleanUpDisposedChildren();
+
+                return m;
+            });
 
             Assert.Empty(main.Children);
         }


### PR DESCRIPTION
Add, Dispose, and the Parent setter now marshal to the main thread queue when called off-thread, so the test no longer runs synchronously on an xUnit worker thread. Run the scenario on the main thread via BubblingInvokeOnMainThread and opt into the MainThread collection fixture so Add/Dispose/CleanUpDisposedChildren execute in order.