### PR TITLE
Fix cooldown message target filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to TazUO will be recorded here.
 Future release notes will be formatted by date instead of by release, most recent changes listed at the top:
 
 ## 9/4/26
-* Changes listed here
+* Custom cooldown bars now continue checking later rules when a sender filter does not match and no longer treat messages without a source as Self or Other
 
 ### Features
 * Added a new modern status gump with progress bars
@@ -36,7 +36,6 @@ Future release notes will be formatted by date instead of by release, most recen
 * Migrated more settings to global scoped json settings
 
 ### Fixes
-* Custom cooldown bars now continue checking later rules when a sender filter does not match and no longer treat messages without a source as Self or Other - [P.R 1057](https://github.com/PlayTazUO/TazUO/pull/1057) ([Aryx75](https://github.com/Aryx75))
 * Fixed the health bar indicator threshold so its percentage setting is applied correctly - [P.R 1052](https://github.com/PlayTazUO/TazUO/pull/1052) ([Aryx75](https://github.com/Aryx75))
 * Fixed a NullReferenceException in `API.UseSkill()` when the player was null (world tearing down) or the skill list was not yet loaded - the call now safely returns without using the skill
 * Fixed missing key codes in plugin keyup processing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Future release notes will be formatted by date instead of by release, most recen
 * Migrated more settings to global scoped json settings
 
 ### Fixes
+* Custom cooldown bars now continue checking later rules when a sender filter does not match and no longer treat messages without a source as Self or Other - [P.R 1057](https://github.com/PlayTazUO/TazUO/pull/1057) ([Aryx75](https://github.com/Aryx75))
 * Fixed the health bar indicator threshold so its percentage setting is applied correctly - [P.R 1052](https://github.com/PlayTazUO/TazUO/pull/1052) ([Aryx75](https://github.com/Aryx75))
 * Fixed a NullReferenceException in `API.UseSkill()` when the player was null (world tearing down) or the skill list was not yet loaded - the call now safely returns without using the skill
 * Fixed missing key codes in plugin keyup processing

--- a/src/ClassicUO.Client/Game/Managers/CoolDownBarManager.cs
+++ b/src/ClassicUO.Client/Game/Managers/CoolDownBarManager.cs
@@ -28,12 +28,12 @@ namespace ClassicUO.Game.Managers
                     case 0:
                         break;
                     case 1: //self
-                        if (e.Parent != null && e.Parent.Serial != World.Player.Serial)
-                            return;
+                        if (e.Parent == null || e.Parent.Serial != World.Player.Serial)
+                            continue;
                         break;
                     case 2:
-                        if (e.Parent != null && e.Parent.Serial == World.Player.Serial)
-                            return;
+                        if (e.Parent == null || e.Parent.Serial == World.Player.Serial)
+                            continue;
                         break;
 
                 }


### PR DESCRIPTION
## Description
Cooldown rules with a non-matching sender filter now skip only that rule so later matching rules are still evaluated. Self and Other rules also require an entity source and no longer both match messages without one.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## Testing
- dotnet build -c Release
- dotnet test tests/ClassicUO.UnitTests/ (1175 passed)
- git diff --check

## Screenshots (if applicable)
Not applicable.

## Additional Notes
The build completes with existing warnings, including NU1903 for SQLitePCLRaw.lib.e_sqlite3 2.1.11.