### PR TITLE
Include own messages in Global Chat tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to TazUO will be recorded here.
 * Migrated more settings to global scoped json settings
 
 ### Fixes
+* Fixed timestamped Global Chat messages sent by the local player not appearing in Global Chat journal tabs - [P.R 1035](https://github.com/PlayTazUO/TazUO/pull/1035) ([Aryx75](https://github.com/Aryx75))
 * Fixed a client crash at startup when the generated `Data/Client` files (`chair.txt`, `lights.txt`, `lightshaders.txt`) could not be written or read because another process (antivirus, OneDrive, a second instance, or an editor) held a lock on them - the client now logs a clear error and continues with the built-in defaults instead of crashing
 * Fixed locked grid container items no longer reclaiming their locked cell (and appearing unlocked) after being moved out of the container and back
 * Addressed a cross-thread issue and hardened controls a bit against future cross threading

--- a/src/ClassicUO.Client/Game/Managers/JournalMessageClassifier.cs
+++ b/src/ClassicUO.Client/Game/Managers/JournalMessageClassifier.cs
@@ -14,44 +14,40 @@ internal static class JournalMessageClassifier
     private static Regex _cachedRegex;
 
     /// <summary>Reclassifies eligible journal text without changing unrelated message types.</summary>
-    /// <param name="messageType">The original server message type.</param>
-    /// <param name="text">The final journal text, matched without preprocessing.</param>
+    /// <param name="message">The original message and its source context.</param>
     /// <param name="classifySystemChat">The profile-level feature switch.</param>
     /// <param name="pattern">A .NET regex; blank or malformed patterns match nothing.</param>
-    /// <param name="isSystemLikeRegularMessage">
-    /// Whether a <see cref="MessageType.Regular"/> message is displayed as a system message because
-    /// it has no valid parent.
-    /// </param>
     /// <returns><see cref="MessageType.ChatSystem"/> on a match; otherwise the original type.</returns>
     public static MessageType Classify(
-        MessageType messageType,
-        string text,
+        MessageEventArgs message,
         bool classifySystemChat,
-        string pattern,
-        bool isSystemLikeRegularMessage = false
+        string pattern
     )
     {
         bool isEligibleMessageType =
-            messageType == MessageType.System
-            || messageType == MessageType.Regular && isSystemLikeRegularMessage;
+            message.Type == MessageType.System
+            || message.Type == MessageType.Regular
+                && (message.Parent == null || !SerialHelper.IsValid(message.Parent.Serial));
 
         if (
             !classifySystemChat
             || !isEligibleMessageType
-            || string.IsNullOrEmpty(text)
+            || string.IsNullOrEmpty(message.Text)
             || string.IsNullOrWhiteSpace(pattern)
         )
         {
-            return messageType;
+            return message.Type;
         }
 
         try
         {
-            return GetPattern(pattern)?.IsMatch(text) == true ? MessageType.ChatSystem : messageType;
+            return GetPattern(pattern)?.IsMatch(message.Text) == true
+                ? MessageType.ChatSystem
+                : message.Type;
         }
         catch (RegexMatchTimeoutException)
         {
-            return messageType;
+            return message.Type;
         }
     }
 

--- a/src/ClassicUO.Client/Game/Managers/JournalMessageClassifier.cs
+++ b/src/ClassicUO.Client/Game/Managers/JournalMessageClassifier.cs
@@ -5,7 +5,7 @@ using ClassicUO.Game.Data;
 namespace ClassicUO.Game.Managers;
 
 /// <summary>
-/// Applies the profile's Global Chat pattern to system messages. Invalid or slow patterns fail
+/// Applies the profile's Global Chat pattern to system-like messages. Invalid or slow patterns fail
 /// closed so user configuration cannot interrupt journal processing.
 /// </summary>
 internal static class JournalMessageClassifier
@@ -13,22 +13,31 @@ internal static class JournalMessageClassifier
     private static string _cachedPattern;
     private static Regex _cachedRegex;
 
-    /// <summary>Reclassifies eligible journal text without changing non-system message types.</summary>
-    /// <param name="messageType">The server type; only <see cref="MessageType.System"/> is eligible.</param>
+    /// <summary>Reclassifies eligible journal text without changing unrelated message types.</summary>
+    /// <param name="messageType">The original server message type.</param>
     /// <param name="text">The final journal text, matched without preprocessing.</param>
     /// <param name="classifySystemChat">The profile-level feature switch.</param>
     /// <param name="pattern">A .NET regex; blank or malformed patterns match nothing.</param>
+    /// <param name="isSystemLikeRegularMessage">
+    /// Whether a <see cref="MessageType.Regular"/> message is displayed as a system message because
+    /// it has no valid parent.
+    /// </param>
     /// <returns><see cref="MessageType.ChatSystem"/> on a match; otherwise the original type.</returns>
     public static MessageType Classify(
         MessageType messageType,
         string text,
         bool classifySystemChat,
-        string pattern
+        string pattern,
+        bool isSystemLikeRegularMessage = false
     )
     {
+        bool isEligibleMessageType =
+            messageType == MessageType.System
+            || messageType == MessageType.Regular && isSystemLikeRegularMessage;
+
         if (
             !classifySystemChat
-            || messageType != MessageType.System
+            || !isEligibleMessageType
             || string.IsNullOrEmpty(text)
             || string.IsNullOrWhiteSpace(pattern)
         )

--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -375,11 +375,16 @@ namespace ClassicUO.Game.Scenes
 
             if (!string.IsNullOrEmpty(text))
             {
+                bool isSystemLikeRegularMessage =
+                    e.Type == MessageType.Regular
+                    && (e.Parent == null || !SerialHelper.IsValid(e.Parent.Serial));
+
                 MessageType journalMessageType = JournalMessageClassifier.Classify(
                     e.Type,
                     text,
                     ProfileManager.CurrentProfile?.ClassifySystemMessagesAsGlobalChat == true,
-                    ProfileManager.CurrentProfile?.SystemMessageGlobalChatRegex
+                    ProfileManager.CurrentProfile?.SystemMessageGlobalChatRegex,
+                    isSystemLikeRegularMessage
                 );
 
                 _world.Journal.Add(text, hue, name, e.TextType, e.IsUnicode, journalMessageType);

--- a/src/ClassicUO.Client/Game/Scenes/GameScene.cs
+++ b/src/ClassicUO.Client/Game/Scenes/GameScene.cs
@@ -375,16 +375,10 @@ namespace ClassicUO.Game.Scenes
 
             if (!string.IsNullOrEmpty(text))
             {
-                bool isSystemLikeRegularMessage =
-                    e.Type == MessageType.Regular
-                    && (e.Parent == null || !SerialHelper.IsValid(e.Parent.Serial));
-
                 MessageType journalMessageType = JournalMessageClassifier.Classify(
-                    e.Type,
-                    text,
+                    e,
                     ProfileManager.CurrentProfile?.ClassifySystemMessagesAsGlobalChat == true,
-                    ProfileManager.CurrentProfile?.SystemMessageGlobalChatRegex,
-                    isSystemLikeRegularMessage
+                    ProfileManager.CurrentProfile?.SystemMessageGlobalChatRegex
                 );
 
                 _world.Journal.Add(text, hue, name, e.TextType, e.IsUnicode, journalMessageType);

--- a/tests/ClassicUO.UnitTests/Game/Managers/JournalMessageClassifierTests.cs
+++ b/tests/ClassicUO.UnitTests/Game/Managers/JournalMessageClassifierTests.cs
@@ -21,6 +21,33 @@ public class JournalMessageClassifierTests
         Assert.Equal(MessageType.ChatSystem, result);
     }
 
+    [Fact]
+    public void Classify_MatchingSystemLikeRegularMessage_ReturnsChatSystem()
+    {
+        MessageType result = JournalMessageClassifier.Classify(
+            MessageType.Regular,
+            "[16:06] Xyrah: only a test 2",
+            true,
+            Profile.DefaultSystemMessageGlobalChatRegex,
+            true
+        );
+
+        Assert.Equal(MessageType.ChatSystem, result);
+    }
+
+    [Fact]
+    public void Classify_MatchingRegularMessageWithoutSystemContext_RemainsRegular()
+    {
+        MessageType result = JournalMessageClassifier.Classify(
+            MessageType.Regular,
+            "[16:06] Xyrah: only a test 2",
+            true,
+            Profile.DefaultSystemMessageGlobalChatRegex
+        );
+
+        Assert.Equal(MessageType.Regular, result);
+    }
+
     [Theory]
     [InlineData("World save complete. The entire process took 6.34 seconds.")]
     [InlineData("You have hidden yourself well.")]

--- a/tests/ClassicUO.UnitTests/Game/Managers/JournalMessageClassifierTests.cs
+++ b/tests/ClassicUO.UnitTests/Game/Managers/JournalMessageClassifierTests.cs
@@ -1,5 +1,6 @@
 using ClassicUO.Configuration;
 using ClassicUO.Game.Data;
+using ClassicUO.Game.GameObjects;
 using ClassicUO.Game.Managers;
 using ClassicUO.Game.UI.Gumps;
 using Xunit;
@@ -12,8 +13,7 @@ public class JournalMessageClassifierTests
     public void Classify_MatchingSystemMessage_ReturnsChatSystem()
     {
         MessageType result = JournalMessageClassifier.Classify(
-            MessageType.System,
-            "[17:00] Maxwe: Hello world",
+            CreateMessage(MessageType.System, "[17:00] Maxwe: Hello world"),
             true,
             Profile.DefaultSystemMessageGlobalChatRegex
         );
@@ -25,11 +25,9 @@ public class JournalMessageClassifierTests
     public void Classify_MatchingSystemLikeRegularMessage_ReturnsChatSystem()
     {
         MessageType result = JournalMessageClassifier.Classify(
-            MessageType.Regular,
-            "[16:06] Xyrah: only a test 2",
+            CreateMessage(MessageType.Regular, "[16:06] Xyrah: only a test 2"),
             true,
-            Profile.DefaultSystemMessageGlobalChatRegex,
-            true
+            Profile.DefaultSystemMessageGlobalChatRegex
         );
 
         Assert.Equal(MessageType.ChatSystem, result);
@@ -38,9 +36,9 @@ public class JournalMessageClassifierTests
     [Fact]
     public void Classify_MatchingRegularMessageWithoutSystemContext_RemainsRegular()
     {
+        var parent = new Mobile(null, 1);
         MessageType result = JournalMessageClassifier.Classify(
-            MessageType.Regular,
-            "[16:06] Xyrah: only a test 2",
+            CreateMessage(MessageType.Regular, "[16:06] Xyrah: only a test 2", parent),
             true,
             Profile.DefaultSystemMessageGlobalChatRegex
         );
@@ -57,8 +55,7 @@ public class JournalMessageClassifierTests
     public void Classify_NonMatchingSystemMessage_RemainsSystem(string text)
     {
         MessageType result = JournalMessageClassifier.Classify(
-            MessageType.System,
-            text,
+            CreateMessage(MessageType.System, text),
             true,
             Profile.DefaultSystemMessageGlobalChatRegex
         );
@@ -70,8 +67,7 @@ public class JournalMessageClassifierTests
     public void Classify_MatchingSystemMessageWhenDisabled_RemainsSystem()
     {
         MessageType result = JournalMessageClassifier.Classify(
-            MessageType.System,
-            "[17:00] Maxwe: Hello world",
+            CreateMessage(MessageType.System, "[17:00] Maxwe: Hello world"),
             false,
             Profile.DefaultSystemMessageGlobalChatRegex
         );
@@ -83,8 +79,7 @@ public class JournalMessageClassifierTests
     public void Classify_MatchingNonSystemMessage_PreservesOriginalType()
     {
         MessageType result = JournalMessageClassifier.Classify(
-            MessageType.Guild,
-            "[17:00] Maxwe: Hello world",
+            CreateMessage(MessageType.Guild, "[17:00] Maxwe: Hello world"),
             true,
             Profile.DefaultSystemMessageGlobalChatRegex
         );
@@ -96,8 +91,7 @@ public class JournalMessageClassifierTests
     public void Classify_CustomPattern_UsesConfiguredFormat()
     {
         MessageType result = JournalMessageClassifier.Classify(
-            MessageType.System,
-            "[Global] Maxwe > Hello world",
+            CreateMessage(MessageType.System, "[Global] Maxwe > Hello world"),
             true,
             @"^\[Global\] [^>]+ > .+$"
         );
@@ -109,8 +103,7 @@ public class JournalMessageClassifierTests
     public void Classify_InvalidPattern_RemainsSystem()
     {
         MessageType result = JournalMessageClassifier.Classify(
-            MessageType.System,
-            "[Global] Maxwe > Hello world",
+            CreateMessage(MessageType.System, "[Global] Maxwe > Hello world"),
             true,
             "["
         );
@@ -135,4 +128,10 @@ public class JournalMessageClassifierTests
         Assert.True(matchesGlobalChat);
         Assert.False(matchesSystem);
     }
+
+    private static MessageEventArgs CreateMessage(
+        MessageType type,
+        string text,
+        Entity parent = null
+    ) => new(parent, text, null, 0, type, 0, TextType.SYSTEM);
 }


### PR DESCRIPTION
## Description
Fixes timestamped Global Chat messages sent by the local player not appearing in Global Chat journal tabs. Regular messages that are displayed as system messages because they have no valid parent now use the configured Global Chat classifier, while ordinary speech remains unchanged.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing
- dotnet test tests/ClassicUO.UnitTests/ --filter FullyQualifiedName~JournalMessageClassifierTests - 13 passed
- dotnet build -c Release - succeeded with 0 errors and 43 existing warnings
- dotnet test tests/ClassicUO.UnitTests/ - 1160 passed
- Verified in game that a message sent by the local player appears in the Global Chat tab

## Screenshots (if applicable)
Not applicable; this changes journal message classification without changing the UI.

## Additional Notes
No related GitHub issue or Discord discussion is available.