### PR TITLE
Added support for forcing DirectX 11.

### DIFF
--- a/src/ClassicUO.Client/Main.cs
+++ b/src/ClassicUO.Client/Main.cs
@@ -224,6 +224,10 @@ namespace ClassicUO
 
                     case 3: // SDL/FNA auto-select
                         break;
+                    case 4: // DirectX 11
+                        Environment.SetEnvironmentVariable("FNA3D_FORCE_DRIVER", "D3D11");
+                        SDL.SDL_SetHint(SDL.SDL_HINT_RENDER_DRIVER, "direct3d11");
+                        break;
                 }
 
                 Client.Run(pluginHost);


### PR DESCRIPTION
Added support for `ForceDriver 4` for DirectX 11, which provides up to **10× better performance** on some machines.

## Description
After a lot of investigation and checking every commit that could have affected performance, as we discussed on Discord, I found that the problem started when commit `c0d1f3e8d8423629207ff7570b9543fd974f9dd9` was changed. That commit makes OpenGL the default, and it turns out that some specific machines don't work well with OpenGL.

My proposal is to extend `ForceDriver` to support DirectX 11, so everyone can choose their preferred configuration. Although, I'm wondering if DirectX 11 should perhaps be the default for Windows when no driver is explicitly specified (the default case).

I **do not recommend** leaving the default empty, as I’ve confirmed that it causes crashes on some machines, just like using `ForceDriver = 3`. I'm not sure whether this is an SDL or FNA bug. (If you check the logs, they're mine.)

**TL;DR:** Added support for `ForceDriver 4` for DirectX 11, which provides up to **10× better performance** on some machines.


## Type of Change
- [ ] Bug fix
- [X] New feature
- [X] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting the DirectX 11 rendering driver through the `ForceDriver` configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->