### PR TITLE
Fix two client crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to TazUO will be recorded here.
 
 ## 9/7/26
 * ***Legion:*** Added optional filters to `API.GetAllMobiles()` - `name` (case-insensitive partial match), `graphics`, `hues`, `minDistance`, `isHuman`, `isFemale`, `isGhost` (dead mobiles), `isFriend` (friends list), `poisoned`, `paralyzed`, and `hasLineOfSight`; each is ignored unless supplied, and `True`/`False` toggles include or exclude
+* ***Fix:*** Added a crash fix suggestion for when SDL cannot start the video system because the OS offers no display to the process (game launched outside a graphical desktop session, e.g. over SSH or on a headless machine) - crash logs now explain the cause and how to launch the game with a desktop display
+* ***Fix:*** Fixed a `ThreadInterruptedException` client crash when stopping a Legion script at the exact moment it was finishing on its own - the stop's pending thread interrupt now surfaces safely at the script's final cleanup instead of killing the script thread as an unhandled exception
 
 ## 9/6/26
 * ***Misc:*** Changed city selection gump to use clilocs for facet location instead of hard coded

--- a/src/ClassicUO.Client/CrashSuggestedFix.cs
+++ b/src/ClassicUO.Client/CrashSuggestedFix.cs
@@ -56,6 +56,9 @@ internal static class CrashSuggestedFix
             if (TryGetDisplayAdapterCrashFix(exception, out string displayFix))
                 return displayFix;
 
+            if (TryGetSdlVideoInitCrashFix(exception, out string sdlVideoInitFix))
+                return sdlVideoInitFix;
+
             if (Client.IsShaderCompileFailure(exception))
                 return Client.GraphicsShaderHelpMessage;
 
@@ -154,6 +157,53 @@ internal static class CrashSuggestedFix
         sb.AppendLine("3. If you use a docking station or KVM switch, try connecting your monitor directly to test.");
         sb.AppendLine("4. Update your graphics card drivers to the latest version.");
         sb.AppendLine("5. Simply restart TazUO - it should start normally once your displays are stable.");
+        fix = sb.ToString();
+        return true;
+    }
+
+    /// <summary>
+    ///     Recognizes SDL failing to bring up the video subsystem on startup - FNA's
+    ///     <c>SDL3_FNAPlatform.ProgramInit</c> throws when <c>SDL_Init</c> returns false. The
+    ///     SDL error "The video driver did not add any displays" means the process was offered
+    ///     no screen to use, which happens when the game runs outside a logged-in graphical
+    ///     desktop session (SSH, an automated launch context) or on a headless/virtual machine
+    ///     with no display configured.
+    /// </summary>
+    /// <param name="e">Exception under inspection.</param>
+    /// <param name="fix">Set to the suggested fix text when recognized.</param>
+    /// <returns>True if the crash was recognized.</returns>
+    private static bool TryGetSdlVideoInitCrashFix(Exception e, out string fix)
+    {
+        fix = null;
+
+        // ToString() on the top-level exception includes the messages and stack traces of any
+        // inner (and aggregated) exceptions, so the whole chain can be inspected in one string.
+        string details = e.ToString();
+
+        // SDL error strings are not localized, so the text is a reliable match. Scoped to the
+        // zero-displays error rather than every SDL_Init failure, since other SDL init errors
+        // need different advice.
+        if (string.IsNullOrEmpty(details) ||
+            !details.Contains("The video driver did not add any displays") ||
+            !details.Contains("SDL3_FNAPlatform.ProgramInit"))
+            return false;
+
+        var sb = new StringBuilder();
+        sb.AppendLine("TazUO could not start because the graphics system had no display to use.");
+        sb.AppendLine(
+            "The game opens its window through SDL, and the operating system did not offer it a single screen " +
+            "('The video driver did not add any displays').");
+        sb.AppendLine("This is an environment problem, not a fault in TazUO: the game was started without access to a graphical desktop session.");
+        sb.AppendLine();
+        sb.AppendLine("Suggested fixes:");
+        sb.AppendLine(
+            "1. Launch TazUO from your logged-in desktop - open it from Finder (macOS), the launcher, or a Terminal inside your desktop session.");
+        sb.AppendLine(
+            "2. Do not start it over SSH, from a scheduled task/login item, or from a script that runs outside your desktop session - those have no screen access.");
+        sb.AppendLine(
+            "3. Make sure a user is logged into the machine's desktop before starting TazUO; if the machine is sitting at the login screen, log in first.");
+        sb.AppendLine("4. On a virtual machine or headless setup, make sure a real or virtual display is available and powered on.");
+        sb.AppendLine("5. Restart the computer and try launching TazUO normally.");
         fix = sb.ToString();
         return true;
     }

--- a/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
+++ b/src/ClassicUO.Client/LegionScripting/LegionScripting.cs
@@ -469,6 +469,27 @@ namespace ClassicUO.LegionScripting
             }
         }
 
+        /// <summary>
+        /// Schedules the thread-finished cleanup (<see cref="StopScript" />) for a script whose
+        /// thread is about to exit. A stop issued just as the script was finishing leaves a pending
+        /// <see cref="ThreadInterruptedException" /> that surfaces on the thread's next blocking
+        /// call - frequently here, taking the dispatch queue's internal lock - which would otherwise
+        /// kill the thread before it schedules its own cleanup. The interrupt is one-shot and is
+        /// consumed by the throw, so a single retry cannot be interrupted again.
+        /// </summary>
+        /// <param name="script">Script whose thread has finished.</param>
+        private static void EnqueueThreadFinishedStop(ScriptFile script)
+        {
+            try
+            {
+                MainThreadQueue.EnqueueAction(() => StopScript(script));
+            }
+            catch (ThreadInterruptedException)
+            {
+                MainThreadQueue.EnqueueAction(() => StopScript(script));
+            }
+        }
+
         private static void ExecutePythonScript(ScriptFile script)
         {
             script.SetupPythonEngine();
@@ -496,7 +517,7 @@ namespace ClassicUO.LegionScripting
                 catch (ThreadAbortException) { }
             }
 
-            MainThreadQueue.EnqueueAction(() => { StopScript(script); });
+            EnqueueThreadFinishedStop(script);
         }
 
         private static void ExecuteCSharpScript(ScriptFile script)
@@ -538,7 +559,7 @@ namespace ClassicUO.LegionScripting
                 ShowCSharpRuntimeError(script, e);
             }
 
-            MainThreadQueue.EnqueueAction(() => { StopScript(script); });
+            EnqueueThreadFinishedStop(script);
         }
 
         /// <summary>

--- a/tests/ClassicUO.UnitTests/CrashSuggestedFixTests.cs
+++ b/tests/ClassicUO.UnitTests/CrashSuggestedFixTests.cs
@@ -58,6 +58,25 @@ public class CrashSuggestedFixTests
     }
 
     [Fact]
+    public void Get_SdlVideoInitZeroDisplays_ReturnsDisplayAdvice()
+    {
+        Exception inner = new InvalidOperationException("SDL_Init failed: The video driver did not add any displays");
+
+        SetStackTrace(
+            inner,
+            "   at Microsoft.Xna.Framework.SDL3_FNAPlatform.ProgramInit(LaunchParameters args) in SDL3_FNAPlatform.cs:line 202\n" +
+            "   at Microsoft.Xna.Framework.FNAPlatform..cctor() in FNAPlatform.cs:line 238");
+
+        Exception exception = new TypeInitializationException("Microsoft.Xna.Framework.FNAPlatform", inner);
+
+        string fix = CrashSuggestedFix.Get(exception);
+
+        fix.Should().NotBeNullOrWhiteSpace();
+        fix.Should().Contain("display");
+        fix.Should().Contain("desktop session");
+    }
+
+    [Fact]
     public void Get_NoStackTrace_ReturnsNull()
     {
         CrashSuggestedFix.Get(new InvalidOperationException("message")).Should().BeNull();
@@ -67,9 +86,14 @@ public class CrashSuggestedFixTests
     {
         Exception exception = new InvalidOperationException("The calling thread cannot access this object because a different thread owns it.");
 
-        FieldInfo field = typeof(Exception).GetField("_stackTraceString", BindingFlags.NonPublic | BindingFlags.Instance);
-        field!.SetValue(exception, stackTrace);
+        SetStackTrace(exception, stackTrace);
 
         return exception;
+    }
+
+    private static void SetStackTrace(Exception exception, string stackTrace)
+    {
+        FieldInfo field = typeof(Exception).GetField("_stackTraceString", BindingFlags.NonPublic | BindingFlags.Instance);
+        field!.SetValue(exception, stackTrace);
     }
 }


### PR DESCRIPTION
- Add a crash fix suggestion for SDL failing to start the video system with no display available (launched outside a graphical desktop session)
- Fix a ThreadInterruptedException client crash when stopping a Legion script just as it was finishing on its own